### PR TITLE
Fix RealVect::Zero

### DIFF
--- a/Src/Base/AMReX_RealVect.H
+++ b/Src/Base/AMReX_RealVect.H
@@ -610,10 +610,10 @@ AMREX_GPU_HOST_DEVICE // __device__ for HIP
 RealVectND(const GpuArray<Real, dim>&) -> RealVectND<dim>;
 
 template <int dim>
-inline constexpr const RealVectND<dim> RealVectND<dim>::Zero{0};
+inline constexpr const RealVectND<dim> RealVectND<dim>::Zero{Real(0)};
 
 template <int dim>
-inline constexpr const RealVectND<dim> RealVectND<dim>::Unit{1};
+inline constexpr const RealVectND<dim> RealVectND<dim>::Unit{Real(1)};
 
 using RealVect = RealVectND<AMREX_SPACEDIM>;
 


### PR DESCRIPTION
There was ambiguity in `RealVectND<dim>::Zero{0}` because there were two candidates. `RealVectND::RealVectND(const Real*)` and `RealVectND::RealVectND(Real)`. The issue was introduced in #4430.
