### PR TITLE
Remove an assertion in AmrLevel::RK

### DIFF
--- a/Src/Amr/AMReX_AmrLevel.H
+++ b/Src/Amr/AMReX_AmrLevel.H
@@ -619,9 +619,6 @@ void AmrLevel::RK (int order, int state_type, Real time, Real dt, int iteration,
 
     MultiFab& S_old = get_old_data(state_type);
     MultiFab& S_new = get_new_data(state_type);
-    const Real t_old = state[state_type].prevTime();
-    const Real t_new = state[state_type].curTime();
-    AMREX_ALWAYS_ASSERT(amrex::almostEqual(time,t_old,10) && amrex::almostEqual(time+dt,t_new,10));
 
     if (order == 2) {
         RungeKutta::RK2(S_old, S_new, time, dt, std::forward<F>(f),


### PR DESCRIPTION
The assertion fails when there are many substeps.

Close #4538 