### PR TITLE
Fix new warnings from size 0 arrays

### DIFF
--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -192,12 +192,14 @@ struct ParticleTileData
         if constexpr (!ParticleType::is_soa_particle) {
             array_start_index = AMREX_SPACEDIM + NStructReal;
         }
-        for (int i = 0; i < NAR; ++i)
-        {
-            if (comm_real[array_start_index + i])
+        if constexpr (NAR > 0) {
+            for (int i = 0; i < NAR; ++i)
             {
-                memcpy(m_rdata[i] + dst_index, src, sizeof(ParticleReal));
-                src += sizeof(ParticleReal);
+                if (comm_real[array_start_index + i])
+                {
+                    memcpy(m_rdata[i] + dst_index, src, sizeof(ParticleReal));
+                    src += sizeof(ParticleReal);
+                }
             }
         }
         int runtime_start_index  = array_start_index + NAR;
@@ -210,12 +212,14 @@ struct ParticleTileData
             }
         }
         array_start_index  = 2 + NStructInt;
-        for (int i = 0; i < NAI; ++i)
-        {
-            if (comm_int[array_start_index + i])
+        if constexpr (NAI > 0) {
+            for (int i = 0; i < NAI; ++i)
             {
-                memcpy(m_idata[i] + dst_index, src, sizeof(int));
-                src += sizeof(int);
+                if (comm_int[array_start_index + i])
+                {
+                    memcpy(m_idata[i] + dst_index, src, sizeof(int));
+                    src += sizeof(int);
+                }
             }
         }
         runtime_start_index  = 2 + NStructInt + NAI;
@@ -241,16 +245,20 @@ struct ParticleTileData
         for (int i = 0; i < NStructReal; ++i) {
             sp.rdata(i) = m_aos[index].rdata(i);
         }
-        for (int i = 0; i < NAR; ++i) {
-            sp.rdata(NStructReal+i) = m_rdata[i][index];
+        if constexpr (NAR >0) {
+            for (int i = 0; i < NAR; ++i) {
+                sp.rdata(NStructReal+i) = m_rdata[i][index];
+            }
         }
         sp.id() = m_aos[index].id();
         sp.cpu() = m_aos[index].cpu();
         for (int i = 0; i < NStructInt; ++i) {
             sp.idata(i) = m_aos[index].idata(i);
         }
-        for (int i = 0; i < NAI; ++i) {
-            sp.idata(NStructInt+i) = m_idata[i][index];
+        if constexpr (NAI > 0) {
+            for (int i = 0; i < NAI; ++i) {
+                sp.idata(NStructInt+i) = m_idata[i][index];
+            }
         }
         return sp;
     }
@@ -605,12 +613,14 @@ struct ConstParticleTileData
         if constexpr (!ParticleType::is_soa_particle) {
             array_start_index = AMREX_SPACEDIM + NStructReal;
         }
-        for (int i = 0; i < NArrayReal; ++i)
-        {
-            if (comm_real[array_start_index + i])
+        if constexpr (NArrayReal > 0) {
+            for (int i = 0; i < NArrayReal; ++i)
             {
-                memcpy(dst, m_rdata[i] + src_index, sizeof(ParticleReal));
-                dst += sizeof(ParticleReal);
+                if (comm_real[array_start_index + i])
+                {
+                    memcpy(dst, m_rdata[i] + src_index, sizeof(ParticleReal));
+                    dst += sizeof(ParticleReal);
+                }
             }
         }
         int runtime_start_index  = array_start_index + NArrayReal;
@@ -623,12 +633,14 @@ struct ConstParticleTileData
             }
         }
         array_start_index  = 2 + NStructInt;
-        for (int i = 0; i < NArrayInt; ++i)
-        {
-            if (comm_int[array_start_index + i])
+        if constexpr (NArrayInt > 0) {
+            for (int i = 0; i < NArrayInt; ++i)
             {
-                memcpy(dst, m_idata[i] + src_index, sizeof(int));
-                dst += sizeof(int);
+                if (comm_int[array_start_index + i])
+                {
+                    memcpy(dst, m_idata[i] + src_index, sizeof(int));
+                    dst += sizeof(int);
+                }
             }
         }
         runtime_start_index  = 2 + NStructInt + NArrayInt;

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -128,14 +128,18 @@ void swapParticle (const ParticleTileData<T_ParticleType, NAR, NAI>& dst,
     } else {
         amrex::Swap(src.m_aos[src_i], dst.m_aos[dst_i]);
     }
-    for (int j = 0; j < NAR; ++j) {
-        amrex::Swap(dst.m_rdata[j][dst_i], src.m_rdata[j][src_i]);
+    if constexpr (NAR > 0) {
+	for (int j = 0; j < NAR; ++j) {
+	    amrex::Swap(dst.m_rdata[j][dst_i], src.m_rdata[j][src_i]);
+	}
     }
     for (int j = 0; j < dst.m_num_runtime_real; ++j) {
         amrex::Swap(dst.m_runtime_rdata[j][dst_i], src.m_runtime_rdata[j][src_i]);
     }
-    for (int j = 0; j < NAI; ++j) {
-        amrex::Swap(dst.m_idata[j][dst_i], src.m_idata[j][src_i]);
+    if constexpr (NAI > 0) {
+	for (int j = 0; j < NAI; ++j) {
+	    amrex::Swap(dst.m_idata[j][dst_i], src.m_idata[j][src_i]);
+	}
     }
     for (int j = 0; j < dst.m_num_runtime_int; ++j) {
         amrex::Swap(dst.m_runtime_idata[j][dst_i], src.m_runtime_idata[j][src_i]);

--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -129,17 +129,17 @@ void swapParticle (const ParticleTileData<T_ParticleType, NAR, NAI>& dst,
         amrex::Swap(src.m_aos[src_i], dst.m_aos[dst_i]);
     }
     if constexpr (NAR > 0) {
-	for (int j = 0; j < NAR; ++j) {
-	    amrex::Swap(dst.m_rdata[j][dst_i], src.m_rdata[j][src_i]);
-	}
+    for (int j = 0; j < NAR; ++j) {
+        amrex::Swap(dst.m_rdata[j][dst_i], src.m_rdata[j][src_i]);
+    }
     }
     for (int j = 0; j < dst.m_num_runtime_real; ++j) {
         amrex::Swap(dst.m_runtime_rdata[j][dst_i], src.m_runtime_rdata[j][src_i]);
     }
     if constexpr (NAI > 0) {
-	for (int j = 0; j < NAI; ++j) {
-	    amrex::Swap(dst.m_idata[j][dst_i], src.m_idata[j][src_i]);
-	}
+    for (int j = 0; j < NAI; ++j) {
+        amrex::Swap(dst.m_idata[j][dst_i], src.m_idata[j][src_i]);
+    }
     }
     for (int j = 0; j < dst.m_num_runtime_int; ++j) {
         amrex::Swap(dst.m_runtime_idata[j][dst_i], src.m_runtime_idata[j][src_i]);

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -293,13 +293,17 @@ public:
                     {
                         AMREX_ALWAYS_ASSERT(ptd.m_aos[i].idata(j) == ptd.m_aos[i].id());
                     }
-                    for (int j = 0; j < NAR; ++j)
-                    {
-                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ptd.m_aos[i].id());
+                    if constexpr (NAR > 0) {
+                        for (int j = 0; j < NAR; ++j)
+                        {
+                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ptd.m_aos[i].id());
+                        }
                     }
-                    for (int j = 0; j < NAI; ++j)
-                    {
-                        AMREX_ALWAYS_ASSERT(ptd.m_idata[j][i] == ptd.m_aos[i].id());
+                    if constexpr (NAI > 0) {
+                        for (int j = 0; j < NAI; ++j)
+                        {
+                            AMREX_ALWAYS_ASSERT(ptd.m_idata[j][i] == ptd.m_aos[i].id());
+                        }
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {


### PR DESCRIPTION
Since #4395, we have been seeing warnings about pointless comparisons to 0 when compiling with `USE_CUDA=TRUE` and `Debug=TRUE` in some of the particle code. This removes these warnings by using `if constexpr` when the size of an array would be 0.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
