### PR TITLE
Parser: Fix a minor memory leak due to exception

### DIFF
--- a/Src/Base/Parser/AMReX_IParser.cpp
+++ b/Src/Base/Parser/AMReX_IParser.cpp
@@ -30,6 +30,8 @@ IParser::define (std::string const& func_body)
         try {
             amrex_iparserparse();
         } catch (const std::runtime_error& e) {
+            amrex_iparser_delete_buffer(buffer); // delete buffer allocated by bison
+            amrex_iparser_delete_ptrs();         // delete ptrs allocated by amrex
             throw std::runtime_error(std::string(e.what()) + " in IParser expression \""
                                      + m_data->m_expression + "\"");
         }

--- a/Src/Base/Parser/AMReX_IParser_Y.H
+++ b/Src/Base/Parser/AMReX_IParser_Y.H
@@ -159,9 +159,9 @@ struct amrex_iparser {
 
 struct amrex_iparser* amrex_iparser_new ();
 void amrex_iparser_delete (struct amrex_iparser* iparser);
+void amrex_iparser_delete_ptrs ();
 
-struct amrex_iparser* iparser_dup (struct amrex_iparser* source);
-struct iparser_node* iparser_ast_dup (struct amrex_iparser* iparser, struct iparser_node* node, int move);
+struct iparser_node* iparser_ast_dup (struct amrex_iparser* iparser, struct iparser_node* node);
 
 void iparser_regvar (struct amrex_iparser* iparser, char const* name, int i);
 void iparser_setconst (struct amrex_iparser* iparser, char const* name, long long c);

--- a/Src/Base/Parser/AMReX_IParser_Y.cpp
+++ b/Src/Base/Parser/AMReX_IParser_Y.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 #include <cstdarg>
-#include <string>
+#include <vector>
 
 void
 amrex_iparsererror (char const *s, ...)
@@ -21,6 +21,7 @@ namespace amrex {
 
 namespace {
     struct iparser_node* iparser_root = nullptr;
+    std::vector<void*>   iparser_ptrs;
 }
 
 // This is called by a bison rule to store the original AST in a static variable.
@@ -33,9 +34,11 @@ iparser_defexpr (struct iparser_node* body)
 struct iparser_symbol*
 iparser_makesymbol (char* name)
 {
-    auto *symbol = (struct iparser_symbol*) std::malloc(sizeof(struct iparser_symbol));
+    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_symbol)));
+    auto *symbol = (struct iparser_symbol*) iparser_ptrs.back();
     symbol->type = IPARSER_SYMBOL;
     symbol->name = strdup(name);
+    iparser_ptrs.push_back((void*)symbol->name);
     symbol->ip = -1;
     return symbol;
 }
@@ -43,7 +46,8 @@ iparser_makesymbol (char* name)
 struct iparser_node*
 iparser_newnode (enum iparser_node_t type, struct iparser_node* l, struct iparser_node* r)
 {
-    auto *tmp = (struct iparser_node*) std::malloc(sizeof(struct iparser_node));
+    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_node)));
+    auto *tmp = (struct iparser_node*) iparser_ptrs.back();
     tmp->type = type;
     tmp->l = l;
     tmp->r = r;
@@ -53,7 +57,8 @@ iparser_newnode (enum iparser_node_t type, struct iparser_node* l, struct iparse
 struct iparser_node*
 iparser_newnumber (long long d)
 {
-    auto *r = (struct iparser_number*) std::malloc(sizeof(struct iparser_number));
+    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_number)));
+    auto *r = (struct iparser_number*) iparser_ptrs.back();
     r->type = IPARSER_NUMBER;
     r->value = d;
     return (struct iparser_node*) r;
@@ -68,7 +73,8 @@ iparser_newsymbol (struct iparser_symbol* symbol)
 struct iparser_node*
 iparser_newf1 (enum iparser_f1_t ftype, struct iparser_node* l)
 {
-    auto *tmp = (struct iparser_f1*) std::malloc(sizeof(struct iparser_f1));
+    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_f1)));
+    auto *tmp = (struct iparser_f1*) iparser_ptrs.back();
     tmp->type = IPARSER_F1;
     tmp->l = l;
     tmp->ftype = ftype;
@@ -78,7 +84,8 @@ iparser_newf1 (enum iparser_f1_t ftype, struct iparser_node* l)
 struct iparser_node*
 iparser_newf2 (enum iparser_f2_t ftype, struct iparser_node* l, struct iparser_node* r)
 {
-    auto *tmp = (struct iparser_f2*) std::malloc(sizeof(struct iparser_f2));
+    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_f2)));
+    auto *tmp = (struct iparser_f2*) iparser_ptrs.back();
     tmp->type = IPARSER_F2;
     tmp->l = l;
     tmp->r = r;
@@ -90,7 +97,8 @@ struct iparser_node*
 iparser_newf3 (enum iparser_f3_t ftype, struct iparser_node* n1, struct iparser_node* n2,
                struct iparser_node* n3)
 {
-    auto *tmp = (struct iparser_f3*) std::malloc(sizeof(struct iparser_f3));
+    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_f3)));
+    auto *tmp = (struct iparser_f3*) iparser_ptrs.back();
     tmp->type = IPARSER_F3;
     tmp->n1 = n1;
     tmp->n2 = n2;
@@ -102,7 +110,8 @@ iparser_newf3 (enum iparser_f3_t ftype, struct iparser_node* n1, struct iparser_
 struct iparser_node*
 iparser_newassign (struct iparser_symbol* sym, struct iparser_node* v)
 {
-    auto *r = (struct iparser_assign*) std::malloc(sizeof(struct iparser_assign));
+    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_assign)));
+    auto *r = (struct iparser_assign*) iparser_ptrs.back();
     r->type = IPARSER_ASSIGN;
     r->s = sym;
     r->v = v;
@@ -115,7 +124,8 @@ iparser_newlist (struct iparser_node* nl, struct iparser_node* nr)
     if (nr == nullptr) {
         return nl;
     } else {
-        auto *r = (struct iparser_node*) std::malloc(sizeof(struct iparser_node));
+        iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_node)));
+        auto *r = (struct iparser_node*) iparser_ptrs.back();
         r->type = IPARSER_LIST;
         r->l = nl;
         r->r = nr;
@@ -134,7 +144,9 @@ amrex_iparser_new ()
     my_iparser->p_root = std::malloc(my_iparser->sz_mempool);
     my_iparser->p_free = my_iparser->p_root;
 
-    my_iparser->ast = iparser_ast_dup(my_iparser, iparser_root, 1); /* 1: free the source iparser_root */
+    my_iparser->ast = iparser_ast_dup(my_iparser, iparser_root);
+
+    amrex_iparser_delete_ptrs();
 
     if ((char*)my_iparser->p_root + my_iparser->sz_mempool != (char*)my_iparser->p_free) {
         amrex::Abort("amrex_iparser_new: error in memory size");
@@ -150,6 +162,15 @@ amrex_iparser_delete (struct amrex_iparser* iparser)
 {
     std::free(iparser->p_root);
     std::free(iparser);
+}
+
+void
+amrex_iparser_delete_ptrs ()
+{
+    for (auto* p : iparser_ptrs) {
+        std::free(p);
+    }
+    iparser_ptrs.clear();
 }
 
 namespace {
@@ -171,19 +192,6 @@ iparser_allocate (struct amrex_iparser* my_iparser, std::size_t N)
     return r;
 }
 
-}
-
-struct amrex_iparser*
-iparser_dup (struct amrex_iparser* source)
-{
-    auto *dest = (struct amrex_iparser*) std::malloc(sizeof(struct amrex_iparser));
-    dest->sz_mempool = source->sz_mempool;
-    dest->p_root = std::malloc(dest->sz_mempool);
-    dest->p_free = dest->p_root;
-
-    dest->ast = iparser_ast_dup(dest, source->ast, 0); /* 0: don't free the source */
-
-    return dest;
 }
 
 std::size_t
@@ -256,7 +264,7 @@ iparser_ast_size (struct iparser_node* node)
 }
 
 struct iparser_node*
-iparser_ast_dup (struct amrex_iparser* my_iparser, struct iparser_node* node, int move)
+iparser_ast_dup (struct amrex_iparser* my_iparser, struct iparser_node* node)
 {
     void* result = nullptr;
 
@@ -288,47 +296,47 @@ iparser_ast_dup (struct amrex_iparser* my_iparser, struct iparser_node* node, in
     case IPARSER_LIST:
         result = iparser_allocate(my_iparser, sizeof(struct iparser_node));
         std::memcpy(result, node            , sizeof(struct iparser_node));
-        ((struct iparser_node*)result)->l = iparser_ast_dup(my_iparser, node->l, move);
-        ((struct iparser_node*)result)->r = iparser_ast_dup(my_iparser, node->r, move);
+        ((struct iparser_node*)result)->l = iparser_ast_dup(my_iparser, node->l);
+        ((struct iparser_node*)result)->r = iparser_ast_dup(my_iparser, node->r);
         break;
     case IPARSER_NEG:
         result = iparser_allocate(my_iparser, sizeof(struct iparser_node));
         std::memcpy(result, node            , sizeof(struct iparser_node));
-        ((struct iparser_node*)result)->l = iparser_ast_dup(my_iparser, node->l, move);
+        ((struct iparser_node*)result)->l = iparser_ast_dup(my_iparser, node->l);
         ((struct iparser_node*)result)->r = nullptr;
         break;
     case IPARSER_F1:
         result = iparser_allocate(my_iparser, sizeof(struct iparser_f1));
         std::memcpy(result, node            , sizeof(struct iparser_f1));
         ((struct iparser_f1*)result)->l = iparser_ast_dup(my_iparser,
-                                                   ((struct iparser_f1*)node)->l, move);
+                                                   ((struct iparser_f1*)node)->l);
         break;
     case IPARSER_F2:
         result = iparser_allocate(my_iparser, sizeof(struct iparser_f2));
         std::memcpy(result, node            , sizeof(struct iparser_f2));
         ((struct iparser_f2*)result)->l = iparser_ast_dup(my_iparser,
-                                                   ((struct iparser_f2*)node)->l, move);
+                                                   ((struct iparser_f2*)node)->l);
         ((struct iparser_f2*)result)->r = iparser_ast_dup(my_iparser,
-                                                   ((struct iparser_f2*)node)->r, move);
+                                                   ((struct iparser_f2*)node)->r);
         break;
     case IPARSER_F3:
         result = iparser_allocate(my_iparser, sizeof(struct iparser_f3));
         std::memcpy(result, node            , sizeof(struct iparser_f3));
         ((struct iparser_f3*)result)->n1 = iparser_ast_dup(my_iparser,
-                                                   ((struct iparser_f3*)node)->n1, move);
+                                                   ((struct iparser_f3*)node)->n1);
         ((struct iparser_f3*)result)->n2 = iparser_ast_dup(my_iparser,
-                                                   ((struct iparser_f3*)node)->n2, move);
+                                                   ((struct iparser_f3*)node)->n2);
         ((struct iparser_f3*)result)->n3 = iparser_ast_dup(my_iparser,
-                                                   ((struct iparser_f3*)node)->n3, move);
+                                                   ((struct iparser_f3*)node)->n3);
         break;
     case IPARSER_ASSIGN:
         result = iparser_allocate(my_iparser, sizeof(struct iparser_assign));
         std::memcpy(result, node            , sizeof(struct iparser_assign));
         ((struct iparser_assign*)result)->s = (struct iparser_symbol*)
             iparser_ast_dup(my_iparser, (struct iparser_node*)
-                                                  (((struct iparser_assign*)node)->s), move);
+                                                  (((struct iparser_assign*)node)->s));
         ((struct iparser_assign*)result)->v = iparser_ast_dup(my_iparser,
-                                                   ((struct iparser_assign*)node)->v, move);
+                                                   ((struct iparser_assign*)node)->v);
         break;
     case IPARSER_ADD_VP:
     case IPARSER_SUB_VP:
@@ -337,25 +345,15 @@ iparser_ast_dup (struct amrex_iparser* my_iparser, struct iparser_node* node, in
     case IPARSER_DIV_PV:
         result = iparser_allocate(my_iparser, sizeof(struct iparser_node));
         std::memcpy(result, node            , sizeof(struct iparser_node));
-        ((struct iparser_node*)result)->r = iparser_ast_dup(my_iparser, node->r, move);
+        ((struct iparser_node*)result)->r = iparser_ast_dup(my_iparser, node->r);
         break;
     case IPARSER_NEG_P:
         result = iparser_allocate(my_iparser, sizeof(struct iparser_node));
         std::memcpy(result, node            , sizeof(struct iparser_node));
-        ((struct iparser_node*)result)->l = iparser_ast_dup(my_iparser, node->l, move);
+        ((struct iparser_node*)result)->l = iparser_ast_dup(my_iparser, node->l);
         break;
     default:
         amrex::Abort("iparser_ast_dup: unknown node type " + std::to_string(node->type));
-    }
-    if (move) {
-        /* Note that we only do this on the original AST.  We do not
-         * need to call free for AST stored in amrex_iparser because the
-         * memory is not allocated with std::malloc directly.
-         */
-        if (node->type == IPARSER_SYMBOL) {
-            std::free(((struct iparser_symbol*)node)->name);
-        }
-        std::free((void*)node);
     }
     return (struct iparser_node*)result;
 }

--- a/Src/Base/Parser/AMReX_Parser.cpp
+++ b/Src/Base/Parser/AMReX_Parser.cpp
@@ -30,6 +30,8 @@ Parser::define (std::string const& func_body)
         try {
             amrex_parserparse();
         } catch (const std::runtime_error& e) {
+            amrex_parser_delete_buffer(buffer); // delete buffer allocated by bison
+            amrex_parser_delete_ptrs();         // delete ptrs allocated by amrex
             throw std::runtime_error(std::string(e.what()) + " in Parser expression \""
                                      + m_data->m_expression + "\"");
         }

--- a/Src/Base/Parser/AMReX_Parser_Y.H
+++ b/Src/Base/Parser/AMReX_Parser_Y.H
@@ -264,9 +264,9 @@ struct amrex_parser {
 
 struct amrex_parser* amrex_parser_new ();
 void amrex_parser_delete (struct amrex_parser* parser);
+void amrex_parser_delete_ptrs ();
 
-struct amrex_parser* parser_dup (struct amrex_parser* source);
-struct parser_node* parser_ast_dup (struct amrex_parser* parser, struct parser_node* node, int move);
+struct parser_node* parser_ast_dup (struct amrex_parser* parser, struct parser_node* node);
 
 void parser_regvar (struct amrex_parser* parser, char const* name, int i);
 void parser_setconst (struct amrex_parser* parser, char const* name, double c);
@@ -289,6 +289,7 @@ void parser_ast_sort (struct parser_node* node);
 double parser_get_number (struct parser_node* node);
 void parser_set_number (struct parser_node* node, double v);
 bool parser_node_equal (struct parser_node* a, struct parser_node* b);
+bool parser_same_symbol (struct parser_node* a, struct parser_node* b);
 /*******************************************************************/
 
 template <typename T>

--- a/Src/Base/Parser/AMReX_Parser_Y.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Y.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstdarg>
+#include <vector>
 
 void
 amrex_parsererror (char const *s, ...)
@@ -20,6 +21,7 @@ namespace amrex {
 
 namespace {
     struct parser_node* parser_root = nullptr;
+    std::vector<void*>  parser_ptrs;
 }
 
 // This is called by a bison rule to store the original AST in a static variable.
@@ -34,9 +36,11 @@ parser_makesymbol (char* name)
 {
     // We allocate more than enough space so that late we can turn parser_symbol
     // into into parser_node if necessary.
-    auto *symbol = (struct parser_symbol*) std::malloc(sizeof(struct parser_node)); // NOLINT
+    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *symbol = (struct parser_symbol*) parser_ptrs.back(); // NOLINT
     symbol->type = PARSER_SYMBOL;
     symbol->name = strdup(name);
+    parser_ptrs.push_back(symbol->name);
     symbol->ip = -1;
     return symbol;
 }
@@ -44,7 +48,8 @@ parser_makesymbol (char* name)
 struct parser_node*
 parser_newnode (enum parser_node_t type, struct parser_node* l, struct parser_node* r)
 {
-    auto *tmp = (struct parser_node*) std::malloc(sizeof(struct parser_node));
+    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_node*) parser_ptrs.back();
     if (type == PARSER_SUB) {
         tmp->type = PARSER_ADD;
         tmp->l = l;
@@ -60,7 +65,8 @@ parser_newnode (enum parser_node_t type, struct parser_node* l, struct parser_no
 struct parser_node*
 parser_newneg (struct parser_node* n)
 {
-    auto *tmp = (struct parser_node*) std::malloc(sizeof(struct parser_node));
+    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_node*) parser_ptrs.back();
     tmp->type = PARSER_MUL;
     tmp->l = parser_newnumber(-1.0);
     tmp->r = n;
@@ -72,7 +78,8 @@ parser_newnumber (double d)
 {
     // We allocate more than enough space so that late we can turn parser_number
     // into into parser_node if necessary.
-    auto *r = (struct parser_number*) std::malloc(sizeof(struct parser_node)); // NOLINT
+    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *r = (struct parser_number*) parser_ptrs.back(); // NOLINT
     r->type = PARSER_NUMBER;
     r->value = d;
     return (struct parser_node*) r;
@@ -87,7 +94,8 @@ parser_newsymbol (struct parser_symbol* symbol)
 struct parser_node*
 parser_newf1 (enum parser_f1_t ftype, struct parser_node* l)
 {
-    auto *tmp = (struct parser_f1*) std::malloc(sizeof(struct parser_node)); // NOLINT
+    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_f1*) parser_ptrs.back(); // NOLINT
     tmp->type = PARSER_F1;
     tmp->l = l;
     tmp->ftype = ftype;
@@ -97,7 +105,8 @@ parser_newf1 (enum parser_f1_t ftype, struct parser_node* l)
 struct parser_node*
 parser_newf2 (enum parser_f2_t ftype, struct parser_node* l, struct parser_node* r)
 {
-    auto *tmp = (struct parser_f2*) std::malloc(sizeof(struct parser_node)); // NOLINT
+    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_f2*) parser_ptrs.back(); // NOLINT
     tmp->type = PARSER_F2;
     tmp->l = l;
     tmp->r = r;
@@ -109,7 +118,8 @@ struct parser_node*
 parser_newf3 (enum parser_f3_t ftype, struct parser_node* n1, struct parser_node* n2,
               struct parser_node* n3)
 {
-    auto *tmp = (struct parser_f3*) std::malloc(sizeof(struct parser_node)); // NOLINT
+    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_f3*) parser_ptrs.back(); // NOLINT
     tmp->type = PARSER_F3;
     tmp->n1 = n1;
     tmp->n2 = n2;
@@ -121,7 +131,8 @@ parser_newf3 (enum parser_f3_t ftype, struct parser_node* n1, struct parser_node
 struct parser_node*
 parser_newassign (struct parser_symbol* sym, struct parser_node* v)
 {
-    auto *r = (struct parser_assign*) std::malloc(sizeof(struct parser_node)); // NOLINT
+    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *r = (struct parser_assign*) parser_ptrs.back(); // NOLINT
     r->type = PARSER_ASSIGN;
     r->s = sym;
     r->v = v;
@@ -134,7 +145,8 @@ parser_newlist (struct parser_node* nl, struct parser_node* nr)
     if (nr == nullptr) {
         return nl;
     } else {
-        auto *r = (struct parser_node*) std::malloc(sizeof(struct parser_node));
+        parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+        auto *r = (struct parser_node*) parser_ptrs.back();
         r->type = PARSER_LIST;
         r->l = nl;
         r->r = nr;
@@ -153,7 +165,9 @@ amrex_parser_new ()
     my_parser->p_root = std::malloc(my_parser->sz_mempool);
     my_parser->p_free = my_parser->p_root;
 
-    my_parser->ast = parser_ast_dup(my_parser, parser_root, 1); /* 1: free the source parser_root */
+    my_parser->ast = parser_ast_dup(my_parser, parser_root);
+
+    amrex_parser_delete_ptrs();
 
     if ((char*)my_parser->p_root + my_parser->sz_mempool != (char*)my_parser->p_free) {
         amrex::Abort("amrex_parser_new: error in memory size");
@@ -171,6 +185,15 @@ amrex_parser_delete (struct amrex_parser* parser)
 {
     std::free(parser->p_root);
     std::free(parser);
+}
+
+void
+amrex_parser_delete_ptrs ()
+{
+    for (auto* p : parser_ptrs) {
+        std::free(p);
+    }
+    parser_ptrs.clear();
 }
 
 namespace {
@@ -192,19 +215,6 @@ parser_allocate (struct amrex_parser* my_parser, std::size_t N)
     return r;
 }
 
-}
-
-struct amrex_parser*
-parser_dup (struct amrex_parser* source)
-{
-    auto *dest = (struct amrex_parser*) std::malloc(sizeof(struct amrex_parser));
-    dest->sz_mempool = source->sz_mempool;
-    dest->p_root = std::malloc(dest->sz_mempool);
-    dest->p_free = dest->p_root;
-
-    dest->ast = parser_ast_dup(dest, source->ast, 0); /* 0: don't free the source */
-
-    return dest;
 }
 
 std::size_t
@@ -257,7 +267,7 @@ parser_ast_size (struct parser_node* node)
 }
 
 struct parser_node*
-parser_ast_dup (struct amrex_parser* my_parser, struct parser_node* node, int move)
+parser_ast_dup (struct amrex_parser* my_parser, struct parser_node* node)
 {
     void* result = nullptr;
 
@@ -285,54 +295,44 @@ parser_ast_dup (struct amrex_parser* my_parser, struct parser_node* node, int mo
     case PARSER_LIST:
         result = parser_allocate(my_parser, sizeof(struct parser_node));
         std::memcpy(result, node          , sizeof(struct parser_node));
-        ((struct parser_node*)result)->l = parser_ast_dup(my_parser, node->l, move);
-        ((struct parser_node*)result)->r = parser_ast_dup(my_parser, node->r, move);
+        ((struct parser_node*)result)->l = parser_ast_dup(my_parser, node->l);
+        ((struct parser_node*)result)->r = parser_ast_dup(my_parser, node->r);
         break;
     case PARSER_F1:
         result = parser_allocate(my_parser, sizeof(struct parser_node));
         std::memcpy(result, node          , sizeof(struct parser_f1));
         ((struct parser_f1*)result)->l = parser_ast_dup(my_parser,
-                                                 ((struct parser_f1*)node)->l, move);
+                                                 ((struct parser_f1*)node)->l);
         break;
     case PARSER_F2:
         result = parser_allocate(my_parser, sizeof(struct parser_node));
         std::memcpy(result, node          , sizeof(struct parser_f2));
         ((struct parser_f2*)result)->l = parser_ast_dup(my_parser,
-                                                 ((struct parser_f2*)node)->l, move);
+                                                 ((struct parser_f2*)node)->l);
         ((struct parser_f2*)result)->r = parser_ast_dup(my_parser,
-                                                 ((struct parser_f2*)node)->r, move);
+                                                 ((struct parser_f2*)node)->r);
         break;
     case PARSER_F3:
         result = parser_allocate(my_parser, sizeof(struct parser_node));
         std::memcpy(result, node          , sizeof(struct parser_f3));
         ((struct parser_f3*)result)->n1 = parser_ast_dup(my_parser,
-                                                 ((struct parser_f3*)node)->n1, move);
+                                                 ((struct parser_f3*)node)->n1);
         ((struct parser_f3*)result)->n2 = parser_ast_dup(my_parser,
-                                                 ((struct parser_f3*)node)->n2, move);
+                                                 ((struct parser_f3*)node)->n2);
         ((struct parser_f3*)result)->n3 = parser_ast_dup(my_parser,
-                                                 ((struct parser_f3*)node)->n3, move);
+                                                 ((struct parser_f3*)node)->n3);
         break;
     case PARSER_ASSIGN:
         result = parser_allocate(my_parser, sizeof(struct parser_node));
         std::memcpy(result, node          , sizeof(struct parser_assign));
         ((struct parser_assign*)result)->s = (struct parser_symbol*)
             parser_ast_dup(my_parser, (struct parser_node*)
-                                                (((struct parser_assign*)node)->s), move);
+                                                (((struct parser_assign*)node)->s));
         ((struct parser_assign*)result)->v = parser_ast_dup(my_parser,
-                                                 ((struct parser_assign*)node)->v, move);
+                                                 ((struct parser_assign*)node)->v);
         break;
     default:
         amrex::Abort("parser_ast_dup: unknown node type " + std::to_string(node->type));
-    }
-    if (move) {
-        /* Note that we only do this on the original AST.  We do not
-         * need to call free for AST stored in amrex_parser because the
-         * memory is not allocated with std::malloc directly.
-         */
-        if (node->type == PARSER_SYMBOL) {
-            std::free(((struct parser_symbol*)node)->name);
-        }
-        std::free((void*)node);
     }
     return (struct parser_node*)result;
 }
@@ -342,14 +342,6 @@ namespace {
     {
         AMREX_ASSERT(node->type == PARSER_SYMBOL);
         return ((struct parser_symbol*)node)->name;
-    }
-
-    bool parser_same_symbol (struct parser_node* a, struct parser_node* b)
-    {
-        return (a->type == PARSER_SYMBOL)
-            && (b->type == PARSER_SYMBOL)
-            && (std::strcmp(((struct parser_symbol*)a)->name,
-                            ((struct parser_symbol*)b)->name) == 0);
     }
 
     bool is_add_combinable (struct parser_node* a, struct parser_node*b)
@@ -603,6 +595,14 @@ namespace {
         }
         return false;
     }
+}
+
+bool parser_same_symbol (struct parser_node* a, struct parser_node* b)
+{
+    return (a->type == PARSER_SYMBOL)
+        && (b->type == PARSER_SYMBOL)
+        && (std::strcmp(((struct parser_symbol*)a)->name,
+                        ((struct parser_symbol*)b)->name) == 0);
 }
 
 bool parser_node_equal (struct parser_node* a, struct parser_node* b)


### PR DESCRIPTION
* If an exception is thrown, we need to delete the memory.

* Remove unused functions.

* Minor reorganization.

* Minor optimization of constant folding.
