### PR TITLE
[DO NOT MERGE] GPU TX: Annotate Unpack

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -444,22 +444,29 @@ void unpackBuffer (PC& pc, const ParticleCopyPlan& plan, const Buffer& snd_buffe
     // count how many particles we have to add to each tile
     std::vector<int> sizes;
     std::vector<PTile*> tiles;
-    for (int lev = 0; lev < num_levels; ++lev)
     {
-        for(MFIter mfi = pc.MakeMFIter(lev); mfi.isValid(); ++mfi)
+        BL_PROFILE("amrex::unpackBuffer::double_loop_start");
+
+        for (int lev = 0; lev < num_levels; ++lev)
         {
-            int gid = mfi.index();
-            int tid = mfi.LocalTileIndex();
-            auto& tile = pc.DefineAndReturnParticleTile(lev, gid, tid);
-            int num_copies = plan.m_box_counts_h[pc.BufferMap().gridAndLevToBucket(gid, lev)];
-            sizes.push_back(num_copies);
-            tiles.push_back(&tile);
+            for(MFIter mfi = pc.MakeMFIter(lev); mfi.isValid(); ++mfi)
+            {
+                int gid = mfi.index();
+                int tid = mfi.LocalTileIndex();
+                auto& tile = pc.DefineAndReturnParticleTile(lev, gid, tid);
+                int num_copies = plan.m_box_counts_h[pc.BufferMap().gridAndLevToBucket(gid, lev)];
+                sizes.push_back(num_copies);
+                tiles.push_back(&tile);
+            }
         }
     }
 
     // resize the tiles and compute offsets
     std::vector<int> offsets;
-    policy.resizeTiles(tiles, sizes, offsets);
+    {
+        BL_PROFILE("amrex::unpackRemotes::resizeTiles");
+        policy.resizeTiles(tiles, sizes, offsets);
+    }
 
     const auto* p_comm_real = plan.d_real_comp_mask.dataPtr();
     const auto* p_comm_int  = plan.d_int_comp_mask.dataPtr();
@@ -471,26 +478,36 @@ void unpackBuffer (PC& pc, const ParticleCopyPlan& plan, const Buffer& snd_buffe
         auto& plev  = pc.GetParticles(lev);
         for(MFIter mfi = pc.MakeMFIter(lev); mfi.isValid(); ++mfi)
         {
+            BL_PROFILE_VAR("amrex::unpackRemotes::mfiter_start", blpv_mfiter_start);
             int gid = mfi.index();
             int tid = mfi.LocalTileIndex();
             auto index = std::make_pair(gid, tid);
 
             auto& tile = plev[index];
+            BL_PROFILE_VAR_STOP(blpv_mfiter_start);
 
+            BL_PROFILE_VAR("amrex::unpackRemotes::mfiter_getoffset", blpv_mfiter_getoffset);
             GetSendBufferOffset get_offset(plan, pc.BufferMap());
             auto p_snd_buffer = snd_buffer.dataPtr();
+            BL_PROFILE_VAR_STOP(blpv_mfiter_getoffset);
 
             int offset = offsets[uindex];
             int size = sizes[uindex];
             ++uindex;
 
+            BL_PROFILE_VAR("amrex::unpackRemotes::mfiter_ptd", blpv_mfiter_ptd);
             auto ptd = tile.getParticleTileData();
+            BL_PROFILE_VAR_STOP(blpv_mfiter_ptd);
+
+            BL_PROFILE_VAR("amrex::unpackRemotes::mfiter_for1d", blpv_mfiter_for1d);
             AMREX_FOR_1D ( size, i,
             {
                 auto src_offset = get_offset(gid, lev, psize, i);
                 int dst_index = offset + i;
                 ptd.unpackParticleData(p_snd_buffer, src_offset, dst_index, p_comm_real, p_comm_int);
             });
+
+            BL_PROFILE_VAR_STOP(blpv_mfiter_for1d);
         }
     }
 }

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -617,33 +617,43 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
 
         std::vector<int> sizes;
         std::vector<PTile*> tiles;
-        for (int i = 0, N = int(plan.m_rcv_box_counts.size()); i < N; ++i)
         {
-            int copy_size = plan.m_rcv_box_counts[i];
-            int lev = plan.m_rcv_box_levs[i];
-            int gid = plan.m_rcv_box_ids[i];
-            int tid = 0;
-            auto& tile = pc.DefineAndReturnParticleTile(lev, gid, tid);
-            sizes.push_back(copy_size);
-            tiles.push_back(&tile);
+            BL_PROFILE("amrex::unpackRemotes::plan_boxes");
+            for (int i = 0, N = int(plan.m_rcv_box_counts.size()); i < N; ++i)
+            {
+                int copy_size = plan.m_rcv_box_counts[i];
+                int lev = plan.m_rcv_box_levs[i];
+                int gid = plan.m_rcv_box_ids[i];
+                int tid = 0;
+                auto& tile = pc.DefineAndReturnParticleTile(lev, gid, tid);
+                sizes.push_back(copy_size);
+                tiles.push_back(&tile);
+            }
         }
 
         Vector<int> offsets;
-        policy.resizeTiles(tiles, sizes, offsets);
-        Gpu::streamSynchronize();
+        {
+            BL_PROFILE("amrex::unpackRemotes::resizeTiles");
+            policy.resizeTiles(tiles, sizes, offsets);
+            Gpu::streamSynchronize();
+        }
         int uindex = 0;
         int procindex = 0, rproc = plan.m_rcv_box_pids[0];
         for (int i = 0, N = int(plan.m_rcv_box_counts.size()); i < N; ++i)
         {
+            BL_PROFILE_VAR("amrex::unpackRemotes::loop_start", blpv_loop_start);
             int lev = plan.m_rcv_box_levs[i];
             int gid = plan.m_rcv_box_ids[i];
             int tid = 0;
             auto offset = plan.m_rcv_box_offsets[i];
             procindex = (rproc == plan.m_rcv_box_pids[i]) ? procindex : procindex+1;
             rproc = plan.m_rcv_box_pids[i];
+            BL_PROFILE_VAR_STOP(blpv_loop_start);
 
+            BL_PROFILE_VAR("amrex::unpackRemotes::loop_ptd", blpv_loop_ptd);
             auto& tile = pc.DefineAndReturnParticleTile(lev, gid, tid);
             auto ptd = tile.getParticleTileData();
+            BL_PROFILE_VAR_STOP(blpv_loop_ptd);
 
             AMREX_ASSERT(MyProc ==
                 ParallelContext::global_to_local_rank(pc.ParticleDistributionMap(lev)[gid]));
@@ -652,9 +662,12 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
             int size = sizes[uindex];
             ++uindex;
 
+            BL_PROFILE_VAR("amrex::unpackRemotes::loop_superParticleSize", blpv_loop_sps);
             Long psize = plan.superParticleSize();
             const auto* p_pad_adjust = plan.m_rcv_pad_correction_d.dataPtr();
+            BL_PROFILE_VAR_STOP(blpv_loop_sps);
 
+            BL_PROFILE_VAR("amrex::unpackRemotes::loop_for1d", blpv_loop_for1d);
             AMREX_FOR_1D ( size, ip, {
                 Long src_offset = psize*(offset + ip) + p_pad_adjust[procindex];
                 int dst_index = dst_offset + ip;
@@ -663,6 +676,7 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
               });
 
             Gpu::streamSynchronize();
+            BL_PROFILE_VAR_STOP(blpv_loop_for1d);
         }
     }
 #else


### PR DESCRIPTION
## Summary

- [x] `unpackRemotes`
- [x] `unpackBuffers`

## Additional background

Debugging memory leaks on AMD GPUs.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
