### PR TITLE
Add getInvalidRandomEngine() for CPU

### DIFF
--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -68,6 +68,7 @@ namespace amrex
 
 #endif
 
+    AMREX_FORCE_INLINE
     RandomEngine getInvalidRandomEngine () {
 #ifdef AMREX_USE_GPU
         return RandomEngine{nullptr};

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -64,12 +64,17 @@ namespace amrex
 
 #else
 
-    struct RandomEngine {
-        RandomEngine () = default;
-        RandomEngine (void*) {}
-    }; // CPU
+    struct RandomEngine {}; // CPU
 
 #endif
+
+    RandomEngine getInvalidRandomEngine () {
+#ifdef AMREX_USE_GPU
+        return RandomEngine{nullptr};
+#else
+        return RandomEngine{};
+#endif
+    }
 
 }
 

--- a/Src/Base/AMReX_RandomEngine.H
+++ b/Src/Base/AMReX_RandomEngine.H
@@ -64,7 +64,10 @@ namespace amrex
 
 #else
 
-    struct RandomEngine {}; // CPU
+    struct RandomEngine {
+        RandomEngine () = default;
+        RandomEngine (void*) {}
+    }; // CPU
 
 #endif
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -67,7 +67,7 @@ fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F const& f)
     for (int k = 0; k < np; ++k) {
         const auto p = ptd.getSuperParticle(k);
         if constexpr (IsCallable<F,decltype(p),RandomEngine>::value) {
-            flag_ptr[k] = f(p,RandomEngine{nullptr});
+            flag_ptr[k] = f(p,getInvalidRandomEngine());
         } else {
             flag_ptr[k] = f(p);
         }

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -67,11 +67,7 @@ fillFlags (Container<int, Allocator>& pflags, const PTile& ptile, F const& f)
     for (int k = 0; k < np; ++k) {
         const auto p = ptd.getSuperParticle(k);
         if constexpr (IsCallable<F,decltype(p),RandomEngine>::value) {
-#ifdef AMREX_USE_GPU
             flag_ptr[k] = f(p,RandomEngine{nullptr});
-#else
-            flag_ptr[k] = f(p,RandomEngine{});
-#endif
         } else {
             flag_ptr[k] = f(p);
         }


### PR DESCRIPTION
## Summary

#4443 deleted the default constructor of RandomEngine for GPU. However for CPU still the default constructor must be used, forcing \#ifdef to be used in code that uses the constructor. This PR adds a `getInvalidRandomEngine()` function to get a dummy RandomEngine. Note the only use for RandomEngine on CPU is to make GPU code work on CPU.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
