### PR TITLE
Adding a new overload for MultiFab::norm2 (int comp, int numcomp)

### DIFF
--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -225,6 +225,11 @@ public:
     */
     [[nodiscard]] Real norm2 (int comp = 0) const;
     /**
+    * \brief Returns the L2 norm of \p numcomp components starting from \p comp component over the MultiFab.
+    * No ghost cells are used.
+    */
+    [[nodiscard]] Real norm2 (int comp, int numcomp) const;
+    /**
     * \brief Returns the L2 norm of component \p comp over the MultiFab.
     * No ghost cells are used. This version has no double counting for nodal data.
     */

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1072,6 +1072,16 @@ MultiFab::norm2 (int comp) const
 }
 
 Real
+MultiFab::norm2 (int comp, int numcomp) const
+{
+    BL_ASSERT(ixType().cellCentered());
+
+    Real nm2 = MultiFab::Dot(*this, comp, numcomp, 0);
+    nm2 = std::sqrt(nm2);
+    return nm2;
+}
+
+Real
 MultiFab::norm2 (int comp, const Periodicity& period) const
 {
     BL_PROFILE("MultiFab::norm2(period)");


### PR DESCRIPTION
## Summary
Adding an optional argument numcomp=1 to MultiFab::norm2 (int comp=0, int numcomp=1) enables getting norm2 over multiple components of a MultiFab.