### PR TITLE
Add an --output_dir option to makebuildinfo_C.py

### DIFF
--- a/Tools/C_scripts/makebuildinfo_C.py
+++ b/Tools/C_scripts/makebuildinfo_C.py
@@ -263,6 +263,10 @@ if __name__ == "__main__":
                         help="style options for the 'git describe' command used to construct hash strings",
                         type=str, default="--always --tags --dirty")
 
+    parser.add_argument("--output_dir",
+                        help="the directory where AMReX_buildInfo.cpp should be placed",
+                        type=str, default="")
+
 
     # parse and convert to a dictionary
     args = parser.parse_args()
@@ -320,7 +324,11 @@ if __name__ == "__main__":
         AUX = args.AUX.split()
 
 
-    fout = open("AMReX_buildInfo.cpp", "w")
+    dest_path = "AMReX_buildInfo.cpp"
+    if args.output_dir:
+        os.makedirs(args.output_dir, exist_ok=True)
+        dest_path = os.path.join(args.output_dir, dest_path)
+    fout = open(dest_path, "w")
 
     # dictionary view of the args
     dargs = vars(args)


### PR DESCRIPTION
## Summary

This allows specifying the directory where `AMReX_buildInfo.cpp` is written (instead of the current directory), which I needed to avoid a race condition with simultaneous builds from a single source directory.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
