### PR TITLE
Delete RandomEngine's default constructor

### DIFF
--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -37,6 +37,7 @@ namespace amrex
 
     struct RandomEngine {
         sycl_rng_engine* engine;
+        AMREX_GPU_HOST_DEVICE RandomEngine (sycl_rng_engine* e) : engine(e) {}
     };
 
 #else
@@ -56,6 +57,7 @@ namespace amrex
 
     struct RandomEngine {
         randState_t* rand_state;
+        AMREX_GPU_HOST_DEVICE RandomEngine (randState_t* rs) : rand_state(rs) {}
     };
 
 #endif

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -66,7 +66,11 @@ fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F const& f)
     for (int k = 0; k < np; ++k) {
         const auto p = ptd.getSuperParticle(k);
         if constexpr (IsCallable<F,decltype(p),RandomEngine>::value) {
+#ifdef AMREX_USE_GPU
+            flag_ptr[k] = f(p,RandomEngine{nullptr});
+#else
             flag_ptr[k] = f(p,RandomEngine{});
+#endif
         } else {
             flag_ptr[k] = f(p);
         }


### PR DESCRIPTION
This prevents a common bug like below.

        amrex::ParallelFor(100, [=] AMREX_GPU_DEVICE (int i) {
            auto eng = RandomEngine() ;
            auto t = amrex::Random(eng);
            AMREX_DEVICE_PRINTF("random: %g", t);
        });
