### PR TITLE
Parallel Copy with Offset

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -980,6 +980,18 @@ public:
                               const FabArrayBase::CPC* a_cpc = nullptr,
                               bool                 to_ghost_cells_only = false);
 
+    void ParallelCopy_nowait (const FabArray<FAB>& src,
+                              int                  scomp,
+                              int                  dcomp,
+                              int                  ncomp,
+                              const IntVect&       snghost,
+                              const IntVect&       dnghost,
+                              const IntVect&       offset,
+                              const Periodicity&   period = Periodicity::NonPeriodic(),
+                              CpOp                 op = FabArrayBase::COPY,
+                              const FabArrayBase::CPC* a_cpc = nullptr,
+                              bool                 to_ghost_cells_only = false);
+
     void ParallelCopy_finish ();
 
     void ParallelCopyToGhost (const FabArray<FAB>& src,
@@ -999,6 +1011,38 @@ public:
                                      const Periodicity&   period = Periodicity::NonPeriodic());
 
     void ParallelCopyToGhost_finish();
+
+    /**
+     * \brief This function copies data from src to this FabArray.
+     *
+     * \param src       source FabArray
+     * \param src_comp  starting component of source involved in this function
+     * \param dest_comp starting component of this FabArray involved in this function
+     * \param num_comp  number of components involved in this function
+     * \param snghost   number of source ghost cells involved in this function
+     * \param dnghost   number of destination ghost cells involved in this function
+     * \param offset    index shift. dest(iv,dest_comp+n) = src(iv-offset,src_comp+n)
+     * \param period    periodicity of the data
+     */
+    void ParallelCopy (const FabArray<FAB>& src, int src_comp, int dest_comp, int num_comp,
+                       const IntVect& snghost, const IntVect& dnghost,
+                       const IntVect& offset, const Periodicity& period);
+
+    /**
+     * \brief This function adds data from src to this FabArray.
+     *
+     * \param src       source FabArray
+     * \param src_comp  starting component of source involved in this function
+     * \param dest_comp starting component of this FabArray involved in this function
+     * \param num_comp  number of components involved in this function
+     * \param snghost   number of source ghost cells involved in this function
+     * \param dnghost   number of destination ghost cells involved in this function
+     * \param offset    index shift. dest(iv,dest_comp+n) = src(iv-offset,src_comp+n)
+     * \param period    periodicity of the data
+     */
+    void ParallelAdd (const FabArray<FAB>& src, int src_comp, int dest_comp, int num_comp,
+                      const IntVect& snghost, const IntVect& dnghost,
+                      const IntVect& offset, const Periodicity& period);
 
     [[deprecated("Use FabArray::ParallelCopy() instead.")]]
     void copy (const FabArray<FAB>& src,

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -535,7 +535,8 @@ public:
     {
         CPC (const FabArrayBase& dstfa, const IntVect& dstng,
              const FabArrayBase& srcfa, const IntVect& srcng,
-             const Periodicity& period, bool to_ghost_cells_only = false);
+             const Periodicity& period, bool to_ghost_cells_only = false,
+             const IntVect& offset = IntVect(0));
         CPC (const BoxArray& dstba, const DistributionMapping& dstdm,
              const Vector<int>& dstidx, const IntVect& dstng,
              const BoxArray& srcba, const DistributionMapping& srcdm,
@@ -551,6 +552,7 @@ public:
         BDKey       m_dstbdk;
         IntVect     m_srcng;
         IntVect     m_dstng;
+        IntVect     m_offset;
         Periodicity m_period;
         bool        m_tgco;
         BoxArray    m_srcba;
@@ -574,7 +576,8 @@ public:
     static CacheStats m_CPC_stats;
     //
     const CPC& getCPC (const IntVect& dstng, const FabArrayBase& src, const IntVect& srcng,
-                       const Periodicity& period, bool to_ghost_cells_only = false) const;
+                       const Periodicity& period, bool to_ghost_cells_only = false,
+                       const IntVect& offset = IntVect(0)) const;
 
     //
     //! Rotate Boundary by 90

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -291,12 +291,14 @@ FabArrayBase::TileArray::bytes () const
 
 FabArrayBase::CPC::CPC (const FabArrayBase& dstfa, const IntVect& dstng,
                         const FabArrayBase& srcfa, const IntVect& srcng,
-                        const Periodicity& period, bool to_ghost_cells_only)
+                        const Periodicity& period, bool to_ghost_cells_only,
+                        const IntVect& offset)
     : m_id(comm_meta_data_id++),
       m_srcbdk(srcfa.getBDKey()),
       m_dstbdk(dstfa.getBDKey()),
       m_srcng(srcng),
       m_dstng(dstng),
+      m_offset(offset),
       m_period(period),
       m_tgco(to_ghost_cells_only),
       m_srcba(srcfa.boxArray()),
@@ -347,7 +349,8 @@ FabArrayBase::CPC::define (const BoxArray& ba_dst, const DistributionMapping& dm
 
         std::vector< std::pair<int,Box> > isects;
 
-        const std::vector<IntVect>& pshifts = m_period.shiftIntVect(ng_dst);
+        std::vector<IntVect> pshifts = m_period.shiftIntVect(ng_dst);
+        for (auto& pit : pshifts) { pit += m_offset; }
 
         auto& send_tags = *m_SndTags;
 
@@ -408,12 +411,12 @@ FabArrayBase::CPC::define (const BoxArray& ba_dst, const DistributionMapping& dm
 
             for (auto const& pit : pshifts)
             {
-                ba_src.intersections(bx_dst+pit, isects, false, ng_src);
+                ba_src.intersections(bx_dst-pit, isects, false, ng_src);
 
                 for (auto const& is : isects)
                 {
                     const int k_src     = is.first;
-                    const Box& bx       = is.second - pit;
+                    const Box& bx       = is.second + pit;
                     const int src_owner = dm_src[k_src];
 
                     BoxList const bl_dst = m_tgco ? boxDiff(bx,bx_dst_valid) : BoxList(bx);
@@ -421,13 +424,13 @@ FabArrayBase::CPC::define (const BoxArray& ba_dst, const DistributionMapping& dm
                         if (ParallelDescriptor::sameTeam(src_owner, MyProc)) { // local copy
                             const BoxList tilelist(b, FabArrayBase::comm_tile_size);
                             for (auto const& btile : tilelist) {
-                                m_LocTags->emplace_back(btile, btile+pit, k_dst, k_src);
+                                m_LocTags->emplace_back(btile, btile-pit, k_dst, k_src);
                             }
                             if (check_local) {
                                 bl_local.push_back(b);
                             }
                         } else if (MyProc == dm_dst[k_dst]) {
-                            recv_tags[src_owner].emplace_back(b, b+pit, k_dst, k_src);
+                            recv_tags[src_owner].emplace_back(b, b-pit, k_dst, k_src);
                             if (check_remote) {
                                 bl_remote.push_back(b);
                             }
@@ -574,7 +577,8 @@ FabArrayBase::flushCPCache ()
 
 const FabArrayBase::CPC&
 FabArrayBase::getCPC (const IntVect& dstng, const FabArrayBase& src, const IntVect& srcng,
-                      const Periodicity& period, bool to_ghost_cells_only) const
+                      const Periodicity& period, bool to_ghost_cells_only,
+                      const IntVect& offset) const
 {
     BL_PROFILE("FabArrayBase::getCPC()");
 
@@ -591,6 +595,7 @@ FabArrayBase::getCPC (const IntVect& dstng, const FabArrayBase& src, const IntVe
     {
         if (it->second->m_srcng  == srcng &&
             it->second->m_dstng  == dstng &&
+            it->second->m_offset == offset &&
             it->second->m_srcbdk == srckey &&
             it->second->m_dstbdk == dstkey &&
             it->second->m_period == period &&
@@ -605,7 +610,7 @@ FabArrayBase::getCPC (const IntVect& dstng, const FabArrayBase& src, const IntVe
     }
 
     // Have to build a new one
-    CPC* new_cpc = new CPC(*this, dstng, src, srcng, period, to_ghost_cells_only);
+    CPC* new_cpc = new CPC(*this, dstng, src, srcng, period, to_ghost_cells_only, offset);
 
 #ifdef AMREX_MEM_PROFILING
     m_CPC_stats.bytes += new_cpc->bytes();

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -273,6 +273,31 @@ FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src,
 
 template <class FAB>
 void
+FabArray<FAB>::ParallelCopy (const FabArray<FAB>& src, int src_comp, int dest_comp,
+                             int num_comp, const IntVect& snghost, const IntVect& dnghost,
+                             const IntVect& offset, const Periodicity& period)
+{
+    BL_PROFILE("FabArray::ParallelCopy()");
+
+    ParallelCopy_nowait(src,src_comp,dest_comp,num_comp,snghost,dnghost,offset,period);
+    ParallelCopy_finish();
+}
+
+template <class FAB>
+void
+FabArray<FAB>::ParallelAdd (const FabArray<FAB>& src, int src_comp, int dest_comp,
+                             int num_comp, const IntVect& snghost, const IntVect& dnghost,
+                             const IntVect& offset, const Periodicity& period)
+{
+    BL_PROFILE("FabArray::ParallelAdd()");
+
+    ParallelCopy_nowait(src,src_comp,dest_comp,num_comp,snghost,dnghost,offset,period,
+                        FabArray::ADD);
+    ParallelCopy_finish();
+}
+
+template <class FAB>
+void
 FabArray<FAB>::ParallelCopyToGhost (const FabArray<FAB>& src,
                                     int                  scomp,
                                     int                  dcomp,
@@ -323,6 +348,24 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
                                     const FabArrayBase::CPC * a_cpc,
                                     bool                 to_ghost_cells_only)
 {
+    ParallelCopy_nowait(src,scomp,dcomp,ncomp,snghost,dnghost,IntVect(0),period,op,a_cpc,
+                        to_ghost_cells_only);
+}
+
+template <class FAB>
+void
+FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
+                                    int                  scomp,
+                                    int                  dcomp,
+                                    int                  ncomp,
+                                    const IntVect&       snghost,
+                                    const IntVect&       dnghost,
+                                    const IntVect&       offset,
+                                    const Periodicity&   period,
+                                    CpOp                 op,
+                                    const FabArrayBase::CPC * a_cpc,
+                                    bool                 to_ghost_cells_only)
+{
     BL_PROFILE_SYNC_START_TIMED("SyncBeforeComms: PC");
     BL_PROFILE("FabArray::ParallelCopy_nowait()");
 
@@ -341,7 +384,7 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
 
     if ((ParallelDescriptor::NProcs() == 1) &&
         (this->size() == 1) &&  (src.size() == 1) &&
-        !period.isAnyPeriodic() && !to_ghost_cells_only)
+        !period.isAnyPeriodic() && !to_ghost_cells_only && (offset == 0))
     {
         if (this != &src) { // avoid self copy or plus
             auto const& da = this->array(0, dcomp);
@@ -409,7 +452,7 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
         (boxarray == src.boxarray && distributionMap == src.distributionMap) &&
         snghost == IntVect::TheZeroVector() &&
         dnghost == IntVect::TheZeroVector() &&
-        !period.isAnyPeriodic() && !to_ghost_cells_only)
+        !period.isAnyPeriodic() && !to_ghost_cells_only && (offset == 0))
     {
         //
         // Short-circuit full intersection code if we're doing copy()s or if
@@ -426,7 +469,8 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
         return;
     }
 
-    const CPC& thecpc = (a_cpc) ? *a_cpc : getCPC(dnghost, src, snghost, period, to_ghost_cells_only);
+    const CPC& thecpc = (a_cpc) ? *a_cpc : getCPC(dnghost, src, snghost, period,
+                                                  to_ghost_cells_only,offset);
 
     if (ParallelContext::NProcsSub() == 1)
     {


### PR DESCRIPTION
Add new versions of ParallelCopy and ParallelAdd that effectively shift the source multifab first and then perform copy/add.
