### PR TITLE
make_alike should also copy the tile_size

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1387,6 +1387,8 @@ public:
         tmp.h_redistribute_real_comp = h_redistribute_real_comp;
         tmp.h_redistribute_int_comp = h_redistribute_int_comp;
 
+        tmp.tile_size = tile_size;
+
         return tmp;
     }
 


### PR DESCRIPTION
This should fix Issue #4498 observed in ImpactX.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
