### PR TITLE
Avoid freeing GPU memory inside MFIter loop

### DIFF
--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -2,6 +2,7 @@
 #include <AMReX_CArena.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_Gpu.H>
+#include <AMReX_MFIter.H>
 #include <AMReX_ParallelReduce.H>
 
 #include <utility>
@@ -43,7 +44,13 @@ CArena::alloc_protected (std::size_t nbytes)
     }
 #endif
 
-    if (static_cast<Long>(m_used+nbytes) >= arena_info.release_threshold) {
+    bool free_unused_called = false;
+    if (static_cast<Long>(m_used+nbytes) >= arena_info.release_threshold
+#ifdef AMREX_USE_GPU
+        && (MFIter::currentDepth() == 0)
+#endif
+        ) {
+        free_unused_called = true;
         freeUnused_protected();
     }
 
@@ -64,7 +71,14 @@ CArena::alloc_protected (std::size_t nbytes)
     {
         // Both freeUnused_protected and allocate_system may invalidate free_it.
         // All unused memory allocations are combined with the new one to reduce fragmentation.
-        const std::size_t freed_bytes = freeUnused_protected();
+        std::size_t freed_bytes = 0;
+        if (!free_unused_called
+#ifdef AMREX_USE_GPU
+            && (MFIter::currentDepth() == 0)
+#endif
+        ) {
+            freed_bytes = freeUnused_protected();
+        }
 
         const std::size_t N = std::max(m_hunk, freed_bytes + nbytes);
 
@@ -356,9 +370,8 @@ std::size_t
 CArena::freeUnused_protected ()
 {
     std::size_t nbytes = 0;
-    std::vector<std::pair<void*, std::size_t>> to_free{};
     m_alloc.erase(std::remove_if(m_alloc.begin(), m_alloc.end(),
-                                 [&nbytes,&to_free,this] (std::pair<void*,std::size_t> a)
+                                 [&nbytes,this] (std::pair<void*,std::size_t> a)
                                  {
                                      // We cannot simply use std::set::erase because
                                      // Node::operator== only compares the starting address.
@@ -369,25 +382,13 @@ CArena::freeUnused_protected ()
                                      {
                                          it = m_freelist.erase(it);
                                          nbytes += a.second;
-                                         to_free.emplace_back(a.first, a.second);
+                                         deallocate_system(a.first,a.second);
                                          return true;
                                      }
                                      return false;
                                  }),
                   m_alloc.end());
     m_used -= nbytes;
-
-    // deallocate_system can call cudafree which may perform implicit synchronization
-    // of all cuda streams. In case amrex::Gpu::Elixir is used, a cudaLaunchHostFunc can be
-    // in the steam which calls CArena::free that acquires carena_mutex.
-    // So here carena_mutex needs to be unlocked first to avoid a deadlock.
-    // Note that other threads to allocate/free memory from the CArena in the meantime.
-    carena_mutex.unlock();
-    for (auto& a : to_free) {
-        deallocate_system(a.first, a.second);
-    }
-    carena_mutex.lock();
-
     return nbytes;
 }
 
@@ -400,7 +401,11 @@ CArena::hasFreeDeviceMemory (std::size_t sz)
 
         std::size_t nbytes = Arena::align(sz == 0 ? 1 : sz);
 
-        if (static_cast<Long>(m_used+nbytes) >= arena_info.release_threshold) {
+        if (static_cast<Long>(m_used+nbytes) >= arena_info.release_threshold
+#ifdef AMREX_USE_GPU
+            && (MFIter::currentDepth() == 0)
+#endif
+        ) {
             freeUnused_protected();
         }
 


### PR DESCRIPTION
This reverts part of the changes in #4451, which caused performance regression for some applications on Frontier. For example, a Castro test had a 20% performance hit.
