### PR TITLE
Always FillSignedDistance with max grid size of 32

### DIFF
--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -223,7 +223,7 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(mf, fsd_tilesize, MFIter::Flags::Tiling); mfi.isValid(); ++mfi)
+    for (MFIter mfi(mf, fsd_tilesize); mfi.isValid(); ++mfi)
     {
         Box const& gbx = mfi.growntilebox();
         Array4<Real> const& fab = mf.array(mfi);

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -205,9 +205,9 @@ void FillSignedDistance (MultiFab& mf_in, EB2::Level const& ls_lev,
     // because the algorithm below is N^2 in the number of points per box,
     // we always do this operation with a max grid size of 32.
     auto new_ba = mf_in.boxArray();
-    new_ba.convert({0, 0, 0});
+    new_ba.convert(IntVect::TheZeroVector());
     new_ba.maxSize(32);
-    new_ba.convert({1, 1, 1});
+    new_ba.convert(IntVect::TheUnitVector());
     int max_guard = eb_factory_in.getBndryCent().nGrow();
     auto eb_factory_ptr = amrex::makeEBFabFactory(ls_lev.Geom(), new_ba,
                                                   DistributionMapping(new_ba),

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -196,11 +196,25 @@ facets_nearest_pt (IntVect const& ind_pt, IntVect const& ind_loop, RealVect cons
 }
 }
 
-void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
-                         EBFArrayBoxFactory const& eb_factory, int refratio,
+void FillSignedDistance (MultiFab& mf_in, EB2::Level const& ls_lev,
+                         EBFArrayBoxFactory const& eb_factory_in, int refratio,
                          bool fluid_has_positive_sign)
 {
-    AMREX_ALWAYS_ASSERT(mf.is_nodal());
+    AMREX_ALWAYS_ASSERT(mf_in.is_nodal());
+
+    // because the algorithm below is N^2 in the number of points per box,
+    // we always do this operation with a max grid size of 32.
+    auto new_ba = mf_in.boxArray();
+    new_ba.convert({0, 0, 0});
+    new_ba.maxSize(32);
+    new_ba.convert({1, 1, 1});
+    int max_guard = eb_factory_in.getBndryCent().nGrow();
+    auto eb_factory_ptr = amrex::makeEBFabFactory(ls_lev.Geom(), new_ba,
+                                                  DistributionMapping(new_ba),
+                                                  {max_guard, max_guard, max_guard},
+                                                  amrex::EBSupport::full);
+    EBFArrayBoxFactory const& eb_factory = *eb_factory_ptr;
+    MultiFab mf(new_ba, DistributionMapping(new_ba), mf_in.nComp(), mf_in.nGrow());
 
     ls_lev.fillLevelSet(mf, ls_lev.Geom()); // This is the implicit function, not the SDF.
 
@@ -406,6 +420,7 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
     }
 
     mf.FillBoundary(0,1,ls_lev.Geom().periodicity());
+    mf_in.ParallelCopy(mf);
 }
 
 } // end namespace

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -205,16 +205,14 @@ void FillSignedDistance (MultiFab& mf_in, EB2::Level const& ls_lev,
     // because the algorithm below is N^2 in the number of points per box,
     // we always do this operation with a max grid size of 32.
     auto new_ba = mf_in.boxArray();
-    new_ba.convert(IntVect::TheZeroVector());
     new_ba.maxSize(32);
-    new_ba.convert(IntVect::TheUnitVector());
+    auto new_dm = DistributionMapping(new_ba);
     int max_guard = eb_factory_in.getBndryCent().nGrow();
-    auto eb_factory_ptr = amrex::makeEBFabFactory(ls_lev.Geom(), new_ba,
-                                                  DistributionMapping(new_ba),
+    auto eb_factory_ptr = amrex::makeEBFabFactory(ls_lev.Geom(), new_ba, new_dm,
                                                   {max_guard, max_guard, max_guard},
                                                   amrex::EBSupport::full);
     EBFArrayBoxFactory const& eb_factory = *eb_factory_ptr;
-    MultiFab mf(new_ba, DistributionMapping(new_ba), mf_in.nComp(), mf_in.nGrow());
+    MultiFab mf(new_ba, new_dm, mf_in.nComp(), mf_in.nGrow());
 
     ls_lev.fillLevelSet(mf, ls_lev.Geom()); // This is the implicit function, not the SDF.
 
@@ -420,7 +418,7 @@ void FillSignedDistance (MultiFab& mf_in, EB2::Level const& ls_lev,
     }
 
     mf.FillBoundary(0,1,ls_lev.Geom().periodicity());
-    mf_in.ParallelCopy(mf);
+    mf_in.ParallelCopy(mf, 0, 0, mf.nComp(), mf.nGrow(), mf.nGrow());
 }
 
 } // end namespace

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -196,23 +196,11 @@ facets_nearest_pt (IntVect const& ind_pt, IntVect const& ind_loop, RealVect cons
 }
 }
 
-void FillSignedDistance (MultiFab& mf_in, EB2::Level const& ls_lev,
-                         EBFArrayBoxFactory const& eb_factory_in, int refratio,
+void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
+                         EBFArrayBoxFactory const& eb_factory, int refratio,
                          bool fluid_has_positive_sign)
 {
-    AMREX_ALWAYS_ASSERT(mf_in.is_nodal());
-
-    // because the algorithm below is N^2 in the number of points per box,
-    // we always do this operation with a max grid size of 32.
-    auto new_ba = mf_in.boxArray();
-    new_ba.maxSize(32);
-    auto new_dm = DistributionMapping(new_ba);
-    int max_guard = eb_factory_in.getBndryCent().nGrow();
-    auto eb_factory_ptr = amrex::makeEBFabFactory(ls_lev.Geom(), new_ba, new_dm,
-                                                  {max_guard, max_guard, max_guard},
-                                                  amrex::EBSupport::full);
-    EBFArrayBoxFactory const& eb_factory = *eb_factory_ptr;
-    MultiFab mf(new_ba, new_dm, mf_in.nComp(), mf_in.nGrow());
+    AMREX_ALWAYS_ASSERT(mf.is_nodal());
 
     ls_lev.fillLevelSet(mf, ls_lev.Geom()); // This is the implicit function, not the SDF.
 
@@ -228,19 +216,23 @@ void FillSignedDistance (MultiFab& mf_in, EB2::Level const& ls_lev,
 
     Real fluid_sign = fluid_has_positive_sign ? 1._rt : -1._rt;
 
+    // because the algorithm below is N^2 in the number of points per box,
+    // we always tile this loop with a size of 32, on CPU and GPU,
+    // whatever the user's requested tiling behavior.
+    constexpr IntVect fsd_tilesize = IntVect(AMREX_D_DECL(32, 32, 32));
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(mf); mfi.isValid(); ++mfi)
+    for (MFIter mfi(mf, fsd_tilesize, MFIter::Flags::Tiling); mfi.isValid(); ++mfi)
     {
-        Box const& gbx = mfi.fabbox();
+        Box const& gbx = mfi.growntilebox();
         Array4<Real> const& fab = mf.array(mfi);
 
         if (bndrycent.ok(mfi))
         {
             const auto& flag = flags.const_array(mfi);
 
-            Box eb_search = mfi.validbox();
+            Box eb_search = mfi.tilebox();
             eb_search.coarsen(refratio).enclosedCells().grow(eb_pad);
 
             const auto nallcells = static_cast<int>(eb_search.numPts());
@@ -418,7 +410,6 @@ void FillSignedDistance (MultiFab& mf_in, EB2::Level const& ls_lev,
     }
 
     mf.FillBoundary(0,1,ls_lev.Geom().periodicity());
-    mf_in.ParallelCopy(mf, 0, 0, mf.nComp(), mf.nGrow(), mf.nGrow());
 }
 
 } // end namespace


### PR DESCRIPTION
This function does an operation that is $N^{2}$ in the number of points per box. So, under some situations, it greatly improves the runtime to always tile this operation with a tilesize of (32, 32, 32). On CPU, using the inputs file in the WarpX issue [here](https://github.com/BLAST-WarpX/warpx/issues/5862), before this change I get:

```
Total Time                     : 252.8447199


TinyProfiler total time across processes [min...avg...max]: 252.8 ... 252.8 ... 252.8

---------------------------------------------------------------------------------------------
Name                                          NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------
ComputeDistanceToEB                                1      241.1      241.1      241.1  95.34%
MLNodeLinOp::applyBC()                          5947      4.363      4.363      4.363   1.73%

```

and after I get:

```
Total Time                     : 11.23438139


TinyProfiler total time across processes [min...avg...max]: 11.23 ... 11.23 ... 11.23

---------------------------------------------------------------------------------------------
Name                                          NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------
MLNodeLinOp::applyBC()                          5948      3.384      3.384      3.384  30.13%
MLEBNodeFDLaplacian::Fsmooth()                   756      2.986      2.986      2.986  26.58%
ComputeDistanceToEB                                1      1.544      1.544      1.544  13.74%
```

On the GPU, I get:

```
Total Time                     : 6.932015912


TinyProfiler total time across processes [min...avg...max]: 6.932 ... 6.932 ... 6.932

---------------------------------------------------------------------------------------------
Name                                          NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------
ComputeDistanceToEB                                1      5.465      5.465      5.465  78.84%

```

before and:

```
Total Time                     : 1.496398807


TinyProfiler total time across processes [min...avg...max]: 1.496 ... 1.496 ... 1.496

---------------------------------------------------------------------------------------------
Name                                          NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
---------------------------------------------------------------------------------------------
MLEBNodeFDLaplacian::Fsmooth()                   756     0.5078     0.5078     0.5078  33.94%
MLEBNodeFDLaplacian::Fapply()                   4437     0.1756     0.1756     0.1756  11.73%
ComputeDistanceToEB                                1     0.1593     0.1593     0.1593  10.65%
```
after.
