### PR TITLE
CMake: NVTX is header-only for CUDA >= 11.2

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -69,6 +69,14 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
        if (AMReX_LINEAR_SOLVERS)
            target_link_libraries(amrex_${D}d PUBLIC CUDA::cusparse)
        endif ()
+
+       if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.2)
+           # nvToolsExt: if tiny profiler or base profiler are on.
+           if (AMReX_TINY_PROFILE OR AMReX_BASE_PROFILE)
+               target_link_libraries(amrex_${D}d PUBLIC CUDA::nvToolsExt)
+           endif ()
+       endif ()
+
    endforeach()
 
    # Check cuda compiler and host compiler

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -76,7 +76,6 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
                target_link_libraries(amrex_${D}d PUBLIC CUDA::nvToolsExt)
            endif ()
        endif ()
-
    endforeach()
 
    # Check cuda compiler and host compiler

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -69,11 +69,6 @@ if (  AMReX_GPU_BACKEND STREQUAL "CUDA"
        if (AMReX_LINEAR_SOLVERS)
            target_link_libraries(amrex_${D}d PUBLIC CUDA::cusparse)
        endif ()
-
-       # nvToolsExt: if tiny profiler or base profiler are on.
-       if (AMReX_TINY_PROFILE OR AMReX_BASE_PROFILE)
-           target_link_libraries(amrex_${D}d PUBLIC CUDA::nvToolsExt)
-       endif ()
    endforeach()
 
    # Check cuda compiler and host compiler


### PR DESCRIPTION
## Summary
The old NVTX library is removed in CUDA 12.9, so we have to remove it as a link-time dependecy. AMReX does not build with CUDA 12.9 otherwise.

Note that the new NVTXv3 is header-only and is already supported by AMReX.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
