### PR TITLE
Incorrect kernel used in amrex::sum_fine_to_coarse()

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -413,7 +413,7 @@ namespace amrex
             ParallelFor(crse_S_fine, nGrow, ncomp,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
-                amrex_avgdown(i,j,k,n,crsema[box_no],finema[box_no],0,scomp,ratio);
+                amrex_sum_fine_to_crse(i,j,k,n,crsema[box_no],finema[box_no],0,scomp,ratio);
             });
             if (!Gpu::inNoSyncRegion()) {
                 Gpu::streamSynchronize();
@@ -433,7 +433,7 @@ namespace amrex
 
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
                 {
-                    amrex_avgdown(i,j,k,n,crsearr,finearr,0,scomp,ratio);
+                    amrex_sum_fine_to_crse(i,j,k,n,crsearr,finearr,0,scomp,ratio);
                 });
             }
         }

--- a/Src/Base/AMReX_MultiFabUtil_1D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_1D_C.H
@@ -233,6 +233,21 @@ void amrex_avgdown (int i, int, int, int n, Array4<T> const& crse,
 
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void amrex_sum_fine_to_crse (int i, int, int, int n, Array4<T> const& crse,
+                    Array4<T const> const& fine,
+                    int ccomp, int fcomp, IntVect const& ratio) noexcept
+{
+    const int facx = ratio[0];
+    const int ii = i*facx;
+    T c = 0;
+    for (int iref = 0; iref < facx; ++iref) {
+        c += fine(ii+iref,0,0,n+fcomp);
+    }
+    crse(i,0,0,n+ccomp) = c;
+}
+
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void amrex_avgdown_with_vol (int i, int, int, int n, Array4<T> const& crse,
                              Array4<T const> const& fine,
                              Array4<T const> const& fv,

--- a/Src/Base/AMReX_MultiFabUtil_2D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_2D_C.H
@@ -298,6 +298,24 @@ void amrex_avgdown (int i, int j, int, int n, Array4<T> const& crse,
 
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void amrex_sum_fine_to_crse (int i, int j, int, int n, Array4<T> const& crse,
+                    Array4<T const> const& fine,
+                    int ccomp, int fcomp, IntVect const& ratio) noexcept
+{
+    const int facx = ratio[0];
+    const int facy = ratio[1];
+    const int ii = i*facx;
+    const int jj = j*facy;
+    T c = 0;
+    for (int jref = 0; jref < facy; ++jref) {
+    for (int iref = 0; iref < facx; ++iref) {
+        c += fine(ii+iref,jj+jref,0,n+fcomp);
+    }}
+    crse(i,j,0,n+ccomp) = c;
+}
+
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void amrex_avgdown_nodes (Box const& bx, Array4<T> const& crse,
                           Array4<T const> const& fine,
                           int ccomp, int fcomp, int ncomp,

--- a/Src/Base/AMReX_MultiFabUtil_3D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_3D_C.H
@@ -394,6 +394,27 @@ void amrex_avgdown (int i, int j, int k, int n, Array4<T> const& crse,
     crse(i,j,k,n+ccomp) = volfrac * c;
 }
 
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void amrex_sum_fine_to_crse (int i, int j, int k, int n, Array4<T> const& crse,
+                    Array4<T const> const& fine,
+                    int ccomp, int fcomp, IntVect const& ratio) noexcept
+{
+    const int facx = ratio[0];
+    const int facy = ratio[1];
+    const int facz = ratio[2];
+    const int ii = i*facx;
+    const int jj = j*facy;
+    const int kk = k*facz;
+    T c = 0;
+    for (int kref = 0; kref < facz; ++kref) {
+    for (int jref = 0; jref < facy; ++jref) {
+    for (int iref = 0; iref < facx; ++iref) {
+        c += fine(ii+iref,jj+jref,kk+kref,n+fcomp);
+    }}}
+    crse(i,j,k,n+ccomp) = c;
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void amrex_avgdown_with_vol (int i, int j, int k, int n, Array4<Real> const& crse,
                              Array4<Real const> const& fine,


### PR DESCRIPTION


## Summary
The previous implementation resulted `amrex::average_down()` and `amrex::sum_fine_to_coarse()` to yield the same result. 

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
