### PR TITLE
Reduce use of SuperParticle

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -376,7 +376,7 @@ jobs:
       # /home/runner/work/amrex/amrex/Src/Base/AMReX_IntVect.H:194:92: error: array subscript -1 is below array bounds of ‘int [3]’ [-Werror=array-bounds]
       # int& operator[] (int i) noexcept { BL_ASSERT(i>=0 && i < AMREX_SPACEDIM); return vect[i]; }
       #
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-array-bounds"}
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-array-bounds"}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -861,8 +861,8 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
         if (count[grid] == 0) { continue; }
 
-        Vector<int> istuff;
-        Vector<ParticleReal> rstuff;
+        Vector<int> istuff(0);
+        Vector<ParticleReal> rstuff(0);
         particle_detail::packIOData(istuff, rstuff, *this, lev, grid,
                                     write_real_comp, write_int_comp,
                                     particle_io_flags, tile_map[grid], count[grid],

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -861,8 +861,8 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
         if (count[grid] == 0) { continue; }
 
-        Vector<int> istuff(0);
-        Vector<ParticleReal> rstuff(0);
+        Vector<int> istuff;
+        Vector<ParticleReal> rstuff;
         particle_detail::packIOData(istuff, rstuff, *this, lev, grid,
                                     write_real_comp, write_int_comp,
                                     particle_io_flags, tile_map[grid], count[grid],

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -66,7 +66,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
                           tmp_real_comp_names, tmp_int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i) -> int
+                          [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i) -> int
                           {
                               return ptd.id(i) > 0;
                           }, true);
@@ -102,7 +102,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i) -> int
+                          [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i) -> int
                           {
                               return ptd.id(i) > 0;
                           });
@@ -138,7 +138,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
+                          [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
                               return ptd.id(i) > 0;
                           });
@@ -166,7 +166,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
+                          [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
                               return ptd.id(i) > 0;
                           });
@@ -200,7 +200,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
+                          [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
                               return ptd.id(i) > 0;
                           });
@@ -238,7 +238,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
+                          [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
                               return ptd.id(i) > 0;
                           });
@@ -261,7 +261,7 @@ WritePlotFileHDF5 (const std::string& dir, const std::string& name,
                           write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
+                          [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
                               return ptd.id(i) > 0;
                           });

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -66,9 +66,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
                           tmp_real_comp_names, tmp_int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p) -> int
+                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i) -> int
                           {
-                              return p.id() > 0;
+                              return ptd.id(i) > 0;
                           }, true);
 }
 
@@ -102,9 +102,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p) -> int
+                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i) -> int
                           {
-                              return p.id() > 0;
+                              return ptd.id(i) > 0;
                           });
 }
 
@@ -138,9 +138,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p)
+                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
                           {
-                              return p.id() > 0;
+                              return ptd.id(i) > 0;
                           });
 }
 
@@ -166,9 +166,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p)
+                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
                           {
-                              return p.id() > 0;
+                              return ptd.id(i) > 0;
                           });
 }
 
@@ -200,9 +200,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const ParticleType& p)
+                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
                           {
-                              return p.id() > 0;
+                              return ptd.id(i) > 0;
                           });
 }
 
@@ -238,9 +238,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p)
+                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
                           {
-                              return p.id() > 0;
+                              return ptd.id(i) > 0;
                           });
 }
 
@@ -261,9 +261,9 @@ WritePlotFileHDF5 (const std::string& dir, const std::string& name,
                           write_real_comp, write_int_comp,
                           real_comp_names, int_comp_names,
                           compression,
-                          [=] AMREX_GPU_HOST_DEVICE (const SuperParticleType& p)
+                          [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, int i)
                           {
-                              return p.id() > 0;
+                              return ptd.id(i) > 0;
                           });
 }
 

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -337,6 +337,7 @@ struct alignas(sizeof(double)) Particle
 
     //! The floating point type used for the particles.
     using RealType = ParticleReal;
+    using IntType = int;
 
     static Long the_next_id;
 
@@ -365,6 +366,12 @@ struct alignas(sizeof(double)) Particle
         amrex::Gpu::Atomic::Exch(old_ptr, (unsigned long long) wrapper.m_idata);
 #endif
     }
+
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    uint64_t& idcpu () & { return this->m_idcpu; }
+
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    const uint64_t& idcpu () const & { return this->m_idcpu; }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     RealVect pos () const & {return RealVect(AMREX_D_DECL(this->m_pos[0], this->m_pos[1], this->m_pos[2]));}

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -186,6 +186,7 @@ public:
     //! for both SoA and AoS data.
     using ParticleLevel = std::map<std::pair<int, int>, ParticleTileType>;
     using PTDType = typename ParticleTileType::ParticleTileDataType;
+    using ConstPTDType = typename ParticleTileType::ConstParticleTileDataType;
     using AoS = typename ParticleTileType::AoS;
     using SoA = typename ParticleTileType::SoA;
 

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -185,6 +185,7 @@ public:
     //! A single level worth of particles is indexed (grid id, tile id)
     //! for both SoA and AoS data.
     using ParticleLevel = std::map<std::pair<int, int>, ParticleTileType>;
+    using PTDType = typename ParticleTileType::ParticleTileDataType;
     using AoS = typename ParticleTileType::AoS;
     using SoA = typename ParticleTileType::SoA;
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -954,42 +954,47 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         auto dst = virts.getParticleTileData();
         ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
         {
-             if(imf_arr(i,j,k,0)!=0)
-             {
-                 SuperParticleType p;
-                 p.cpu() = 0;
-                 p.id() = LongParticleIds::VirtualParticleID;
+            if(imf_arr(i,j,k,0)!=0)
+            {
+                const auto idx = last_offset + offsets_ptr[
+                    ((i-imf_arr.begin.x)
+                    +(j-imf_arr.begin.y)*imf_arr.jstride
+                    +(k-imf_arr.begin.z)*imf_arr.kstride)
+                ];
 
-                 //Set rdata(0) first so we can normalize the weighted fields
-                 p.rdata(0) = static_cast<ParticleReal>(partData(i,j,k,AMREX_SPACEDIM));
-                 //Set pos with the normalized weighted field
-                 for (int n = 0; n < AMREX_SPACEDIM; ++n)
-                 {
-                     p.pos(n) = static_cast<ParticleReal>(partData(i,j,k,n) / p.rdata(0));
-                 }
-                 //Set rdata(n>0) with the normalized weighted field for NStructReal
-                 for (int n = 1; n < NStructReal; ++n)
-                 {
-                     p.rdata(n) = static_cast<ParticleReal>(partData(i,j,k,AMREX_SPACEDIM+n) / p.rdata(0));
-                 }
-                 //Set rdata(n>0) with the normalized weighted field for NArrayReal
-                 for (int n = 0; n < NArrayReal; ++n)
-                 {
-                     p.rdata(NStructReal+n) = static_cast<ParticleReal>(partData(i,j,k,AMREX_SPACEDIM+NStructReal+n));
-                 }
-                 //Set idata with the "first" particles idata field for NStructInt
-                 for (int n = 0; n < NStructInt; ++n)
-                 {
-                     p.idata(n) = imf_arr(i,j,k,1+n);
-                 }
-                 //Set idata with the "first" particles idata field for NArrayInt
-                 for (int n = 0; n < NArrayInt; ++n)
-                 {
-                     p.idata(NStructInt+n) = imf_arr(i,j,k,1+NStructInt+n);
-                 }
-                 //Set the new particle in dst tile
-                 dst.setSuperParticle(p, last_offset+offsets_ptr[((i-imf_arr.begin.x)+(j-imf_arr.begin.y)*imf_arr.jstride+(k-imf_arr.begin.z)*imf_arr.kstride)]);
-             }
+                dst.cpu() = 0;
+                dst.id(idx) = LongParticleIds::VirtualParticleID;
+
+                auto& p = dst[idx];
+                //Set rdata(0) first so we can normalize the weighted fields
+                //Note that this does not work for soa PC
+                p.rdata(0) = static_cast<ParticleReal>(partData(i,j,k,AMREX_SPACEDIM));;
+                //Set pos with the normalized weighted field
+                for (int n = 0; n < AMREX_SPACEDIM; ++n)
+                {
+                    p.pos(n) = static_cast<ParticleReal>(partData(i,j,k,n) / p.rdata(0));
+                }
+                //Set rdata(n>0) with the normalized weighted field for NStructReal
+                for (int n = 1; n < NStructReal; ++n)
+                {
+                    p.rdata(n) = static_cast<ParticleReal>(partData(i,j,k,AMREX_SPACEDIM+n) / p.rdata(0));
+                }
+                //Set rdata(n>0) with the normalized weighted field for NArrayReal
+                for (int n = 0; n < NArrayReal; ++n)
+                {
+                    dst.rdata(n)[idx] = static_cast<ParticleReal>(partData(i,j,k,AMREX_SPACEDIM+NStructReal+n));
+                }
+                //Set idata with the "first" particles idata field for NStructInt
+                for (int n = 0; n < NStructInt; ++n)
+                {
+                    p.idata(n) = imf_arr(i,j,k,1+n);
+                }
+                //Set idata with the "first" particles idata field for NArrayInt
+                for (int n = 0; n < NArrayInt; ++n)
+                {
+                    dst.idata(n)[idx] = imf_arr(i,j,k,1+NStructInt+n);
+                }
+            }
 
         });
         last_offset+=next_offset;

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -962,7 +962,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                     +(k-imf_arr.begin.z)*imf_arr.kstride)
                 ];
 
-                dst.cpu() = 0;
+                dst.cpu(idx) = 0;
                 dst.id(idx) = LongParticleIds::VirtualParticleID;
 
                 auto& p = dst[idx];

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -607,8 +607,8 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
         if (count[grid] == 0) { continue; }
 
-        Vector<int> istuff(0);
-        Vector<ParticleReal> rstuff(0);
+        Vector<int> istuff;
+        Vector<ParticleReal> rstuff;
         particle_detail::packIOData(istuff, rstuff, *this, lev, grid,
                                     write_real_comp, write_int_comp,
                                     particle_io_flags, tile_map[grid], count[grid], is_checkpoint);

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -607,8 +607,8 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
         if (count[grid] == 0) { continue; }
 
-        Vector<int> istuff;
-        Vector<ParticleReal> rstuff;
+        Vector<int> istuff(0);
+        Vector<ParticleReal> rstuff(0);
         particle_detail::packIOData(istuff, rstuff, *this, lev, grid,
                                     write_real_comp, write_int_comp,
                                     particle_io_flags, tile_map[grid], count[grid], is_checkpoint);

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -66,18 +66,18 @@ auto call_f (F const& f,
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto sm = amrex::ReduceSum(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
  *                  {
- *                      return ptd.m_aos[i].rdata(0);
+ *                      return ptd.rdata(0)[i];
  *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceSum (PC const& pc, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
 {
     return ReduceSum(pc, 0, pc.finestLevel(), std::forward<F>(f));
 }
@@ -114,18 +114,18 @@ ReduceSum (PC const& pc, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto sm = amrex::ReduceSum(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
  *                  {
- *                      return ptd.m_aos[i].rdata(0);
+ *                      return ptd.rdata(0)[i];
  *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceSum (PC const& pc, int lev, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
 {
     return ReduceSum(pc, lev, lev, std::forward<F>(f));
 }
@@ -163,20 +163,20 @@ ReduceSum (PC const& pc, int lev, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto sm = amrex::ReduceSum(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
  *                  {
- *                      return ptd.m_aos[i].rdata(0);
+ *                      return ptd.rdata(0)[i];
  *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceSum (PC const& pc, int lev_min, int lev_max, F const& f)
-    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
 {
-    using value_type = decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()));
+    using value_type = decltype(particle_detail::call_f(f, typename PC::PTDType(), int()));
     value_type sm = 0;
 
 #ifdef AMREX_USE_GPU
@@ -266,18 +266,18 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F const& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto mx = amrex::ReduceMax(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
  *                  {
- *                      return ptd.m_aos[i].rdata(0);
+ *                      return ptd.rdata(0)[i];
  *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMax (PC const& pc, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
 {
     return ReduceMax(pc, 0, pc.finestLevel(), std::forward<F>(f));
 }
@@ -314,18 +314,18 @@ ReduceMax (PC const& pc, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto mx = amrex::ReduceMax(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
  *                  {
- *                      return ptd.m_aos[i].rdata(0);
+ *                      return ptd.rdata(0)[i];
  *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMax (PC const& pc, int lev, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
 {
     return ReduceMax(pc, lev, lev, std::forward<F>(f));
 }
@@ -363,20 +363,20 @@ ReduceMax (PC const& pc, int lev, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto mx = amrex::ReduceMax(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
  *                  {
- *                      return ptd.m_aos[i].rdata(0);
+ *                      return ptd.rdata(0)[i];
  *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMax (PC const& pc, int lev_min, int lev_max, F const& f)
-    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
 {
-    using value_type = decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()));
+    using value_type = decltype(particle_detail::call_f(f, typename PC::PTDType(), int()));
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
 
@@ -467,18 +467,18 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F const& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto mn = amrex::ReduceMin(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
  *                  {
- *                      return ptd.m_aos[i].rdata(0);
+ *                      return ptd.rdata(0)[i];
  *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMin (PC const& pc, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
 {
     return ReduceMin(pc, 0, pc.finestLevel(), std::forward<F>(f));
 }
@@ -515,18 +515,18 @@ ReduceMin (PC const& pc, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto mn = amrex::ReduceMin(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
  *                  {
- *                      return ptd.m_aos[i].rdata(0);
+ *                      return ptd.rdata(0)[i];
  *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMin (PC const& pc, int lev, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
 {
     return ReduceMin(pc, lev, lev, std::forward<F>(f));
 }
@@ -564,20 +564,20 @@ ReduceMin (PC const& pc, int lev, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto mn = amrex::ReduceMin(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
  *                  {
- *                      return ptd.m_aos[i].rdata(0);
+ *                      return ptd.rdata(0)[i];
  *                  });
  *
  */
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMin (PC const& pc, int lev_min, int lev_max, F const& f)
-    -> decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
 {
-    using value_type = decltype(particle_detail::call_f(f, typename PC::ParticleTileType::ConstParticleTileDataType(), int()));
+    using value_type = decltype(particle_detail::call_f(f, typename PC::PTDType(), int()));
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
 
@@ -668,11 +668,11 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F const& f)
  *                      return p.id() > 0;
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.m_aos[i].id() > 0;
+ *                      return ptd.id(i) > 0;
  *                  });
  *
  */
@@ -715,11 +715,11 @@ ReduceLogicalAnd (PC const& pc, F&& f)
  *                      return p.id() > 0;
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.m_aos[i].id() > 0;
+ *                      return ptd.id(i) > 0;
  *                  });
  *
  */
@@ -756,18 +756,18 @@ ReduceLogicalAnd (PC const& pc, int lev, F&& f)
  *                      return p.id() > 0;
  *                  });
  *
- *        using SPType  = typename PC::SuperParticleType;
+ *        using SPType  = typename PC::;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
  *                  {
  *                      return p.id() > 0;
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.m_aos[i].id() > 0;
+ *                      return ptd.id(i) > 0;
  *                  });
  *
  */
@@ -864,11 +864,11 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F const& f)
  *                      return p.id() < 1;
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.m_aos[i].id() < 1;
+ *                      return ptd.id(i) < 1;
  *                  });
  *
  */
@@ -911,11 +911,11 @@ ReduceLogicalOr (PC const& pc, F&& f)
  *                      return p.id() < 1;
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.m_aos[i].id() < 1;
+ *                      return ptd.id(i) < 1;
  *                  });
  *
  */
@@ -959,11 +959,11 @@ ReduceLogicalOr (PC const& pc, int lev, F&& f)
  *                      return p.id() < 1;
  *                  });
  *
- *        using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *        using PTDType = typename PC::PTDType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.m_aos[i].id() < 1;
+ *                      return ptd.id(i) < 1;
  *                  });
  *
  */
@@ -1078,15 +1078,15 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F const& f)
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
- *    using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *    using PTDType = typename PC::PTDType;
  *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
  *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
  *                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
  *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
  *             {
- *                 const amrex::Real a = ptd.m_aos[i].rdata(1);
- *                 const amrex::Real b = ptd.m_aos[i].rdata(2);
- *                 const int c = ptd.m_aos[i].idata(1);
+ *                 const amrex::Real a = ptd.rdata(1)[i];
+ *                 const amrex::Real b = ptd.rdata(2)[i];
+ *                 const int c = ptd.idata(1)[i];
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
@@ -1148,15 +1148,15 @@ ParticleReduce (PC const& pc, F&& f, ReduceOps& reduce_ops)
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
- *    using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *    using PTDType = typename PC::PTDType;
  *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
  *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
  *                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
  *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
  *             {
- *                 const amrex::Real a = ptd.m_aos[i].rdata(1);
- *                 const amrex::Real b = ptd.m_aos[i].rdata(2);
- *                 const int c = ptd.m_aos[i].idata(1);
+ *                 const amrex::Real a = ptd.rdata(1)[i];
+ *                 const amrex::Real b = ptd.rdata(2)[i];
+ *                 const int c = ptd.idata(1)[i];
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
@@ -1219,15 +1219,15 @@ ParticleReduce (PC const& pc, int lev, F&& f, ReduceOps& reduce_ops)
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
- *    using PTDType = typename PC::ParticleTileType::ConstParticleTileDataType;
+ *    using PTDType = typename PC::PTDType;
  *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
  *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
  *                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
  *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
  *             {
- *                 const amrex::Real a = ptd.m_aos[i].rdata(1);
- *                 const amrex::Real b = ptd.m_aos[i].rdata(2);
- *                 const int c = ptd.m_aos[i].idata(1);
+ *                 const amrex::Real a = ptd.rdata(1)[i];
+ *                 const amrex::Real b = ptd.rdata(2)[i];
+ *                 const int c = ptd.idata(1)[i];
  *                 return {a, b, c};
  *             }, reduce_ops);
  *

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -66,9 +66,9 @@ auto call_f (F const& f,
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto sm = amrex::ReduceSum(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> ParticleReal
  *                  {
  *                      return ptd.rdata(0)[i];
  *                  });
@@ -77,7 +77,7 @@ auto call_f (F const& f,
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceSum (PC const& pc, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()))
 {
     return ReduceSum(pc, 0, pc.finestLevel(), std::forward<F>(f));
 }
@@ -114,9 +114,9 @@ ReduceSum (PC const& pc, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto sm = amrex::ReduceSum(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> ParticleReal
  *                  {
  *                      return ptd.rdata(0)[i];
  *                  });
@@ -125,7 +125,7 @@ ReduceSum (PC const& pc, F&& f)
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceSum (PC const& pc, int lev, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()))
 {
     return ReduceSum(pc, lev, lev, std::forward<F>(f));
 }
@@ -163,9 +163,9 @@ ReduceSum (PC const& pc, int lev, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto sm = amrex::ReduceSum(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> ParticleReal
  *                  {
  *                      return ptd.rdata(0)[i];
  *                  });
@@ -174,9 +174,9 @@ ReduceSum (PC const& pc, int lev, F&& f)
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceSum (PC const& pc, int lev_min, int lev_max, F const& f)
-    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()))
 {
-    using value_type = decltype(particle_detail::call_f(f, typename PC::PTDType(), int()));
+    using value_type = decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()));
     value_type sm = 0;
 
 #ifdef AMREX_USE_GPU
@@ -266,9 +266,9 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F const& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto mx = amrex::ReduceMax(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> ParticleReal
  *                  {
  *                      return ptd.rdata(0)[i];
  *                  });
@@ -277,7 +277,7 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F const& f)
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMax (PC const& pc, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()))
 {
     return ReduceMax(pc, 0, pc.finestLevel(), std::forward<F>(f));
 }
@@ -314,9 +314,9 @@ ReduceMax (PC const& pc, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto mx = amrex::ReduceMax(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> ParticleReal
  *                  {
  *                      return ptd.rdata(0)[i];
  *                  });
@@ -325,7 +325,7 @@ ReduceMax (PC const& pc, F&& f)
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMax (PC const& pc, int lev, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()))
 {
     return ReduceMax(pc, lev, lev, std::forward<F>(f));
 }
@@ -363,9 +363,9 @@ ReduceMax (PC const& pc, int lev, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto mx = amrex::ReduceMax(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> ParticleReal
  *                  {
  *                      return ptd.rdata(0)[i];
  *                  });
@@ -374,9 +374,9 @@ ReduceMax (PC const& pc, int lev, F&& f)
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMax (PC const& pc, int lev_min, int lev_max, F const& f)
-    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()))
 {
-    using value_type = decltype(particle_detail::call_f(f, typename PC::PTDType(), int()));
+    using value_type = decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()));
     constexpr value_type value_lowest = std::numeric_limits<value_type>::lowest();
     value_type r = value_lowest;
 
@@ -467,9 +467,9 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F const& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto mn = amrex::ReduceMin(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> ParticleReal
  *                  {
  *                      return ptd.rdata(0)[i];
  *                  });
@@ -478,7 +478,7 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F const& f)
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMin (PC const& pc, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()))
 {
     return ReduceMin(pc, 0, pc.finestLevel(), std::forward<F>(f));
 }
@@ -515,9 +515,9 @@ ReduceMin (PC const& pc, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto mn = amrex::ReduceMin(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> ParticleReal
  *                  {
  *                      return ptd.rdata(0)[i];
  *                  });
@@ -526,7 +526,7 @@ ReduceMin (PC const& pc, F&& f)
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMin (PC const& pc, int lev, F&& f)
-    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()))
 {
     return ReduceMin(pc, lev, lev, std::forward<F>(f));
 }
@@ -564,9 +564,9 @@ ReduceMin (PC const& pc, int lev, F&& f)
  *                      return p.idata(0);
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto mn = amrex::ReduceMin(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> ParticleReal
  *                  {
  *                      return ptd.rdata(0)[i];
  *                  });
@@ -575,9 +575,9 @@ ReduceMin (PC const& pc, int lev, F&& f)
 template <class PC, class F, std::enable_if_t<IsParticleContainer<PC>::value, int> foo = 0>
 auto
 ReduceMin (PC const& pc, int lev_min, int lev_max, F const& f)
-    -> decltype(particle_detail::call_f(f, typename PC::PTDType(), int()))
+    -> decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()))
 {
-    using value_type = decltype(particle_detail::call_f(f, typename PC::PTDType(), int()));
+    using value_type = decltype(particle_detail::call_f(f, typename PC::ConstPTDType(), int()));
     constexpr value_type value_max = std::numeric_limits<value_type>::max();
     value_type r = value_max;
 
@@ -668,9 +668,9 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F const& f)
  *                      return p.id() > 0;
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
  *                      return ptd.id(i) > 0;
  *                  });
@@ -715,9 +715,9 @@ ReduceLogicalAnd (PC const& pc, F&& f)
  *                      return p.id() > 0;
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
  *                      return ptd.id(i) > 0;
  *                  });
@@ -763,9 +763,9 @@ ReduceLogicalAnd (PC const& pc, int lev, F&& f)
  *                      return p.id() > 0;
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
  *                      return ptd.id(i) > 0;
  *                  });
@@ -864,9 +864,9 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F const& f)
  *                      return p.id() < 1;
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
  *                      return ptd.id(i) < 1;
  *                  });
@@ -911,9 +911,9 @@ ReduceLogicalOr (PC const& pc, F&& f)
  *                      return p.id() < 1;
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
  *                      return ptd.id(i) < 1;
  *                  });
@@ -959,9 +959,9 @@ ReduceLogicalOr (PC const& pc, int lev, F&& f)
  *                      return p.id() < 1;
  *                  });
  *
- *        using PTDType = typename PC::PTDType;
+ *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
- *                  [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> bool
+ *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
  *                      return ptd.id(i) < 1;
  *                  });
@@ -1078,10 +1078,10 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F const& f)
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
- *    using PTDType = typename PC::PTDType;
+ *    using ConstPTDType = typename PC::ConstPTDType;
  *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
  *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
- *                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
+ *                 pc, [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
  *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
  *             {
  *                 const amrex::Real a = ptd.rdata(1)[i];
@@ -1148,10 +1148,10 @@ ParticleReduce (PC const& pc, F&& f, ReduceOps& reduce_ops)
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
- *    using PTDType = typename PC::PTDType;
+ *    using ConstPTDType = typename PC::ConstPTDType;
  *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
  *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
- *                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
+ *                 pc, [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
  *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
  *             {
  *                 const amrex::Real a = ptd.rdata(1)[i];
@@ -1219,10 +1219,10 @@ ParticleReduce (PC const& pc, int lev, F&& f, ReduceOps& reduce_ops)
  *                 return {a, b, c};
  *             }, reduce_ops);
  *
- *    using PTDType = typename PC::PTDType;
+ *    using ConstPTDType = typename PC::ConstPTDType;
  *    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
  *    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
- *                 pc, [=] AMREX_GPU_DEVICE (const PTDType& ptd, const int i) noexcept
+ *                 pc, [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
  *                               -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
  *             {
  *                 const amrex::Real a = ptd.rdata(1)[i];

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -756,7 +756,7 @@ ReduceLogicalAnd (PC const& pc, int lev, F&& f)
  *                      return p.id() > 0;
  *                  });
  *
- *        using SPType  = typename PC::;
+ *        using SPType  = typename PC::SuperParticleType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
  *                  {

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -515,6 +515,8 @@ struct ConstParticleTileData
     static constexpr int NAI = NArrayInt;
     using ParticleType = T_ParticleType;
     using ParticleRefType = T_ParticleType const&;
+    using RealType = ParticleReal;
+    using IntType = int;
 
     static constexpr int NStructReal = ParticleType::NReal;
     static constexpr int NStructInt = ParticleType::NInt;

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -62,7 +62,7 @@ struct ParticleTileData
     int* AMREX_RESTRICT * AMREX_RESTRICT m_runtime_idata;
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    ParticleReal& pos (const int dir, const int index) const &
+    decltype(auto) pos (const int dir, const int index) const &
     {
         if constexpr(!ParticleType::is_soa_particle) {
             return this->m_aos[index].pos(dir);
@@ -536,7 +536,7 @@ struct ConstParticleTileData
     GpuArray<const int*, NArrayInt > m_idata;
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    const ParticleReal& pos (const int dir, const int index) const &
+    decltype(auto) pos (const int dir, const int index) const &
     {
         if constexpr(!ParticleType::is_soa_particle) {
             return this->m_aos[index].pos(dir);

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -36,6 +36,8 @@ struct ParticleTileData
     using ParticleType = T_ParticleType;
     using ParticleRefType = T_ParticleType&;
     using Self = ParticleTileData<ParticleType, NAR, NAI>;
+    using RealType = ParticleReal;
+    using IntType = int;
 
     static constexpr int NStructReal = ParticleType::NReal;
     static constexpr int NStructInt = ParticleType::NInt;
@@ -95,7 +97,7 @@ struct ParticleTileData
         if constexpr(ParticleType::is_soa_particle) {
             return this->m_idcpu[index];
         } else {
-            amrex::Abort("not implemented");
+            return this->m_aos[index].idcpu();
         }
     }
 
@@ -329,6 +331,7 @@ struct alignas(sizeof(double)) ConstSoAParticle : SoAParticleBase
     static constexpr bool is_constsoa_particle = true;
 
     using RealType = ParticleReal;
+    using IntType = int;
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ConstSoAParticle (ConstPTD const& ptd, long i) : // Note: should this be int instead?
@@ -374,7 +377,7 @@ struct alignas(sizeof(double)) ConstSoAParticle : SoAParticleBase
 
     private :
 
-    static_assert(std::is_trivially_copyable<ParticleTileData<SoAParticleBase, NArrayReal, NArrayInt>>(), "ParticleTileData is not trivially copyable");
+    static_assert(std::is_trivially_copyable<ConstPTD>(), "ParticleTileData is not trivially copyable");
 
     ConstPTD m_constparticle_tile_data;
     int m_index;
@@ -392,6 +395,7 @@ struct alignas(sizeof(double)) SoAParticle : SoAParticleBase
 
     using ConstType = ConstSoAParticle<T_NArrayReal, T_NArrayInt>;
     using RealType = ParticleReal;
+    using IntType = int;
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     SoAParticle (PTD const& ptd, long i) : // Note: should this be int instead?
@@ -456,7 +460,7 @@ struct alignas(sizeof(double)) SoAParticle : SoAParticleBase
 
 private :
 
-    static_assert(std::is_trivially_copyable<ParticleTileData<SoAParticleBase, NArrayReal, NArrayInt>>(), "ParticleTileData is not trivially copyable");
+    static_assert(std::is_trivially_copyable<PTD>(), "ParticleTileData is not trivially copyable");
 
     PTD m_particle_tile_data;
     int m_index;
@@ -565,7 +569,7 @@ struct ConstParticleTileData
         if constexpr(ParticleType::is_soa_particle) {
             return this->m_idcpu[index];
         } else {
-            amrex::Abort("not implemented");
+            return this->m_aos[index].idcpu();
         }
     }
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -346,7 +346,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     }
 
     const Long iChunkSize = 2 + num_output_int;
-    idata.resize(np*iChunkSize);
+    idata.resize(std::max(np*iChunkSize, Long{0})); // max to fix compiler warning
 
     int num_output_real = 0;
     for (int i : write_real_comp) {

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -366,10 +366,10 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
         for (int pindex = 0; pindex < ptile.numParticles(); ++pindex) {
             if (pflags[pindex]) {
                 iPackParticleData(ptd, pindex, iChunkSize, iptr,
-                                  write_int_comp, is_checkpoint);
+                                  write_int_comp.dataPtr(), is_checkpoint);
 
                 rPackParticleData(ptd, pindex, rChunkSize, rptr,
-                                  write_real_comp);
+                                  write_real_comp.dataPtr());
             }
         }
     }

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -860,7 +860,6 @@ void WriteBinaryParticleDataAsync (PC const& pc,
         dms.push_back(pc.ParticleDistributionMap(lev));
     }
 
-    int nrc = pc.NumRealComps();
     int nic = pc.NumIntComps();
     int rnames_size = (int) real_comp_names.size();
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -1015,7 +1015,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                         if (ptd.id(pindex) <= 0) { continue; }
 
                         particle_detail::iPackParticleData(ptd, pindex, iChunkSize, iptr,
-                            write_int_comp, is_checkpoint);
+                            write_int_comp.dataPtr(), is_checkpoint);
                     }
                 }
 
@@ -1041,7 +1041,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                         if (ptd.id(pindex) <= 0) { continue; }
 
                         particle_detail::rPackParticleData(ptd, pindex, rChunkSize, rptr,
-                            write_real_comp);
+                            write_real_comp.dataPtr());
                     }
                 }
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -1014,7 +1014,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     {
                         if (ptd.id(pindex) <= 0) { continue; }
 
-                        iPackParticleData(ptd, pindex, iChunkSize, iptr,
+                        particle_detail::iPackParticleData(ptd, pindex, iChunkSize, iptr,
                             write_int_comp, is_checkpoint);
                     }
                 }
@@ -1040,7 +1040,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     {
                         if (ptd.id(pindex) <= 0) { continue; }
 
-                        rPackParticleData(ptd, pindex, rChunkSize, rptr,
+                        particle_detail::rPackParticleData(ptd, pindex, rChunkSize, rptr,
                             write_real_comp);
                     }
                 }

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -47,8 +47,12 @@ fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F const& f)
             amrex::ignore_unused(flag_ptr, f, engine);
             if constexpr (IsCallable<F,decltype(p),RandomEngine>::value) {
                 flag_ptr[k] = f(p,engine);
-            } else {
+            } else if constexpr (IsCallable<F,decltype(p)>::value) {
                 flag_ptr[k] = f(p);
+            } else if constexpr (IsCallable<F,decltype(ptd),int,RandomEngine>::value) {
+                flag_ptr[k] = f(ptd,k,engine);
+            } else {
+                flag_ptr[k] = f(ptd,k);
             }
         });
 }
@@ -72,8 +76,16 @@ fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F const& f)
 #else
             flag_ptr[k] = f(p,RandomEngine{});
 #endif
-        } else {
+        } else if constexpr (IsCallable<F,decltype(p)>::value) {
             flag_ptr[k] = f(p);
+        } else if constexpr (IsCallable<F,decltype(ptd),int,RandomEngine>::value) {
+#ifdef AMREX_USE_GPU
+            flag_ptr[k] = f(ptd,k,RandomEngine{nullptr});
+#else
+            flag_ptr[k] = f(ptd,k,RandomEngine{});
+#endif
+        } else {
+            flag_ptr[k] = f(ptd,k);
         }
     }
 }
@@ -156,20 +168,96 @@ countFlags (const Container<int,Allocator>& pflags)
 
 template <typename P, typename I>
 AMREX_GPU_HOST_DEVICE
-void packParticleIDs (I* idata, const P& p, bool is_checkpoint) noexcept
+void packParticleIDs (I* idata, const std::uint32_t idcpu, bool is_checkpoint) noexcept
 {
     if (is_checkpoint) {
         std::int32_t  xi, yi;
         std::uint32_t xu, yu;
-        xu = (std::uint32_t)((p.m_idcpu & 0xFFFFFFFF00000000LL) >> 32);
-        yu = (std::uint32_t)( p.m_idcpu & 0xFFFFFFFFLL);
+        xu = (std::uint32_t)((idcpu & 0xFFFFFFFF00000000LL) >> 32);
+        yu = (std::uint32_t)( idcpu & 0xFFFFFFFFLL);
         amrex::Gpu::memcpy(&xi, &xu, sizeof(xu));
         amrex::Gpu::memcpy(&yi, &yu, sizeof(yu));
         idata[0] = xi;
         idata[1] = yi;
     } else {
-        idata[0] = p.id();
-        idata[1] = p.cpu();
+        idata[0] = ConstParticleIDWrapper{idcpu};
+        idata[1] = ConstParticleCPUWrapper{idcpu};
+    }
+}
+
+template<class PTD>
+AMREX_GPU_HOST_DEVICE void
+rPackParticleData (const PTD& ptd, int idx, Long rchunck_size, typename PTD::RealType * rdata_ptr,
+                   const int * write_real_comp)
+{
+    std::size_t rout_index = idx*rchunck_size;
+
+    for (int j = 0; j < AMREX_SPACEDIM; ++j) {
+        rdata_ptr[rout_index] = ptd.pos(j, idx);
+        rout_index++;
+    }
+
+    if constexpr (!PTD::ParticleType::is_soa_particle) {
+        const auto& p = ptd[idx];
+
+        for (int j = 0; j < PTD::ParticleType::NReal; ++j) {
+            if (write_real_comp[j]) {
+                rdata_ptr[rout_index] = p.rdata(j);
+                rout_index++;
+            }
+        }
+    }
+
+    constexpr int real_start_offset = PTD::ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+
+    for (int j = real_start_offset; j < PTD::NAR; ++j) {
+        if (write_real_comp[PTD::ParticleType::NReal + j - real_start_offset]) {
+            rdata_ptr[rout_index] = ptd.rdata(j)[idx];
+            rout_index++;
+        }
+    }
+
+    for (int j = 0; j < ptd.m_num_runtime_real; ++j) {
+        if (write_real_comp[PTD::ParticleType::NReal + PTD::NAR + j - real_start_offset]) {
+            rdata_ptr[rout_index] = ptd.m_runtime_rdata[j][idx];
+            rout_index++;
+        }
+    }
+}
+
+template<class PTD>
+AMREX_GPU_HOST_DEVICE void
+iPackParticleData (const PTD& ptd, int idx, Long ichunck_size, typename PTD::IntType * idata_ptr,
+                   const int * write_int_comp, bool is_checkpoint)
+{
+    std::size_t iout_index = idx*ichunck_size;
+
+    packParticleIDs(&idata_ptr[iout_index], ptd.idcpu(idx), is_checkpoint);
+    iout_index += 2;
+
+    if constexpr (!PTD::ParticleType::is_soa_particle) {
+        const auto& p = ptd[idx];
+
+        for (int j = 0; j < PTD::ParticleType::NInt; ++j) {
+            if (write_int_comp[j]) {
+                idata_ptr[iout_index] = p.idata(j);
+                iout_index++;
+            }
+        }
+    }
+
+    for (int j = 0; j < PTD::NAI; ++j) {
+        if (write_int_comp[PTD::ParticleType::NInt + j]) {
+            idata_ptr[iout_index] = ptd.idata(j)[idx];
+            iout_index++;
+        }
+    }
+
+    for (int j = 0; j < ptd.m_num_runtime_int; ++j) {
+        if (write_int_comp[PTD::ParticleType::NInt + PTD::NAI + j]) {
+            idata_ptr[iout_index] = ptd.m_runtime_idata[j][idx];
+            iout_index++;
+        }
     }
 }
 
@@ -226,50 +314,12 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
         amrex::ParallelFor(num_copies,
         [=] AMREX_GPU_DEVICE (int pindex) noexcept
         {
-            // might be worth using shared memory here
-            const auto p = ptd.getSuperParticle(pindex);
-
             if (flag_ptr[pindex]) {
-                std::size_t iout_index = pindex*iChunkSize;
-                packParticleIDs(&idata_d_ptr[iout_index], p, is_checkpoint);
-                iout_index += 2;
+                iPackParticleData(ptd, pindex, iChunkSize, idata_d_ptr,
+                                  write_int_comp_d_ptr, is_checkpoint);
 
-                std::size_t rout_index = pindex*rChunkSize;
-                for (int j = 0; j < AMREX_SPACEDIM; j++) {
-                  rdata_d_ptr[rout_index] = p.pos(j);
-                  rout_index++;
-                }
-
-                for (int j = 0; j < PC::SuperParticleType::NInt; j++) {
-                    if (write_int_comp_d_ptr[j]) {
-                        idata_d_ptr[iout_index] = p.idata(j);
-                        iout_index++;
-                    }
-                }
-
-                for (int j = 0; j < ptd.m_num_runtime_int; j++) {
-                    if (write_int_comp_d_ptr[PC::SuperParticleType::NInt + j]) {
-                        idata_d_ptr[iout_index] = ptd.m_runtime_idata[j][pindex];
-                        iout_index++;
-                    }
-                }
-
-                // extra SoA Real components
-                const int real_start_offset = PC::ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0; // pure SoA: skip positions
-                for (int j = real_start_offset; j < PC::SuperParticleType::NReal; j++) {
-                    const int write_comp_index = j-real_start_offset;
-                    if (write_real_comp_d_ptr[write_comp_index]) {
-                        rdata_d_ptr[rout_index] = p.rdata(j);
-                        rout_index++;
-                    }
-                }
-
-                for (int j = 0; j < ptd.m_num_runtime_real; j++) {
-                    if (write_real_comp_d_ptr[PC::SuperParticleType::NReal+j-real_start_offset]) {
-                        rdata_d_ptr[rout_index] = ptd.m_runtime_rdata[j][pindex];
-                        rout_index++;
-                    }
-                }
+                rPackParticleData(ptd, pindex, rChunkSize, rdata_d_ptr,
+                                  write_real_comp_d_ptr);
             }
         });
 
@@ -311,84 +361,15 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     for (int tile : tiles) {
         const auto& ptile = pc.ParticlesAt(lev, grid, tile);
         const auto& pflags = particle_io_flags[lev].at(std::make_pair(grid, tile));
+        const auto& ptd = ptile.getConstParticleTileData();
+
         for (int pindex = 0; pindex < ptile.numParticles(); ++pindex) {
             if (pflags[pindex]) {
-                const auto& soa  = ptile.GetStructOfArrays();
+                iPackParticleData(ptd, pindex, iChunkSize, iptr,
+                                  write_int_comp, is_checkpoint);
 
-                // note: for pure SoA particle layouts, we do write the id, cpu and positions as a struct
-                //       for backwards compatibility with readers
-                if constexpr(!PC::ParticleType::is_soa_particle)
-                {
-                    const auto& aos = ptile.GetArrayOfStructs();
-                    const auto& p = aos[pindex];
-
-                    // Int: id, cpu
-                    packParticleIDs(iptr, p, is_checkpoint);
-                    iptr += 2;
-
-                    // Real: positions
-                    for (int j = 0; j < AMREX_SPACEDIM; j++) { rptr[j] = p.pos(j); }
-                    rptr += AMREX_SPACEDIM;
-
-                    // extra AoS Int components
-                    for (int j = 0; j < PC::NStructInt; j++) {
-                        if (write_int_comp[j]) {
-                            *iptr = p.idata(j);
-                            ++iptr;
-                        }
-                    }
-                    // extra AoS Real components
-                    for (int j = 0; j < PC::NStructReal; j++) {
-                        if (write_real_comp[j]) {
-                            *rptr = p.rdata(j);
-                            ++rptr;
-                        }
-                    }
-                }
-                else {
-                    uint64_t idcpu = soa.GetIdCPUData()[pindex];
-                    if (is_checkpoint) {
-                        std::int32_t  xi, yi;
-                        std::uint32_t xu, yu;
-                        xu = (std::uint32_t)((idcpu & 0xFFFFFFFF00000000LL) >> 32);
-                        yu = (std::uint32_t)( idcpu & 0xFFFFFFFFLL);
-                        std::memcpy(&xi, &xu, sizeof(xu));
-                        std::memcpy(&yi, &yu, sizeof(yu));
-                        *iptr = xi;
-                        iptr += 1;
-                        *iptr = yi;
-                        iptr += 1;
-                    } else {
-                        // Int: id, cpu
-                        *iptr = (int) ParticleIDWrapper(idcpu);
-                        iptr += 1;
-                        *iptr = (int) ParticleCPUWrapper(idcpu);
-                        iptr += 1;
-                    }
-
-                    // Real: position
-                    for (int j = 0; j < AMREX_SPACEDIM; j++) { rptr[j] = soa.GetRealData(j)[pindex]; }
-                    rptr += AMREX_SPACEDIM;
-                }
-
-                // SoA int data
-                const int int_start_offset = 0;
-                for (int j = int_start_offset; j < pc.NumIntComps(); j++) {
-                    if (write_int_comp[PC::NStructInt+j]) {
-                        *iptr = soa.GetIntData(j)[pindex];
-                        ++iptr;
-                    }
-                }
-
-                // extra SoA Real components
-                const int real_start_offset = PC::ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0; // pure SoA: skip positions
-                for (int j = real_start_offset; j < pc.NumRealComps(); j++) {
-                    const int write_comp_index = PC::NStructReal+j-real_start_offset;
-                    if (write_real_comp[write_comp_index]) {
-                        *rptr = (ParticleReal) soa.GetRealData(j)[pindex];
-                        ++rptr;
-                    }
-                }
+                rPackParticleData(ptd, pindex, rChunkSize, rptr,
+                                  write_real_comp);
             }
         }
     }
@@ -1032,62 +1013,10 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     const auto& ptd = pbox.getConstParticleTileData();
                     for (int pindex = 0; pindex < pbox.numParticles(); ++pindex)
                     {
-                        const auto& soa  = pbox.GetStructOfArrays();
+                        if (ptd.id(pindex) <= 0) { continue; }
 
-                        make_particle<typename PC::ConstParticleType> mp{};
-                        const auto& p = mp(ptd, pindex);
-                        if (p.id() <= 0) { continue; }
-
-                        // note: for pure SoA particle layouts, we do write the id, cpu and positions as a struct
-                        //       for backwards compatibility with readers
-                        if constexpr(!PC::ParticleType::is_soa_particle)
-                        {
-                            // Ints: id, cpu
-                            particle_detail::packParticleIDs(iptr, p, is_checkpoint);
-                            iptr += 2;
-
-                            // extra AoS Int components
-                            for (int j = 0; j < NStructInt; j++)
-                            {
-                                if (write_int_comp[j])
-                                {
-                                    *iptr = p.idata(j);
-                                    ++iptr;
-                                }
-                            }
-                        }
-                        else {
-                            uint64_t idcpu = soa.GetIdCPUData()[pindex];
-                            if (is_checkpoint) {
-                                std::int32_t  xi, yi;
-                                std::uint32_t xu, yu;
-                                xu = (std::uint32_t)((idcpu & 0xFFFFFFFF00000000LL) >> 32);
-                                yu = (std::uint32_t)( idcpu & 0xFFFFFFFFLL);
-                                std::memcpy(&xi, &xu, sizeof(xu));
-                                std::memcpy(&yi, &yu, sizeof(yu));
-                                *iptr = xi;
-                                iptr += 1;
-                                *iptr = yi;
-                                iptr += 1;
-                            } else {
-                                // Int: id, cpu
-                                *iptr = (int) ParticleIDWrapper(idcpu);
-                                iptr += 1;
-                                *iptr = (int) ParticleCPUWrapper(idcpu);
-                                iptr += 1;
-                            }
-                        }
-
-                        // extra SoA Ints
-                        const int int_start_offset = 0;
-                        for (int j = int_start_offset; j < nic; j++)
-                        {
-                            if (write_int_comp[NStructInt+j])
-                            {
-                                *iptr = soa.GetIntData(j)[pindex];
-                                ++iptr;
-                            }
-                        }
+                        iPackParticleData(ptd, pindex, iChunkSize, iptr,
+                            write_int_comp, is_checkpoint);
                     }
                 }
 
@@ -1108,49 +1037,12 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     auto ptile_index = std::make_pair(grid, tile_map[grid][i]);
                     const auto& pbox = (*myptiles)[lev][ptile_index];
                     const auto& ptd = pbox.getConstParticleTileData();
-                    for (int pindex = 0;
-                         pindex < pbox.numParticles(); ++pindex)
+                    for (int pindex = 0; pindex < pbox.numParticles(); ++pindex)
                     {
-                        const auto& soa  = pbox.GetStructOfArrays();
-                        make_particle<typename PC::ConstParticleType> mp{};
-                        const auto& p = mp(ptd, pindex);
+                        if (ptd.id(pindex) <= 0) { continue; }
 
-                        if (p.id() <= 0) { continue; }
-
-                        if constexpr(!PC::ParticleType::is_soa_particle)
-                        {
-                            // Real: position
-                            for (int j = 0; j < AMREX_SPACEDIM; j++) { rptr[j] = p.pos(j); }
-                            rptr += AMREX_SPACEDIM;
-
-                            // extra AoS real
-                            for (int j = 0; j < NStructReal; j++)
-                            {
-                                if (write_real_comp[j])
-                                {
-                                    *rptr = p.rdata(j);
-                                    ++rptr;
-                                }
-                            }
-                        }
-                        else {
-                            // Real: position
-                            for (int j = 0; j < AMREX_SPACEDIM; j++) { rptr[j] = soa.GetRealData(j)[pindex]; }
-                            rptr += AMREX_SPACEDIM;
-                        }
-
-                        // extra SoA real
-                        const int real_start_offset = PC::ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0; // pure SoA: positions
-                        for (int j = real_start_offset; j < nrc; j++)
-                        {
-                    const int write_comp_offset = PC::ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0; // pure SoA: skip positions
-                    const int write_comp_index = PC::NStructReal+j-write_comp_offset;
-                            if (write_real_comp[write_comp_index])
-                            {
-                                *rptr = (typename PC::ParticleType::RealType) soa.GetRealData(j)[pindex];
-                                ++rptr;
-                            }
-                        }
+                        rPackParticleData(ptd, pindex, rChunkSize, rptr,
+                            write_real_comp);
                     }
                 }
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -340,7 +340,6 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     }
 
     const Long iChunkSize = 2 + num_output_int;
-    AMREX_ALWAYS_ASSERT(idata.size() >= 0 && idata.capacity() >= 0);
     idata.resize(np*iChunkSize);
 
     int num_output_real = 0;
@@ -1013,7 +1012,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
 
                         particle_detail::iPackParticleData(ptd, pindex, iptr,
                             write_int_comp.dataPtr(), is_checkpoint);
-                        iptr+ = iChunkSize;
+                        iptr += iChunkSize;
                     }
                 }
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -166,9 +166,9 @@ countFlags (const Container<int,Allocator>& pflags)
     return nparticles;
 }
 
-template <typename P, typename I>
+template <typename I>
 AMREX_GPU_HOST_DEVICE
-void packParticleIDs (I* idata, const std::uint32_t idcpu, bool is_checkpoint) noexcept
+void packParticleIDs (I* idata, const std::uint64_t idcpu, bool is_checkpoint) noexcept
 {
     if (is_checkpoint) {
         std::int32_t  xi, yi;

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -346,7 +346,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     }
 
     const Long iChunkSize = 2 + num_output_int;
-    idata.resize(std::max(np*iChunkSize, Long{0})); // max to fix compiler warning
+    idata.resize(static_cast<std::size_t>(np*iChunkSize));
 
     int num_output_real = 0;
     for (int i : write_real_comp) {
@@ -354,7 +354,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     }
 
     const Long rChunkSize = AMREX_SPACEDIM + num_output_real;
-    rdata.resize(np*rChunkSize);
+    rdata.resize(static_cast<std::size_t>(np*rChunkSize));
 
     int* iptr = idata.dataPtr();
     ParticleReal* rptr = rdata.dataPtr();

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -179,10 +179,10 @@ void packParticleIDs (I* idata, const std::uint64_t idcpu, bool is_checkpoint) n
 
 template<class PTD>
 AMREX_GPU_HOST_DEVICE void
-rPackParticleData (const PTD& ptd, int idx, Long rchunck_size, typename PTD::RealType * rdata_ptr,
+rPackParticleData (const PTD& ptd, int idx, typename PTD::RealType * rdata_ptr,
                    const int * write_real_comp)
 {
-    std::size_t rout_index = idx*rchunck_size;
+    std::size_t rout_index = 0;
 
     for (int j = 0; j < AMREX_SPACEDIM; ++j) {
         rdata_ptr[rout_index] = ptd.pos(j, idx);
@@ -219,10 +219,10 @@ rPackParticleData (const PTD& ptd, int idx, Long rchunck_size, typename PTD::Rea
 
 template<class PTD>
 AMREX_GPU_HOST_DEVICE void
-iPackParticleData (const PTD& ptd, int idx, Long ichunck_size, typename PTD::IntType * idata_ptr,
+iPackParticleData (const PTD& ptd, int idx, typename PTD::IntType * idata_ptr,
                    const int * write_int_comp, bool is_checkpoint)
 {
-    std::size_t iout_index = idx*ichunck_size;
+    std::size_t iout_index = 0;
 
     packParticleIDs(&idata_ptr[iout_index], ptd.idcpu(idx), is_checkpoint);
     iout_index += 2;
@@ -298,19 +298,21 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
         typename PC::RealVector rdata_d(num_copies*rChunkSize);
 
         const auto flag_ptr = pflags.data();
+        const auto offset_ptr = offsets.data();
 
         auto idata_d_ptr = idata_d.data();
         auto rdata_d_ptr = rdata_d.data();
 
         const auto& ptd = ptile.getConstParticleTileData();
-        amrex::ParallelFor(num_copies,
+        amrex::ParallelFor(ptile.numParticles(),
         [=] AMREX_GPU_DEVICE (int pindex) noexcept
         {
             if (flag_ptr[pindex]) {
-                iPackParticleData(ptd, pindex, iChunkSize, idata_d_ptr,
+                const int out_indx = offset_ptr[pindex];
+                iPackParticleData(ptd, pindex, idata_d_ptr + out_indx * iChunkSize,
                                   write_int_comp_d_ptr, is_checkpoint);
 
-                rPackParticleData(ptd, pindex, rChunkSize, rdata_d_ptr,
+                rPackParticleData(ptd, pindex, rdata_d_ptr + out_indx * rChunkSize,
                                   write_real_comp_d_ptr);
             }
         });
@@ -338,7 +340,8 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     }
 
     const Long iChunkSize = 2 + num_output_int;
-    idata.resize(static_cast<std::size_t>(np*iChunkSize));
+    AMREX_ALWAYS_ASSERT(idata.size() >= 0 && idata.capacity() >= 0);
+    idata.resize(np*iChunkSize);
 
     int num_output_real = 0;
     for (int i : write_real_comp) {
@@ -346,7 +349,7 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
     }
 
     const Long rChunkSize = AMREX_SPACEDIM + num_output_real;
-    rdata.resize(static_cast<std::size_t>(np*rChunkSize));
+    rdata.resize(np*rChunkSize);
 
     int* iptr = idata.dataPtr();
     ParticleReal* rptr = rdata.dataPtr();
@@ -357,11 +360,13 @@ packIOData (Vector<int>& idata, Vector<ParticleReal>& rdata, const PC& pc, int l
 
         for (int pindex = 0; pindex < ptile.numParticles(); ++pindex) {
             if (pflags[pindex]) {
-                iPackParticleData(ptd, pindex, iChunkSize, iptr,
+                iPackParticleData(ptd, pindex, iptr,
                                   write_int_comp.dataPtr(), is_checkpoint);
+                iptr += iChunkSize;
 
-                rPackParticleData(ptd, pindex, rChunkSize, rptr,
+                rPackParticleData(ptd, pindex, rptr,
                                   write_real_comp.dataPtr());
+                rptr += rChunkSize;
             }
         }
     }
@@ -1006,8 +1011,9 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     {
                         if (ptd.id(pindex) <= 0) { continue; }
 
-                        particle_detail::iPackParticleData(ptd, pindex, iChunkSize, iptr,
+                        particle_detail::iPackParticleData(ptd, pindex, iptr,
                             write_int_comp.dataPtr(), is_checkpoint);
+                        iptr+ = iChunkSize;
                     }
                 }
 
@@ -1032,8 +1038,9 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     {
                         if (ptd.id(pindex) <= 0) { continue; }
 
-                        particle_detail::rPackParticleData(ptd, pindex, rChunkSize, rptr,
+                        particle_detail::rPackParticleData(ptd, pindex, rptr,
                             write_real_comp.dataPtr());
+                        rptr += rChunkSize;
                     }
                 }
 

--- a/Tests/Particles/CheckpointRestartSOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartSOA/main.cpp
@@ -156,15 +156,15 @@ void test ()
         {
             amrex::Print() << "working on comp " << icomp << "\n";
             auto sm_new = amrex::ReduceSum(newPC,
-                [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+                [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real
                 {
-                    return p.rdata(icomp);
+                    return ptd.rdata(icomp)[i];
                 });
 
             auto sm_old = amrex::ReduceSum(myPC,
-                [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+                [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real
                 {
-                    return p.rdata(icomp);
+                    return ptd.rdata(icomp)[i];
                 });
 
             ParallelDescriptor::ReduceRealSum(sm_new);
@@ -178,15 +178,15 @@ void test ()
         {
             amrex::Print() << "working on comp " << icomp << "\n";
             auto sm_new = amrex::ReduceSum(newPC,
-                [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+                [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real
                 {
-                    return p.idata(icomp);
+                    return ptd.idata(icomp)[i];
                 });
 
             auto sm_old = amrex::ReduceSum(myPC,
-                [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
+                [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real
                 {
-                    return p.idata(icomp);
+                    return ptd.idata(icomp)[i];
                 });
 
             ParallelDescriptor::ReduceRealSum(sm_new);

--- a/Tests/Particles/CheckpointRestartSOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartSOA/main.cpp
@@ -150,19 +150,19 @@ void test ()
         std::snprintf(directory_path, sizeof directory_path, "%s%s", directory.c_str(), "plt00000");
         newPC.Restart(directory_path, "particle0");
 
-        using PTDType = typename MyPC::PTDType;
+        using ConstPTDType = typename MyPC::ConstPTDType;
 
         for (int icomp=0; icomp<NReal; ++icomp)
         {
             amrex::Print() << "working on comp " << icomp << "\n";
             auto sm_new = amrex::ReduceSum(newPC,
-                [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real
+                [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real
                 {
                     return ptd.rdata(icomp)[i];
                 });
 
             auto sm_old = amrex::ReduceSum(myPC,
-                [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real
+                [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real
                 {
                     return ptd.rdata(icomp)[i];
                 });
@@ -178,13 +178,13 @@ void test ()
         {
             amrex::Print() << "working on comp " << icomp << "\n";
             auto sm_new = amrex::ReduceSum(newPC,
-                [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real
+                [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real
                 {
                     return ptd.idata(icomp)[i];
                 });
 
             auto sm_old = amrex::ReduceSum(myPC,
-                [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real
+                [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real
                 {
                     return ptd.idata(icomp)[i];
                 });

--- a/Tests/Particles/CheckpointRestartSOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartSOA/main.cpp
@@ -150,7 +150,7 @@ void test ()
         std::snprintf(directory_path, sizeof directory_path, "%s%s", directory.c_str(), "plt00000");
         newPC.Restart(directory_path, "particle0");
 
-        using PType = typename MyPC::SuperParticleType;
+        using PTDType = typename MyPC::PTDType;
 
         for (int icomp=0; icomp<NReal; ++icomp)
         {


### PR DESCRIPTION
## Summary

In preparation of #4404, this PR reduces the reliance of SuperParticle. The issue with getSuperParticle is that the compiler is instructed to read in all the data of the particle into registers even if most of it is not needed. Additionally, runtime data is not accessible through SuperParticle.

## Additional background

The previous version of packIOData with RunOnGpu had a bug when some particles were invalid.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
