### PR TITLE
Use geometric grow for resize in RedistributeGPU

### DIFF
--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1142,7 +1142,7 @@ Memory
 
 .. py:data:: amrex.vector_growth_factor
    :type: amrex::Real
-   :value: 1.5
+   :value: 1.25
 
    This controls the growth factor of :cpp:`amrex::PODVector` and its
    derived classes such as :cpp:`amrex::Gpu::DeviceVector`,

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -660,6 +660,21 @@ namespace amrex
             }
         }
 
+
+        void resize_geometric_grow (size_type a_new_size)
+        {
+            auto old_size = m_size;
+            if (m_capacity < a_new_size) {
+                size_type new_capacity = std::max(a_new_size, GetNewCapacityForPush());
+                reserve(new_capacity);
+            }
+            m_size = a_new_size;
+            if (old_size < a_new_size) {
+                detail::maybe_init_snan(m_data + old_size,
+                                        m_size - old_size, (Allocator const&)(*this));
+            }
+        }
+
         void reserve (size_type a_capacity)
         {
             if (m_capacity < a_capacity) {

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -4,7 +4,7 @@
 
 namespace amrex::VectorGrowthStrategy
 {
-    Real growth_factor = 1.5_rt;
+    Real growth_factor = 1.25_rt;
 
     // clamp user input to reasonable values
     constexpr Real min_factor = 1.001_rt;

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -49,7 +49,7 @@ struct RedistributeUnpackPolicy
         }
 
         for (auto& kv : tile_sizes) {
-            kv.first->resize(kv.second);
+            kv.first->resize_geometric_grow(kv.second);
         }
     }
 };

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -928,6 +928,26 @@ struct ParticleTile
         m_soa_tile.resize(count);
     }
 
+    void resize_geometric_grow (std::size_t count)
+    {
+        if constexpr (ParticleType::is_soa_particle) {
+            GetStructOfArrays().GetIdCPUData().resize_geometric_grow(count);
+        } else {
+            m_aos_tile().resize_geometric_grow(count);
+        }
+        for (int j = 0; j < NumRealComps(); ++j)
+        {
+            auto& rdata = GetStructOfArrays().GetRealData(j);
+            rdata.resize_geometric_grow(count);
+        }
+
+        for (int j = 0; j < NumIntComps(); ++j)
+        {
+            auto& idata = GetStructOfArrays().GetIntData(j);
+            idata.resize_geometric_grow(count);
+        }
+    }
+
     ///
     /// Add one particle to this tile.
     ///


### PR DESCRIPTION
## Summary

In an attempt to help with #4531 I used the `resize_geometric_grow` function from #4529 to resize the particle tiles in RedistributeGPU. Additionally, this PR changes the default `amrex.vector_growth_factor` from 1.5 to 1.25.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
