### PR TITLE
AMReX SIMD Helpers

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -455,6 +455,8 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_MPI                    |  Build with MPI support                         | YES                     | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
+   | AMReX_SIMD                   |  Enable SIMD Primitives (using vir::stdx::simd) | NO                      | YES, NO               |
+   +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_OMP                    |  Build with OpenMP support                      | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_GPU_BACKEND            |  Build with on-node, accelerated GPU backend    | NONE                    | NONE, SYCL, HIP, CUDA |
@@ -682,6 +684,8 @@ A list of AMReX component names and related configure options are shown in the t
    | AMReX_PIC                    | PIC             |
    +------------------------------+-----------------+
    | AMReX_MPI                    | MPI             |
+   +------------------------------+-----------------+
+   | AMReX_SIMD                   | SIMD            |
    +------------------------------+-----------------+
    | AMReX_OMP                    | OMP             |
    +------------------------------+-----------------+

--- a/Src/Base/AMReX_GpuComplex.H
+++ b/Src/Base/AMReX_GpuComplex.H
@@ -53,8 +53,9 @@ struct alignas(2*sizeof(T)) GpuComplex
     /**
      * \brief Add a real number to this complex number.
      */
+    template <typename U>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    GpuComplex<T>& operator+= (const T& a_t) noexcept
+    GpuComplex<T>& operator+= (const U& a_t) noexcept
     {
         m_real += a_t;
         return *this;
@@ -63,8 +64,9 @@ struct alignas(2*sizeof(T)) GpuComplex
    /**
      * \brief Subtract a real number from this complex number.
      */
+    template <typename U>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    GpuComplex<T>& operator-= (const T& a_t) noexcept
+    GpuComplex<T>& operator-= (const U& a_t) noexcept
     {
         m_real -= a_t;
         return *this;
@@ -73,8 +75,9 @@ struct alignas(2*sizeof(T)) GpuComplex
     /**
      * \brief Multiply this complex number by a real.
      */
+    template <typename U>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    GpuComplex<T>& operator*= (const T& a_t) noexcept
+    GpuComplex<T>& operator*= (const U& a_t) noexcept
     {
         m_real *= a_t;
         m_imag *= a_t;
@@ -84,8 +87,9 @@ struct alignas(2*sizeof(T)) GpuComplex
     /**
      * \brief Divide this complex number by a real.
      */
+    template <typename U>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    GpuComplex<T>& operator/= (const T& a_t) noexcept
+    GpuComplex<T>& operator/= (const U& a_t) noexcept
     {
         m_real /= a_t;
         m_imag /= a_t;
@@ -247,9 +251,9 @@ GpuComplex<T> operator+ (const T& a_x, const GpuComplex<T>& a_y) noexcept
 /**
  * \brief Multiply two complex numbers.
  */
-template <typename T>
+template <typename T, typename U>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-GpuComplex<T> operator* (const GpuComplex<T>& a_x, const GpuComplex<T>& a_y) noexcept
+GpuComplex<T> operator* (const GpuComplex<T>& a_x, const GpuComplex<U>& a_y) noexcept
 {
     GpuComplex<T> r = a_x;
     r *= a_y;
@@ -259,9 +263,9 @@ GpuComplex<T> operator* (const GpuComplex<T>& a_x, const GpuComplex<T>& a_y) noe
 /**
  * \brief Multiply a complex number by a real one.
  */
-template <typename T>
+template <typename T, typename U>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-GpuComplex<T> operator* (const GpuComplex<T>& a_x, const T& a_y) noexcept
+GpuComplex<T> operator* (const GpuComplex<T>& a_x, const U& a_y) noexcept
 {
     GpuComplex<T> r = a_x;
     r *= a_y;

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -234,6 +234,7 @@ namespace Gpu {
 #else
 #include <AMReX_GpuLaunchMacrosC.H>
 #include <AMReX_GpuLaunchFunctsC.H>
+#include <AMReX_SIMD.H>
 #endif
 
 #include <AMReX_GpuLaunch.nolint.H>

--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -4,6 +4,24 @@
 
 namespace amrex {
 
+/** Helper type to store/access the SIMD width in ParallelForSIMD lambdas
+ *
+ * Use instead of int as the running index i. Used to pass the
+ * SIMD WIDTH as compile-time meta-data into a called function/method.
+ *
+ * @tparam WIDTH SIMD width in elements
+ * @tparam N index type (integer)
+ */
+template<int WIDTH, class N=int>
+struct SIMDindex
+{
+    /** SIMD width in elements */
+    static constexpr int width = WIDTH;
+
+    /** The linear loop index of ParallelFor(SIMD) */
+    N index = 0;
+};
+
 namespace detail {
 
     // call_f_scalar_handler
@@ -22,16 +40,6 @@ namespace detail {
         noexcept -> decltype(f(0,Gpu::Handler{}))
     {
         f(i, Gpu::Handler{});
-    }
-
-    // call_f_vector_handler
-
-    template <int SIMD_WIDTH, typename F, typename N>
-    AMREX_FORCE_INLINE
-    auto call_f_vector_handler (F const& f, N i)
-        noexcept -> decltype(f.template operator()<SIMD_WIDTH>(0))
-    {
-        f.template operator()<SIMD_WIDTH>(i);
     }
 
     // call_f_intvect_inner
@@ -190,23 +198,23 @@ void ParallelFor (T n, L&& f) noexcept
  * SIMD load/Write-back operations need to be performed before/after calling this.
  *
  * @tparam WIDTH SIMD width in elements
- * @tparam T index type (integer)
+ * @tparam N index type (integer)
  * @tparam L function/functor to call per SIMD set of elements
  */
-template <int WIDTH, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
+template <int WIDTH, typename N, typename L, typename M=std::enable_if_t<std::is_integral_v<N>> >
 AMREX_ATTRIBUTE_FLATTEN_FOR
-void ParallelForSIMD (T n, L const& f) noexcept
+void ParallelForSIMD (N n, L const& f) noexcept
 {
-    T i = 0;
+    N i = 0;
     // vectorize full lanes
     for (; i + WIDTH <= n; i+=WIDTH) {
-        detail::call_f_vector_handler<WIDTH>(f, i);
+        f(SIMDindex<WIDTH, N>{i});
     }
     // scalar handling of the remainder
     // note: we could make the remainder calls faster, by repeatedly
-    //       calling call_f_vector_handler with WIDTH / 2 until we reach 1
+    //       decreasing the SIMD width by 2 until we reach 1
     for (; i < n; ++i) {
-        detail::call_f_scalar_handler(f, i);
+        f(SIMDindex<1, N>{i});
     }
 }
 

--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -24,6 +24,16 @@ namespace detail {
         f(i, Gpu::Handler{});
     }
 
+    // call_f_vector_handler
+
+    template <int SIMD_WIDTH, typename F, typename N>
+    AMREX_FORCE_INLINE
+    auto call_f_vector_handler (F const& f, N i)
+        noexcept -> decltype(f.template operator()<SIMD_WIDTH>(0))
+    {
+        f.template operator()<SIMD_WIDTH>(i);
+    }
+
     // call_f_intvect_inner
 
     template <typename F, std::size_t...Ns, class...Args>
@@ -173,6 +183,31 @@ void ParallelFor (T n, L&& f) noexcept
 {
     amrex::ignore_unused(MT);
     ParallelFor(n, std::forward<L>(f));
+}
+
+/** ParallelFor with a SIMD Width (in elements)
+ *
+ * SIMD load/Write-back operations need to be performed before/after calling this.
+ *
+ * @tparam WIDTH SIMD width in elements
+ * @tparam T index type (integer)
+ * @tparam L function/functor to call per SIMD set of elements
+ */
+template <int WIDTH, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
+AMREX_ATTRIBUTE_FLATTEN_FOR
+void ParallelForSIMD (T n, L const& f) noexcept
+{
+    T i = 0;
+    // vectorize full lanes
+    for (; i + WIDTH <= n; i+=WIDTH) {
+        detail::call_f_vector_handler<WIDTH>(f, i);
+    }
+    // scalar handling of the remainder
+    // note: we could make the remainder calls faster, by repeatedly
+    //       calling call_f_vector_handler with WIDTH / 2 until we reach 1
+    for (; i < n; ++i) {
+        detail::call_f_scalar_handler(f, i);
+    }
 }
 
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -5,6 +5,7 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_Extension.H>
 #include <AMReX_INT.H>
+#include <AMReX_SIMD.H>
 #include <AMReX_REAL.H>
 #include <cmath>
 #include <cstdlib>
@@ -133,6 +134,24 @@ namespace detail {
 }
 
 //! Return sine and cosine of given number
+template<typename T_Real>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+std::pair<T_Real,T_Real> sincos (T_Real x)
+{
+#ifdef AMREX_USE_SIMD
+    using namespace amrex::simd::stdx;
+#else
+    using namespace std;
+#endif
+
+    std::pair<T_Real,T_Real> r;
+    r.first = sin(x);
+    r.second = cos(x);
+    return r;
+}
+
+//! Return sine and cosine of given number
+template<>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 std::pair<double,double> sincos (double x)
 {
@@ -147,6 +166,7 @@ std::pair<double,double> sincos (double x)
 }
 
 //! Return sine and cosine of given number
+template<>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 std::pair<float,float> sincos (float x)
 {
@@ -161,6 +181,25 @@ std::pair<float,float> sincos (float x)
 }
 
 //! Return sin(pi*x) and cos(pi*x) given x
+template<typename T_Real>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+std::pair<T_Real,T_Real> sincospi (T_Real x)
+{
+#ifdef AMREX_USE_SIMD
+    using namespace amrex::simd::stdx;
+#else
+    using namespace std;
+#endif
+
+    T_Real const px = pi<T_Real>() * x;
+    std::pair<T_Real,T_Real> r;
+    r.first = sin(px);
+    r.second = cos(px);
+    return r;
+}
+
+//! Return sin(pi*x) and cos(pi*x) given x
+template<>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 std::pair<double,double> sincospi (double x)
 {
@@ -175,6 +214,7 @@ std::pair<double,double> sincospi (double x)
 }
 
 //! Return sin(pi*x) and cos(pi*x) given x
+template<>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 std::pair<float,float> sincospi (float x)
 {

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -10,6 +10,8 @@
 #   include <vir/simd.h>  // includes SIMD TS2 header <experimental/simd>
 #endif
 
+#include <type_traits>
+
 
 namespace amrex::simd
 {
@@ -107,6 +109,45 @@ namespace amrex::simd
      */
     template<typename T>
     constexpr bool is_vectorized = std::is_base_of_v<detail::InternalVectorized, T>;
+
+    /** Check if a function argument is declared as non-const
+     *
+     * Use in conjunction with conditional write-back logic from vector registers, e.g.,
+     *
+     * ```c++
+     * template<typename T_Real>
+     * void compute (T_Real & AMREX_RESTRICT x,
+     *               T_Real const & AMREX_RESTRICT y) { ... }
+     *
+     * part_x.copy_from(&m_part_x[i], stdx::element_aligned);
+     * part_y.copy_from(&m_part_y[i], stdx::element_aligned);
+     *
+     * compute(part_x, part_y);
+     *
+     * if constexpr (is_nth_arg_non_const(compute<double>, 0))
+     *     part_x.copy_to(&m_part_x[i], stdx::element_aligned);
+     * if constexpr (is_nth_arg_non_const(compute<double>, 1))
+     *     part_y.copy_to(&m_part_y[i], stdx::element_aligned);
+     */
+    template<typename R, typename... Args>
+    constexpr bool is_nth_arg_non_const (R(*)(Args...), int n)
+    {
+        constexpr bool val_arr[sizeof...(Args)] {!std::is_const_v<std::remove_reference_t<Args>>...};
+        return val_arr[n];
+    }
+    // same for functors (const/non-const ::operator() members)
+    template<typename C, typename R, typename... Args>
+    constexpr bool is_nth_arg_non_const (R(C::*)(Args...), int n)
+    {
+        constexpr bool val_arr[sizeof...(Args)] {!std::is_const_v<std::remove_reference_t<Args>>...};
+        return val_arr[n];
+    }
+    template<typename C, typename R, typename... Args>
+    constexpr bool is_nth_arg_non_const (R(C::*)(Args...) const, int n)
+    {
+        constexpr bool val_arr[sizeof...(Args)] {!std::is_const_v<std::remove_reference_t<Args>>...};
+        return val_arr[n];
+    }
 
 } // namespace amrex::simd
 

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -10,6 +10,7 @@
 #   include <vir/simd.h>  // includes SIMD TS2 header <experimental/simd>
 #endif
 
+#include <cstdint>
 #include <type_traits>
 
 
@@ -49,7 +50,7 @@ namespace amrex::simd
 
     // Type that has the same amount of IdCpu SIMD elements as the SIMDParticleReal type
     template<typename T_ParticleReal = SIMDParticleReal<>>
-    using SIMDIdCpu = std::experimental::rebind_simd_t<uint64_t, T_ParticleReal>;
+    using SIMDIdCpu = std::experimental::rebind_simd_t<std::uint64_t, T_ParticleReal>;
 #else
     constexpr auto native_simd_size_real = 1;
     constexpr auto native_simd_size_particlereal = 1;
@@ -62,7 +63,7 @@ namespace amrex::simd
 
     // Type that has the same amount of IdCpu SIMD elements as the SIMDParticleReal type
     template<typename T_ParticleReal = SIMDParticleReal<>>
-    using SIMDIdCpu = uint64_t;
+    using SIMDIdCpu = std::uint64_t;
 #endif
 
     namespace detail {

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -1,0 +1,113 @@
+#ifndef AMREX_SIMD_H_
+#define AMREX_SIMD_H_
+
+#include <AMReX_Config.H>
+
+#include <AMReX_REAL.H>
+
+#ifdef AMREX_USE_SIMD
+// TODO make SIMD provider configurable: VIR (C++17 TS2) or C++26 (later)
+#   include <vir/simd.h>  // includes SIMD TS2 header <experimental/simd>
+#endif
+
+
+namespace amrex::simd
+{
+    // TODO make SIMD provider configurable: VIR (C++17 TS2) or C++26 (later)
+    //namespace stdx = std::experimental;
+    // for https://en.cppreference.com/w/cpp/experimental/simd/simd_cast.html
+    namespace stdx {
+#ifdef AMREX_USE_SIMD
+        using namespace std::experimental;
+        using namespace std::experimental::__proposed;
+        using namespace vir::stdx;
+#else
+        // fallback implementations for functions that are commonly used in portable code paths
+
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        bool any_of (bool const v) { return v; }
+#endif
+    }
+
+    // TODO: move to AMReX_REAL.H?
+
+#ifdef AMREX_USE_SIMD
+    // TODO: not sure why std::experimental::simd_abi::native<T> does not work, so we use this long version
+    constexpr auto native_simd_size_real = std::experimental::native_simd<amrex::Real>::size();
+    constexpr auto native_simd_size_particlereal = std::experimental::native_simd<amrex::ParticleReal>::size();
+
+    // Note: to make use of not only vector registers but also ILP, user might want to use * 2 or more of the native size
+    //       for selected compute kernels.
+    // TODO Check if a default with * 2 or similar is sensible.
+    template<int SIMD_WIDTH = native_simd_size_real>
+    using SIMDReal = std::experimental::fixed_size_simd<amrex::Real, SIMD_WIDTH>;
+
+    template<int SIMD_WIDTH = native_simd_size_particlereal>
+    using SIMDParticleReal = std::experimental::fixed_size_simd<amrex::ParticleReal, SIMD_WIDTH>;
+
+    // Type that has the same amount of IdCpu SIMD elements as the SIMDParticleReal type
+    template<typename T_ParticleReal = SIMDParticleReal<>>
+    using SIMDIdCpu = std::experimental::rebind_simd_t<uint64_t, T_ParticleReal>;
+#else
+    constexpr auto native_simd_size_real = 1;
+    constexpr auto native_simd_size_particlereal = 1;
+
+    template<int SIMD_WIDTH = native_simd_size_real>
+    using SIMDReal = amrex::Real;
+
+    template<int SIMD_WIDTH = native_simd_size_particlereal>
+    using SIMDParticleReal = amrex::ParticleReal;
+
+    // Type that has the same amount of IdCpu SIMD elements as the SIMDParticleReal type
+    template<typename T_ParticleReal = SIMDParticleReal<>>
+    using SIMDIdCpu = uint64_t;
+#endif
+
+    namespace detail {
+        struct InternalVectorized {};
+    }
+
+    /** Mixin Helper Class
+     *
+     * Use this class as a mixin (base) class to simplify writing functors that support/do not support
+     * ParallelForSIMD.
+     *
+     * Example:
+     * ```c++
+     * struct Compute : public Vectorized<>
+     * {
+     *     template<typename T_Real>
+     *     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+     *     void operator() (T_Real & AMREX_RESTRICT x) { ... }
+     * };
+     *
+     * // ... call site below
+     * {
+     *     Compute c;
+     *
+     *     if constexpr (amrex::simd::is_vectorized<Compute>) {
+     *         ParallelForSIMD<...>(np, c).
+     *     } else {
+     *         ParallelFor(np, c);
+     *     }
+     * }
+     * ```
+     */
+    template<int SIMD_WIDTH = native_simd_size_real>
+    struct
+    Vectorized : detail::InternalVectorized
+    {
+        //! SIMD width in elements
+        static constexpr int simd_width = SIMD_WIDTH;
+    };
+
+    /** Check if a Functor Class works with amrex::ParallelForSIMD
+     *
+     * @see amrex::simd::Vectorized
+     */
+    template<typename T>
+    constexpr bool is_vectorized = std::is_base_of_v<detail::InternalVectorized, T>;
+
+} // namespace amrex::simd
+
+#endif

--- a/Src/Base/AMReX_SmallMatrix.H
+++ b/Src/Base/AMReX_SmallMatrix.H
@@ -14,6 +14,8 @@
 #include <iostream>
 #include <tuple>
 #include <type_traits>
+#include <utility>
+
 
 namespace amrex {
 
@@ -377,11 +379,11 @@ namespace amrex {
         }
 
         //! Returns matrix product of two matrices
-        template <class U, int N1, int N2, int N3, Order Ord, int SI>
+        template <class U, class V, int N1, int N2, int N3, Order Ord, int SI>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        friend SmallMatrix<U,N1,N3,Ord,SI>
+        friend decltype(auto)
         operator* (SmallMatrix<U,N1,N2,Ord,SI> const& lhs,
-                   SmallMatrix<U,N2,N3,Ord,SI> const& rhs);
+                   SmallMatrix<V,N2,N3,Ord,SI> const& rhs);
 
         //! Returns the dot product of two vectors
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -406,17 +408,20 @@ namespace amrex {
         T m_mat[NRows*NCols];
     };
 
-    template <class U, int N1, int N2, int N3, Order Ord, int SI>
+    template <class U, class V, int N1, int N2, int N3, Order Ord, int SI>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    SmallMatrix<U,N1,N3,Ord,SI>
+    decltype(auto)
     operator* (SmallMatrix<U,N1,N2,Ord,SI> const& lhs,
-               SmallMatrix<U,N2,N3,Ord,SI> const& rhs)
+               SmallMatrix<V,N2,N3,Ord,SI> const& rhs)
     {
         static_assert(SI == 0 || SI == 1);
-        SmallMatrix<U,N1,N3,Ord,SI> r;
+
+        using P = decltype(std::declval<U>() * std::declval<V>());
+        SmallMatrix<P,N1,N3,Ord,SI> r;
+
         if constexpr (Ord == Order::F) {
             for (int j = SI; j < N3+SI; ++j) {
-                constexpr_for<SI,N1+SI>([&] (int i) { r(i,j) = U(0); });
+                constexpr_for<SI,N1+SI>([&] (int i) { r(i,j) = P(0); });
                 for (int k = SI; k < N2+SI; ++k) {
                     auto b = rhs(k,j);
                     constexpr_for<SI,N1+SI>([&] (int i)
@@ -427,7 +432,7 @@ namespace amrex {
             }
         } else {
             for (int i = SI; i < N1+SI; ++i) {
-                constexpr_for<SI,N3+SI>([&] (int j) { r(i,j) = U(0); });
+                constexpr_for<SI,N3+SI>([&] (int j) { r(i,j) = P(0); });
                 for (int k = SI; k < N2+SI; ++k) {
                     auto a = lhs(i,k);
                     constexpr_for<SI,N3+SI>([&] (int j)

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -242,6 +242,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_MFParallelFor.H
        AMReX_MFParallelForC.H
        AMReX_MFParallelForG.H
+       AMReX_SIMD.H
        AMReX_TagParallelFor.H
        AMReX_CTOParallelForImpl.H
        AMReX_ParReduce.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -115,6 +115,8 @@ C$(AMREX_BASE)_headers += AMReX_MFParallelFor.H
 C$(AMREX_BASE)_headers += AMReX_MFParallelForC.H
 C$(AMREX_BASE)_headers += AMReX_MFParallelForG.H
 
+C$(AMREX_BASE)_headers += AMReX_SIMD.H
+
 C$(AMREX_BASE)_headers += AMReX_TagParallelFor.H
 C$(AMREX_BASE)_headers += AMReX_CTOParallelForImpl.H
 

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -2,14 +2,15 @@
 #define AMREX_PARTICLE_H_
 #include <AMReX_Config.H>
 
-#include <AMReX_REAL.H>
 #include <AMReX_FArrayBox.H>
-#include <AMReX_IntVect.H>
-#include <AMReX_RealVect.H>
-#include <AMReX_ParmParse.H>
 #include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_REAL.H>
+#include <AMReX_RealVect.H>
 
-#include <string>
+#include <type_traits>
+
 
 namespace amrex {
 
@@ -93,10 +94,50 @@ namespace amrex {
         idcpu &= ~(uint64_t(1) << 63);
     }
 
+    template<typename T_SIMD, typename T_Mask>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void make_invalid (T_SIMD & idcpu, T_Mask const & mask) noexcept {
+        // RHS mask: 0111...
+        if constexpr (std::is_same_v<T_Mask, bool>) {
+            // scalar
+            static_assert(std::is_same_v<T_SIMD, uint64_t>, "make_invalid: forgot template on wrapper?");
+            if (mask) { make_invalid(idcpu); }
+        } else {
+#ifdef AMREX_USE_SIMD
+            // SIMD
+            static_assert(!std::is_same_v<T_SIMD, uint64_t>, "make_invalid: forgot template on wrapper?");
+            // .__cvt() because of: https://github.com/VcDevel/std-simd/issues/41
+            simd::stdx::where(mask.__cvt(), idcpu) &= ~(T_SIMD{1} << 63);
+#else
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false, "make_invalid: AMReX_SIMD was not enabled!");
+#endif
+        }
+    }
+
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void make_valid (uint64_t& idcpu) noexcept {
         // RHS mask: 1000...
         idcpu |= uint64_t(1) << 63;
+    }
+
+    template<typename T_SIMD, typename T_Mask>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void make_valid (T_SIMD & idcpu, T_Mask const & mask) noexcept {
+        // RHS mask: 1000...
+        if constexpr (std::is_same_v<T_Mask, bool>) {
+            // scalar
+            static_assert(std::is_same_v<T_SIMD, uint64_t>, "make_valid: forgot template on wrapper?");
+            if (mask) { make_valid(idcpu); }
+        } else {
+#ifdef AMREX_USE_SIMD
+            // SIMD
+            static_assert(!std::is_same_v<T_SIMD, uint64_t>, "make_valid: forgot template on wrapper?");
+            // .__cvt() because of: https://github.com/VcDevel/std-simd/issues/41
+            simd::stdx::where(mask.__cvt(), idcpu) |= T_SIMD{1} << 63;
+#else
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false, "make_valid: AMReX_SIMD was not enabled!");
+#endif
+        }
     }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -104,16 +145,24 @@ namespace amrex {
         // the leftmost bit is our id's valid sign
         return idcpu >> 63;
     }
-    }
+    } // namespace particle_impl
 
+template<typename T = uint64_t>
 struct ParticleIDWrapper
 {
-    uint64_t* m_idata;
+    /*
+    static_assert(std::is_same<T, uint64_t>::value ||
+                  std::is_same<T, simd::SIMDIdCpu<>>::value,  // note: this one will not work because users can change the SIMDIdCpu width
+                  "ParticleIDWrapper only supports uint64_t or SIMD thereof"
+    );
+    */
+
+    T* m_idata;
 
     ~ParticleIDWrapper () noexcept = default;
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    ParticleIDWrapper (uint64_t& idata) noexcept
+    ParticleIDWrapper (T& idata) noexcept
         : m_idata(&idata)
     {}
 
@@ -158,6 +207,18 @@ struct ParticleIDWrapper
         particle_impl::make_invalid(*m_idata);
     }
 
+    /** Mark the particle as invalid
+     *
+     * Swaps the is_valid (sign) bit to invalid.
+     * This is NOT identical to id = -id, but it is equally reversible via make_valid().
+     */
+    template<typename T_Bool>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void make_invalid (T_Bool const & mask) const noexcept
+    {
+        particle_impl::make_invalid(*m_idata, mask);
+    }
+
     /** Mark the particle as valid
      *
      * Swaps the is_valid (sign) bit to valid.
@@ -167,6 +228,18 @@ struct ParticleIDWrapper
     void make_valid () const noexcept
     {
         particle_impl::make_valid(*m_idata);
+    }
+
+    /** Mark the particle as valid
+     *
+     * Swaps the is_valid (sign) bit to valid.
+     * This is NOT identical to id = -id, but it is equally reversible via make_invalid().
+     */
+    template<typename T_Bool>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void make_valid (T_Bool const & mask) const noexcept
+    {
+        particle_impl::make_valid(*m_idata, mask);
     }
 
     /** Check the particle is valid, via the sign of the id.
@@ -345,7 +418,7 @@ struct alignas(sizeof(double)) Particle
     ParticleCPUWrapper cpu () & { return ParticleCPUWrapper(this->m_idcpu); }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    ParticleIDWrapper id () & { return ParticleIDWrapper(this->m_idcpu); }
+    ParticleIDWrapper<> id () & { return ParticleIDWrapper(this->m_idcpu); }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ConstParticleCPUWrapper cpu () const & { return ConstParticleCPUWrapper(this->m_idcpu); }

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -411,7 +411,7 @@ struct alignas(sizeof(double)) SoAParticle : SoAParticleBase
     ParticleCPUWrapper cpu () & { return this->m_particle_tile_data.m_idcpu[m_index]; }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    ParticleIDWrapper id () & { return this->m_particle_tile_data.m_idcpu[m_index]; }
+    ParticleIDWrapper<> id () & { return this->m_particle_tile_data.m_idcpu[m_index]; }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     uint64_t& idcpu () & { return this->m_particle_tile_data.m_idcpu[m_index]; }

--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -62,6 +62,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${AMReX_MODULE_PATH})
 # General options
 set(AMReX_MPI_FOUND                 @AMReX_MPI@)
 set(AMReX_MPI_THREAD_MULTIPLE_FOUND @AMReX_MPI_THREAD_MULTIPLE@)
+set(AMReX_SIMD_FOUND                @AMReX_SIMD@)
 set(AMReX_OMP_FOUND                 @AMReX_OMP@)
 set(AMReX_CUDA_FOUND                @AMReX_CUDA@)
 set(AMReX_SYCL_FOUND                @AMReX_SYCL@)
@@ -118,6 +119,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
 endforeach()
 set(AMReX_MPI                       @AMReX_MPI@)
 set(AMReX_MPI_THREAD_MULTIPLE       @AMReX_MPI_THREAD_MULTIPLE@)
+set(AMReX_SIMD                      @AMReX_SIMD@)
 set(AMReX_OMP                       @AMReX_OMP@)
 set(AMReX_CUDA                      @AMReX_CUDA@)
 set(AMReX_SYCL                      @AMReX_SYCL@)
@@ -202,6 +204,10 @@ endif ()
 #
 # Third party libraries
 #
+if (@AMReX_SIMD@)
+   find_dependency(vir-simd REQUIRED)
+endif ()
+
 if (@AMReX_SENSEI@)
     set(SENSEI_DIR @SENSEI_DIR@)
     find_dependency(SENSEI REQUIRED)

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -276,6 +276,9 @@ cmake_dependent_option( AMReX_MPI_THREAD_MULTIPLE
    "AMReX_MPI" OFF)
 print_option( AMReX_MPI_THREAD_MULTIPLE )
 
+option( AMReX_SIMD  "Enable SIMD Primitives" OFF)
+print_option( AMReX_SIMD )
+
 option( AMReX_OMP  "Enable OpenMP" OFF)
 print_option( AMReX_OMP )
 

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -30,6 +30,18 @@ endif ()
 
 #
 #
+#  VIR-SIMD
+#
+#
+if (AMReX_SIMD)
+   find_package(vir-simd REQUIRED)
+   foreach(D IN LISTS AMReX_SPACEDIM)
+       target_link_libraries(amrex_${D}d PUBLIC vir-simd::vir-simd)
+   endforeach()
+endif ()
+
+#
+#
 #  OpenMP
 #
 #

--- a/Tools/CMake/AMReXSetDefines.cmake
+++ b/Tools/CMake/AMReXSetDefines.cmake
@@ -47,6 +47,9 @@ add_amrex_define( AMREX_TESTING NO_LEGACY IF AMReX_TESTING )
 add_amrex_define( AMREX_USE_MPI IF AMReX_MPI )
 add_amrex_define( AMREX_MPI_THREAD_MULTIPLE NO_LEGACY IF AMReX_MPI_THREAD_MULTIPLE)
 
+# SIMD
+add_amrex_define( AMREX_USE_SIMD NO_LEGACY IF AMReX_SIMD )
+
 # OpenMP -- This one has legacy definition only in Base/AMReX_omp_mod.F90
 add_amrex_define( AMREX_USE_OMP IF AMReX_OMP )
 

--- a/Tools/CMake/AMReX_Config_ND.H.in
+++ b/Tools/CMake/AMReX_Config_ND.H.in
@@ -16,6 +16,7 @@
 #cmakedefine AMREX_USE_MPI
 #cmakedefine BL_USE_MPI
 #cmakedefine AMREX_MPI_THREAD_MULTIPLE
+#cmakedefine AMREX_USE_SIMD
 #cmakedefine AMREX_USE_OMP
 #cmakedefine BL_USE_OMP
 #cmakedefine AMREX_USE_SYCL


### PR DESCRIPTION
## Summary

AMReX does not have a concept yet to help users write effective SIMD code on CPU, besides relying on auto-vectorization and pragmas, which are unreliable for any complex enough code. [1]

Lucky enough, C++ `std::datapar` was just accepted into C++26, which gives an easy in to write portable SIMD/scalar code. Yet, I did not find a compiler/stdlib yet with support for it, so I finally had play with the C++17 `<experimental/simd>` headers, which are not as complete as C++26 but a good in, especially if complemented with the https://github.com/mattkretz/vir-simd library.

This PR adds initial support for portable user-code by providing:
- build system support: `AMReX_SIMD` (default is OFF), relying on [vir-simd](https://github.com/mattkretz/vir-simd)
- an `AMReX_SIMD.H` header that handles includes & helper types
- `ParallelForSIMD<SIMD_WIDTH>(...)`

## Additional background

[1] Fun fact one: As written in the [story behind Intel's iscp compiler](https://pharr.org/matt/blog/2018/04/18/ispc-origins) and credited to [Tim Foley](http://graphics.stanford.edu/~tfoley/), *auto-vectorization is not a programming model.*

Fun fact two: This is as ad-hoc as the implementation for [data parallel types / SIMD in Kokkos](https://kokkos.org/kokkos-core-wiki/API/simd/simd.html), it seems.

## User-Code Examples & Benchmark

[Please see this ImpactX PR for details.](https://github.com/BLAST-ImpactX/impactx/pull/1002)

## Checklist

- [x] clean up commits (separate commits)
- [x] finalize fallbacks & CI checks
- [ ] add a `vir::stdx::simd` test in CI
- [x] CMake
- [ ] GnuMake
- [x] `AMReX_SIMD.H` 
- [x] `ParallelForSIMD` 
- [x] `ParticleIdWrapper::make_(in)valid(mask)`
- [x] clean up `sincos` support
- [x] `SmallMatrix`
- [x] Support for `GpuComplex` (minimal)
- [x] Support [passing WIDTH as compile-time meta-data](https://godbolt.org/z/7455hqrEc) to callee in `ParallelForSIMD`
- [ ] include documentation in the code and/or rst files, if appropriate
- [x] add `vir::stdx::simd` in package managers:
  - [x] Spack [vir-simd](https://github.com/spack/spack-packages/pull/332)
  - [x] Conda [vir-simd](https://github.com/conda-forge/staged-recipes/pull/30377)

## Future Ideas / PRs

- allocate particle arrays aligned so we can use [stdx::vector_aligned](https://en.cppreference.com/w/cpp/experimental/simd/vector_aligned.html) (for [copies](https://en.cppreference.com/w/cpp/experimental/simd/simd/copy_from) into/out of vector registers - note: makes no difference anymore on modern CPUs)
- Support more/all functions in `ParticleIdWrapper`/`ParticleCpuWrapper`
- Support for [vir::simdize<std::complex<T>>](https://github.com/mattkretz/vir-simd/issues/42) instead of `GpuComplex<SIMD>`
- `ParallelFor` ND support
- `ParallelFor`/`ParallelForSIMD`: one could, maybe, with enable-if magic, etc fuse them into a single name again
- CMake superbuild: `vir-simd` auto-download for convenience (opt-out)
- Build system: "SIMD provider" selection, once we can opt-in to a C++26 compiler+stdlib instead of C++17 TS2 + vir-simd
- Update AMReX package in package management:
  - Spack [vir-simd](https://github.com/spack/spack-packages/pull/332)
  - Conda [vir-simd](https://github.com/conda-forge/staged-recipes/pull/30377)