### PR TITLE
Docs and script for paraview series

### DIFF
--- a/Docs/sphinx_documentation/source/Visualization.rst
+++ b/Docs/sphinx_documentation/source/Visualization.rst
@@ -362,7 +362,11 @@ save this script. Then run the bash script by executing the following command in
 
     bash write_series_file.sh
 
-This will generate a file ``plot_files.series``. Open ParaView, and then select
+This will generate a file ``plot_files.series`` which indexes the time variable based on the order of the plotfile numbers.
+
+To make a ``.series`` file which reads the time out of the plotfile header, use :download:`write_series_file_timestamp.sh </Visualization/write_series_file_timestamp.sh>`.
+
+Open ParaView, and then select
 "File" :math:`\rightarrow` "Open". In the "Files of Type" dropdown menu (see :numref:`fig:ParaView_filegroup`)
 choose the option ``All Files (*)``. Then choose ``plot_files.series`` and click "OK". Now the plotfiles have been
 loaded as a Group as in Step 2 of section :ref:`section-1`. Now, you can follow the steps 2 to 7 in the section

--- a/Docs/sphinx_documentation/source/Visualization/write_series_file_timestamp.sh
+++ b/Docs/sphinx_documentation/source/Visualization/write_series_file_timestamp.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Specify the root directory for traversal
+root_directory="./"
+
+# Initialize an empty array to store directory information
+declare -a dir_info
+
+# Find all plt directories
+for dir in plt*; do
+    if [[ -d "$dir" && -f "$dir/Header" ]]; then
+        # Extract time from the fifth line of the Header file
+        time_value=$(sed -n '5p' "$dir/Header")
+
+        # Store directory and time as a pair
+        dir_info+=("$dir:$time_value")
+    fi
+done
+
+# Sort directories numerically by their numbers
+IFS=$'\n' sorted_dirs=($(for entry in "${dir_info[@]}"; do
+    echo "$entry"
+done | sort -t: -k1.4,1 -n))
+unset IFS
+
+# Initialize an empty string to store file information
+files_list=""
+
+# Process sorted directories
+for entry in "${sorted_dirs[@]}"; do
+    dir=$(echo "$entry" | cut -d: -f1)
+    time_value=$(echo "$entry" | cut -d: -f2)
+
+    # Round to 6 decimal places and format nicely
+    rounded_time=$(awk -v t="$time_value" 'BEGIN{printf "%.6f", t}' | sed 's/\.0*$//;s/\.\([0-9]*[1-9]\)0*$/.\1/')
+
+    echo "Processing $dir with time $rounded_time"
+
+    # Create file information
+    files_list+="$(printf "{ \"name\": \"$dir\", \"time\": $rounded_time},")"
+    files_list+=$'\n'
+done
+
+# Remove trailing comma from the last entry
+files_list="${files_list%,}"
+
+# Create the final JSON structure
+header_line="{ \"file-series-version\": \"1.0\", \"files\": ["
+all_files="$(printf '%s\n' "$files_list") ] }"
+
+file_series_data="$header_line"
+file_series_data+=$'\n'
+file_series_data+="$all_files"
+
+# Write the generated JSON structure to a file named plot_files.series
+echo "$file_series_data" > plot_files.series
+
+echo "JSON structure has been written to plot_files.series"


### PR DESCRIPTION
## Summary

* Adds write_series_file_timestamp.sh which has a rounded time
* Adds to the documentation describing how to use it

## Additional background

This script is based on an existing script from PR #3934  and adds a non-integer time

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [X] include documentation in the code and/or rst files, if appropriate
