### PR TITLE
hypre with hip GNUmake improvements

### DIFF
--- a/Tools/GNUMake/packages/Make.hypre
+++ b/Tools/GNUMake/packages/Make.hypre
@@ -15,7 +15,7 @@ ifdef AMREX_HYPRE_HOME
   HYPRE_ABSPATH = $(abspath $(AMREX_HYPRE_HOME))
   SYSTEM_INCLUDE_LOCATIONS += $(HYPRE_ABSPATH)/include
   LIBRARY_LOCATIONS += $(HYPRE_ABSPATH)/lib $(HYPRE_ABSPATH)/lib64
-  LIBRARIES += -Wl,-rpath,$(HYPRE_ABSPATH)/lib -lHYPRE
+  LIBRARIES += -Wl,-rpath,$(HYPRE_ABSPATH)/lib -Wl,-rpath,$(HYPRE_ABSPATH)/lib64 -lHYPRE
 endif
 
 ifeq ($(USE_CUDA),TRUE)
@@ -25,4 +25,3 @@ endif
 ifeq ($(USE_HIP),TRUE)
   LIBRARIES += -lrocblas -lrocsolver
 endif
-

--- a/Tools/GNUMake/packages/Make.hypre
+++ b/Tools/GNUMake/packages/Make.hypre
@@ -14,10 +14,15 @@ endif
 ifdef AMREX_HYPRE_HOME
   HYPRE_ABSPATH = $(abspath $(AMREX_HYPRE_HOME))
   SYSTEM_INCLUDE_LOCATIONS += $(HYPRE_ABSPATH)/include
-  LIBRARY_LOCATIONS += $(HYPRE_ABSPATH)/lib
+  LIBRARY_LOCATIONS += $(HYPRE_ABSPATH)/lib $(HYPRE_ABSPATH)/lib64
   LIBRARIES += -Wl,-rpath,$(HYPRE_ABSPATH)/lib -lHYPRE
 endif
 
 ifeq ($(USE_CUDA),TRUE)
   LIBRARIES += -lcusparse -lcurand -lcublas
 endif
+
+ifeq ($(USE_HIP),TRUE)
+  LIBRARIES += -lrocblas -lrocsolver
+endif
+


### PR DESCRIPTION
## Summary

When compiling with HIP and HYPRE, use the `rocblas` and `rocsolver` libraries (similar to additional libraries for CUDA + HYPRE) so these don't have to be turned off when building HYPRE. Also, check in `lib64` for the HYPRE library, which is where it gets put when building HYPRE with cmake.

These modifications helped with building PeleLMeX with HYPRE support on Frontier.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
