### PR TITLE
Add paramters for controlling CArena defragmentation

### DIFF
--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1085,6 +1085,36 @@ Memory
    this is only relevant for the CUDA (>= 11.2) and HIP backends that
    support stream-ordered memory allocator.
 
+.. py:data:: amrex.the_arena_defragmentation
+   :type: bool
+   :value: true
+
+   This controls the defragmentation behavior of the main arena.
+
+.. py:data:: amrex.the_device_arena_defragmentation
+   :type: bool
+   :value: true
+
+   This controls the defragmentation behavior of the device arena.
+
+.. py:data:: amrex.the_managed_arena_defragmentation
+   :type: bool
+   :value: true
+
+   This controls the defragmentation behavior of the managed arena.
+
+.. py:data:: amrex.the_pinned_arena_defragmentation
+   :type: bool
+   :value: true
+
+   This controls the defragmentation behavior of the pinned arena.
+
+.. py:data:: amrex.the_comms_arena_defragmentation
+   :type: bool
+   :value: false
+
+   This controls the defragmentation behavior of the communication arena.
+
 .. py:data:: amrex.the_arena_is_managed
    :type: bool
    :value: false

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1111,9 +1111,10 @@ Memory
 
 .. py:data:: amrex.the_comms_arena_defragmentation
    :type: bool
-   :value: false
+   :value: [build dependent]
 
-   This controls the defragmentation behavior of the communication arena.
+   This controls the defragmentation behavior of the communication arena. The default is
+   false for HIP builds and true for others.
 
 .. py:data:: amrex.the_arena_is_managed
    :type: bool

--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -57,6 +57,7 @@ struct ArenaInfo
     bool device_set_readonly = false;
     bool device_set_preferred = false;
     bool device_use_hostalloc = false;
+    bool defragmentation = false;
     ArenaInfo& SetReleaseThreshold (Long rt) noexcept {
         release_threshold = rt;
         return *this;
@@ -87,6 +88,10 @@ struct ArenaInfo
         device_set_readonly = false;
         device_set_preferred = false;
         device_use_hostalloc = false;
+        return *this;
+    }
+    ArenaInfo& SetDefragmentation (bool b) noexcept {
+        defragmentation = b;
         return *this;
     }
 };

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -47,6 +47,11 @@ namespace {
     Long the_pinned_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_comms_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_async_arena_release_threshold = std::numeric_limits<Long>::max();
+    bool the_arena_defragmentation = false;
+    bool the_device_arena_defragmentation = false;
+    bool the_managed_arena_defragmentation = false;
+    bool the_pinned_arena_defragmentation = false;
+    bool the_comms_arena_defragmentation = false;
     bool the_arena_is_managed = false;
     bool abort_on_out_of_gpu_memory = false;
 }
@@ -314,13 +319,18 @@ Arena::Initialize (bool minimal)
     pp.queryAdd( "the_device_arena_init_size",  the_device_arena_init_size);
     pp.queryAdd("the_managed_arena_init_size", the_managed_arena_init_size);
     pp.queryAdd( "the_pinned_arena_init_size",  the_pinned_arena_init_size);
-    pp.queryAdd( "the_comms_arena_init_size",  the_comms_arena_init_size);
-    pp.queryAdd(       "the_arena_release_threshold" ,         the_arena_release_threshold);
+    pp.queryAdd(  "the_comms_arena_init_size",   the_comms_arena_init_size);
+    pp.queryAdd(        "the_arena_release_threshold",         the_arena_release_threshold);
     pp.queryAdd( "the_device_arena_release_threshold",  the_device_arena_release_threshold);
     pp.queryAdd("the_managed_arena_release_threshold", the_managed_arena_release_threshold);
     pp.queryAdd( "the_pinned_arena_release_threshold",  the_pinned_arena_release_threshold);
-    pp.queryAdd("the_comms_arena_release_threshold", the_comms_arena_release_threshold);
+    pp.queryAdd(  "the_comms_arena_release_threshold",   the_comms_arena_release_threshold);
     pp.queryAdd(  "the_async_arena_release_threshold",   the_async_arena_release_threshold);
+    pp.queryAdd(        "the_arena_defragmentation",         the_arena_defragmentation);
+    pp.queryAdd( "the_device_arena_defragmentation",  the_device_arena_defragmentation);
+    pp.queryAdd("the_managed_arena_defragmentation", the_managed_arena_defragmentation);
+    pp.queryAdd( "the_pinned_arena_defragmentation",  the_pinned_arena_defragmentation);
+    pp.queryAdd(  "the_comms_arena_defragmentation",   the_comms_arena_defragmentation);
     pp.queryAdd("the_arena_is_managed", the_arena_is_managed);
     pp.queryAdd("abort_on_out_of_gpu_memory", abort_on_out_of_gpu_memory);
 
@@ -328,6 +338,7 @@ Arena::Initialize (bool minimal)
 #if defined(BL_COALESCE_FABS) || defined(AMREX_USE_GPU)
         ArenaInfo ai{};
         ai.SetReleaseThreshold(the_arena_release_threshold);
+        ai.SetDefragmentation(the_arena_defragmentation);
         if (the_arena_is_managed) {
             the_arena = new CArena(0, ai.SetPreferred());
 #ifdef AMREX_USE_GPU
@@ -361,8 +372,11 @@ Arena::Initialize (bool minimal)
     if (the_arena->isDevice()) {
         the_device_arena = the_arena;
     } else {
-        the_device_arena = new CArena(0, ArenaInfo{}.SetDeviceMemory().SetReleaseThreshold
-                                      (the_device_arena_release_threshold));
+        ArenaInfo ai{};
+        ai.SetDeviceMemory();
+        ai.SetReleaseThreshold(the_device_arena_release_threshold);
+        ai.SetDefragmentation(the_device_arena_defragmentation);
+        the_device_arena = new CArena(0, ai);
         the_device_arena->registerForProfiling("Device Memory");
     }
 #else
@@ -373,8 +387,10 @@ Arena::Initialize (bool minimal)
     if (the_arena->isManaged()) {
         the_managed_arena = the_arena;
     } else {
-        the_managed_arena = new CArena(0, ArenaInfo{}.SetReleaseThreshold
-                                       (the_managed_arena_release_threshold));
+        ArenaInfo ai{};
+        ai.SetReleaseThreshold(the_managed_arena_release_threshold);
+        ai.SetDefragmentation(the_managed_arena_defragmentation);
+        the_managed_arena = new CArena(0, ai);
         the_managed_arena->registerForProfiling("Managed Memory");
     }
 #else
@@ -383,17 +399,25 @@ Arena::Initialize (bool minimal)
 
     // When USE_CUDA=FALSE, we call mlock to pin the cpu memory.
     // When USE_CUDA=TRUE, we call cudaHostAlloc to pin the host memory.
-    the_pinned_arena = new CArena(0, ArenaInfo{}.SetHostAlloc().SetReleaseThreshold
-                                  (the_pinned_arena_release_threshold));
-    the_pinned_arena->registerForProfiling("Pinned Memory");
+    {
+        ArenaInfo ai{};
+        ai.SetHostAlloc();
+        ai.SetReleaseThreshold(the_pinned_arena_release_threshold);
+        ai.SetDefragmentation(the_pinned_arena_defragmentation);
+        the_pinned_arena = new CArena(0, ai);
+        the_pinned_arena->registerForProfiling("Pinned Memory");
+    }
 
 #ifdef AMREX_USE_GPU
     if (ParallelDescriptor::UseGpuAwareMpi()) {
         if (!(the_arena->isDevice())) {
             the_comms_arena = the_device_arena;
         } else {
-            the_comms_arena = new CArena(0, ArenaInfo{}.SetDeviceMemory().SetReleaseThreshold
-                                        (the_comms_arena_release_threshold));
+            ArenaInfo ai{};
+            ai.SetDeviceMemory();
+            ai.SetReleaseThreshold(the_comms_arena_release_threshold);
+            ai.SetDefragmentation(the_comms_arena_defragmentation);
+            the_comms_arena = new CArena(0, ai);
             the_comms_arena->registerForProfiling("Comms Memory");
         }
     } else {

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -47,10 +47,10 @@ namespace {
     Long the_pinned_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_comms_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_async_arena_release_threshold = std::numeric_limits<Long>::max();
-    bool the_arena_defragmentation = false;
-    bool the_device_arena_defragmentation = false;
-    bool the_managed_arena_defragmentation = false;
-    bool the_pinned_arena_defragmentation = false;
+    bool the_arena_defragmentation = true;
+    bool the_device_arena_defragmentation = true;
+    bool the_managed_arena_defragmentation = true;
+    bool the_pinned_arena_defragmentation = true;
     bool the_comms_arena_defragmentation = false;
     bool the_arena_is_managed = false;
     bool abort_on_out_of_gpu_memory = false;
@@ -355,10 +355,12 @@ Arena::Initialize (bool minimal)
 #endif
         }
 #ifdef AMREX_USE_GPU
-        BL_PROFILE("The_Arena::Initialize()");
-        void *p = the_arena->alloc(static_cast<std::size_t>(the_arena_init_size));
-        the_arena->free(p);
-        the_arena->ResetMaxUsageCounter();
+        if (the_arena_init_size > 0) {
+            BL_PROFILE("The_Arena::Initialize()");
+            void *p = the_arena->alloc(static_cast<std::size_t>(the_arena_init_size));
+            the_arena->free(p);
+            the_arena->ResetMaxUsageCounter();
+        }
 #endif
 #else
         the_arena = The_BArena();
@@ -410,7 +412,9 @@ Arena::Initialize (bool minimal)
 
 #ifdef AMREX_USE_GPU
     if (ParallelDescriptor::UseGpuAwareMpi()) {
-        if (!(the_arena->isDevice())) {
+        if (!(the_arena->isDevice()) &&
+            the_device_arena_defragmentation == the_comms_arena_defragmentation)
+        {
             the_comms_arena = the_device_arena;
         } else {
             ArenaInfo ai{};

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -51,7 +51,11 @@ namespace {
     bool the_device_arena_defragmentation = true;
     bool the_managed_arena_defragmentation = true;
     bool the_pinned_arena_defragmentation = true;
+#ifdef AMREX_USE_HIP
     bool the_comms_arena_defragmentation = false;
+#else
+    bool the_comms_arena_defragmentation = true;
+#endif
     bool the_arena_is_managed = false;
     bool abort_on_out_of_gpu_memory = false;
 }

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -192,7 +192,6 @@ protected:
     //! The max amount of memory given out via alloc().
     std::size_t m_max_actually_used{0};
 
-
     std::mutex carena_mutex;
 
     friend std::ostream& operator<< (std::ostream& os, const CArena& arena);

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -43,8 +43,10 @@ CArena::alloc_protected (std::size_t nbytes)
     }
 #endif
 
+    bool freeunused_called = false;
     if (static_cast<Long>(m_used+nbytes) >= arena_info.release_threshold) {
         freeUnused_protected();
+        freeunused_called = true;
     }
 
     //
@@ -64,7 +66,8 @@ CArena::alloc_protected (std::size_t nbytes)
     {
         // Both freeUnused_protected and allocate_system may invalidate free_it.
         // All unused memory allocations are combined with the new one to reduce fragmentation.
-        const std::size_t freed_bytes = freeUnused_protected();
+        const auto freed_bytes = (freeunused_called || !arena_info.defragmentation)
+            ? std::size_t(0) : freeUnused_protected();
 
         const std::size_t N = std::max(m_hunk, freed_bytes + nbytes);
 
@@ -382,11 +385,13 @@ CArena::freeUnused_protected ()
     // in the steam which calls CArena::free that acquires carena_mutex.
     // So here carena_mutex needs to be unlocked first to avoid a deadlock.
     // Note that other threads to allocate/free memory from the CArena in the meantime.
-    carena_mutex.unlock();
-    for (auto& a : to_free) {
-        deallocate_system(a.first, a.second);
+    if (!to_free.empty()) {
+        carena_mutex.unlock();
+        for (auto& a : to_free) {
+            deallocate_system(a.first, a.second);
+        }
+        carena_mutex.lock();
     }
-    carena_mutex.lock();
 
     return nbytes;
 }


### PR DESCRIPTION
The defragmentation in #4451 has caused performance regression for some applications on Frontier. For example, a Castro test had a 20% performance hit. The issue appears to be that the GPU aware MPI on Frontier does not work well with defragmenting the comms arena. In this PR, we introduce a number of runtime parameters and disable defragmentation for the comms arena by default.
