### PR TITLE
Refactor Array4: Compute strides on the fly

### DIFF
--- a/Src/AmrCore/AMReX_MFInterp_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_C.H
@@ -14,7 +14,7 @@ Real mf_compute_slopes_x (int i, int j, int k, Array4<Real const> const& u, int 
     Real dc = Real(0.5) * (u(i+1,j,k,nu) - u(i-1,j,k,nu));
     if (i == domain.smallEnd(0) && (bc.lo(0) == BCType::ext_dir ||
                                     bc.lo(0) == BCType::hoextrap)) {
-        if (i+2 < u.end.x) {
+        if (i+2 < (u.begin.x+u.len.x)) {
             dc = -Real(16./15.)*u(i-1,j,k,nu) + Real(0.5)*u(i,j,k,nu)
                 + Real(2./3.)*u(i+1,j,k,nu) - Real(0.1)*u(i+2,j,k,nu);
         } else {
@@ -40,7 +40,7 @@ Real mf_compute_slopes_y (int i, int j, int k, Array4<Real const> const& u, int 
     Real dc = Real(0.5) * (u(i,j+1,k,nu) - u(i,j-1,k,nu));
     if (j == domain.smallEnd(1) && (bc.lo(1) == BCType::ext_dir ||
                                     bc.lo(1) == BCType::hoextrap)) {
-        if (j+2 < u.end.y) {
+        if (j+2 < (u.begin.y+u.len.y)) {
             dc = -Real(16./15.)*u(i,j-1,k,nu) + Real(0.5)*u(i,j,k,nu)
                 + Real(2./3.)*u(i,j+1,k,nu) - Real(0.1)*u(i,j+2,k,nu);
         } else {
@@ -66,7 +66,7 @@ Real mf_compute_slopes_z (int i, int j, int k, Array4<Real const> const& u, int 
     Real dc = Real(0.5) * (u(i,j,k+1,nu) - u(i,j,k-1,nu));
     if (k == domain.smallEnd(2) && (bc.lo(2) == BCType::ext_dir ||
                                     bc.lo(2) == BCType::hoextrap)) {
-        if (k+2 < u.end.z) {
+        if (k+2 < (u.begin.z+u.len.z)) {
             dc = -Real(16./15.)*u(i,j,k-1,nu) + Real(0.5)*u(i,j,k,nu)
                 + Real(2./3.)*u(i,j,k+1,nu) - Real(0.1)*u(i,j,k+2,nu);
         } else {
@@ -93,7 +93,7 @@ Real mf_cell_quadratic_compute_slopes_xx (int i, int j, int k,
     Real xx = u(i-1,j,k,nu) - 2.0_rt * u(i,j,k,nu) + u(i+1,j,k,nu);
     if (i == domain.smallEnd(0) && (bc.lo(0) == BCType::ext_dir ||
                                     bc.lo(0) == BCType::hoextrap)) {
-        if (i+2 < u.end.x) {
+        if (i+2 < (u.begin.x+u.len.x)) {
             xx = 0._rt;
         }
     }
@@ -114,7 +114,7 @@ Real mf_cell_quadratic_compute_slopes_yy (int i, int j, int k,
     Real yy = u(i,j-1,k,nu) - 2.0_rt * u(i,j,k,nu) + u(i,j+1,k,nu);
     if (j == domain.smallEnd(1) && (bc.lo(1) == BCType::ext_dir ||
                                     bc.lo(1) == BCType::hoextrap)) {
-        if (j+2 < u.end.y) {
+        if (j+2 < (u.begin.y+u.len.y)) {
             yy = 0._rt;
         }
     }
@@ -135,7 +135,7 @@ Real mf_cell_quadratic_compute_slopes_zz (int i, int j, int k,
     Real zz = u(i,j,k-1,nu) - 2.0_rt * u(i,j,k,nu) + u(i,j,k+1,nu);
     if (k == domain.smallEnd(2) && (bc.lo(2) == BCType::ext_dir ||
                                     bc.lo(2) == BCType::hoextrap)) {
-        if (k+2 < u.end.z) {
+        if (k+2 < (u.begin.z+u.len.z)) {
             zz = 0._rt;
         }
     }
@@ -157,7 +157,7 @@ Real mf_cell_quadratic_compute_slopes_xy (int i, int j, int k,
                               - u(i-1,j+1,k,nu) + u(i+1,j+1,k,nu) );
     if (i == domain.smallEnd(0) && (bc.lo(0) == BCType::ext_dir ||
                                     bc.lo(0) == BCType::hoextrap)) {
-        if (i+2 < u.end.x) {
+        if (i+2 < (u.begin.x+u.len.x)) {
             xy = 0._rt;
         }
     }
@@ -169,7 +169,7 @@ Real mf_cell_quadratic_compute_slopes_xy (int i, int j, int k,
     }
     if (j == domain.smallEnd(1) && (bc.lo(1) == BCType::ext_dir ||
                                     bc.lo(1) == BCType::hoextrap)) {
-        if (j+2 < u.end.y) {
+        if (j+2 < (u.begin.y+u.len.y)) {
             xy = 0._rt;
         }
     }
@@ -191,7 +191,7 @@ Real mf_cell_quadratic_compute_slopes_xz (int i, int j, int k,
                               - u(i-1,j,k+1,nu) + u(i+1,j,k+1,nu) );
     if (i == domain.smallEnd(0) && (bc.lo(0) == BCType::ext_dir ||
                                     bc.lo(0) == BCType::hoextrap)) {
-        if (i+2 < u.end.x) {
+        if (i+2 < (u.begin.x+u.len.x)) {
             xz = 0._rt;
         }
     }
@@ -203,7 +203,7 @@ Real mf_cell_quadratic_compute_slopes_xz (int i, int j, int k,
     }
     if (k == domain.smallEnd(2) && (bc.lo(2) == BCType::ext_dir ||
                                     bc.lo(2) == BCType::hoextrap)) {
-        if (k+2 < u.end.z) {
+        if (k+2 < (u.begin.z+u.len.z)) {
             xz = 0._rt;
         }
     }
@@ -225,7 +225,7 @@ Real mf_cell_quadratic_compute_slopes_yz (int i, int j, int k,
                               - u(i,j+1,k-1,nu) + u(i,j+1,k+1,nu) );
     if (j == domain.smallEnd(1) && (bc.lo(1) == BCType::ext_dir ||
                                     bc.lo(1) == BCType::hoextrap)) {
-        if (j+2 < u.end.y) {
+        if (j+2 < (u.begin.y+u.len.y)) {
             yz = 0._rt;
         }
     }
@@ -237,7 +237,7 @@ Real mf_cell_quadratic_compute_slopes_yz (int i, int j, int k,
     }
     if (k == domain.smallEnd(2) && (bc.lo(2) == BCType::ext_dir ||
                                     bc.lo(2) == BCType::hoextrap)) {
-        if (k+2 < u.end.z) {
+        if (k+2 < (u.begin.z+u.len.z)) {
             yz = 0._rt;
         }
     }

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -126,7 +126,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(i,j,k,0);
 #endif
-            return p[(i-begin.x)+(j-begin.y)*jstride()+(k-begin.z)*kstride()];
+            return p[(i-begin.x)+Long(len.x)*((j-begin.y)+Long(len.y)*(k-begin.z))];
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
@@ -144,7 +144,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(i,j,k,0);
 #endif
-            return p + ((i-begin.x)+(j-begin.y)*jstride()+(k-begin.z)*kstride());
+            return p + ((i-begin.x)+Long(len.x)*((j-begin.y)+Long(len.y)*(k-begin.z)));
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
@@ -153,7 +153,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(i,j,k,n);
 #endif
-            return p + ((i-begin.x)+(j-begin.y)*jstride()+(k-begin.z)*kstride()+n*nstride());
+            return p + ((i-begin.x)+Long(len.x)*((j-begin.y)+Long(len.y)*((k-begin.z)+Long(len.z)*n)));
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -60,11 +60,8 @@ namespace amrex {
     struct Array4
     {
         T* AMREX_RESTRICT p;
-        Long jstride = 0;
-        Long kstride = 0;
-        Long nstride = 0;
         Dim3 begin{1,1,1};
-        Dim3 end{0,0,0};  // end is hi + 1
+        Dim3 len{0,0,0};
         int  ncomp=0;
 
         AMREX_GPU_HOST_DEVICE
@@ -74,22 +71,16 @@ namespace amrex {
         AMREX_GPU_HOST_DEVICE
         constexpr Array4 (Array4<std::remove_const_t<T>> const& rhs) noexcept
             : p(rhs.p),
-              jstride(rhs.jstride),
-              kstride(rhs.kstride),
-              nstride(rhs.nstride),
               begin(rhs.begin),
-              end(rhs.end),
+              len(rhs.len),
               ncomp(rhs.ncomp)
             {}
 
         AMREX_GPU_HOST_DEVICE
         constexpr Array4 (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
             : p(a_p),
-              jstride(a_end.x-a_begin.x),
-              kstride(jstride*(a_end.y-a_begin.y)),
-              nstride(kstride*(a_end.z-a_begin.z)),
               begin(a_begin),
-              end(a_end),
+              len{a_end.x-a_begin.x, a_end.y-a_begin.y, a_end.z-a_begin.z},
               ncomp(a_ncomp)
             {}
 
@@ -99,12 +90,9 @@ namespace amrex {
                                 std::remove_const_t<U>>,int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr Array4 (Array4<U> const& rhs, int start_comp) noexcept
-            : p((T*)(rhs.p+start_comp*rhs.nstride)),
-              jstride(rhs.jstride),
-              kstride(rhs.kstride),
-              nstride(rhs.nstride),
+            : p((T*)(rhs.p+start_comp*rhs.nstride())),
               begin(rhs.begin),
-              end(rhs.end),
+              len(rhs.len),
               ncomp(rhs.ncomp-start_comp)
         {}
 
@@ -114,17 +102,23 @@ namespace amrex {
                                 std::remove_const_t<U>>,int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr Array4 (Array4<U> const& rhs, int start_comp, int num_comps) noexcept
-            : p((T*)(rhs.p+start_comp*rhs.nstride)),
-              jstride(rhs.jstride),
-              kstride(rhs.kstride),
-              nstride(rhs.nstride),
+            : p((T*)(rhs.p+start_comp*rhs.nstride())),
               begin(rhs.begin),
-              end(rhs.end),
+              len(rhs.len),
               ncomp(num_comps)
         {}
 
         AMREX_GPU_HOST_DEVICE
         explicit operator bool() const noexcept { return p != nullptr; }
+
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        Long jstride () const noexcept { return Long(len.x); }
+
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        Long kstride () const noexcept { return Long(len.x)*Long(len.y); }
+
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        Long nstride () const noexcept { return Long(len.x)*Long(len.y)*Long(len.z); }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -132,7 +126,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(i,j,k,0);
 #endif
-            return p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride];
+            return p[(i-begin.x)+(j-begin.y)*jstride()+(k-begin.z)*kstride()];
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
@@ -141,7 +135,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(i,j,k,n);
 #endif
-            return p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride];
+            return p[(i-begin.x)+(j-begin.y)*jstride()+(k-begin.z)*kstride()+n*nstride()];
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
@@ -150,7 +144,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(i,j,k,0);
 #endif
-            return p + ((i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride);
+            return p + ((i-begin.x)+(j-begin.y)*jstride()+(k-begin.z)*kstride());
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
@@ -159,7 +153,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(i,j,k,n);
 #endif
-            return p + ((i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride);
+            return p + ((i-begin.x)+(j-begin.y)*jstride()+(k-begin.z)*kstride()+n*nstride());
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
@@ -241,7 +235,7 @@ namespace amrex {
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         std::size_t size () const noexcept {
-            return this->nstride * this->ncomp;
+            return this->nstride() * this->ncomp;
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -249,14 +243,14 @@ namespace amrex {
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         bool contains (int i, int j, int k) const noexcept {
-            return (i>=begin.x && i<end.x && j>=begin.y && j<end.y && k>=begin.z && k<end.z);
+            return (i>=begin.x && i<(begin.x+len.x) && j>=begin.y && j<(begin.y+len.y) && k>=begin.z && k<(begin.z+len.z));
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         bool contains (IntVect const& iv) const noexcept {
-            return AMREX_D_TERM(   iv[0]>=begin.x && iv[0]<end.x,
-                                && iv[1]>=begin.y && iv[1]<end.y,
-                                && iv[2]>=begin.z && iv[2]<end.z);
+            return AMREX_D_TERM(   iv[0]>=begin.x && iv[0]<(begin.x+len.x),
+                                && iv[1]>=begin.y && iv[1]<(begin.y+len.y),
+                                && iv[2]>=begin.z && iv[2]<(begin.z+len.z));
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -272,21 +266,21 @@ namespace amrex {
 #endif
         void index_assert (int i, int j, int k, int n) const
         {
-            if (i<begin.x || i>=end.x || j<begin.y || j>=end.y || k<begin.z || k>=end.z
+            if (i<begin.x || i>=(begin.x+len.x) || j<begin.y || j>=(begin.y+len.y) || k<begin.z || k>=(begin.z+len.z)
                 || n < 0 || n >= ncomp) {
                 AMREX_IF_ON_DEVICE((
                     AMREX_DEVICE_PRINTF(" (%d,%d,%d,%d) is out of bound (%d:%d,%d:%d,%d:%d,0:%d)\n",
-                                        i, j, k, n, begin.x, end.x-1, begin.y, end.y-1,
-                                        begin.z, end.z-1, ncomp-1);
+                                        i, j, k, n, begin.x, (begin.x+len.x)-1, begin.y, (begin.y+len.y)-1,
+                                        begin.z, (begin.z+len.z)-1, ncomp-1);
                     amrex::Abort();
                 ))
                 AMREX_IF_ON_HOST((
                     std::stringstream ss;
                     ss << " (" << i << "," << j << "," << k << "," <<  n
                     << ") is out of bound ("
-                    << begin.x << ":" << end.x-1 << ","
-                    << begin.y << ":" << end.y-1 << ","
-                    << begin.z << ":" << end.z-1 << ","
+                    << begin.x << ":" << (begin.x+len.x)-1 << ","
+                    << begin.y << ":" << (begin.y+len.y)-1 << ","
+                    << begin.z << ":" << (begin.z+len.z)-1 << ","
                     << "0:" << ncomp-1 << ")";
                     amrex::Abort(ss.str());
                 ))
@@ -296,7 +290,7 @@ namespace amrex {
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         CellData<T> cellData (int i, int j, int k) const noexcept {
-            return CellData<T>{this->ptr(i,j,k), nstride, ncomp};
+            return CellData<T>{this->ptr(i,j,k), nstride(), ncomp};
         }
     };
 
@@ -304,7 +298,11 @@ namespace amrex {
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
     Array4<Tto> ToArray4 (Array4<Tfrom> const& a_in) noexcept
     {
-        return Array4<Tto>((Tto*)(a_in.p), a_in.begin, a_in.end, a_in.ncomp);
+        return Array4<Tto>((Tto*)(a_in.p), a_in.begin,
+                           Dim3{a_in.begin.x + a_in.len.x,
+                                a_in.begin.y + a_in.len.y,
+                                a_in.begin.z + a_in.len.z},
+                           a_in.ncomp);
     }
 
     template <class T>
@@ -318,14 +316,28 @@ namespace amrex {
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Dim3 ubound (Array4<T> const& a) noexcept
     {
-        return Dim3{a.end.x-1,a.end.y-1,a.end.z-1};
+        return Dim3{a.begin.x+a.len.x-1,a.begin.y+a.len.y-1,a.begin.z+a.len.z-1};
+    }
+
+    template <class T>
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Dim3 begin (Array4<T> const& a) noexcept
+    {
+        return a.begin;
+    }
+
+    template <class T>
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Dim3 end (Array4<T> const& a) noexcept
+    {
+        return Dim3{a.begin.x+a.len.x,a.begin.y+a.len.y,a.begin.z+a.len.z};
     }
 
     template <class T>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Dim3 length (Array4<T> const& a) noexcept
     {
-        return Dim3{a.end.x-a.begin.x,a.end.y-a.begin.y,a.end.z-a.begin.z};
+        return a.len;
     }
 
     template <typename T>

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -135,7 +135,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(i,j,k,n);
 #endif
-            return p[(i-begin.x)+(j-begin.y)*jstride()+(k-begin.z)*kstride()+n*nstride()];
+            return p[(i-begin.x)+Long(len.x)*((j-begin.y)+Long(len.y)*((k-begin.z)+Long(len.z)*n))];
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -2013,32 +2013,32 @@ template<class T>
 BaseFab<T>::BaseFab (Array4<T> const& a) noexcept
     : dptr(a.p),
       domain(IntVect(AMREX_D_DECL(a.begin.x,a.begin.y,a.begin.z)),
-             IntVect(AMREX_D_DECL(a.end.x-1,a.end.y-1,a.end.z-1))),
-      nvar(a.ncomp), truesize(a.ncomp*a.nstride)
+             IntVect(AMREX_D_DECL(a.begin.x+a.len.x-1,a.begin.y+a.len.y-1,a.begin.z+a.len.z-1))),
+      nvar(a.ncomp), truesize(a.ncomp*a.nstride())
 {}
 
 template<class T>
 BaseFab<T>::BaseFab (Array4<T> const& a, IndexType t) noexcept
     : dptr(a.p),
       domain(IntVect(AMREX_D_DECL(a.begin.x,a.begin.y,a.begin.z)),
-             IntVect(AMREX_D_DECL(a.end.x-1,a.end.y-1,a.end.z-1)), t),
-      nvar(a.ncomp), truesize(a.ncomp*a.nstride)
+             IntVect(AMREX_D_DECL(a.begin.x+a.len.x-1,a.begin.y+a.len.y-1,a.begin.z+a.len.z-1)), t),
+      nvar(a.ncomp), truesize(a.ncomp*a.nstride())
 {}
 
 template<class T>
 BaseFab<T>::BaseFab (Array4<T const> const& a) noexcept
     : dptr(const_cast<T*>(a.p)),
       domain(IntVect(AMREX_D_DECL(a.begin.x,a.begin.y,a.begin.z)),
-             IntVect(AMREX_D_DECL(a.end.x-1,a.end.y-1,a.end.z-1))),
-      nvar(a.ncomp), truesize(a.ncomp*a.nstride)
+             IntVect(AMREX_D_DECL(a.begin.x+a.len.x-1,a.begin.y+a.len.y-1,a.begin.z+a.len.z-1))),
+      nvar(a.ncomp), truesize(a.ncomp*a.nstride())
 {}
 
 template<class T>
 BaseFab<T>::BaseFab (Array4<T const> const& a, IndexType t) noexcept
     : dptr(const_cast<T*>(a.p)),
       domain(IntVect(AMREX_D_DECL(a.begin.x,a.begin.y,a.begin.z)),
-             IntVect(AMREX_D_DECL(a.end.x-1,a.end.y-1,a.end.z-1)), t),
-      nvar(a.ncomp), truesize(a.ncomp*a.nstride)
+             IntVect(AMREX_D_DECL(a.begin.x+a.len.x-1,a.begin.y+a.len.y-1,a.begin.z+a.len.z-1)), t),
+      nvar(a.ncomp), truesize(a.ncomp*a.nstride())
 {}
 
 template <class T>

--- a/Src/Base/AMReX_Box.H
+++ b/Src/Base/AMReX_Box.H
@@ -95,7 +95,7 @@ public:
     AMREX_GPU_HOST_DEVICE
     explicit BoxND (Array4<T> const& a) noexcept
         : smallend(a.begin),
-          bigend(IntVectND<dim>(a.end) - 1)
+          bigend(IntVectND<dim>(ubound(a)))
         {}
 
     // dtor, copy-ctor, copy-op=, move-ctor, and move-op= are compiler generated.

--- a/Src/Base/AMReX_CudaGraph.H
+++ b/Src/Base/AMReX_CudaGraph.H
@@ -39,16 +39,16 @@ makeCopyMemory (Array4<T> const& src, Array4<U> const& dst, int scomp, int ncomp
     mem.src = (void*)(src.p);
     mem.dst = (void*)(dst.p);
     mem.src_begin = src.begin;
-    mem.src_end = src.end;
+    mem.src_end = end(src);
     mem.dst_begin = dst.begin;
-    mem.dst_end = dst.end;
+    mem.dst_end = end(dst);
     mem.scomp = scomp;
     mem.ncomp = ncomp;
     return mem;
 
 #else
 
-    return CopyMemory{ (void*)(src.p), (void*)(dst.p), src.begin, src.end, dst.begin, dst.end, scomp, ncomp };
+    return CopyMemory{ (void*)(src.p), (void*)(dst.p), src.begin, end(src), dst.begin, end(dst), scomp, ncomp };
 #endif
 }
 

--- a/Src/Base/AMReX_FilCC_1D_C.H
+++ b/Src/Base/AMReX_FilCC_1D_C.H
@@ -23,7 +23,7 @@ struct FilccCell
         const int ilo = domain_lo[0];
         const int ihi = domain_hi[0];
         const int is = amrex::max(q.begin.x,ilo);
-        const int ie = amrex::min(q.end.x-1,ihi);
+        const int ie = amrex::min(q.begin.x+q.len.x-1,ihi);
 
         for (int n = dcomp; n < numcomp+dcomp; ++n)
         {

--- a/Src/Base/AMReX_FilCC_2D_C.H
+++ b/Src/Base/AMReX_FilCC_2D_C.H
@@ -27,8 +27,8 @@ struct FilccCell
         const int jhi = domain_hi[1];
         const int is = amrex::max(q.begin.x,ilo);
         const int js = amrex::max(q.begin.y,jlo);
-        const int ie = amrex::min(q.end.x-1,ihi);
-        const int je = amrex::min(q.end.y-1,jhi);
+        const int ie = amrex::min(q.begin.x+q.len.x-1,ihi);
+        const int je = amrex::min(q.begin.y+q.len.y-1,jhi);
 
         for (int n = dcomp; n < numcomp+dcomp; ++n)
         {

--- a/Src/Base/AMReX_FilCC_3D_C.H
+++ b/Src/Base/AMReX_FilCC_3D_C.H
@@ -48,7 +48,7 @@ struct FilccCell
                         q(i,j,k,n) = q(ilo,j,k,n);
                     }
                     // i == ilo-1
-                    else if (ilo+2 <= amrex::min(q.end.x-1,ihi))
+                    else if (ilo+2 <= amrex::min(q.begin.x+q.len.x-1,ihi))
                     {
                         q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i+1,j,k,n) - Real(10.)*q(i+2,j,k,n) + Real(3.)*q(i+3,j,k,n));
                     }
@@ -135,7 +135,7 @@ struct FilccCell
                         q(i,j,k,n) = q(i,jlo,k,n);
                     }
                     // j == jlo-1
-                    else if (jlo+2 <= amrex::min(q.end.y-1,jhi))
+                    else if (jlo+2 <= amrex::min(q.begin.y+q.len.y-1,jhi))
                     {
                         q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j+1,k,n) - Real(10.)*q(i,j+2,k,n) + Real(3.)*q(i,j+3,k,n));
                     }
@@ -222,7 +222,7 @@ struct FilccCell
                         q(i,j,k,n) = q(i,j,klo,n);
                     }
                     // k == klo-1
-                    else if (klo+2 <= amrex::min(q.end.z-1,khi))
+                    else if (klo+2 <= amrex::min(q.begin.z+q.len.z-1,khi))
                     {
                         q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j,k+1,n) - Real(10.)*q(i,j,k+2,n) + Real(3.)*q(i,j,k+3,n));
                     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -712,11 +712,11 @@ protected:
     [[nodiscard]] Array4<T> compactify (Array4<T> const& a) const noexcept
     {
         if (info.hidden_direction == 0) {
-            return Array4<T>(a.dataPtr(), {a.begin.y,a.begin.z,0}, {a.end.y,a.end.z,1}, a.nComp());
+            return Array4<T>(a.dataPtr(), {a.begin.y,a.begin.z,0}, {(a.begin.y+a.len.y),(a.begin.z+a.len.z),1}, a.nComp());
         } else if (info.hidden_direction == 1) {
-            return Array4<T>(a.dataPtr(), {a.begin.x,a.begin.z,0}, {a.end.x,a.end.z,1}, a.nComp());
+            return Array4<T>(a.dataPtr(), {a.begin.x,a.begin.z,0}, {(a.begin.x+a.len.x),(a.begin.z+a.len.z),1}, a.nComp());
         } else if (info.hidden_direction == 2) {
-            return Array4<T>(a.dataPtr(), {a.begin.x,a.begin.y,0}, {a.end.x,a.end.y,1}, a.nComp());
+            return Array4<T>(a.dataPtr(), {a.begin.x,a.begin.y,0}, {(a.begin.x+a.len.x),(a.begin.y+a.len.y),1}, a.nComp());
         } else {
             return a;
         }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -988,7 +988,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                      p.idata(NStructInt+n) = imf_arr(i,j,k,1+NStructInt+n);
                  }
                  //Set the new particle in dst tile
-                 dst.setSuperParticle(p, last_offset+offsets_ptr[((i-imf_arr.begin.x)+(j-imf_arr.begin.y)*imf_arr.jstride+(k-imf_arr.begin.z)*imf_arr.kstride)]);
+                 dst.setSuperParticle(p, last_offset+offsets_ptr[((i-imf_arr.begin.x)+(j-imf_arr.begin.y)*imf_arr.jstride()+(k-imf_arr.begin.z)*imf_arr.kstride())]);
              }
 
         });

--- a/Src/Particle/AMReX_Particle_mod_K.H
+++ b/Src/Particle/AMReX_Particle_mod_K.H
@@ -18,6 +18,7 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
 #if (AMREX_SPACEDIM == 1)
@@ -124,6 +125,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
 #if (AMREX_SPACEDIM == 1)

--- a/Src/Particle/AMReX_Particle_mod_K.H
+++ b/Src/Particle/AMReX_Particle_mod_K.H
@@ -138,7 +138,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     int hi_x = static_cast<int>(amrex::Math::floor(hx));
 
     for (int i = lo_x; i <= hi_x; ++i) {
-        if (i < rho.begin.x || i >= rho.end.x) { continue; }
+        if (i < rho.begin.x || i >= (rho.begin.x+rho.len.x)) { continue; }
         amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
         amrex::Real weight = wx*factor;
         amrex::Gpu::Atomic::AddNoRet(&rho(i, 0, 0, 0), static_cast<Real>(weight*p.rdata(0)));
@@ -147,7 +147,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     for (int comp = 1; comp < nc; ++comp)
     {
         for (int i = lo_x; i <= hi_x; ++i) {
-            if (i < rho.begin.x || i >= rho.end.x) { continue; }
+            if (i < rho.begin.x || i >= (rho.begin.x+rho.len.x)) { continue; }
             amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
             amrex::Real weight = wx*factor;
             amrex::Gpu::Atomic::AddNoRet(&rho(i, 0, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
@@ -170,10 +170,10 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     int hi_y = static_cast<int>(amrex::Math::floor(hy));
 
     for (int j = lo_y; j <= hi_y; ++j) {
-        if (j < rho.begin.y || j >= rho.end.y) { continue; }
+        if (j < rho.begin.y || j >= (rho.begin.y+rho.len.y)) { continue; }
         amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
         for (int i = lo_x; i <= hi_x; ++i) {
-            if (i < rho.begin.x || i >= rho.end.x) { continue; }
+            if (i < rho.begin.x || i >= (rho.begin.x+rho.len.x)) { continue; }
             amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
             amrex::Real weight = wx*wy*factor;
             amrex::Gpu::Atomic::AddNoRet(&rho(i, j, 0, 0), static_cast<Real>(weight*p.rdata(0)));
@@ -182,10 +182,10 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 
     for (int comp = 1; comp < nc; ++comp) {
         for (int j = lo_y; j <= hi_y; ++j) {
-            if (j < rho.begin.y || j >= rho.end.y) { continue; }
+            if (j < rho.begin.y || j >= (rho.begin.y+rho.len.y)) { continue; }
             amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
             for (int i = lo_x; i <= hi_x; ++i) {
-                if (i < rho.begin.x || i >= rho.end.x) { continue; }
+                if (i < rho.begin.x || i >= (rho.begin.x+rho.len.x)) { continue; }
                 amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
                 amrex::Real weight = wx*wy*factor;
                 amrex::Gpu::Atomic::AddNoRet(&rho(i, j, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
@@ -213,13 +213,13 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     int hi_z = static_cast<int>(amrex::Math::floor(hz));
 
     for (int k = lo_z; k <= hi_z; ++k) {
-        if (k < rho.begin.z || k >= rho.end.z) { continue; }
+        if (k < rho.begin.z || k >= (rho.begin.z+rho.len.z)) { continue; }
         amrex::Real wz = amrex::min(hz - static_cast<Real>(k), amrex::Real(1.0)) - amrex::max(lz - static_cast<Real>(k), amrex::Real(0.0));
         for (int j = lo_y; j <= hi_y; ++j) {
-            if (j < rho.begin.y || j >= rho.end.y) { continue; }
+            if (j < rho.begin.y || j >= (rho.begin.y+rho.len.y)) { continue; }
             amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
             for (int i = lo_x; i <= hi_x; ++i) {
-                if (i < rho.begin.x || i >= rho.end.x) { continue; }
+                if (i < rho.begin.x || i >= (rho.begin.x+rho.len.x)) { continue; }
                 amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
                 amrex::Real weight = wx*wy*wz*factor;
                 amrex::Gpu::Atomic::AddNoRet(&rho(i, j, k, 0), static_cast<Real>(weight*p.rdata(0)));
@@ -229,13 +229,13 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 
     for (int comp = 1; comp < nc; ++comp) {
         for (int k = lo_z; k <= hi_z; ++k) {
-            if (k < rho.begin.z || k >= rho.end.z) { continue; }
+            if (k < rho.begin.z || k >= (rho.begin.z+rho.len.z)) { continue; }
             amrex::Real wz = amrex::min(hz - static_cast<Real>(k), amrex::Real(1.0)) - amrex::max(lz - static_cast<Real>(k), amrex::Real(0.0));
             for (int j = lo_y; j <= hi_y; ++j) {
-                if (j < rho.begin.y || j >= rho.end.y) { continue; }
+                if (j < rho.begin.y || j >= (rho.begin.y+rho.len.y)) { continue; }
                 amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
                 for (int i = lo_x; i <= hi_x; ++i) {
-                    if (i < rho.begin.x || i >= rho.end.x) { continue; }
+                    if (i < rho.begin.x || i >= (rho.begin.x+rho.len.x)) { continue; }
                     amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
                     amrex::Real weight = wx*wy*wz*factor;
                     amrex::Gpu::Atomic::AddNoRet(&rho(i, j, k, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));


### PR DESCRIPTION
This reduces the size of Array4 from 64 to 40 bytes.