### PR TITLE
These methods throw exceptions, so they should not be noexcept

### DIFF
--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -51,10 +51,10 @@ public:
                                   std::map<std::string, MemStat>& memstats) noexcept;
     static void memory_free (std::size_t nbytes, MemStat* stat) noexcept;
 
-    static void Initialize () noexcept;
+    static void Initialize ();
     static void Finalize (bool bFlushing = false) noexcept;
 
-    static void MemoryInitialize () noexcept;
+    static void MemoryInitialize ();
     static void MemoryFinalize (bool bFlushing = false) noexcept;
 
     static bool RegisterArena (const std::string& memory_name,

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -308,7 +308,7 @@ TinyProfiler::memory_free (std::size_t nbytes, MemStat* stat) noexcept
 
 
 void
-TinyProfiler::Initialize () noexcept
+TinyProfiler::Initialize ()
 {
     {
         amrex::ParmParse pp("tiny_profiler");
@@ -332,7 +332,7 @@ TinyProfiler::Initialize () noexcept
 }
 
 void
-TinyProfiler::MemoryInitialize () noexcept
+TinyProfiler::MemoryInitialize ()
 {
     {
         amrex::ParmParse pp("tiny_profiler");


### PR DESCRIPTION
This fixes a defect found by Coverity Scan. I think the exception comes from the ParmParse constructor.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
