### PR TITLE
SYCL: Update link flag for huge device code in GNU Make file

### DIFF
--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -166,7 +166,7 @@ endif
 
 ifeq ($(DEBUG),TRUE)
   # This might be needed for linking device code larger than 2GB.
-  LDFLAGS += -fsycl-link-huge-device-code
+  LDFLAGS += -flink-huge-device-code
 endif
 
 ifeq ($(FSANITIZER),TRUE)


### PR DESCRIPTION
The old flag -fsycl-link-huge-device-code has been removed recently. The change in CMake was done in #4332.
