### PR TITLE
Added GNU compile flags to enable -fPIC for llvm

### DIFF
--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -133,8 +133,8 @@ endif
 
 
 ifeq ($(USE_COMPILE_PIC),TRUE)
-  CXXFLAGS = -fPIC
-  CFLAGS = -fPIC
+  CXXFLAGS += -fPIC
+  CFLAGS += -fPIC
 endif
 
 ifeq ($(ERROR_DEPRECATED),TRUE)
@@ -195,8 +195,8 @@ endif
 
 ifeq ($(USE_COMPILE_PIC),TRUE)
 
-  FFLAGS = -fPIC
-  F90FLAGS = -fPIC
+  FFLAGS += -fPIC
+  F90FLAGS += -fPIC
 
 endif
 

--- a/Tools/GNUMake/comps/llvm.mak
+++ b/Tools/GNUMake/comps/llvm.mak
@@ -60,8 +60,8 @@ ifeq ($(WARN_ERROR),TRUE)
 endif
 
 ifeq ($(USE_COMPILE_PIC),TRUE)
-  CXXFLAGS = -fPIC
-  CFLAGS = -fPIC
+  CXXFLAGS += -fPIC
+  CFLAGS += -fPIC
 endif
 
 # disable some warnings
@@ -81,8 +81,8 @@ CFLAGS   += -std=c11
 
 ifeq ($(USE_COMPILE_PIC),TRUE)
 
-  FFLAGS = -fPIC
-  F90FLAGS = -fPIC
+  FFLAGS += -fPIC
+  F90FLAGS += -fPIC
 
 endif
 

--- a/Tools/GNUMake/comps/llvm.mak
+++ b/Tools/GNUMake/comps/llvm.mak
@@ -59,6 +59,11 @@ ifeq ($(WARN_ERROR),TRUE)
   CFLAGS += -Werror
 endif
 
+ifeq ($(USE_COMPILE_PIC),TRUE)
+  CXXFLAGS = -fPIC
+  CFLAGS = -fPIC
+endif
+
 # disable some warnings
 CXXFLAGS += -Wno-c++17-extensions
 
@@ -72,6 +77,14 @@ endif
 
 CXXFLAGS += -std=$(CXXSTD)
 CFLAGS   += -std=c11
+
+
+ifeq ($(USE_COMPILE_PIC),TRUE)
+
+  FFLAGS = -fPIC
+  F90FLAGS = -fPIC
+
+endif
 
 FFLAGS   += -ffixed-line-length-none -fno-range-check -fno-second-underscore
 F90FLAGS += -ffree-line-length-none -fno-range-check -fno-second-underscore -fimplicit-none


### PR DESCRIPTION
## Summary
Currently, running ./configure with --enable-fpic=yes and --comp=llvm does not add the `-fPIC` flag. 
This PR adds the -fPIC flag to c++ and fortran compile flags when using GNUMake and LLVM. 

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
