### PR TITLE
Added option to use either always use BNorm or ResNorm for calculatin…

### DIFF
--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -159,13 +159,20 @@ to solve the problem given an initial guess and a right-hand side.
 Zero is a perfectly fine initial guess.  The two :cpp:`Reals` in the argument
 list are the targeted relative and absolute error tolerances. The relative
 error tolerance is hard-coded to be at least :math:`10^{-16}`.
-Given the linear system :math:`Ax=b`, the solver will terminate when the
-max-norm of the residual (:math:`b-Ax`) is less than
-:cpp:`std::max(a_tol_abs, a_tol_rel*max_norm)` where :cpp:`max_norm`
-is the max-norm of the rhs, :math:`b`, if the flag :cpp:`always_use_bnorm` is
-set to True or if the rhs max-norm is greater than or equal to the max-norm error
-of the initial guess, otherwise :cpp:`max_norm` is equal to the max-norm error
-of the initial guess.  Set the absolute tolerance to zero if one does not have a
+Given the linear system :math:`Ax = b`, the solver will terminate when the
+max-norm of the residual (:math:`b - Ax`) is less than
+:cpp:`std::max(a_tol_abs, a_tol_rel * max_norm)` where :cpp:`max_norm` is
+equal to the greater of rhs max-norm and residual max-norm. This behavior can
+be modified using the ``MLMG`` member function :cpp:`setConvergenceNormType (NormType norm)`
+where the available options are
+
+- :cpp:`MLMG::NormType::Greater`: The default.
+
+- :cpp:`MLMG::NormType::BNorm`: :cpp:`max_norm` is set to rhs max-norm.
+
+- :cpp:`MLMG::NormType::ResNorm`: :cpp:`max_norm` is set to residual max-norm.
+
+Set the absolute tolerance to zero if one does not have a
 good value for it.  The return value of :cpp:`solve` is the max-norm error.
 
 After the solver returns successfully, if needed, we can call

--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -161,16 +161,16 @@ list are the targeted relative and absolute error tolerances. The relative
 error tolerance is hard-coded to be at least :math:`10^{-16}`.
 Given the linear system :math:`Ax = b`, the solver will terminate when the
 max-norm of the residual (:math:`b - Ax`) is less than
-:cpp:`std::max(a_tol_abs, a_tol_rel * max_norm)` where :cpp:`max_norm` is
+:cpp:`std::max(a_tol_abs, a_tol_rel * max_norm)`. By default, :cpp:`max_norm` is
 equal to the greater of rhs max-norm and residual max-norm. This behavior can
-be modified using the ``MLMG`` member function :cpp:`setConvergenceNormType (NormType norm)`
+be modified using the ``MLMG`` member function :cpp:`setConvergenceNormType (MLMGNormType norm)`,
 where the available options are
 
-- :cpp:`MLMG::NormType::Greater`: The default.
+- :cpp:`MLMGNormType::greater`: The default.
 
-- :cpp:`MLMG::NormType::BNorm`: :cpp:`max_norm` is set to rhs max-norm.
+- :cpp:`MLMGNormType::bnorm`: :cpp:`max_norm` is set to rhs max-norm.
 
-- :cpp:`MLMG::NormType::ResNorm`: :cpp:`max_norm` is set to residual max-norm.
+- :cpp:`MLMGNormType::resnorm`: :cpp:`max_norm` is set to residual max-norm.
 
 Set the absolute tolerance to zero if one does not have a
 good value for it.  The return value of :cpp:`solve` is the max-norm error.

--- a/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_fi.cpp
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_fi.cpp
@@ -103,7 +103,11 @@
 
      void amrex_fi_multigrid_set_always_use_bnorm (MLMG* mlmg, int f)
      {
-         mlmg->setAlwaysUseBNorm(f);
+         if (f != 0) {
+            mlmg->setConvergenceNormType(MLMGNormType::bnorm);
+         } else {
+            mlmg->setConvergenceNormType(MLMGNormType::greater);
+         }
      }
 
      void amrex_fi_multigrid_set_final_fill_bc (MLMG* mlmg, int f)

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -1,11 +1,15 @@
 #ifndef AMREX_ML_MG_H_
 #define AMREX_ML_MG_H_
 #include <AMReX_Config.H>
+#include <AMReX_Enum.H>
 
 #include <AMReX_MLLinOp.H>
 #include <AMReX_MLCGSolver.H>
 
 namespace amrex {
+
+// Norm used to evaluate the target convergece criteria
+AMREX_ENUM(MLMGNormType, greater, bnorm, resnorm);
 
 template <typename MF>
 class MLMGT
@@ -31,9 +35,6 @@ public:
 
     using BottomSolver = amrex::BottomSolver;
     enum class CFStrategy : int {none,ghostnodes};
-
-    // Norm used to evaluate the target convergence criteria.
-    enum class NormType: int {Greater, BNorm, ResNorm};
 
     MLMGT (MLLinOpT<MF>& a_lp);
     ~MLMGT ();
@@ -150,7 +151,7 @@ public:
     [[nodiscard]] RT getBottomToleranceAbs () const noexcept{ return bottom_abstol; }
 
     void setAlwaysUseBNorm (int flag) noexcept;
-    void setConvergenceNormType (NormType norm) noexcept { norm_type = norm; }
+    void setConvergenceNormType (MLMGNormType norm) noexcept { norm_type = norm; }
 
     void setFinalFillBC (int flag) noexcept { final_fill_bc = flag; }
 
@@ -271,7 +272,7 @@ private:
     RT bottom_reltol = std::is_same<RT,double>() ? RT(1.e-4) : RT(1.e-3);
     RT bottom_abstol = RT(-1.0);
 
-    NormType norm_type = NormType::Greater;
+    MLMGNormType norm_type = MLMGNormType::greater;
 
     int final_fill_bc = 0;
 
@@ -367,9 +368,9 @@ void
 MLMGT<MF>::setAlwaysUseBNorm (int flag) noexcept
 {
     if (flag) {
-        norm_type = NormType::BNorm;
+        norm_type = MLMGNormType::bnorm;
     } else {
-        norm_type = NormType::Greater;
+        norm_type = MLMGNormType::greater;
     }
 }
 
@@ -456,7 +457,7 @@ MLMGT<MF>::solve (const Vector<AMF*>& a_sol, const Vector<AMF const*>& a_rhs,
     RT max_norm = resnorm0;
     std::string norm_name = "resid0";
     switch (norm_type) {
-        case NormType::Greater:
+        case MLMGNormType::greater:
             if (rhsnorm0 >= resnorm0) {
                 norm_name = "bnorm";
                 max_norm = rhsnorm0;
@@ -465,11 +466,11 @@ MLMGT<MF>::solve (const Vector<AMF*>& a_sol, const Vector<AMF const*>& a_rhs,
                 max_norm = resnorm0;
             }
             break;
-        case NormType::BNorm:
+        case MLMGNormType::bnorm:
             norm_name = "bnorm";
             max_norm = rhsnorm0;
             break;
-        case NormType::ResNorm:
+        case MLMGNormType::resnorm:
             norm_name = "resid0";
             max_norm = resnorm0;
             break;
@@ -2034,18 +2035,7 @@ MLMGT<MF>::checkPoint (const Vector<MultiFab*>& a_sol,
 
         HeaderFile.precision(17);
 
-        std::string norm_name;
-        switch (norm_type) {
-            case NormType::Greater:
-                norm_name = "Greater";
-                break;
-            case NormType::BNorm:
-                norm_name = "BNorm";
-                break;
-            case NormType::ResNorm:
-                norm_name = "ResNorm";
-                break;
-        }
+        std::string norm_name = getEnumNameString(norm_type);
 
         HeaderFile << linop.name() << "\n"
                    << "a_tol_rel = " << a_tol_rel << "\n"

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -150,7 +150,9 @@ public:
     void setBottomToleranceAbs (RT t) noexcept { bottom_abstol = t;}
     [[nodiscard]] RT getBottomToleranceAbs () const noexcept{ return bottom_abstol; }
 
+    [[deprecated("Use MLMG::setConvergenceNormType() instead.")]]
     void setAlwaysUseBNorm (int flag) noexcept;
+
     void setConvergenceNormType (MLMGNormType norm) noexcept { norm_type = norm; }
 
     void setFinalFillBC (int flag) noexcept { final_fill_bc = flag; }

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -32,6 +32,9 @@ public:
     using BottomSolver = amrex::BottomSolver;
     enum class CFStrategy : int {none,ghostnodes};
 
+    // Norm used to evaluate the target convergence criteria.
+    enum class NormType: int {Greater, BNorm, ResNorm};
+
     MLMGT (MLLinOpT<MF>& a_lp);
     ~MLMGT ();
 
@@ -146,7 +149,8 @@ public:
     void setBottomToleranceAbs (RT t) noexcept { bottom_abstol = t;}
     [[nodiscard]] RT getBottomToleranceAbs () const noexcept{ return bottom_abstol; }
 
-    void setAlwaysUseBNorm (int flag) noexcept { always_use_bnorm = flag; }
+    void setAlwaysUseBNorm (int flag) noexcept;
+    void setAlwaysUseResNorm (int flag) noexcept;
 
     void setFinalFillBC (int flag) noexcept { final_fill_bc = flag; }
 
@@ -267,7 +271,7 @@ private:
     RT bottom_reltol = std::is_same<RT,double>() ? RT(1.e-4) : RT(1.e-3);
     RT bottom_abstol = RT(-1.0);
 
-    int always_use_bnorm = 0;
+    NormType norm_type = NormType::Greater;
 
     int final_fill_bc = 0;
 
@@ -359,6 +363,28 @@ MLMGT<MF>::MLMGT (MLLinOpT<MF>& a_lp)
 template <typename MF> MLMGT<MF>::~MLMGT () = default;
 
 template <typename MF>
+void
+MLMGT<MF>::setAlwaysUseBNorm (int flag) noexcept
+{
+    if (flag) {
+        norm_type = NormType::BNorm;
+    } else {
+        norm_type = NormType::Greater;
+    }
+}
+
+template <typename MF>
+void
+MLMGT<MF>::setAlwaysUseResNorm (int flag) noexcept
+{
+    if (flag) {
+        norm_type = NormType::ResNorm;
+    } else {
+        norm_type = NormType::Greater;
+    }
+}
+
+template <typename MF>
 template <typename AMF>
 auto
 MLMGT<MF>::solve (std::initializer_list<AMF*> a_sol,
@@ -438,15 +464,28 @@ MLMGT<MF>::solve (const Vector<AMF*>& a_sol, const Vector<AMF const*>& a_rhs,
     m_init_resnorm0 = resnorm0;
     m_rhsnorm0 = rhsnorm0;
 
-    RT max_norm;
-    std::string norm_name;
-    if (always_use_bnorm || rhsnorm0 >= resnorm0) {
-        norm_name = "bnorm";
-        max_norm = rhsnorm0;
-    } else {
-        norm_name = "resid0";
-        max_norm = resnorm0;
+    RT max_norm = resnorm0;
+    std::string norm_name = "resid0";
+    switch (norm_type) {
+        case NormType::Greater:
+            if (rhsnorm0 >= resnorm0) {
+                norm_name = "bnorm";
+                max_norm = rhsnorm0;
+            } else {
+                norm_name = "resid0";
+                max_norm = resnorm0;
+            }
+            break;
+        case NormType::BNorm:
+            norm_name = "bnorm";
+            max_norm = rhsnorm0;
+            break;
+        case NormType::ResNorm:
+            norm_name = "resid0";
+            max_norm = resnorm0;
+            break;
     }
+
     const RT res_target = std::max(a_tol_abs, std::max(a_tol_rel,RT(1.e-16))*max_norm);
 
     if (!is_nsolve && resnorm0 <= res_target) {
@@ -2006,6 +2045,19 @@ MLMGT<MF>::checkPoint (const Vector<MultiFab*>& a_sol,
 
         HeaderFile.precision(17);
 
+        std::string norm_name;
+        switch (norm_type) {
+            case NormType::Greater:
+                norm_name = "Greater";
+                break;
+            case NormType::BNorm:
+                norm_name = "BNorm";
+                break;
+            case NormType::ResNorm:
+                norm_name = "ResNorm";
+                break;
+        }
+
         HeaderFile << linop.name() << "\n"
                    << "a_tol_rel = " << a_tol_rel << "\n"
                    << "a_tol_abs = " << a_tol_abs << "\n"
@@ -2020,7 +2072,7 @@ MLMGT<MF>::checkPoint (const Vector<MultiFab*>& a_sol,
                    << "bottom_verbose = " << bottom_verbose << "\n"
                    << "bottom_maxiter = " << bottom_maxiter << "\n"
                    << "bottom_reltol = " << bottom_reltol << "\n"
-                   << "always_use_bnorm = " << always_use_bnorm << "\n"
+                   << "norm_type = " << norm_name << "\n"
                    << "namrlevs = " << namrlevs << "\n"
                    << "finest_amr_lev = " << finest_amr_lev << "\n"
                    << "linop_prepared = " << linop_prepared << "\n"

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -150,7 +150,7 @@ public:
     [[nodiscard]] RT getBottomToleranceAbs () const noexcept{ return bottom_abstol; }
 
     void setAlwaysUseBNorm (int flag) noexcept;
-    void setAlwaysUseResNorm (int flag) noexcept;
+    void setConvergenceNormType (NormType norm) noexcept { norm_type = norm; }
 
     void setFinalFillBC (int flag) noexcept { final_fill_bc = flag; }
 
@@ -368,17 +368,6 @@ MLMGT<MF>::setAlwaysUseBNorm (int flag) noexcept
 {
     if (flag) {
         norm_type = NormType::BNorm;
-    } else {
-        norm_type = NormType::Greater;
-    }
-}
-
-template <typename MF>
-void
-MLMGT<MF>::setAlwaysUseResNorm (int flag) noexcept
-{
-    if (flag) {
-        norm_type = NormType::ResNorm;
     } else {
         norm_type = NormType::Greater;
     }
@@ -2072,7 +2061,7 @@ MLMGT<MF>::checkPoint (const Vector<MultiFab*>& a_sol,
                    << "bottom_verbose = " << bottom_verbose << "\n"
                    << "bottom_maxiter = " << bottom_maxiter << "\n"
                    << "bottom_reltol = " << bottom_reltol << "\n"
-                   << "norm_type = " << norm_name << "\n"
+                   << "convergence_norm = " << norm_name << "\n"
                    << "namrlevs = " << namrlevs << "\n"
                    << "finest_amr_lev = " << finest_amr_lev << "\n"
                    << "linop_prepared = " << linop_prepared << "\n"


### PR DESCRIPTION
…g target convergence criteria in MLMG. The default behaviour is using Greater of the two Norms.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
