### PR TITLE
Put MPI datatypes in separate namespace

### DIFF
--- a/Src/Base/AMReX_ccse-mpi.H
+++ b/Src/Base/AMReX_ccse-mpi.H
@@ -41,9 +41,11 @@ namespace amrex::ParallelDescriptor
     template <> MPI_Datatype Mpi_typemap<lull_t>::type();
 }
 
+namespace amrex::mpidatatypes {}
+
 #else
 
-namespace amrex {
+namespace amrex::mpidatatypes {
 
 using MPI_Op       = int;
 using MPI_Comm     = int;
@@ -62,6 +64,10 @@ static constexpr int MPI_MAX_PROCESSOR_NAME = 64;
 static constexpr int MPI_MINLOC = 0;
 static constexpr int MPI_MAXLOC = 0;
 
+}
+
+namespace amrex {
+    using namespace mpidatatypes;
 }
 
 namespace amrex::ParallelDescriptor


### PR DESCRIPTION
## Summary

This allows user code to add `using namespace amrex::mpidatatypes;` without needing to import the full amrex namespace.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
