### PR TITLE
Avoid polluting global namespace with MPI types for non-MPI builds

### DIFF
--- a/Src/Base/AMReX_ccse-mpi.H
+++ b/Src/Base/AMReX_ccse-mpi.H
@@ -43,6 +43,8 @@ namespace amrex::ParallelDescriptor
 
 #else
 
+namespace amrex {
+
 using MPI_Op       = int;
 using MPI_Comm     = int;
 using MPI_Group    = int;
@@ -59,6 +61,8 @@ static constexpr int MPI_MAX_PROCESSOR_NAME = 64;
 
 static constexpr int MPI_MINLOC = 0;
 static constexpr int MPI_MAXLOC = 0;
+
+}
 
 namespace amrex::ParallelDescriptor
 {

--- a/Tests/MultiBlock/Advection/main.cpp
+++ b/Tests/MultiBlock/Advection/main.cpp
@@ -7,6 +7,8 @@
 
 #include "AMReX_PlotFileUtil.H"
 
+using namespace amrex;
+
 void MyMain();
 
 int main(int argc, char** argv) {
@@ -23,8 +25,6 @@ int main(int argc, char** argv) {
     MPI_Finalize();
 #endif
 }
-
-using namespace amrex;
 
 enum idirs { ix, iy };
 enum num_components { three_components = 3 };


### PR DESCRIPTION
For convenience we define some fake MPI types for non-MPI build. This causes conflicts with the fake MPI types defined by PETSc. So we put them into amrex namespace. This should work because of the argument-dependent lookup rule in C++.
