### PR TITLE
Modernize roctx Annotations

### DIFF
--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -31,10 +31,7 @@
 #if defined(AMREX_USE_HIP)
 #include <hip/hip_runtime.h>
 #if defined(AMREX_USE_ROCTX)
-#include <roctracer/roctracer_ext.h>
-#if defined(AMREX_PROFILING) || defined (AMREX_TINY_PROFILING)
-#include <roctracer/roctx.h>
-#endif
+#include <rocprofiler-sdk-roctx/roctx.h>
 #endif
 #endif
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -1059,7 +1059,7 @@ Device::profilerStart ()
 #ifdef AMREX_USE_CUDA
     AMREX_GPU_SAFE_CALL(cudaProfilerStart());
 #elif (defined(AMREX_USE_HIP) && defined(AMREX_USE_ROCTX))
-    roctracer_start();
+    roctxProfilerResume(0);
 #endif
 
 }
@@ -1070,7 +1070,7 @@ Device::profilerStop ()
 #ifdef AMREX_USE_CUDA
     AMREX_GPU_SAFE_CALL(cudaProfilerStop());
 #elif (defined(AMREX_USE_HIP) && defined(AMREX_USE_ROCTX))
-    roctracer_stop();
+    roctxProfilerPause(0);
 #endif
 }
 

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -25,7 +25,7 @@
 #endif
 
 #if defined(AMREX_USE_HIP) && defined(AMREX_USE_ROCTX)
-#include <roctracer/roctx.h>
+#include <rocprofiler-sdk-roctx/roctx.h>
 #endif
 
 #include <algorithm>

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -302,17 +302,9 @@ if (AMReX_HIP)
    endif()
 
    if(AMReX_ROCTX)
+       find_package(rocprofiler-sdk-roctx REQUIRED CONFIG)
        foreach(D IN LISTS AMReX_SPACEDIM)
-          # To be modernized in the future, please see:
-          # https://github.com/ROCm-Developer-Tools/roctracer/issues/56
-          target_include_directories(amrex_${D}d SYSTEM PUBLIC
-              ${HIP_PATH}/../roctracer/include
-              ${HIP_PATH}/../rocprofiler/include
-          )
-          target_link_libraries(amrex_${D}d PUBLIC
-              "-L${HIP_PATH}/../roctracer/lib -lroctracer64"
-              "-L${HIP_PATH}/../roctracer/lib -lroctx64"
-          )
+          target_link_libraries(amrex_${D}d PUBLIC rocprofiler-sdk-roctx::rocprofiler-sdk-roctx)
       endforeach()
    endif()
    foreach(D IN LISTS AMReX_SPACEDIM)

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -132,7 +132,7 @@ ifeq ($(HIP_COMPILER),clang)
     CXXFLAGS += -DAMREX_USE_ROCTX
     HIPCC_FLAGS += -DAMREX_USE_ROCTX
     LIBRARY_LOCATIONS += $(ROC_PATH)/lib
-    LIBRARIES += -Wl,--rpath=$(ROC_PATH)/lib -lroctracer64 -lroctx64
+    LIBRARIES += -Wl,--rpath=$(ROC_PATH)/lib -lrocprofiler-sdk-roctx
   endif
 
   # hipcc passes a lot of unused arguments to clang


### PR DESCRIPTION
## Summary

ROCm annotations (roctx) for ROCm profiling tools have been modernized in ROCm 6.2+. Use the new modules and tooling support now.

- [x] CMake
- [x] GnuMake
- [x] [Includes](https://github.com/ROCm/roctracer/issues/56#issuecomment-2385675072)
- [x] [Markers](https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofiler-sdk-roctx.html#how-to-use-roctx-in-your-application)

Tested on LLNL Tuolumne with ROCm 6.4.1.

## Additional background

See https://github.com/ROCm/roctracer/issues/56#issuecomment-2375400996

Attention: https://github.com/ROCm/rocprofiler-systems/issues/266

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
