### PR TITLE
add conservative linear interpolation for spherical 2d geometry

### DIFF
--- a/Src/AmrCore/AMReX_Interpolater.cpp
+++ b/Src/AmrCore/AMReX_Interpolater.cpp
@@ -868,7 +868,33 @@ CellConservativeLinear::interp (const FArrayBox& crse,
         });
     } else
 #elif (AMREX_SPACEDIM == 2)
-    if (crse_geom.IsRZ()) {
+    if (crse_geom.IsSPHERICAL()) {
+        Real drf = fine_geom.CellSize(0);
+        Real dtf = fine_geom.CellSize(1);
+        Real rlo = fine_geom.Offset(0);
+        Real tlo = fine_geom.Offset(1);
+        if (do_linear_limiting) {
+            AMREX_HOST_DEVICE_PARALLEL_FOR_3D_FLAG(runon, cslope_bx, i, j, k,
+            {
+                mf_cell_cons_lin_interp_llslope(i,j,k, tmp, crsearr, crse_comp, ncomp,
+                                                cdomain, ratio, bcrp);
+            });
+        } else {
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D_FLAG(runon, cslope_bx, ncomp, i, j, k, n,
+            {
+                amrex::ignore_unused(k);
+                mf_cell_cons_lin_interp_mcslope_sph(i, j, n, tmp, crsearr, crse_comp, ncomp,
+                                                    cdomain, ratio, bcrp, drf, rlo, dtf, tlo);
+            });
+        }
+
+        AMREX_HOST_DEVICE_PARALLEL_FOR_4D_FLAG(runon, fine_region, ncomp, i, j, k, n,
+        {
+            amrex::ignore_unused(k);
+            mf_cell_cons_lin_interp_sph(i, j, n, finearr, fine_comp, ctmp, crsearr, crse_comp,
+                                        ncomp, ratio, drf, rlo, dtf, tlo);
+        });
+    } else if (crse_geom.IsRZ()) {
         Real drf = fine_geom.CellSize(0);
         Real rlo = fine_geom.Offset(0);
         if (do_linear_limiting) {

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -305,10 +305,10 @@ void mf_cell_cons_lin_interp_sph (int i, int j, int ns, Array4<Real> const& fine
     const Real rcp = (ic+1) * drc + rlo;
     const Real rfm =  i     * drf + rlo;
     const Real rfp = (i +1) * drf + rlo;
-    Real vcm = rcm*rcm;
-    Real vcp = rcp*rcp;
-    Real vfm = rfm*rfm;
-    Real vfp = rfp*rfp;
+    Real vcm = rcm*rcm*rcm;
+    Real vcp = rcp*rcp*rcp;
+    Real vfm = rfm*rfm*rfm;
+    Real vfp = rfp*rfp*rfp;
     const Real xoff = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
 
     // y-direction
@@ -322,8 +322,7 @@ void mf_cell_cons_lin_interp_sph (int i, int j, int ns, Array4<Real> const& fine
     vcp = std::cos(tcp);
     vfm = std::cos(tfm);
     vfp = std::cos(tfp);
-    // const Real yoff = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
-    const Real yoff = (j - jc*ratio[1] + Real(0.5)) / Real(ratio[1]) - Real(0.5);
+    const Real yoff = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
 
     fine(i,j,0,fcomp+ns) = crse(ic,jc,0,ccomp+ns)
         + xoff * slope(ic,jc,0,ns)

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -203,6 +203,134 @@ void mf_cell_cons_lin_interp (int i, int j, int /*k*/, int ns, Array4<Real> cons
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mf_cell_cons_lin_interp_mcslope_sph (int i, int j, int ns, Array4<Real> const& slope,
+                                          Array4<Real const> const& u, int scomp, int ncomp,
+                                          Box const& domain, IntVect const& ratio,
+                                          BCRec const* bc, Real drf, Real rlo,
+                                          Real dtf, Real tlo) noexcept
+{
+    int nu = ns + scomp;
+
+    Real sx = Real(0.0);
+    Real sy = Real(0.0);
+
+    // x-direction
+    if (ratio[0] > 1) {
+        Real dc = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
+        Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
+        sx = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sx = std::copysign(Real(1.),dc)*amrex::min(sx,std::abs(dc));
+    }
+
+    // y-direction
+    if (ratio[1] > 1) {
+        Real dc = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
+        Real db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
+        sy = (df*db >= Real(0.0)) ? amrex::min(std::abs(df),std::abs(db)) : Real(0.);
+        sy = std::copysign(Real(1.),dc)*amrex::min(sy,std::abs(dc));
+    }
+
+    Real alpha = Real(1.0);
+    if (sx != Real(0.0) || sy != Real(0.0)) {
+
+        // x-direction
+        const Real drc = drf * ratio[0];
+        const Real rcm =  i    * drc + rlo;
+        const Real rcp = (i+1) * drc + rlo;
+        Real vcm = rcm*rcm*rcm;
+        Real vcp = rcp*rcp*rcp;
+        Real rfm =  i*ratio[0]      * drf + rlo;
+        Real rfp = (i*ratio[0] + 1) * drf + rlo;
+        Real vfm = rfm*rfm*rfm;
+        Real vfp = rfp*rfp*rfp;
+        Real xlo = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
+        rfm = ((i+1)*ratio[0] - 1) * drf + rlo;
+        rfp =  (i+1)*ratio[0]      * drf + rlo;
+        vfm = rfm*rfm*rfm;
+        vfp = rfp*rfp*rfp;
+        Real xhi = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
+
+        // y-direction
+        const Real dtc = dtf * ratio[1];
+        const Real tcm = j     * dtc + tlo;
+        const Real tcp = (j+1) * dtc + tlo;
+        vcm = std::cos(tcm);
+        vcp = std::cos(tcp);
+        Real tfm =  j*ratio[1]      * dtf + tlo;
+        Real tfp = (j*ratio[1] + 1) * dtf + tlo;
+        vfm = std::cos(tfm);
+        vfp = std::cos(tfp);
+        Real ylo = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
+        tfm = ((j+1)*ratio[1] - 1) * dtf + tlo;
+        tfp =  (j+1)*ratio[1]      * dtf + tlo;
+        vfm = std::cos(tfm);
+        vfp = std::cos(tfp);
+        Real yhi = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
+
+        Real dumax =  amrex::max(sx*xlo, sx*xhi) + amrex::max(sy*ylo, sy*yhi);
+        Real dumin = -amrex::min(sx*xlo, sx*xhi) - amrex::min(sy*ylo, sy*yhi);;
+        Real umax = u(i,j,0,nu);
+        Real umin = u(i,j,0,nu);
+        int ilim = ratio[0] > 1 ? 1 : 0;
+        int jlim = ratio[1] > 1 ? 1 : 0;
+        for (int joff = -jlim; joff <= jlim; ++joff) {
+        for (int ioff = -ilim; ioff <= ilim; ++ioff) {
+            umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
+            umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
+        }}
+        if (dumax * alpha > (umax - u(i,j,0,nu))) {
+            alpha = (umax - u(i,j,0,nu)) / dumax;
+        }
+        if (dumin * alpha > (u(i,j,0,nu) - umin)) {
+            alpha = (u(i,j,0,nu) - umin) / dumin;
+        }
+    }
+
+    slope(i,j,0,ns        ) = sx * alpha;
+    slope(i,j,0,ns+  ncomp) = sy * alpha;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mf_cell_cons_lin_interp_sph (int i, int j, int ns, Array4<Real> const& fine, int fcomp,
+                                  Array4<Real const> const& slope, Array4<Real const> const& crse,
+                                  int ccomp, int ncomp, IntVect const& ratio, Real drf, Real rlo,
+                                  Real dtf, Real tlo) noexcept
+{
+    // x-direction
+    const int ic = amrex::coarsen(i, ratio[0]);
+    const Real drc =  drf * ratio[0];
+    const Real rcm =  ic    * drc + rlo;
+    const Real rcp = (ic+1) * drc + rlo;
+    const Real rfm =  i     * drf + rlo;
+    const Real rfp = (i +1) * drf + rlo;
+    Real vcm = rcm*rcm;
+    Real vcp = rcp*rcp;
+    Real vfm = rfm*rfm;
+    Real vfp = rfp*rfp;
+    const Real xoff = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
+
+    // y-direction
+    const int jc = amrex::coarsen(j, ratio[1]);
+    const Real dtc =  dtf * ratio[1];
+    const Real tcm =  jc    * dtc + tlo;
+    const Real tcp = (jc+1) * dtc + tlo;
+    const Real tfm =  j     * dtf + tlo;
+    const Real tfp = (j +1) * dtf + tlo;
+    vcm = std::cos(tcm);
+    vcp = std::cos(tcp);
+    vfm = std::cos(tfm);
+    vfp = std::cos(tfp);
+    // const Real yoff = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
+    const Real yoff = (j - jc*ratio[1] + Real(0.5)) / Real(ratio[1]) - Real(0.5);
+
+    fine(i,j,0,fcomp+ns) = crse(ic,jc,0,ccomp+ns)
+        + xoff * slope(ic,jc,0,ns)
+        + yoff * slope(ic,jc,0,ns+ncomp);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_cell_cons_lin_interp_mcslope_rz (int i, int j, int ns, Array4<Real> const& slope,
                                          Array4<Real const> const& u, int scomp, int ncomp,
                                          Box const& domain, IntVect const& ratio,

--- a/Src/AmrCore/AMReX_MFInterpolater.cpp
+++ b/Src/AmrCore/AMReX_MFInterpolater.cpp
@@ -148,7 +148,36 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
             });
         } else
 #elif (AMREX_SPACEDIM == 2)
-        if (cgeom.IsRZ()) {
+        if (cgeom.IsSPHERICAL()) {
+            Real drf = fgeom.CellSize(0);
+            Real dtf = fgeom.CellSize(1);
+            Real rlo = fgeom.Offset(0);
+            Real tlo = fgeom.Offset(1);
+            if (do_linear_limiting) {
+                ParallelFor(crsemf, minus1,
+                [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int) noexcept
+                {
+                    mf_cell_cons_lin_interp_llslope(i,j,0, tmp[box_no], crse[box_no], ccomp, nc,
+                                                    cdomain, ratio, pbc);
+                });
+            } else {
+                ParallelFor(crsemf, minus1, nc,
+                [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int, int n) noexcept
+                {
+                    mf_cell_cons_lin_interp_mcslope_sph(i,j,n, tmp[box_no], crse[box_no], ccomp, nc,
+                                                        cdomain, ratio, pbc, drf, rlo, dtf, tlo);
+                });
+            }
+
+            ParallelFor(finemf, ng, nc,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int, int n) noexcept
+            {
+                if (dest_domain.contains(i,j,0)) {
+                    mf_cell_cons_lin_interp_sph(i, j, n, fine[box_no], fcomp, ctmp[box_no],
+                                                crse[box_no], ccomp, nc, ratio, drf, rlo, dtf, tlo);
+                }
+            });
+        } else if (cgeom.IsRZ()) {
             Real drf = fgeom.CellSize(0);
             Real rlo = fgeom.Offset(0);
             if (do_linear_limiting) {
@@ -254,7 +283,36 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                     });
                 } else
 #elif (AMREX_SPACEDIM == 2)
-                if (cgeom.IsRZ()) {
+                if (cgeom.IsSPHERICAL()) {
+                    Real drf = fgeom.CellSize(0);
+                    Real dtf = fgeom.CellSize(1);
+                    Real rlo = fgeom.Offset(0);
+                    Real tlo = fgeom.Offset(1);
+                    if (do_linear_limiting) {
+                        amrex::LoopConcurrentOnCpu(cbox,
+                        [&] (int i, int j, int) noexcept
+                        {
+                            mf_cell_cons_lin_interp_llslope(i,j,0, tmp, crse, ccomp, nc,
+                                                            cdomain, ratio, pbc);
+                        });
+                    } else {
+                        amrex::LoopConcurrentOnCpu(cbox, nc,
+                        [&] (int i, int j, int, int n) noexcept
+                        {
+                            mf_cell_cons_lin_interp_mcslope_sph(i, j, n, tmp, crse, ccomp, nc,
+                                                                cdomain, ratio, pbc,
+                                                                drf, rlo, dtf, tlo);
+                        });
+                    }
+
+                    amrex::LoopConcurrentOnCpu(fbox, nc,
+                    [&] (int i, int j, int, int n) noexcept
+                    {
+                        mf_cell_cons_lin_interp_sph(i, j, n, fine, fcomp, ctmp,
+                                                    crse, ccomp, nc, ratio,
+                                                    drf, rlo, dtf, tlo);
+                    });
+                } else if (cgeom.IsRZ()) {
                     Real drf = fgeom.CellSize(0);
                     Real rlo = fgeom.Offset(0);
                     if (do_linear_limiting) {


### PR DESCRIPTION
## Summary
this adds conservative linear interpolation for spherical 2d geometry.
It calculates `xoff` and `yoff` in "volume" space. For xoff, its the same as spherical 1d. For yoff, it uses cosine as weighting factor, since cell volume in spherical geometry $\propto (\cos(\theta_r) - \cos(\theta_l)) (r_r^3 - r_l^3)$
## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
