### PR TITLE
GNU Make: Use -g1 for optimized builds with GCC and Clang

### DIFF
--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -83,21 +83,11 @@ CXXFLAGS += -Werror=return-type
 CFLAGS   += -Werror=return-type
 
 ifeq ($(DEBUG),TRUE)
-  ifeq ($(gcc_major_ge_11),1)
-    CXXFLAGS += -gdwarf-4 -O0 -ggdb -ftrapv
-    CFLAGS   += -gdwarf-4 -O0 -ggdb -ftrapv
-  else
-    CXXFLAGS += -g -O0 -ggdb -ftrapv
-    CFLAGS   += -g -O0 -ggdb -ftrapv
-  endif
+  CXXFLAGS += -g -O0 -ggdb -ftrapv
+  CFLAGS   += -g -O0 -ggdb -ftrapv
 else
-  ifeq ($(gcc_major_ge_11),1)
-    CXXFLAGS += -gdwarf-4 -O3
-    CFLAGS   += -gdwarf-4 -O3
-  else
-    CXXFLAGS += -g -O3
-    CFLAGS   += -g -O3
-  endif
+  CXXFLAGS += -g1 -O3
+  CFLAGS   += -g1 -O3
   ifneq ($(USE_COMPILER_DEFAULT_INLINE),TRUE)
     CXXFLAGS += -finline-limit=$(INLINE_LIMIT)
   endif
@@ -191,8 +181,8 @@ ifeq ($(DEBUG),TRUE)
 
 else
 
-  FFLAGS   += -g -O3
-  F90FLAGS += -g -O3
+  FFLAGS   += -g1 -O3
+  F90FLAGS += -g1 -O3
 
 endif
 

--- a/Tools/GNUMake/comps/intel-llvm.mak
+++ b/Tools/GNUMake/comps/intel-llvm.mak
@@ -34,8 +34,8 @@ else
 
   CXXFLAGS += -g1 -O3
   CFLAGS   += -g1 -O3
-  FFLAGS   += -g -O3
-  F90FLAGS += -g -O3
+  FFLAGS   += -g1 -O3
+  F90FLAGS += -g1 -O3
 
 endif
 

--- a/Tools/GNUMake/comps/llvm-flang.mak
+++ b/Tools/GNUMake/comps/llvm-flang.mak
@@ -31,10 +31,10 @@ ifeq ($(DEBUG),TRUE)
 
 else
 
-  CXXFLAGS += -g -O3
-  CFLAGS   += -g -O3
-  FFLAGS   += -g -O3
-  F90FLAGS += -g -O3
+  CXXFLAGS += -g1 -O3
+  CFLAGS   += -g1 -O3
+  FFLAGS   += -g1 -O3
+  F90FLAGS += -g1 -O3
 
 endif
 

--- a/Tools/GNUMake/comps/llvm.mak
+++ b/Tools/GNUMake/comps/llvm.mak
@@ -31,10 +31,10 @@ ifeq ($(DEBUG),TRUE)
 
 else
 
-  CXXFLAGS += -g -O3
-  CFLAGS   += -g -O3
-  FFLAGS   += -g -O3
-  F90FLAGS += -g -O3
+  CXXFLAGS += -g1 -O3
+  CFLAGS   += -g1 -O3
+  FFLAGS   += -g1 -O3
+  F90FLAGS += -g1 -O3
 
 endif
 


### PR DESCRIPTION
This makes the executable much smaller. For example, the size of a WarpX CUDA build on perlmutter goes down from 1.1 GB to 650 MB. Also note that CMake Release builds do not add any debug information. With `-g1, we still have line information like below.
```
2: ./CNS3d.gnu.TPROF.MPI.CUDA.ex(+0x1023f7) [0x629b2091f3f7]
    amrex::Abort(char const*) at /home/wqzhang/mygitrepo/amrex/Tests/GPU/CNS/Exec/RT/../../../../../Src/Base/AMReX.H:176
 (inlined by) CNS::advance(double, double, int, int) at /home/wqzhang/mygitrepo/amrex/Tests/GPU/CNS/Exec/RT/../../../../../Tests/GPU/CNS/Source/CNS_advance.cpp:43
```

