### PR TITLE
Fix GPU communication for non-arithmetic types

### DIFF
--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -107,13 +107,13 @@ fab_to_fab (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp, int dcom
             int* m = &(tag.mask(i,j,k));
             bool my_turn = false;
             do {
-                my_turn = (atomicCAS(m, 0, 1) == 0);
+                my_turn = (Gpu::Atomic::CAS(m, 0, 1) == 0);
                 if (my_turn) {
                     for (int n = 0; n < ncomp; ++n) {
                         f(&(tag.dfab(i,j,k,n+dcomp)),
                           tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
                     }
-                    atomicExch(m, 0);
+                    Gpu::Atomic::Exch(m, 0);
                 }
             } while (!my_turn);
         });

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -92,10 +92,6 @@ template <class TagType, class F>
 void
 fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, F&&f)
 {
-#if defined(AMREX_USE_SYCL) || defined(AMREX_USE_HIP)
-    amrex::Abort("xxxxx TODO: This function hangs with SYCL and HIP");
-#endif
-
     amrex::ParallelFor(tags,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
     {
@@ -119,6 +115,27 @@ fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, 
                 __threadfence(); // It appears that we need this fence too if a GPU is shared.
 #endif
                 Gpu::Atomic::Exch(m, 0);
+            }
+            else {
+#if defined(AMREX_USE_CUDA)
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)
+                for (unsigned int i = 0; i < 2; ++i) {
+                    __asm__ volatile(""); // prevent optimization
+                }
+#else
+                __nanosleep(ns);
+#endif
+
+#elif defined(AMREX_USE_HIP)
+
+                __builtin_amdgcn_s_sleep(1);
+
+#elif defined(AMREX_USE_SYCL)
+
+                for (volite unsigned int i = 0; i < 2; ++i) {}
+
+#endif
             }
         } while (!my_turn);
     });

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -124,7 +124,7 @@ fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, 
 #if defined(AMREX_USE_CUDA)
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)
-                for (unsigned int i = 0; i < 2; ++i) {
+                for (unsigned int c = 0; c < 2; ++c) {
                     __asm__ volatile(""); // prevent optimization
                 }
 #else
@@ -137,7 +137,7 @@ fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, 
 
 #elif defined(AMREX_USE_SYCL)
 
-                for (unsigned int i = 0; i < 8; ++i) {
+                for (unsigned int c = 0; c < 8; ++c) {
                     __asm__ volatile(""); // prevent optimization
                 }
 

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -71,6 +71,45 @@ fab_to_fab (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp, int dcom
     });
 }
 
+template <class TagType, class F>
+void
+fab_to_fab_store (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, F&&f)
+{
+    amrex::ParallelFor(tags,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
+    {
+        int m = Gpu::Atomic::Add(&(tag.mask(i,j,k)), 1);
+        if (m == 0) {
+            for (int n = 0; n < ncomp; ++n) {
+                f(&(tag.dfab(i,j,k,n+dcomp)),
+                  tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
+            }
+        }
+    });
+}
+
+template <class TagType, class F>
+void
+fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, F&&f)
+{
+    amrex::ParallelFor(tags,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
+    {
+        int* m = &(tag.mask(i,j,k));
+        bool my_turn = false;
+        do {
+            my_turn = (Gpu::Atomic::CAS(m, 0, 1) == 0);
+            if (my_turn) {
+                for (int n = 0; n < ncomp; ++n) {
+                    f(&(tag.dfab(i,j,k,n+dcomp)),
+                      tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
+                }
+                Gpu::Atomic::Exch(m, 0);
+            }
+        } while (!my_turn);
+    });
+}
+
 template <class T0, class T1, class F>
 void
 fab_to_fab (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp, int dcomp,
@@ -87,36 +126,11 @@ fab_to_fab (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp, int dcom
 
     if constexpr (std::is_same_v<F, CellStore<T0,T1>>)
     {
-        amrex::ParallelFor(tags,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
-        {
-            int m = Gpu::Atomic::Add(&(tag.mask(i,j,k)), 1);
-            if (m == 0) {
-                for (int n = 0; n < ncomp; ++n) {
-                    f(&(tag.dfab(i,j,k,n+dcomp)),
-                      tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
-                }
-            }
-        });
+        fab_to_fab_store(tags, scomp, dcomp, ncomp, std::forward<F>(f));
     }
     else
     {
-        amrex::ParallelFor(tags,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
-        {
-            int* m = &(tag.mask(i,j,k));
-            bool my_turn = false;
-            do {
-                my_turn = (Gpu::Atomic::CAS(m, 0, 1) == 0);
-                if (my_turn) {
-                    for (int n = 0; n < ncomp; ++n) {
-                        f(&(tag.dfab(i,j,k,n+dcomp)),
-                          tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
-                    }
-                    Gpu::Atomic::Exch(m, 0);
-                }
-            } while (!my_turn);
-        });
+        fab_to_fab_other(tags, scomp, dcomp, ncomp, std::forward<F>(f));
     }
     // Note that Tag ParalleFor has a stream sync call in the end.
 }

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -100,10 +100,20 @@ fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, 
         do {
             my_turn = (Gpu::Atomic::CAS(m, 0, 1) == 0);
             if (my_turn) {
+#if defined(AMREX_USE_SYCL)
+                sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::device);
+#else
+                __threadfence();
+#endif
                 for (int n = 0; n < ncomp; ++n) {
                     f(&(tag.dfab(i,j,k,n+dcomp)),
                       tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
                 }
+#if defined(AMREX_USE_SYCL)
+                sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::device);
+#else
+                __threadfence(); // It appears that we need this fence too if a GPU is shared.
+#endif
                 Gpu::Atomic::Exch(m, 0);
             }
         } while (!my_turn);

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -92,6 +92,10 @@ template <class TagType, class F>
 void
 fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, F&&f)
 {
+#if defined(AMREX_USE_SYCL)
+    amrex::Abort("xxxxx TODO: This function hangs with SYCL");
+#endif
+
     amrex::ParallelFor(tags,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
     {

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -92,6 +92,10 @@ template <class TagType, class F>
 void
 fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, F&&f)
 {
+#if defined(AMREX_USE_SYCL)
+    amrex::Abort("xxxxx TODO: This function hangs with SYCL");
+#endif
+
     amrex::ParallelFor(tags,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
     {
@@ -124,7 +128,7 @@ fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, 
                     __asm__ volatile(""); // prevent optimization
                 }
 #else
-                __nanosleep(ns);
+                __nanosleep(1);
 #endif
 
 #elif defined(AMREX_USE_HIP)
@@ -133,7 +137,9 @@ fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, 
 
 #elif defined(AMREX_USE_SYCL)
 
-                for (volite unsigned int i = 0; i < 2; ++i) {}
+                for (unsigned int i = 0; i < 8; ++i) {
+                    __asm__ volatile(""); // prevent optimization
+                }
 
 #endif
             }

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -92,17 +92,17 @@ template <class TagType, class F>
 void
 fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, F&&f)
 {
-#if defined(AMREX_USE_SYCL)
-    amrex::Abort("xxxxx TODO: This function hangs with SYCL");
-#endif
-
     amrex::ParallelFor(tags,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
     {
         int* m = &(tag.mask(i,j,k));
         bool my_turn = false;
         do {
+#if defined(AMREX_USE_SYCL)
+            my_turn = (Gpu::Atomic::Exch(m, 1) == 0);
+#else
             my_turn = (Gpu::Atomic::CAS(m, 0, 1) == 0);
+#endif
             if (my_turn) {
 #if defined(AMREX_USE_SYCL)
                 sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::device);
@@ -124,7 +124,7 @@ fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, 
 #if defined(AMREX_USE_CUDA)
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 700)
-                for (unsigned int c = 0; c < 2; ++c) {
+                for (int c = 0; c < 2; ++c) {
                     __asm__ volatile(""); // prevent optimization
                 }
 #else
@@ -137,7 +137,7 @@ fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, 
 
 #elif defined(AMREX_USE_SYCL)
 
-                for (unsigned int c = 0; c < 8; ++c) {
+                for (int c = 0; c < 2; ++c) {
                     __asm__ volatile(""); // prevent optimization
                 }
 

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -92,8 +92,8 @@ template <class TagType, class F>
 void
 fab_to_fab_other (Vector<TagType> const& tags, int scomp, int dcomp, int ncomp, F&&f)
 {
-#if defined(AMREX_USE_SYCL)
-    amrex::Abort("xxxxx TODO: This function hangs with SYCL");
+#if defined(AMREX_USE_SYCL) || defined(AMREX_USE_HIP)
+    amrex::Abort("xxxxx TODO: This function hangs with SYCL and HIP");
 #endif
 
     amrex::ParallelFor(tags,

--- a/Src/Base/AMReX_FBI.H
+++ b/Src/Base/AMReX_FBI.H
@@ -85,89 +85,40 @@ fab_to_fab (Vector<Array4CopyTag<T0, T1> > const& copy_tags, int scomp, int dcom
                                copy_tags[i].dbox, copy_tags[i].offset});
     }
 
-    amrex::Abort("xxxxx TODO This function still has a bug.  Even if we fix the bug, it should still be avoided because it is slow due to the lack of atomic operations for this type.");
-
-    TagVector<TagType> tv{tags};
-
-    detail::ParallelFor_doit(tv,
-    [=] AMREX_GPU_DEVICE (
-#ifdef AMREX_USE_SYCL
-        sycl::nd_item<1> const& item,
-#endif
-        int icell, int ncells, int i, int j, int k, TagType const& tag) noexcept
+    if constexpr (std::is_same_v<F, CellStore<T0,T1>>)
     {
-#ifdef AMREX_USE_SYCL
-        int g_tid = item.get_global_id(0);
-        int g_wid = g_tid / Gpu::Device::warp_size;
-
-        int* m = (icell < ncells) ? tag.mask.ptr(i,j,k) : nullptr;
-        int mypriority = g_wid+1;
-        int to_try  = 1;
-        while (true) {
-            int msk = (m && to_try) ? Gpu::Atomic::CAS(m, 0, mypriority) : 0;
-            if (sycl::all_of_group(item.get_sub_group(), msk == 0)) {  // 0 means lock acquired
-                break; // all threads have acquired.
-            } else {
-                if (sycl::any_of_group(item.get_sub_group(), msk > mypriority)) {
-                    if (m) { *m = 0; } // yield
-                    sycl::atomic_fence(sycl::memory_order::acq_rel, sycl::memory_scope::device);
-                    to_try = 1;
-                } else {
-                    to_try = (msk > 0); // hold on to my lock
+        amrex::ParallelFor(tags,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
+        {
+            int m = Gpu::Atomic::Add(&(tag.mask(i,j,k)), 1);
+            if (m == 0) {
+                for (int n = 0; n < ncomp; ++n) {
+                    f(&(tag.dfab(i,j,k,n+dcomp)),
+                      tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
                 }
             }
-        };
-
-        if (icell < ncells) {
-            for (int n = 0; n < ncomp; ++n) {
-                f(&(tag.dfab(i,j,k,n+dcomp)),
-                  tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
-            }
-        }
-
-        if (m) *m = 0;
-
-#else
-
-        int g_tid = blockDim.x*blockIdx.x + threadIdx.x;
-        int g_wid = g_tid / Gpu::Device::warp_size;
-
-        int* m = (icell < ncells) ? tag.mask.ptr(i,j,k) : nullptr;
-        int mypriority = g_wid+1;
-        int to_try  = 1;
-        while (true) {
-            int msk = (m && to_try) ? atomicCAS(m, 0, mypriority) : 0;
-#ifdef AMREX_USE_CUDA
-            if (__all_sync(0xffffffff, msk == 0)) {  // 0 means lock acquired
-#elif defined(AMREX_USE_HIP)
-            if (__all(msk == 0)) {
-#endif
-                break; // all threads have acquired.
-            } else {
-#ifdef AMREX_USE_CUDA
-                if (__any_sync(0xffffffff, msk > mypriority)) {
-#elif defined(AMREX_USE_HIP)
-                if (__any(msk > mypriority)) {
-#endif
-                    if (m) *m = 0; // yield
-                    __threadfence();
-                    to_try = 1;
-                } else {
-                    to_try = (msk > 0); // hold on to my lock
+        });
+    }
+    else
+    {
+        amrex::ParallelFor(tags,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, TagType const& tag) noexcept
+        {
+            int* m = &(tag.mask(i,j,k));
+            bool my_turn = false;
+            do {
+                my_turn = (atomicCAS(m, 0, 1) == 0);
+                if (my_turn) {
+                    for (int n = 0; n < ncomp; ++n) {
+                        f(&(tag.dfab(i,j,k,n+dcomp)),
+                          tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
+                    }
+                    atomicExch(m, 0);
                 }
-            }
-        };
-
-        if (icell < ncells) {
-            for (int n = 0; n < ncomp; ++n) {
-                f(&(tag.dfab(i,j,k,n+dcomp)),
-                  tag.sfab(i+tag.offset.x,j+tag.offset.y,k+tag.offset.z,n+scomp));
-            }
-        }
-
-        if (m) *m = 0;
-#endif
-    });
+            } while (!my_turn);
+        });
+    }
+    // Note that Tag ParalleFor has a stream sync call in the end.
 }
 
 template <typename T0, typename T1,
@@ -321,29 +272,69 @@ FabArray<FAB>::FB_local_copy_gpu (const FB& TheFB, int scomp, int ncomp)
     if (N_locs == 0) { return; }
     bool is_thread_safe = TheFB.m_threadsafe_loc;
 
-    if (!amrex::IsStoreAtomic<value_type>::value && !is_thread_safe) {
-        amrex::Abort("xxxxx TODO This function still has a bug for non-atomic types. Even if we fix the bug, it should still be avoided because it is slow due to the lack of atomic operations for this type.");
-    }
-
     using TagType = Array4CopyTag<value_type>;
 
-    auto* tv = FB_get_local_copy_tag_vector(TheFB);
-
-    detail::ParallelFor_doit(*tv,
-        [=] AMREX_GPU_DEVICE (
-#ifdef AMREX_USE_SYCL
-            sycl::nd_item<1> const& /*item*/,
-#endif
-            int icell, int ncells, int i, int j, int k, TagType const& tag) noexcept
+    if (is_thread_safe || amrex::IsStoreAtomic<value_type>::value)
     {
-        if (icell < ncells) {
-            for (int n = 0; n < ncomp; ++n) {
-                tag.dfab(i,j,k,n+scomp) = tag.sfab(i+tag.offset.x,
-                                                   j+tag.offset.y,
-                                                   k+tag.offset.z,n+scomp);
+        auto* tv = FB_get_local_copy_tag_vector(TheFB);
+
+        detail::ParallelFor_doit(*tv,
+            [=] AMREX_GPU_DEVICE (
+#ifdef AMREX_USE_SYCL
+                sycl::nd_item<1> const& /*item*/,
+#endif
+                int icell, int ncells, int i, int j, int k, TagType const& tag) noexcept
+        {
+            if (icell < ncells) {
+                for (int n = 0; n < ncomp; ++n) {
+                    tag.dfab(i,j,k,n+scomp) = tag.sfab(i+tag.offset.x,
+                                                       j+tag.offset.y,
+                                                       k+tag.offset.z,n+scomp);
+                }
             }
+        });
+    }
+    else
+    {
+        Vector<TagType> loc_copy_tags;
+        loc_copy_tags.reserve(N_locs);
+
+        Vector<BaseFab<int>> maskfabs(this->local_size());
+        Vector<Array4Tag<int> > masks_unique;
+        masks_unique.reserve(this->local_size());
+        Vector<Array4Tag<int> > masks;
+        masks.reserve(N_locs);
+
+        for (int i = 0; i < N_locs; ++i)
+        {
+            const CopyComTag& tag = LocTags[i];
+
+            BL_ASSERT(distributionMap[tag.dstIndex] == ParallelDescriptor::MyProc());
+            BL_ASSERT(distributionMap[tag.srcIndex] == ParallelDescriptor::MyProc());
+
+            int li = this->localindex(tag.dstIndex);
+            loc_copy_tags.push_back
+                ({this->atLocalIdx(li).array(),
+                  this->fabPtr(tag.srcIndex)->const_array(),
+                  tag.dbox,
+                  (tag.sbox.smallEnd()-tag.dbox.smallEnd()).dim3()});
+
+            if (!maskfabs[li].isAllocated()) {
+                maskfabs[li].resize(this->atLocalIdx(li).box());
+                masks_unique.emplace_back(Array4Tag<int>{maskfabs[li].array()});
+            }
+            masks.emplace_back(Array4Tag<int>{maskfabs[li].array()});
         }
-    });
+
+        amrex::ParallelFor(masks_unique,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, Array4Tag<int> const& msk) noexcept
+            {
+                msk.dfab(i,j,k) = 0;
+            });
+
+        detail::fab_to_fab_atomic_cpy<value_type, value_type>(
+            loc_copy_tags, scomp, scomp, ncomp, masks);
+    }
 }
 
 template <class FAB>
@@ -917,43 +908,27 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
     const int N_rcvs = recv_cctc.size();
     if (N_rcvs == 0) { return; }
 
+    bool use_mask = false;
     if (!is_thread_safe)
     {
         if ((op == FabArrayBase::COPY && !amrex::IsStoreAtomic<value_type>::value) ||
             (op == FabArrayBase::ADD  && !amrex::HasAtomicAdd <value_type>::value))
         {
-            amrex::Abort("xxxxx TODO This function still has a bug for non-atomic types. Even if we fix the bug, it should still be avoided because it is slow due to the lack of atomic operations for this type.");
+            use_mask = true;
         }
     }
 
-    using TagType = CommRecvBufTag<value_type>;
-    auto* tv = dst.template get_recv_copy_tag_vector<BUF>
-        (recv_data, recv_size, recv_cctc, ncomp, id);
-    if (tv == nullptr) { return; }
-
-    char* pbuffer = recv_data[0];
-
-    if (op == FabArrayBase::COPY)
+    if (!use_mask)
     {
-        detail::ParallelFor_doit(*tv,
-            [=] AMREX_GPU_DEVICE (
-#ifdef AMREX_USE_SYCL
-                sycl::nd_item<1> const& /*item*/,
-#endif
-                int icell, int ncells, int i, int j, int k, TagType const& tag) noexcept
+        using TagType = CommRecvBufTag<value_type>;
+        auto* tv = dst.template get_recv_copy_tag_vector<BUF>
+            (recv_data, recv_size, recv_cctc, ncomp, id);
+        if (tv == nullptr) { return; }
+
+        char* pbuffer = recv_data[0];
+
+        if (op == FabArrayBase::COPY)
         {
-            if (icell < ncells) {
-                Array4<BUF const> sfab{(BUF const*)(pbuffer+tag.poff),
-                    amrex::begin(tag.bx), amrex::end(tag.bx), ncomp};
-                for (int n = 0; n < ncomp; ++n) {
-                    tag.dfab(i,j,k,n+dcomp) = (value_type)sfab(i,j,k,n);
-                }
-            }
-        });
-    }
-    else
-    {
-        if (is_thread_safe) {
             detail::ParallelFor_doit(*tv,
                 [=] AMREX_GPU_DEVICE (
 #ifdef AMREX_USE_SYCL
@@ -965,12 +940,14 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                     Array4<BUF const> sfab{(BUF const*)(pbuffer+tag.poff),
                         amrex::begin(tag.bx), amrex::end(tag.bx), ncomp};
                     for (int n = 0; n < ncomp; ++n) {
-                        tag.dfab(i,j,k,n+dcomp) += (value_type)sfab(i,j,k,n);
+                        tag.dfab(i,j,k,n+dcomp) = (value_type)sfab(i,j,k,n);
                     }
                 }
             });
-        } else {
-            if constexpr (amrex::HasAtomicAdd<value_type>::value) {
+        }
+        else
+        {
+            if (is_thread_safe) {
                 detail::ParallelFor_doit(*tv,
                     [=] AMREX_GPU_DEVICE (
 #ifdef AMREX_USE_SYCL
@@ -982,18 +959,95 @@ FabArray<FAB>::unpack_recv_buffer_gpu (FabArray<FAB>& dst, int dcomp, int ncomp,
                         Array4<BUF const> sfab{(BUF const*)(pbuffer+tag.poff),
                             amrex::begin(tag.bx), amrex::end(tag.bx), ncomp};
                         for (int n = 0; n < ncomp; ++n) {
-                            Gpu::Atomic::AddNoRet(tag.dfab.ptr(i,j,k,n+dcomp),
-                                                  (value_type)sfab(i,j,k,n));
+                            tag.dfab(i,j,k,n+dcomp) += (value_type)sfab(i,j,k,n);
                         }
                     }
                 });
             } else {
-                amrex::Abort("unpack_recv_buffer_gpu: should NOT get here");
+                if constexpr (amrex::HasAtomicAdd<value_type>::value) {
+                    detail::ParallelFor_doit(*tv,
+                        [=] AMREX_GPU_DEVICE (
+#ifdef AMREX_USE_SYCL
+                            sycl::nd_item<1> const& /*item*/,
+#endif
+                            int icell, int ncells, int i, int j, int k, TagType const& tag) noexcept
+                    {
+                        if (icell < ncells) {
+                            Array4<BUF const> sfab{(BUF const*)(pbuffer+tag.poff),
+                                amrex::begin(tag.bx), amrex::end(tag.bx), ncomp};
+                            for (int n = 0; n < ncomp; ++n) {
+                                Gpu::Atomic::AddNoRet(tag.dfab.ptr(i,j,k,n+dcomp),
+                                                      (value_type)sfab(i,j,k,n));
+                            }
+                        }
+                    });
+                } else {
+                    amrex::Abort("unpack_recv_buffer_gpu: should NOT get here");
+                }
             }
         }
+        Gpu::streamSynchronize();
     }
+    else
+    {
+        char* pbuffer = recv_data[0];
 
-    Gpu::streamSynchronize();
+        using TagType = Array4CopyTag<value_type, BUF>;
+        Vector<TagType> recv_copy_tags;
+        recv_copy_tags.reserve(N_rcvs);
+
+        Vector<BaseFab<int> > maskfabs(dst.local_size());
+        Vector<Array4Tag<int> > masks_unique;
+        masks_unique.reserve(dst.local_size());
+        Vector<Array4Tag<int> > masks;
+
+        for (int k = 0; k < N_rcvs; ++k)
+        {
+            if (recv_size[k] > 0)
+            {
+                std::size_t offset = recv_data[k]-recv_data[0];
+                const char* dptr = pbuffer + offset;
+                auto const& cctc = *recv_cctc[k];
+                for (auto const& tag : cctc)
+                {
+                    const int li = dst.localindex(tag.dstIndex);
+                    recv_copy_tags.emplace_back(TagType{
+                            dst.atLocalIdx(li).array(),
+                            amrex::makeArray4((BUF const*)(dptr), tag.dbox, ncomp),
+                            tag.dbox,
+                            Dim3{0,0,0}
+                        });
+                    dptr += tag.dbox.numPts() * ncomp * sizeof(BUF);
+
+                    if (!maskfabs[li].isAllocated()) {
+                        maskfabs[li].resize(dst.atLocalIdx(li).box());
+                        masks_unique.emplace_back(Array4Tag<int>{maskfabs[li].array()});
+                    }
+                    masks.emplace_back(Array4Tag<int>{maskfabs[li].array()});
+                }
+                BL_ASSERT(dptr <= pbuffer + offset + recv_size[k]);
+            }
+        }
+
+        amrex::ParallelFor(masks_unique,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k, Array4Tag<int> const& msk) noexcept
+            {
+                msk.dfab(i,j,k) = 0;
+            });
+
+        if (op == FabArrayBase::COPY)
+        {
+            detail::fab_to_fab_atomic_cpy<value_type, BUF>(
+                recv_copy_tags, 0, dcomp, ncomp, masks);
+        }
+        else
+        {
+            detail::fab_to_fab_atomic_add<value_type, BUF>(
+                recv_copy_tags, 0, dcomp, ncomp, masks);
+        }
+
+        // There is Gpu::streamSynchronize in fab_to_fab.
+    }
 }
 
 #endif /* AMREX_USE_GPU */

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -2140,7 +2140,7 @@ OverlapMask (FabArray<FAB> const& fa, IntVect const& nghost, Periodicity const& 
     const DistributionMapping& dm = fa.DistributionMap();
 
     FabArray<BaseFab<int>> mask(ba, dm, 1, nghost);
-    mask.setVal(0);
+    mask.setVal(1);
 
     const std::vector<IntVect>& pshifts = period.shiftIntVect();
 
@@ -2165,6 +2165,7 @@ OverlapMask (FabArray<FAB> const& fa, IntVect const& nghost, Periodicity const& 
                 for (const auto& is : isects)
                 {
                     Box const& b = is.second-iv;
+                    if (iv == 0 && b == bx) { continue; }
 #ifdef AMREX_USE_GPU
                     if (run_on_gpu) {
                         tags.push_back({arr,b});

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -2123,6 +2123,75 @@ DistributionMap (Array<MF,N> const& mf)
     return mf[0].DistributionMap();
 }
 
+/*
+ * \brief Return a mask indicating how many duplicates are in each point
+ *
+ * \param fa     input FabArray
+ * \param nghost number of ghost cells included in counting
+ * \param period periodicity
+ */
+template <class FAB>
+FabArray<BaseFab<int>>
+OverlapMask (FabArray<FAB> const& fa, IntVect const& nghost, Periodicity const& period)
+{
+    BL_PROFILE("OverlapMask()");
+
+    const BoxArray& ba = fa.boxArray();
+    const DistributionMapping& dm = fa.DistributionMap();
+
+    FabArray<BaseFab<int>> mask(ba, dm, 1, nghost);
+    mask.setVal(0);
+
+    const std::vector<IntVect>& pshifts = period.shiftIntVect();
+
+    Vector<Array4BoxTag<int> > tags;
+
+    bool run_on_gpu = Gpu::inLaunchRegion();
+    amrex::ignore_unused(run_on_gpu, tags);
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (!run_on_gpu)
+#endif
+    {
+        std::vector< std::pair<int,Box> > isects;
+
+        for (MFIter mfi(mask); mfi.isValid(); ++mfi)
+        {
+            const Box& bx = mask[mfi].box();
+            auto const& arr = mask.array(mfi);
+
+            for (const auto& iv : pshifts)
+            {
+                ba.intersections(bx+iv, isects, false, nghost);
+                for (const auto& is : isects)
+                {
+                    Box const& b = is.second-iv;
+#ifdef AMREX_USE_GPU
+                    if (run_on_gpu) {
+                        tags.push_back({arr,b});
+                    } else
+#endif
+                    {
+                        amrex::LoopConcurrentOnCpu(b, [=] (int i, int j, int k) noexcept
+                        {
+                            arr(i,j,k) += 1;
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+#ifdef AMREX_USE_GPU
+    amrex::ParallelFor(tags, 1,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n, Array4BoxTag<int> const& tag) noexcept
+    {
+        Gpu::Atomic::AddNoRet(tag.dfab.ptr(i,j,k,n), 1);
+    });
+#endif
+
+    return mask;
+}
+
 }
 
 #endif

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -1529,8 +1529,8 @@ MultiFab::OverlapMask (const Periodicity& period) const
     amrex::ParallelFor(tags, 1,
     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n, Array4BoxTag<Real> const& tag) noexcept
     {
-        Real* p = tag.dfab.ptr(i,j,k,n);
-        Gpu::Atomic::AddNoRet(p, Real(1.0));
+        Real* ptr = tag.dfab.ptr(i,j,k,n);
+        Gpu::Atomic::AddNoRet(ptr, Real(1.0));
     });
 #endif
 

--- a/Src/Base/AMReX_PCI.H
+++ b/Src/Base/AMReX_PCI.H
@@ -97,6 +97,7 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
     loc_copy_tags.reserve(N_locs);
 
     Vector<BaseFab<int> > maskfabs;
+    Vector<Array4Tag<int> > masks_unique;
     Vector<Array4Tag<int> > masks;
     if (!is_thread_safe)
     {
@@ -104,6 +105,7 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
             (op == FabArrayBase::ADD  && !amrex::HasAtomicAdd <value_type>::value))
         {
             maskfabs.resize(this->local_size());
+            masks_unique.resize(N_locs);
             masks.reserve(N_locs);
         }
     }
@@ -122,6 +124,7 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
             if (maskfabs.size() > 0) {
                 if (!maskfabs[li].isAllocated()) {
                     maskfabs[li].resize(this->atLocalIdx(li).box());
+                    masks_unique.emplace_back(Array4Tag<int>{maskfabs[li].array()});
                 }
                 masks.emplace_back(Array4Tag<int>{maskfabs[li].array()});
             }
@@ -129,7 +132,7 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
     }
 
     if (maskfabs.size() > 0) {
-        amrex::ParallelFor(masks,
+        amrex::ParallelFor(masks_unique,
         [=] AMREX_GPU_DEVICE (int i, int j, int k, Array4Tag<int> const& msk) noexcept
         {
             msk.dfab(i,j,k) = 0;

--- a/Src/Base/AMReX_PCI.H
+++ b/Src/Base/AMReX_PCI.H
@@ -105,7 +105,7 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
             (op == FabArrayBase::ADD  && !amrex::HasAtomicAdd <value_type>::value))
         {
             maskfabs.resize(this->local_size());
-            masks_unique.reserve(N_locs);
+            masks_unique.reserve(this->local_size());
             masks.reserve(N_locs);
         }
     }

--- a/Src/Base/AMReX_PCI.H
+++ b/Src/Base/AMReX_PCI.H
@@ -105,7 +105,7 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
             (op == FabArrayBase::ADD  && !amrex::HasAtomicAdd <value_type>::value))
         {
             maskfabs.resize(this->local_size());
-            masks_unique.resize(N_locs);
+            masks_unique.reserve(N_locs);
             masks.reserve(N_locs);
         }
     }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -125,7 +125,7 @@ else()
    #
    # List of subdirectories to search for CMakeLists.
    #
-   set( AMREX_TESTS_SUBDIRS Amr AsyncOut CLZ CTOParFor DeviceGlobal Enum
+   set( AMREX_TESTS_SUBDIRS Amr AsyncOut CLZ CommType CTOParFor DeviceGlobal Enum
                             MultiBlock MultiPeriod ParmParse Parser Parser2 ParserUserFn Reinit
                             RoundoffDomain SmallMatrix)
 

--- a/Tests/CommType/CMakeLists.txt
+++ b/Tests/CommType/CMakeLists.txt
@@ -1,0 +1,9 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources     main.cpp)
+    set(_input_files)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/CommType/GNUmakefile
+++ b/Tests/CommType/GNUmakefile
@@ -1,0 +1,22 @@
+AMREX_HOME = ../../
+
+DEBUG	= FALSE
+DIM	= 3
+COMP    = gcc
+
+USE_MPI   = TRUE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+USE_HIP   = FALSE
+USE_SYCL  = FALSE
+
+BL_NO_FORT = TRUE
+
+TINY_PROFILE = FALSE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/CommType/Make.package
+++ b/Tests/CommType/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/CommType/main.cpp
+++ b/Tests/CommType/main.cpp
@@ -1,0 +1,168 @@
+#include <AMReX.H>
+#include <AMReX_Print.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_GpuComplex.H>
+
+using namespace amrex;
+
+int main(int argc, char* argv[])
+{
+    amrex::Initialize(argc,argv);
+
+    int ret_code = EXIT_SUCCESS;
+
+    {
+        int ncells = 128;
+        BoxArray ba(Box(IntVect(0), IntVect(ncells-1)));
+        ba.maxSize(32);
+        ba.convert(IntVect(1));
+        DistributionMapping dm(ba);
+
+        constexpr int ncomp = 2;
+        IntVect nghost(2);
+        Periodicity period{IntVect(ncells)};
+
+        auto value = [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) -> Real
+        {
+            if (i < 0) {
+                i += ncells;
+            } else if (i >= ncells) {
+                i -= ncells;
+            }
+            if (j < 0) {
+                j += ncells;
+            } else if (j >= ncells) {
+                j -= ncells;
+            }
+            if (k < 0) {
+                k += ncells;
+            } else if (k >= ncells) {
+                k -= ncells;
+            }
+            return n + i*ncomp + j*ncomp*ncells + k*ncomp*ncells*ncells;
+        };
+
+        // Test GpuArray
+        {
+            using T = GpuArray<Real,ncomp>;
+            FabArray<BaseFab<T>> fa(ba,dm,1,nghost);
+            FabArray<BaseFab<T>> fa2(ba,dm,1,nghost);
+            FabArray<BaseFab<T>> fa3(ba,dm,1,nghost);
+            auto const& ma = fa.arrays();
+            auto const& ma2 = fa2.arrays();
+            auto const& ma3 = fa3.arrays();
+
+            ParallelFor(fa, IntVect(0),
+                        [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
+            {
+                auto const& a = ma[b];
+                for (int n = 0; n < ncomp; ++n) {
+                    a(i,j,k)[n] = value(i,j,k,n);
+                }
+            });
+
+            fa.FillBoundary(period);
+
+            fa2.ParallelCopy(fa, 0, 0, 1, IntVect(0), nghost, period);
+
+            fa3.setVal(T{});
+            fa3.ParallelAdd(fa, 0, 0, 1, nghost, nghost, period);
+
+            auto mask = OverlapMask(fa3,nghost,period);
+            auto const& mma = mask.const_arrays();
+
+            auto err = ParReduce(TypeList<ReduceOpMax,ReduceOpMax,ReduceOpMax>{},
+                                 TypeList<Real,Real,Real>{},
+                                 fa, nghost,
+            [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
+                                 -> GpuTuple<Real,Real,Real>
+            {
+                Real r1 = 0, r2 = 0, r3 = 0;
+                auto const& a1 = ma[b];
+                auto const& a2 = ma2[b];
+                auto const& a3 = ma3[b];
+                auto const& m = mma[b];
+                for (int n = 0; n < ncomp; ++n) {
+                    auto v = value(i,j,k,n);
+                    r1 = std::max(r1, std::abs(a1(i,j,k)[n] - v));
+                    r2 = std::max(r2, std::abs(a2(i,j,k)[n] - v));
+                    r3 = std::max(r3, std::abs(a3(i,j,k)[n] - v*m(i,j,k)));
+                }
+                return {r1, r2, r3};
+            });
+
+            AMREX_ALWAYS_ASSERT(amrex::get<0>(err) == 0);
+            AMREX_ALWAYS_ASSERT(amrex::get<1>(err) == 0);
+            AMREX_ALWAYS_ASSERT(amrex::get<2>(err) == 0);
+
+            Real errmax = std::max({amrex::get<0>(err),
+                                    amrex::get<1>(err),
+                                    amrex::get<2>(err)});
+            ParallelDescriptor::ReduceRealSum(errmax);
+            if (errmax != 0) {
+                ret_code = EXIT_FAILURE;
+            }
+        }
+
+        // Test GpuComplex
+        {
+            using T = GpuComplex<Real>;
+            FabArray<BaseFab<T>> fa(ba,dm,1,nghost);
+            FabArray<BaseFab<T>> fa2(ba,dm,1,nghost);
+            FabArray<BaseFab<T>> fa3(ba,dm,1,nghost);
+            auto const& ma = fa.arrays();
+            auto const& ma2 = fa2.arrays();
+            auto const& ma3 = fa3.arrays();
+
+            ParallelFor(fa, IntVect(0),
+                        [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
+            {
+                auto const& a = ma[b];
+                a(i,j,k) = T{value(i,j,k,0),value(i,j,k,1)};
+            });
+
+            fa.FillBoundary(period);
+
+            fa2.ParallelCopy(fa, 0, 0, 1, IntVect(0), nghost, period);
+
+            fa3.setVal(T{});
+            fa3.ParallelAdd(fa, 0, 0, 1, nghost, nghost, period);
+
+            auto mask = OverlapMask(fa3,nghost,period);
+            auto const& mma = mask.const_arrays();
+
+            auto err = ParReduce(TypeList<ReduceOpMax,ReduceOpMax,ReduceOpMax>{},
+                                 TypeList<Real,Real,Real>{},
+                                 fa, nghost,
+            [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
+                                 -> GpuTuple<Real,Real,Real>
+            {
+                Real r1 = 0, r2 = 0, r3 = 0;
+                auto const& a1 = ma[b];
+                auto const& a2 = ma2[b];
+                auto const& a3 = ma3[b];
+                auto const& m = mma[b];
+                auto v = GpuComplex{value(i,j,k,0), value(i,j,k,1)};
+                r1 = std::max(r1, amrex::norm(a1(i,j,k) - v));
+                r2 = std::max(r2, amrex::norm(a2(i,j,k) - v));
+                r3 = std::max(r3, amrex::norm(a3(i,j,k) - v*Real(m(i,j,k))));
+                return {r1, r2, r3};
+            });
+
+            AMREX_ALWAYS_ASSERT(amrex::get<0>(err) == 0);
+            AMREX_ALWAYS_ASSERT(amrex::get<1>(err) == 0);
+            AMREX_ALWAYS_ASSERT(amrex::get<2>(err) == 0);
+
+            Real errmax = std::max({amrex::get<0>(err),
+                                    amrex::get<1>(err),
+                                    amrex::get<2>(err)});
+            ParallelDescriptor::ReduceRealSum(errmax);
+            if (errmax != 0) {
+                ret_code = EXIT_FAILURE;
+            }
+        }
+    }
+    amrex::Finalize();
+
+    return ret_code;
+}


### PR DESCRIPTION
Tested on Nvidia GTX 1060, GV100, V100, A100 and H100, AMD MI250X and MI300A, and Intel PVC.
