### PR TITLE
Add `AMReX_Order.H`

### DIFF
--- a/Src/Base/AMReX_Array.H
+++ b/Src/Base/AMReX_Array.H
@@ -10,7 +10,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Algorithm.H>
 #include <AMReX_Dim3.H>
-#include <AMReX_SmallMatrix.H>
+#include <AMReX_Order.H>
 
 #include <array>
 #include <memory>

--- a/Src/Base/AMReX_Order.H
+++ b/Src/Base/AMReX_Order.H
@@ -1,0 +1,10 @@
+#ifndef AMREX_ORDER_H_
+#define AMREX_ORDER_H_
+#include <AMReX_Config.H>
+
+namespace amrex
+{
+    enum struct Order { C, F, RowMajor=C, ColumnMajor=F };
+}
+#endif
+

--- a/Src/Base/AMReX_SmallMatrix.H
+++ b/Src/Base/AMReX_SmallMatrix.H
@@ -7,6 +7,7 @@
 #include <AMReX_Extension.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_ConstexprFor.H>
+#include <AMReX_Order.H>
 
 #include <algorithm>
 #include <initializer_list>
@@ -15,8 +16,6 @@
 #include <type_traits>
 
 namespace amrex {
-
-    enum struct Order { C, F, RowMajor=C, ColumnMajor=F };
 
     /**
      * \brief Matrix class with compile-time size

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -14,6 +14,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_BlockMutex.cpp
        AMReX_Enum.H
        AMReX_GpuComplex.H
+       AMReX_Order.H
        AMReX_SmallMatrix.H
        AMReX_ConstexprFor.H
        AMReX_Vector.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -4,6 +4,7 @@ AMREX_BASE=EXE
 C$(AMREX_BASE)_headers += AMReX_ccse-mpi.H AMReX_Algorithm.H AMReX_Any.H AMReX_Array.H
 C$(AMREX_BASE)_headers += AMReX_Enum.H
 C$(AMREX_BASE)_headers += AMReX_Vector.H AMReX_TableData.H AMReX_Tuple.H AMReX_Math.H
+C$(AMREX_BASE)_headers += AMReX_Order.H
 C$(AMREX_BASE)_headers += AMReX_SmallMatrix.H AMReX_ConstexprFor.H
 
 C$(AMREX_BASE)_headers += AMReX_TypeList.H


### PR DESCRIPTION
## Summary

Clean up includes: SmallMatrix does not need to be included in other base files like Array just because we use the order enum. Simplify include logic/chains.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
