### PR TITLE
Add support for force-inlined methods in GDB

### DIFF
--- a/Tools/GDB/README.md
+++ b/Tools/GDB/README.md
@@ -1,0 +1,21 @@
+# GDB xmethod support
+
+GDB doesn't have access to inlined methods, so it allows providing replacement
+implementations for these methods in Python using the Xmethod API.
+`gdb_amrex_xmethods.py` contains implementations for the non-trivial
+subscription operators for the various `amrex::Array*` classes.
+
+## Usage
+
+Run `source <path to amrex>/Tools/GDB/gdb_amrex_xmethods.py` during an
+interactive session, or add that line to `~/.gdbinit` to be run in every
+session.
+
+Note: built-in support for user-defined function call operators (`operator()`)
+was only added in GDB 16 (included in GNU Binutils 2.44). If you're using an
+older version, you must explicitly call the `operator()` function, like this:
+
+```
+(gdb) p array4.operator()(1, 2, 3, 4)
+$1 = 1847849.7974222905
+```

--- a/Tools/GDB/gdb_amrex_xmethods.py
+++ b/Tools/GDB/gdb_amrex_xmethods.py
@@ -1,0 +1,301 @@
+# pylint: disable=too-few-public-methods, too-many-arguments, too-many-boolean-expressions
+
+import os.path
+import sys
+
+sys.path.insert(1, os.path.join(os.path.dirname(os.path.abspath(__file__)), "util"))
+import class_methods
+
+
+def is_f_order(obj):
+    return obj.ORDER.name == "amrex::Order::F"
+
+
+def is_c_order(obj):
+    return obj.ORDER.name == "amrex::Order::C"
+
+
+@class_methods.Class("amrex::Array1D", template_types=["T", "XLO", "XHI"])
+class AmrexArray1D:  # pylint: disable=no-member
+    @class_methods.member_function("unsigned int", "len", [])
+    def len(self, _obj):
+        return self.XHI - self.XLO + 1
+
+    @class_methods.member_function("unsigned int", "size", [])
+    def size(self, obj):
+        return self.len(obj)
+
+    @class_methods.member_function("T&", "operator()", ["int"])
+    def subscript(self, obj, i):
+        if not self.XLO <= i <= self.XHI:
+            msg = 'Array1D index "{}" should be between {} and {}.'.format(
+                i, self.XLO, self.XHI
+            )
+            raise IndexError(msg)
+        return obj["arr"][i - self.XLO]
+
+
+@class_methods.Class(
+    "amrex::Array2D", template_types=["T", "XLO", "XHI", "YLO", "YHI", "ORDER"]
+)
+class AmrexArray2D:  # pylint: disable=no-member
+    @class_methods.member_function("unsigned int", "xlen", [])
+    def xlen(self, _obj):
+        return self.XHI - self.XLO + 1
+
+    @class_methods.member_function("unsigned int", "ylen", [])
+    def ylen(self, _obj):
+        return self.YHI - self.YLO + 1
+
+    @class_methods.member_function("unsigned int", "size", [])
+    def size(self, obj):
+        return self.xlen(obj) * self.ylen(obj)
+
+    @class_methods.member_function("T&", "operator()", ["int", "int"])
+    def subscript(self, obj, i, j):
+        if not self.XLO <= i <= self.XHI:
+            msg = 'Array2D index i="{}" should be between {} and {}.'.format(
+                i, self.XLO, self.XHI
+            )
+            raise IndexError(msg)
+        if not self.YLO <= j <= self.YHI:
+            msg = 'Array2D index j="{}" should be between {} and {}.'.format(
+                j, self.YLO, self.YHI
+            )
+            raise IndexError(msg)
+
+        xlen = self.xlen(obj)
+        ylen = self.ylen(obj)
+        if is_f_order(self):
+            return obj["arr"][i + j * xlen - (self.YLO * xlen + self.XLO)]
+        if is_c_order(self):
+            return obj["arr"][j + i * ylen - (self.XLO * ylen + self.YLO)]
+        assert False
+
+
+@class_methods.Class(
+    "amrex::Array3D",
+    template_types=["T", "XLO", "XHI", "YLO", "YHI", "ZLO", "ZHI", "ORDER"],
+)
+class AmrexArray3D:  # pylint: disable=no-member
+    @class_methods.member_function("unsigned int", "xlen", [])
+    def xlen(self, _obj):
+        return self.XHI - self.XLO + 1
+
+    @class_methods.member_function("unsigned int", "ylen", [])
+    def ylen(self, _obj):
+        return self.YHI - self.YLO + 1
+
+    @class_methods.member_function("unsigned int", "zlen", [])
+    def zlen(self, _obj):
+        return self.ZHI - self.ZLO + 1
+
+    @class_methods.member_function("unsigned int", "size", [])
+    def size(self, obj):
+        return self.xlen(obj) * self.ylen(obj) * self.zlen(obj)
+
+    @class_methods.member_function("T&", "operator()", ["int", "int", "int"])
+    def element(self, obj, i, j, k):
+        if not self.XLO <= i <= self.XHI:
+            msg = 'Array3D index i="{}" should be between {} and {}.'.format(
+                i, self.XLO, self.XHI
+            )
+            raise IndexError(msg)
+        if not self.YLO <= j <= self.YHI:
+            msg = 'Array3D index j="{}" should be between {} and {}.'.format(
+                j, self.YLO, self.YHI
+            )
+            raise IndexError(msg)
+        if not self.ZLO <= k <= self.ZHI:
+            msg = 'Array3D index k="{}" should be between {} and {}.'.format(
+                k, self.ZLO, self.ZHI
+            )
+            raise IndexError(msg)
+
+        xlen = self.xlen(obj)
+        ylen = self.ylen(obj)
+        zlen = self.zlen(obj)
+        if is_f_order(self):
+            return obj["arr"][
+                i
+                + j * xlen
+                + k * (xlen * ylen)
+                - (self.ZLO * (xlen * ylen) + self.YLO * xlen + self.XLO)
+            ]
+        if is_c_order(self):
+            return obj["arr"][
+                k
+                + j * zlen
+                + i * (zlen * ylen)
+                - (self.XLO * (zlen * ylen) + self.YLO * zlen + self.ZLO)
+            ]
+        assert False
+
+
+@class_methods.Class("amrex::Array4", template_types=["T"])
+class AmrexArray4:
+    @class_methods.member_function("std::size_t", "size", [])
+    def size(self, obj):
+        return obj["nstride"] * obj["ncomp"]
+
+    def subscript_helper(self, obj, i, j, k, n):
+        begin = obj["begin"]
+        end = obj["end"]
+        # fmt: off
+        if (
+            i < begin["x"] or i >= end["x"] or
+            j < begin["y"] or j >= end["y"] or
+            k < begin["z"] or k >= end["z"] or
+            n < 0 or n >= obj["ncomp"]
+        ):
+            msg = "Array4 index ({},{},{},{}) is out of bound ({}:{},{}:{},{}:{},0:{})".format(
+                i, j, k, n,
+                begin["x"], end["x"] - 1,
+                begin["y"], end["y"] - 1,
+                begin["z"], end["z"] - 1,
+                obj["ncomp"] - 1,
+            )
+            raise IndexError(msg)
+        # fmt: on
+        return obj["p"][
+            (i - begin["x"])
+            + (j - begin["y"]) * obj["jstride"]
+            + (k - begin["z"]) * obj["kstride"]
+            + n * obj["nstride"]
+        ]
+
+    # GDB's overload resolution ignores any missing arguments at the end, so
+    # this handles both the 3-int and 4-int overloads
+    @class_methods.member_function("T&", "operator()", ["int"] * 4)
+    def subscript(self, obj, i, j, k, n=0):
+        return self.subscript_helper(obj, i, j, k, n)
+
+    @class_methods.member_function("T&", "operator()", ["amrex::IntVect&", "int"])
+    def subscript_IntVect(self, obj, iv, n=0):
+        spacedim = int(iv.type.template_argument(0))
+        indices = [iv["vect"][0], 0, 0]
+        if spacedim >= 2:
+            indices[1] = iv["vect"][1]
+        if spacedim >= 3:
+            indices[2] = iv["vect"][2]
+        return self.subscript_helper(obj, *indices, n)
+
+    @class_methods.member_function("T&", "operator()", ["amrex::Dim3&", "int"])
+    def subscript_Dim3(self, obj, cell, n=0):
+        return self.subscript_helper(obj, cell["x"], cell["y"], cell["z"], n)
+
+
+@class_methods.Class("amrex::Table1D", template_types=["T"])
+class AmrexTable1D:
+    @class_methods.member_function("T&", "operator()", ["int"])
+    def subscript(self, obj, i):
+        begin = obj["begin"]
+        end = obj["end"]
+        if i < begin or i >= end:
+            msg = f"({i}) is out of bound ({begin}:{end-1})"
+            raise IndexError(msg)
+        return obj["p"][i - begin]
+
+
+@class_methods.Class("amrex::Table2D", template_types=["T", "ORDER"])
+class AmrexTable2D:
+    @class_methods.member_function("T&", "operator()", ["int"] * 2)
+    def subscript(self, obj, i, j):
+        begin = obj["begin"]
+        end = obj["end"]
+        # fmt: off
+        if (
+            i < begin[0] or i >= end[0] or
+            j < begin[1] or j >= end[1]
+        ):
+            msg = "({},{}) is out of bound ({}:{},{}:{})".format(
+                i, j,
+                begin[0], end[0] - 1,
+                begin[1], end[1] - 1,
+            )
+            raise IndexError(msg)
+        # fmt: on
+
+        stride1 = obj["stride1"]
+        if is_f_order(self):
+            return obj["p"][(i - begin[0]) + (j - begin[1]) * stride1]
+        if is_c_order(self):
+            return obj["p"][(i - begin[0]) * stride1 + (j - begin[1])]
+        assert False
+
+
+@class_methods.Class("amrex::Table3D", template_types=["T", "ORDER"])
+class AmrexTable3D:
+    @class_methods.member_function("T&", "operator()", ["int"] * 3)
+    def subscript(self, obj, i, j, k):
+        begin = obj["begin"]["arr"]
+        end = obj["end"]["arr"]
+        # fmt: off
+        if (
+            i < begin[0] or i >= end[0] or
+            j < begin[1] or j >= end[1] or
+            k < begin[2] or k >= end[2]
+        ):
+            msg = "({},{},{}) is out of bound ({}:{},{}:{},{}:{})".format(
+                i, j, k,
+                begin[0], end[0] - 1,
+                begin[1], end[1] - 1,
+                begin[2], end[2] - 1,
+            )
+            raise ValueError(msg)
+        # fmt: on
+
+        stride1 = obj["stride1"]
+        stride2 = obj["stride2"]
+        if is_f_order(self):
+            return obj["p"][
+                (i - begin[0]) + (j - begin[1]) * stride1 + (k - begin[2]) * stride2
+            ]
+        if is_c_order(self):
+            return obj["p"][
+                (i - begin[0]) * stride2 + (j - begin[1]) * stride1 + (k - begin[2])
+            ]
+        assert False
+
+
+@class_methods.Class("amrex::Table4D", template_types=["T", "ORDER"])
+class AmrexTable4D:
+    @class_methods.member_function("T&", "operator()", ["int"] * 4)
+    def subscript(self, obj, i, j, k, n):
+        begin = obj["begin"]["arr"]
+        end = obj["end"]["arr"]
+        # fmt: off
+        if (
+            i < begin[0] or i >= end[0] or
+            j < begin[1] or j >= end[1] or
+            k < begin[2] or k >= end[2] or
+            n < begin[3] or n >= end[3]
+        ):
+            msg = "({},{},{},{}) is out of bound ({}:{},{}:{},{}:{},{}:{})".format(
+                i, j, k, n,
+                begin[0], end[0] - 1,
+                begin[1], end[1] - 1,
+                begin[2], end[2] - 1,
+                begin[3], end[3] - 1,
+            )
+            raise ValueError(msg)
+        # fmt: on
+
+        stride1 = obj["stride1"]
+        stride2 = obj["stride2"]
+        stride3 = obj["stride3"]
+        if is_f_order(self):
+            return obj["p"][
+                (i - begin[0])
+                + (j - begin[1]) * stride1
+                + (k - begin[2]) * stride2
+                + (n - begin[3]) * stride3
+            ]
+        if is_c_order(self):
+            return obj["p"][
+                (i - begin[0]) * stride3
+                + (j - begin[1]) * stride2
+                + (k - begin[2]) * stride1
+                + (n - begin[3])
+            ]
+        assert False

--- a/Tools/GDB/util/class_methods.py
+++ b/Tools/GDB/util/class_methods.py
@@ -1,0 +1,185 @@
+# Copyright 2018 The Chromium Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+"""Helper library for defining XMethod implementations on C++ classes.
+
+Include this library and then define python implementations of C++ methods
+using the Class and member_function decorator functions.
+"""
+
+import gdb
+import gdb.xmethod
+import operator
+import re
+
+
+class MemberFunction(object):
+  def __init__(self, return_type, name, arguments, wrapped_function):
+    self.return_type = return_type
+    self.name = name
+    self.arguments = arguments
+    self.function_ = wrapped_function
+
+  def __call__(self, *args):
+    self.function_(*args)
+
+
+def member_function(return_type, name, arguments):
+  """Decorate a member function.
+
+  See Class decorator for example usage within a class.
+
+  Args:
+    return_type: The return type of the function (e.g. 'int')
+    name: The function name (e.g. 'sum')
+    arguments: The argument types for this function (e.g. ['int', 'int'])
+
+    Each type can be a string (e.g. 'int', 'std::string', 'T*') or a
+    function which constructs the return type. See CreateTypeResolver
+    for details about type resolution.
+  """
+  def DefineMember(fn):
+    return MemberFunction(return_type, name, arguments, fn)
+  return DefineMember
+
+
+def Class(class_name, template_types):
+  """Decorate a python class with its corresponding C++ type.
+  Args:
+    class_name: The canonical string identifier for the class (e.g. base::Foo)
+    template_types: An array of names for each templated type (e.g. ['K',
+    'V'])
+
+  Example:
+    As an example, the following is an implementation of size() and operator[]
+    on std::__1::vector, functions which are normally inlined and not
+    normally callable from gdb.
+
+    @class_methods.Class('std::__1::vector', template_types=['T'])
+    class LibcppVector(object):
+      @class_methods.member_function('T&', 'operator[]', ['int'])
+      def element(obj, i):
+        return obj['__begin_'][i]
+
+      @class_methods.member_function('size_t', 'size', [])
+      def size(obj):
+        return obj['__end_'] - obj['__begin_']
+
+  Note:
+    Note that functions are looked up by the function name, which means that
+    functions cannot currently have overloaded implementations for different
+    arguments.
+  """
+
+  class MethodWorkerWrapper(gdb.xmethod.XMethod):
+    """Wrapper of an XMethodWorker class as an XMethod."""
+    def __init__(self, name, worker_class):
+      super(MethodWorkerWrapper, self).__init__(name)
+      self.name = name
+      self.worker_class = worker_class
+
+
+  class ClassMatcher(gdb.xmethod.XMethodMatcher):
+    """Matches member functions of one class template."""
+    def __init__(self, obj):
+      super(ClassMatcher, self).__init__(class_name)
+
+      # Constructs a regular expression to match this type.
+      self._class_regex = re.compile(
+          '^' + re.escape(class_name) +
+          ('<.*>' if len(template_types) > 0 else '') + '$')
+
+      # Construct a dictionary and array of methods
+      self.dict = {}
+      self.methods = []
+      for name in dir(obj):
+        attr = getattr(obj, name)
+        if not isinstance(attr, MemberFunction):
+          continue
+
+        name = attr.name
+        return_type = CreateTypeResolver(attr.return_type)
+        arguments = [CreateTypeResolver(arg) for arg in
+                     attr.arguments]
+        method = MethodWorkerWrapper(
+            attr.name,
+            CreateTemplatedMethodWorker(return_type,
+                                        arguments, attr.function_))
+        self.methods.append(method)
+
+    def match(self, class_type, method_name):
+      if not re.match(self._class_regex, class_type.tag):
+        return None
+      templates = [class_type.template_argument(i) for i in
+                   range(len(template_types))]
+      return [method.worker_class(templates) for method in self.methods
+              if method.name == method_name and method.enabled]
+
+
+  def CreateTypeResolver(type_desc):
+    """Creates a callback which resolves to the appropriate type when
+    invoked.
+
+    This is a helper to allow specifying simple types as strings when
+    writing function descriptions. For complex cases, a callback can be
+    passed which will be invoked when template instantiation is known.
+
+    Args:
+      type_desc: A callback generating the type or a string description of
+          the type to lookup. Supported types are classes in the
+          template_classes array (e.g. T) which will be looked up when those
+          templated classes are known, or globally visible type names (e.g.
+          int, base::Foo).
+
+          Types can be modified by appending a '*' or '&' to denote a
+          pointer or reference.
+
+          If a callback is used, the callback will be passed an array of the
+          instantiated template types.
+
+    Note:
+      This does not parse complex types such as std::vector<T>::iterator,
+      to refer to types like these you must currently write a callback
+      which constructs the appropriate type.
+    """
+    if callable(type_desc):
+      return type_desc
+    if type_desc == 'void':
+      return lambda T: None
+    if type_desc[-1] == '&':
+      inner_resolver = CreateTypeResolver(type_desc[:-1])
+      return lambda template_types: inner_resolver(template_types).reference()
+    if type_desc[-1] == '*':
+      inner_resolver = CreateTypeResolver(type_desc[:-1])
+      return lambda template_types: inner_resolver(template_types).pointer()
+    try:
+      template_index = template_types.index(type_desc)
+      return operator.itemgetter(template_index)
+    except ValueError:
+      return lambda template_types: gdb.lookup_type(type_desc)
+
+
+  def CreateTemplatedMethodWorker(return_callback, args_callbacks,
+                                  method_callback):
+    class TemplatedMethodWorker(gdb.xmethod.XMethodWorker):
+      def __init__(self, templates):
+        super(TemplatedMethodWorker, self).__init__()
+        self._templates = templates
+
+      def get_arg_types(self):
+        return [cb(self._templates) for cb in args_callbacks]
+
+      def get_result_type(self, obj):
+        return return_callback(self._templates)
+
+      def __call__(self, *args):
+        return method_callback(*args)
+    return TemplatedMethodWorker
+
+  def DefineClass(obj):
+    matcher = ClassMatcher(obj)
+    gdb.xmethod.register_xmethod_matcher(None, matcher)
+    return matcher
+
+  return DefineClass

--- a/Tools/GDB/util/class_methods.py
+++ b/Tools/GDB/util/class_methods.py
@@ -21,9 +21,6 @@ class MemberFunction(object):
     self.arguments = arguments
     self.function_ = wrapped_function
 
-  def __call__(self, *args):
-    self.function_(*args)
-
 
 def member_function(return_type, name, arguments):
   """Decorate a member function.
@@ -59,17 +56,12 @@ def Class(class_name, template_types):
     @class_methods.Class('std::__1::vector', template_types=['T'])
     class LibcppVector(object):
       @class_methods.member_function('T&', 'operator[]', ['int'])
-      def element(obj, i):
+      def element(self, obj, i):
         return obj['__begin_'][i]
 
       @class_methods.member_function('size_t', 'size', [])
-      def size(obj):
+      def size(self, obj):
         return obj['__end_'] - obj['__begin_']
-
-  Note:
-    Note that functions are looked up by the function name, which means that
-    functions cannot currently have overloaded implementations for different
-    arguments.
   """
 
   class MethodWorkerWrapper(gdb.xmethod.XMethod):
@@ -104,7 +96,7 @@ def Class(class_name, template_types):
                      attr.arguments]
         method = MethodWorkerWrapper(
             attr.name,
-            CreateTemplatedMethodWorker(return_type,
+            CreateTemplatedMethodWorker(obj, return_type,
                                         arguments, attr.function_))
         self.methods.append(method)
 
@@ -160,12 +152,18 @@ def Class(class_name, template_types):
       return lambda template_types: gdb.lookup_type(type_desc)
 
 
-  def CreateTemplatedMethodWorker(return_callback, args_callbacks,
-                                  method_callback):
-    class TemplatedMethodWorker(gdb.xmethod.XMethodWorker):
+  def CreateTemplatedMethodWorker(parent_class, return_callback,
+                                  args_callbacks, method_callback):
+    class TemplatedMethodWorker(parent_class, gdb.xmethod.XMethodWorker):
       def __init__(self, templates):
         super(TemplatedMethodWorker, self).__init__()
         self._templates = templates
+
+      def __getattr__(self, name):
+        if name in template_types:
+          return self._templates[template_types.index(name)]
+        msg = f"'{type(self).__name__:.100s}' has no attribute '{name}'"
+        raise AttributeError(msg)
 
       def get_arg_types(self):
         return [cb(self._templates) for cb in args_callbacks]
@@ -174,7 +172,7 @@ def Class(class_name, template_types):
         return return_callback(self._templates)
 
       def __call__(self, *args):
-        return method_callback(*args)
+        return method_callback(self, *args)
     return TemplatedMethodWorker
 
   def DefineClass(obj):


### PR DESCRIPTION
## Summary

GDB doesn't have access to inlined methods, so it allows providing replacement implementations for these methods in Python using the Xmethod API. This PR adds a Python library containing implementations for the non-trivial subscription operators for the various `amrex::Array*` classes.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
