### PR TITLE
ParmParse: Fix backward compatibility issue in #4457

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -230,6 +230,27 @@ eat_garbage (const char*& str)
     return num_linefeeds;
 }
 
+void eat_comment (const char*& str)
+{
+    for (;;)
+    {
+        if ( *str == 0 ) { break; } // NOLINT
+        else if ( *str == '#' )
+        {
+            while ( *str && *str != '\n' )
+            {
+                str++;
+            }
+            if (*str == '\n') { str++; }
+            continue;
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
 PType
 getToken (const char*& str, std::string& ostr, int& num_linefeeds)
 {
@@ -307,7 +328,7 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds)
            }
            break;
        case LIST:
-           eat_garbage(str);
+           eat_comment(str);
            ch = *str;
            if ( ch == '(' )
            {

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -232,21 +232,11 @@ eat_garbage (const char*& str)
 
 void eat_comment (const char*& str)
 {
-    for (;;)
+    if ( *str == '#' )
     {
-        if ( *str == 0 ) { break; } // NOLINT
-        else if ( *str == '#' )
+        while ( *str && *str != '\n' )
         {
-            while ( *str && *str != '\n' )
-            {
-                str++;
-            }
-            if (*str == '\n') { str++; }
-            continue;
-        }
-        else
-        {
-            break;
+            str++;
         }
     }
 }


### PR DESCRIPTION
We made some changes in reading IntVect and Box in #4457 to support inline comments. However, WarpX uses unquoted strings for parser expressions. These strings often contains parentheses. We need to preserve the white spaces inside parentheses, otherwise `(z and z)` will become `(zandz)`.

Note that this is not an issue for quoted strings.
