### PR TITLE
SUNDIALS interface updates

### DIFF
--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -17,8 +17,8 @@ to :cpp:`amrex::Initialize` and the function adds parameters to AMReX's
 .. important:: AMReX reserves the following prefixes in :cpp:`ParmParse`
                parameters: ``amr``, ``amrex``, ``blprofiler``, ``device``,
                ``DistributionMapping``, ``eb2``, ``fab``, ``fabarray``,
-               ``geometry``, ``particles``, ``tiny_profiler``, and
-               ``vismf``.
+               ``geometry``, ``integration``, ``particles``, ``tiny_profiler``,
+               and ``vismf``.
 
 AMR
 ---
@@ -268,7 +268,7 @@ Amr Class
 ^^^^^^^^^
 
 .. warning:: These parameters are specific to :cpp:`class Amr` based
-             applications. If your application use :cpp:`class AmrCore`
+             applications. If your application uses :cpp:`class AmrCore`
              directly, they do not apply unless you have provided
              implementations for them.
 
@@ -937,7 +937,7 @@ Geometry
 --------
 
 All these parameters are optional for constructing a :ref:`Geometry <sec:basics:geom>`
-object. There are only used if the information is not provided via function
+object. They are only used if the information is not provided via function
 arguments.
 
 .. py:data:: geometry.coord_sys
@@ -1200,6 +1200,350 @@ Tiling
    communication buffer . It is disabled by default for GPU runs, but
    enabled for CPU runs with a tile size of 8 in the y and z-directions (if
    they exist).
+
+.. _sec:inputs:timeintegration:
+
+Time Integration
+----------------
+
+All these parameters are optional for constructing or configuring a
+:ref:`TimeIntegrator <sec:basics:timeintegration>` object.
+
+.. py:data:: integration.type
+   :type: string
+   :value: [none]
+
+   This parameter sets the type of time integrator to use. The supported values
+   are:
+
+   * ForwardEuler
+   * RungeKutta
+   * SUNDIALS
+
+.. py:data:: integration.time_step
+   :type: amrex::Real
+   :value: [none]
+
+   This parameter sets the fixed time step size to use.
+
+   For SUNDIALS methods, this parameter sets a fixed step size for single rate
+   methods (e.g., ERK) or a fixed slow time scale step size for multirate
+   methods (e.g., EX-MRI).
+
+.. _sec:inputs:timeintegration:rungekutta:
+
+Runge--Kutta Methods
+^^^^^^^^^^^^^^^^^^^^
+
+These parameters are relevant only when :py:data:`integration.type` is
+"RungeKutta".
+
+.. py:data:: integration.rk.type
+   :type: string
+   :value: [none]
+
+   This parameter sets the Runge--Kutta method to use. The supported values are:
+
+   * User
+   * ForwardEuler
+   * Trapezoid
+   * SSPRK3
+   * RK4
+
+User-specificed Runge--Kutta Method
+"""""""""""""""""""""""""""""""""""
+
+When :py:data:`integration.rk.type` is "User", the following parameters can be
+used to set a user-specificed explicit Butcher tableau,
+
+.. math::
+
+   B \; \equiv \;
+   \begin{array}{r|c}
+     c & A \\
+     \hline
+       & b \\
+       & \tilde{b}
+   \end{array},
+
+where, for a method with :math:`s` stages, :math:`c`, and :math:`b`,
+:math:`\tilde{b}` are arrays of :math:`s` values and :math:`A` is a lower
+triangular :math:`s \times s` matrix.
+
+.. py:data:: integration.rk.nodes
+   :type: amrex::Real array
+   :value: [none]
+
+   The :math:`c` values of the Butcher tableau.
+
+.. py:data:: integration.rk.tableau
+   :type: amrex::Real array
+   :value: [none]
+
+   The :math:`A` values of the Butcher tableau.
+
+.. py:data:: integration.rk.weights
+   :type: amrex::Real array
+   :value: [none]
+
+   The :math:`b` values of the Butcher tableau.
+
+.. py:data:: integration.rk.extended_weights
+   :type: amrex::Real array
+   :value: [none]
+
+   The :math:`\tilde{b}` values of the Butcher tableau. These values are only
+   required if the method has an embedding.
+
+.. _sec:inputs:timeintegration:sundials:
+
+SUNDIALS
+^^^^^^^^
+
+These parameters are relevant only when support for SUNDIALS time integrators is
+enabled (see :ref:`sec:time_int:sundials`) and :py:data:`integration.type` is
+"SUNDIALS".
+
+.. _sec:inputs:timeintegration:sundials:methods:
+
+Methods
+"""""""
+
+.. py:data:: integration.sundials.type
+   :type: string
+   :value: ERK
+
+   This parameter sets type of SUNDIALS time integrator to use. See the table
+   below for supported values.
+
+   +-----------------+---------------------------------------------------------+
+   | Parameter Value | SUNDIALS Method Type                                    |
+   +=================+=========================================================+
+   | ERK             | Explicit Runge-Kutta method                             |
+   +-----------------+---------------------------------------------------------+
+   | DIRK            | Diagonally Implicit Runge-Kutta method                  |
+   +-----------------+---------------------------------------------------------+
+   | IMEX-RK         | Implicit-Explicit Additive Runge-Kutta method           |
+   +-----------------+---------------------------------------------------------+
+   | EX-MRI          | Explicit Multirate Infinitesimal method                 |
+   +-----------------+---------------------------------------------------------+
+   | IM-MRI          | Implicit Multirate Infinitesimal method                 |
+   +-----------------+---------------------------------------------------------+
+   | IMEX-MRI        | Implicit-Explicit Multirate Infinitesimal method        |
+   +-----------------+---------------------------------------------------------+
+
+.. py:data:: integration.sundials.fast_type
+   :type: string
+   :value: ERK
+
+   When using a multirate method, this parameter sets the type of time
+   integrator to use at the fast time scale. Currently, ERK and DIRK methods are
+   supported.
+
+.. py:data:: integration.sundials.method
+   :type: string
+   :value: [none]
+
+   This parameter sets the name of the specific time integration method to
+   use. See the sections listed below in the SUNDIALS documentation for valid
+   method names. Note, IMEX method must be specified using the
+   :py:data:`integration.sundials.method_i` and
+   :py:data:`integration.sundials.method_e` parameters. If a method name is not
+   provided, the SUNDIALS default method is used.
+
+   * `ERK methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#explicit-butcher-tables>`__
+   * `DIRK methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#implicit-butcher-tables>`__
+   * `MRI methods <https://sundials.readthedocs.io/en/latest/arkode/Usage/MRIStep/MRIStepCoupling.html#mri-coupling-tables>`__
+
+.. py:data:: integration.sundials.method_i
+   :type: string
+   :value: [none]
+
+   When using an IMEX method, both the implicit and explicit methods must be
+   specified. This parameter can be used to select the *impicit* portion of the
+   IMEX method. See the `ImEx methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#additive-butcher-tables>`__
+   section in the SUNDIALS documentation for valid method names. If a method
+   name is not provided, the SUNDIALS default method is used.
+
+.. py:data:: integration.sundials.method_e
+   :type: string
+   :value: [none]
+
+   When using an IMEX method, both the implicit and explicit methods must be
+   specified. This parameter can be used to select the *explicit* portion of the
+   IMEX method. See the `ImEx methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#additive-butcher-tables>`__
+   section in the SUNDIALS documentation for valid method names. If a method
+   name is not provided, the SUNDIALS default method is used.
+
+.. py:data:: integration.sundials.fast_method
+   :type: string
+   :value: [none]
+
+   When using a multirate method, this parameter sets the method to use at the
+   fast time scale. If a method name is not provided, the SUNDIALS default
+   method is used.
+
+.. _sec:inputs:timeintegration:sundials:stepsizes:
+
+Step Sizes
+""""""""""
+
+.. note::
+
+   The parameter :py:data:`integration.time_step` is used to set a fixed step
+   size with single rate methods (e.g., ERK) or a fixed slow time scale step
+   size with multirate methods (e.g., EX-MRI).
+
+.. py:data:: integration.fast_time_step
+   :type: amrex::Real
+   :value: [none]
+
+   When using a multirate method, this parameter sets the fixed step size to use
+   at the fast time scale.
+
+.. py:data:: integration.use_adaptive_time_step
+   :type: bool
+   :value: false
+
+   This parameter enables adaptive time step sizes with single rate methods
+   (e.g., ERK) or adaptive time step sizes at the slow time scale with multirate
+   methods (e.g., EX-MRI).
+
+.. py:data:: integration.use_adaptive_fast_time_step
+   :type: bool
+   :value: false
+
+   This parameter enables adaptive time step sizes at the fast time scale with
+   multirate methods (e.g., EX-MRI).
+
+.. py:data:: integration.sundials.max_num_steps
+   :type: int
+   :value: 500
+
+   When using the ``evolve`` method, which allows the integrator to take
+   multiple time steps to reach the specified output time, this parameter sets
+   the maximum number of time steps allowed before reaching the output time. If
+   this limit is reached before the output time, SUNDIALS will return an error.
+
+.. py:data:: integration.sundials.stop_time
+   :type: amrex::Real
+   :value: [none]
+
+   When using the ``evolve`` method (especially with adaptive time step sizes),
+   the SUNDIALS integrator may step past the requested output time and return an
+   interpolated solution at the requested time. This parameter will force the
+   integrator to stop and return the solution at the requested time.
+
+.. _sec:inputs:timeintegration:sundials:tolerances:
+
+Tolerances
+""""""""""
+
+When using adaptive time step sizes or an implicit method (e.g., DIRK),
+selecting appropriate tolerances for the target application is a critical factor
+in method performance. For advice on selecting tolerances see the `SUNDIALS
+documentation
+<https://sundials.readthedocs.io/en/latest/arkode/Usage/User_callable.html#general-advice-on-the-choice-of-tolerances>`__.
+
+.. py:data:: integration.rel_tol
+   :type: amrex::Real
+   :value: 1.e-4
+
+   Relative tolerance for temporal error control.
+
+.. py:data:: integration.abs_tol
+   :type: amrex::Real
+   :value: 1.e-9
+
+   Absolute tolerance for temporal error control.
+
+.. py:data:: integration.fast_rel_tol
+   :type: amrex::Real
+   :value: 1.e-4
+
+   Relative tolerance for the temporal error at the fast time scale with
+   multrate methods.
+
+.. py:data:: integration.fast_abs_tol
+   :type: amrex::Real
+   :value: 1.e-9
+
+   Absolute tolerance for the temporal error at the fast time scale with
+   multrate methods.
+
+.. _sec:inputs:timeintegration:sundials:algebraicsolvers:
+
+Algebraic Solvers
+"""""""""""""""""
+
+The parameters provide control over the nonlinear and linear solvers utilized
+with implicit methods (e.g., DIRK).
+
+.. py:data:: integration.sundials.nonlinear_solver
+   :type: string
+   :value: Newton
+
+   The nonlinear solver used with single rate methods (e.g., DIRK) or at the
+   slow time scale with multirate methods (e.g., IM-MRI). The supported values
+   are:
+
+   * Newton
+   * fixed-point
+
+.. py:data:: integration.sundials.max_nonlinear_iters
+   :type: int
+   :value: 3
+
+   The maximum number of nonlinear iterations allowed per solve with single rate
+   methods (e.g., DIRK) or at the slow time scale with multirate methods (e.g.,
+   IM-MRI).
+
+.. py:data:: integration.sundials.linear_solver
+   :type: string
+   :value: GMRES
+
+   The linear solver used with Newton's method for single rate methods (e.g.,
+   DIRK) or at the slow time scale with multirate methods (e.g., IM-MRI).
+
+.. py:data:: integration.sundials.max_linear_iters
+   :type: int
+   :value: 5
+
+   The maximum number of linear iterations allowed per solve with single rate
+   methods (e.g., DIRK) or at the slow time scale with multirate methods (e.g.,
+   IM-MRI).
+
+.. py:data:: integration.sundials.fast_nonlinear_solver
+   :type: string
+   :value: Newton
+
+   The nonlinear solver used at the fast time scale with multirate methods
+   (e.g., when the fast method is DIRK). The supported values are:
+
+   * Newton
+   * fixed-point
+
+.. py:data:: integration.sundials.fast_max_nonlinear_iters
+   :type: int
+   :value: 3
+
+   The maximum number of nonlinear iterations allowed per solve at the fast time
+   scale (e.g., when the fast method is DIRK).
+
+.. py:data:: integration.sundials.fast_linear_solver
+   :type: string
+   :value: GMRES
+
+   The linear solver used with Newton's method at the fast time scale with
+   multirate methods (e.g., when the fast method is DIRK).
+
+.. py:data:: integration.sundials.fast_max_linear_iters
+   :type: int
+   :value: 5
+
+   The maximum number of linear iterations allowed at the fast time scale per
+   solve with multirate methods (e.g., when the fast method is DIRK).
+
 
 Tiny Profiler
 -------------

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1360,7 +1360,7 @@ Methods
    :value: [none]
 
    When using an IMEX method, both the implicit and explicit methods must be
-   specified. This parameter can be used to select the *impicit* portion of the
+   specified. This parameter can be used to select the *implicit* portion of the
    IMEX method. See the `ImEx methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#additive-butcher-tables>`__
    section in the SUNDIALS documentation for valid method names. If a method
    name is not provided, the SUNDIALS default method is used.

--- a/Docs/sphinx_documentation/source/TimeIntegration_Chapter.rst
+++ b/Docs/sphinx_documentation/source/TimeIntegration_Chapter.rst
@@ -55,7 +55,9 @@ a generic explicit Runge-Kutta method. If Runge-Kutta is selected, then the user
 can choose which of a set of predefined Butcher Tables to use, or can choose to
 use a custom table and supply it manually.
 
-The full set of integrator options are detailed as follows:
+An example of integrator options is given below. For a complete list of options
+see the section on :ref:`Time Integration Runtime Parameters
+<sec:inputs:timeintegration>`.
 
 ::
 
@@ -117,7 +119,7 @@ at runtime:
   integration.sundials.type = ERK
 
 One can select a different method type by changing the value of
-``integration.sundials.type`` to one of the following values:
+:py:data:`integration.sundials.type` to one of the following values:
 
 +------------------------+--------------------------------------------------+
 | Input Option           | SUNDIALS Method Type                             |
@@ -142,24 +144,27 @@ needs to supply slow and fast right-hand side functions using
 ``TimeIntegrator::set_rhs()`` to set the slow function and
 ``TimeIntegrator::set_fast_rhs()`` to set the fast function. With multirate
 methods, one also needs to select the fast time scale method type using the
-input option ``integration.sundials.fast_type`` which maybe set to ``ERK`` or
-``DIRK``.
+input option :py:data:`integration.sundials.fast_type` which maybe set to
+``ERK`` or ``DIRK``.
 
 To select a specific SUNDIALS method use the input option
-``integration.sundials.method`` for ERK and DIRK methods as well as the slow
-time scale method with an MRI integrator, use ``integration.sundials.method_i``
-and ``integration.sundials.method_e`` to set the implicit and explicit method in
-an ImEx method, and ``integration.sundials.fast_method`` to set the ERK or DIRK
-method used at the fast time scale with an MRI integrator. These options may be
-set to any valid SUNDIALS method name, see the following sections in the
-SUNDIALS documentation for more details:
+:py:data:`integration.sundials.method` for ERK and DIRK methods as well as the
+slow time scale method with an MRI integrator, use
+:py:data:`integration.sundials.method_i` and
+:py:data:`integration.sundials.method_e` to set the implicit and explicit method
+in an ImEx method, and :py:data:`integration.sundials.fast_method` to set the
+ERK or DIRK method used at the fast time scale with an MRI integrator. These
+options may be set to any valid SUNDIALS method name, see the following sections
+in the SUNDIALS documentation for more details:
 
-* `ERK methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#explicit-butcher-tables>`_
-* `DIRK methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#implicit-butcher-tables>`_
-* `ImEx methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#additive-butcher-tables>`_
-* `MRI methods <https://sundials.readthedocs.io/en/latest/arkode/Usage/MRIStep/MRIStepCoupling.html#mri-coupling-tables>`_
+* `ERK methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#explicit-butcher-tables>`__
+* `DIRK methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#implicit-butcher-tables>`__
+* `ImEx methods <https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#additive-butcher-tables>`__
+* `MRI methods <https://sundials.readthedocs.io/en/latest/arkode/Usage/MRIStep/MRIStepCoupling.html#mri-coupling-tables>`__
 
-The full set of integrator options are detailed as follows:
+An example of integrator options is given below. For a complete list of options
+see the section on :ref:`Time Integration Runtime Parameters
+<sec:inputs:timeintegration>`.
 
 ::
 

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -4,6 +4,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 #include <AMReX_MultiFab.H>
+#include <AMReX_ParmParse.H>
 
 #if defined(AMREX_PARTICLES)
 #include <AMReX_Particles.H>
@@ -165,9 +166,9 @@ private:
   void initialize_base_parameters ()
   {
     amrex::ParmParse pp("integration");
-    pp.quarty("use_adaptive_time_step", use_adaptive_time_step);
+    pp.query("use_adaptive_time_step", use_adaptive_time_step);
     pp.query("time_step", time_step);
-    pp.quarty("use_adaptive_fast_time_step", use_adaptive_fast_time_step);
+    pp.query("use_adaptive_fast_time_step", use_adaptive_fast_time_step);
     pp.query("time_step", fast_time_step);
     pp.query("rel_tol", rel_tol);
     pp.query("abs_tol", abs_tol);

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -161,6 +161,19 @@ struct IntegratorOps<T, std::enable_if_t<std::is_same_v<amrex::MultiFab, T> > >
 template<class T>
 class IntegratorBase
 {
+private:
+  void initialize_base_parameters ()
+  {
+    amrex::ParmParse pp("integration");
+    pp.quarty("use_adaptive_time_step", use_adaptive_time_step);
+    pp.query("time_step", time_step);
+    pp.quarty("use_adaptive_fast_time_step", use_adaptive_fast_time_step);
+    pp.query("time_step", fast_time_step);
+    pp.query("rel_tol", rel_tol);
+    pp.query("abs_tol", abs_tol);
+    pp.query("fast_rel_tol", fast_rel_tol);
+    pp.query("fast_abs_tol", fast_abs_tol);
+  }
 protected:
     /**
      * \brief Rhs is the right-hand-side function the integrator will use.
@@ -271,9 +284,13 @@ protected:
 
 
 public:
-    IntegratorBase () = default;
+    IntegratorBase () {
+      initialize_base_parameters();
+    }
 
-    IntegratorBase (const T& /* S_data */) {}
+    IntegratorBase (const T& /* S_data */) {
+      initialize_base_parameters();
+    }
 
     virtual ~IntegratorBase () = default;
 

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -169,7 +169,7 @@ private:
     pp.query("use_adaptive_time_step", use_adaptive_time_step);
     pp.query("time_step", time_step);
     pp.query("use_adaptive_fast_time_step", use_adaptive_fast_time_step);
-    pp.query("time_step", fast_time_step);
+    pp.query("fast_time_step", fast_time_step);
     pp.query("rel_tol", rel_tol);
     pp.query("abs_tol", abs_tol);
     pp.query("fast_rel_tol", fast_rel_tol);

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -64,7 +64,7 @@ private:
 
     void set_default_functions ()
     {
-        // By default, abort if the RHS function was not set
+        // Abort if the RHS function is called but was not set
         set_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */) { amrex::Abort("RHS function not set!"); });
         set_imex_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */) { amrex::Abort("Implicit RHS function not set!"); },
                      [](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */) { amrex::Abort("Explicit RHS function not set!"); } );

--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -64,11 +64,11 @@ private:
 
     void set_default_functions ()
     {
-        // By default, do nothing in the RHS
-        set_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */){});
-        set_imex_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */){},
-                     [](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */){});
-        set_fast_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */){});
+        // By default, abort if the RHS function was not set
+        set_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */) { amrex::Abort("RHS function not set!"); });
+        set_imex_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */) { amrex::Abort("Implicit RHS function not set!"); },
+                     [](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */) { amrex::Abort("Explicit RHS function not set!"); } );
+        set_fast_rhs([](T& /* S_rhs */, T& /* S_data */, const amrex::Real /* time */) { amrex::Abort("Fast RHS function not set!"); } );
 
         // In general, the following functions can be used to fill BCs. Which
         // function to set will depend on the method type and intended use case

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -219,7 +219,7 @@ private:
         if (BaseT::use_adaptive_time_step || type == "DIRK" || type == "IMEX-RK") {
             if (amrex::Verbose()) {
                 amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
-                amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
+                amrex::Print() << "Absolute tolerance: " << BaseT::abs_tol << "\n";
             }
             flag = ARKStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
             AMREX_ALWAYS_ASSERT(flag == 0);
@@ -308,7 +308,7 @@ private:
         if (BaseT::use_adaptive_fast_time_step || fast_type == "DIRK" || fast_type == "IMEX-RK") {
             if (amrex::Verbose()) {
                 amrex::Print() << "Fast relative tolerance: " << BaseT::fast_rel_tol << "\n";
-                amrex::Print() << "Fast abolute tolerance: " << BaseT::fast_abs_tol << "\n";
+                amrex::Print() << "Fast absolute tolerance: " << BaseT::fast_abs_tol << "\n";
             }
           flag = ARKStepSStolerances(arkode_fast_mem, BaseT::fast_rel_tol, BaseT::fast_abs_tol);
           AMREX_ALWAYS_ASSERT(flag == 0);
@@ -365,7 +365,7 @@ private:
         if (BaseT::use_adaptive_time_step || fast_type == "IM-MRI" || fast_type == "IMEX-MRI") {
             if (amrex::Verbose()) {
                 amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
-                amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
+                amrex::Print() << "Absolute tolerance: " << BaseT::abs_tol << "\n";
             }
             flag = MRIStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
             AMREX_ALWAYS_ASSERT(flag == 0);

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -204,7 +204,7 @@ private:
             amrex::Print() << "SUNDIALS ERK time integrator\n";
             arkode_fast_mem = ARKStepCreate(SundialsUserFun::ff, nullptr, time, y_data, sunctx);
 
-            if (method != "DEFAULT") {
+            if (fast_method != "DEFAULT") {
                 amrex::Print() << "SUNDIALS ERK method " << method << "\n";
                 ARKStepSetTableName(arkode_fast_mem, "ARKODE_DIRK_NONE", fast_method.c_str());
             }
@@ -213,7 +213,7 @@ private:
             amrex::Print() << "SUNDIALS DIRK time integrator\n";
             arkode_fast_mem = ARKStepCreate(nullptr, SundialsUserFun::ff, time, y_data, sunctx);
 
-            if (method != "DEFAULT") {
+            if (fast_method != "DEFAULT") {
                 amrex::Print() << "SUNDIALS DIRK method " << method << "\n";
                 ARKStepSetTableName(arkode_fast_mem, fast_method.c_str(), "ARKODE_ERK_NONE");
             }

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -149,31 +149,27 @@ private:
 
     void SetupRK (amrex::Real time, N_Vector y_data)
     {
+        amrex::Print() << "Using SUNDIALS time integrator\n";
+
         // Create integrator and select method
         if (type == "ERK") {
-            amrex::Print() << "SUNDIALS ERK time integrator\n";
+            amrex::Print() << "ERK method: " << method << "\n";
             arkode_mem = ARKStepCreate(SundialsUserFun::f, nullptr, time, y_data, sunctx);
-
-            amrex::Print() << "SUNDIALS ERK method " << method << "\n";
             if (method != "DEFAULT") {
                 ARKStepSetTableName(arkode_mem, "ARKODE_DIRK_NONE", method.c_str());
             }
         }
         else if (type == "DIRK") {
-            amrex::Print() << "SUNDIALS DIRK time integrator\n";
+            amrex::Print() << "DIRK method: " << method << "\n";
             arkode_mem = ARKStepCreate(nullptr, SundialsUserFun::f, time, y_data, sunctx);
-
-            amrex::Print() << "SUNDIALS DIRK method " << method << "\n";
             if (method != "DEFAULT") {
                 ARKStepSetTableName(arkode_mem, method.c_str(), "ARKODE_ERK_NONE");
             }
         }
         else if (type == "IMEX-RK") {
-            amrex::Print() << "SUNDIALS IMEX time integrator\n";
-            arkode_mem = ARKStepCreate(SundialsUserFun::fe, SundialsUserFun::fi, time, y_data, sunctx);
-
-            amrex::Print() << "SUNDIALS IMEX method " << method_i << " and "
+            amrex::Print() << "IMEX-RK method: " << method_i << " and "
                            << method_e << "\n";
+            arkode_mem = ARKStepCreate(SundialsUserFun::fe, SundialsUserFun::fi, time, y_data, sunctx);
             if (method_e != "DEFAULT" && method_i != "DEFAULT")
             {
                 ARKStepSetTableName(arkode_mem, method_i.c_str(), method_e.c_str());
@@ -184,7 +180,11 @@ private:
         ARKStepSetUserData(arkode_mem, &udata);
 
         // Set integrator tolerances
-        ARKStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+        if (BaseT::use_adaptive_time_step || type == "DIRK" || type == "IMEX-RK") {
+          amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
+          amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
+          ARKStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+        }
 
         // Create and attach linear solver for implicit methods
         if (type == "DIRK" || type == "IMEX-RK") {
@@ -199,30 +199,19 @@ private:
 
     void SetupMRI (amrex::Real time, N_Vector y_data)
     {
-        if (type == "EX-MRI") {
-            amrex::Print() << "SUNDIALS EX-MRI time integrator\n";
-        } else if (type == "IM-MRI") {
-            amrex::Print() << "SUNDIALS IM-MRI time integrator\n";
-        } else if (type == "IMEX-MRI") {
-            amrex::Print() << "SUNDIALS IMEX-MRI time integrator\n";
-        }
-        amrex::Print() << "SUNDIALS MRI method " << method << "\n";
+        amrex::Print() << "Using SUNDIALS multirate time integrator\n";
 
         // Create the fast integrator and select method
         if (fast_type == "ERK") {
-            amrex::Print() << "SUNDIALS MRI fast time scale ERK time integrator\n";
+            amrex::Print() << "Fast ERK method: " << method << "\n";
             arkode_fast_mem = ARKStepCreate(SundialsUserFun::ff, nullptr, time, y_data, sunctx);
-
-            amrex::Print() << "SUNDIALS MRI fast time scale ERK method " << method << "\n";
             if (fast_method != "DEFAULT") {
                 ARKStepSetTableName(arkode_fast_mem, "ARKODE_DIRK_NONE", fast_method.c_str());
             }
         }
         else if (fast_type == "DIRK") {
-            amrex::Print() << "SUNDIALS MRI fast time scale DIRK time integrator\n";
+            amrex::Print() << "Fast DIRK method: " << method << "\n";
             arkode_fast_mem = ARKStepCreate(nullptr, SundialsUserFun::ff, time, y_data, sunctx);
-
-            amrex::Print() << "SUNDIALS MRI fast time scale DIRK method " << method << "\n";
             if (fast_method != "DEFAULT") {
                 ARKStepSetTableName(arkode_fast_mem, fast_method.c_str(), "ARKODE_ERK_NONE");
             }
@@ -235,7 +224,11 @@ private:
         ARKStepSetUserData(arkode_fast_mem, &udata);
 
         // Set integrator tolerances
-        ARKStepSStolerances(arkode_fast_mem, BaseT::fast_rel_tol, BaseT::fast_abs_tol);
+        if (BaseT::use_adaptive_fast_time_step || fast_type == "DIRK" || fast_type == "IMEX-RK") {
+          amrex::Print() << "Fast relative tolerance: " << BaseT::fast_rel_tol << "\n";
+          amrex::Print() << "Fast abolute tolerance: " << BaseT::fast_abs_tol << "\n";
+          ARKStepSStolerances(arkode_fast_mem, BaseT::fast_rel_tol, BaseT::fast_abs_tol);
+        }
 
         // Set post stage and step function
         ARKStepSetPostprocessStageFn(arkode_fast_mem, SundialsUserFun::post_fast_stage);
@@ -246,14 +239,17 @@ private:
 
         // Create slow integrator
         if (type == "EX-MRI") {
+            amrex::Print() << "EX-MRI method: " << method << "\n";
             arkode_mem = MRIStepCreate(SundialsUserFun::f, nullptr, time, y_data,
                                        fast_stepper, sunctx);
         }
         else if (type == "IM-MRI") {
+            amrex::Print() << "IM-MRI method: " << method << "\n";
             arkode_mem = MRIStepCreate(nullptr, SundialsUserFun::f, time, y_data,
                                        fast_stepper, sunctx);
         }
         else if (type == "IMEX-MRI") {
+            amrex::Print() << "IMEX-MRI method: " << method << "\n";
             arkode_mem = MRIStepCreate(SundialsUserFun::fe, SundialsUserFun::fi,
                                        time, y_data, fast_stepper, sunctx);
         }
@@ -269,7 +265,11 @@ private:
         MRIStepSetUserData(arkode_mem, &udata);
 
         // Set integrator tolerances
-        MRIStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+        if (BaseT::use_adaptive_time_step || fast_type == "IM-MRI" || fast_type == "IMEX-MRI") {
+          amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
+          amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
+          MRIStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+        }
 
         // Create and attach linear solver
         if (type == "IM-MRI" || type == "IMEX-MRI") {

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -103,7 +103,11 @@ private:
 
     // Nonlinear solver
     std::string nonlinear_solver = "Newton";
+    int max_nonlinear_iters = 0;
+
+    // Linear solver
     std::string linear_solver = "GMRES";
+    int max_linear_iters = 0;
 
     // SUNDIALS package flags, set based on type
     bool use_ark = false;
@@ -154,7 +158,10 @@ private:
         }
 
         pp.query("nonlinear_solver", nonlinear_solver);
+        pp.query("max_nonlinear_iters", max_nonlinear_iters);
+
         pp.query("linear_solver", linear_solver);
+        pp.query("max_linear_iters", max_linear_iters);
     }
 
     void SetupRK (amrex::Real time, N_Vector y_data)
@@ -208,16 +215,20 @@ private:
         // Create and attach linear solver for implicit methods
         if (type == "DIRK" || type == "IMEX-RK") {
           amrex::Print() << "Nonlinear solver: " << nonlinear_solver << "\n";
+          amrex::Print() << "Max nonlinear iters: " << max_nonlinear_iters << "\n";
           if (nonlinear_solver == "fixed-point") {
             NLS = SUNNonlinSol_FixedPoint(y_data, 4, sunctx);
             AMREX_ALWAYS_ASSERT(NLS != nullptr);
             flag = ARKStepSetNonlinearSolver(arkode_mem, NLS);
             AMREX_ALWAYS_ASSERT(flag == 0);
-            flag = ARKStepSetMaxNonlinIters(arkode_mem, 10);
-            AMREX_ALWAYS_ASSERT(flag == 0);
-          } else {
+          }
+          flag = ARKStepSetMaxNonlinIters(arkode_mem, max_nonlinear_iters);
+          AMREX_ALWAYS_ASSERT(flag == 0);
+
+          if (nonlinear_solver == "Newton") {
             amrex::Print() << "Linear solver: " << linear_solver << "\n";
-            LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, 0, sunctx);
+            amrex::Print() << "Max linear iters: " << max_linear_iters << "\n";
+            LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, max_linear_iters, sunctx);
             AMREX_ALWAYS_ASSERT(LS != nullptr);
             flag = ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
             AMREX_ALWAYS_ASSERT(flag == 0);

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -12,6 +12,7 @@
 #include <AMReX_Sundials.H>
 
 #include <nvector/nvector_manyvector.h>
+#include <sunnonlinsol/sunnonlinsol_fixedpoint.h>
 #include <sunlinsol/sunlinsol_spgmr.h>
 #include <arkode/arkode_arkstep.h>
 #include <arkode/arkode_mristep.h>
@@ -100,6 +101,10 @@ private:
     std::string fast_type   = "ERK";
     std::string fast_method = "DEFAULT";
 
+    // Nonlinear solver
+    std::string nonlinear_solver = "Newton";
+    std::string linear_solver = "GMRES";
+
     // SUNDIALS package flags, set based on type
     bool use_ark = false;
     bool use_mri = false;
@@ -116,11 +121,13 @@ private:
     // Single rate or slow time scale
     void *arkode_mem   = nullptr;
     SUNLinearSolver LS = nullptr;
+    SUNNonlinearSolver NLS = nullptr;
 
     // Fast time scale
     void *arkode_fast_mem            = nullptr;
     MRIStepInnerStepper fast_stepper = nullptr;
     SUNLinearSolver fast_LS          = nullptr;
+    SUNNonlinearSolver fast_NLS      = nullptr;
 
     void initialize_parameters ()
     {
@@ -145,6 +152,9 @@ private:
             msg += type;
             amrex::Error(msg.c_str());
         }
+
+        pp.query("nonlinear_solver", nonlinear_solver);
+        pp.query("linear_solver", linear_solver);
     }
 
     void SetupRK (amrex::Real time, N_Vector y_data)
@@ -197,10 +207,21 @@ private:
 
         // Create and attach linear solver for implicit methods
         if (type == "DIRK" || type == "IMEX-RK") {
+          amrex::Print() << "Nonlinear solver: " << nonlinear_solver << "\n";
+          if (nonlinear_solver == "fixed-point") {
+            NLS = SUNNonlinSol_FixedPoint(y_data, 4, sunctx);
+            AMREX_ALWAYS_ASSERT(NLS != nullptr);
+            flag = ARKStepSetNonlinearSolver(arkode_mem, NLS);
+            AMREX_ALWAYS_ASSERT(flag == 0);
+            flag = ARKStepSetMaxNonlinIters(arkode_mem, 10);
+            AMREX_ALWAYS_ASSERT(flag == 0);
+          } else {
+            amrex::Print() << "Linear solver: " << linear_solver << "\n";
             LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, 0, sunctx);
             AMREX_ALWAYS_ASSERT(LS != nullptr);
             flag = ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
             AMREX_ALWAYS_ASSERT(flag == 0);
+          }
         }
 
         // Set post stage and step function
@@ -595,6 +616,7 @@ public:
         // Clean up allocated memory
         SUNLinSolFree(LS);
         SUNLinSolFree(fast_LS);
+        SUNNonlinSolFree(NLS);
         MRIStepInnerStepper_Free(&fast_stepper);
         MRIStepFree(&arkode_fast_mem);
         ARKStepFree(&arkode_mem);

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -311,9 +311,9 @@ private:
                 amrex::Print() << "Fast max nonlinear iters: " << fast_max_nonlinear_iters << "\n";
             }
             if (fast_nonlinear_solver == "fixed-point") {
-                NLS = SUNNonlinSol_FixedPoint(y_data, 0, sunctx);
-                AMREX_ALWAYS_ASSERT(NLS != nullptr);
-                flag = ARKStepSetNonlinearSolver(arkode_mem, NLS);
+                fast_NLS = SUNNonlinSol_FixedPoint(y_data, 0, sunctx);
+                AMREX_ALWAYS_ASSERT(fast_NLS != nullptr);
+                flag = ARKStepSetNonlinearSolver(arkode_mem, fast_NLS);
                 AMREX_ALWAYS_ASSERT(flag == 0);
             }
             flag = ARKStepSetMaxNonlinIters(arkode_mem, fast_max_nonlinear_iters);
@@ -324,9 +324,9 @@ private:
                     amrex::Print() << "Linear solver: " << fast_linear_solver << "\n";
                     amrex::Print() << "Max linear iters: " << fast_max_linear_iters << "\n";
                 }
-                LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, fast_max_linear_iters, sunctx);
-                AMREX_ALWAYS_ASSERT(LS != nullptr);
-                flag = ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
+                fast_LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, fast_max_linear_iters, sunctx);
+                AMREX_ALWAYS_ASSERT(fast_LS != nullptr);
+                flag = ARKStepSetLinearSolver(arkode_mem, fast_LS, nullptr);
                 AMREX_ALWAYS_ASSERT(flag == 0);
             }
         }
@@ -727,6 +727,7 @@ public:
         SUNLinSolFree(LS);
         SUNLinSolFree(fast_LS);
         SUNNonlinSolFree(NLS);
+        SUNNonlinSolFree(fast_NLS);
         MRIStepInnerStepper_Free(&fast_stepper);
         MRIStepFree(&arkode_fast_mem);
         ARKStepFree(&arkode_mem);

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -154,8 +154,8 @@ private:
             amrex::Print() << "SUNDIALS ERK time integrator\n";
             arkode_mem = ARKStepCreate(SundialsUserFun::f, nullptr, time, y_data, sunctx);
 
+            amrex::Print() << "SUNDIALS ERK method " << method << "\n";
             if (method != "DEFAULT") {
-                amrex::Print() << "SUNDIALS ERK method " << method << "\n";
                 ARKStepSetTableName(arkode_mem, "ARKODE_DIRK_NONE", method.c_str());
             }
         }
@@ -163,8 +163,8 @@ private:
             amrex::Print() << "SUNDIALS DIRK time integrator\n";
             arkode_mem = ARKStepCreate(nullptr, SundialsUserFun::f, time, y_data, sunctx);
 
+            amrex::Print() << "SUNDIALS DIRK method " << method << "\n";
             if (method != "DEFAULT") {
-                amrex::Print() << "SUNDIALS DIRK method " << method << "\n";
                 ARKStepSetTableName(arkode_mem, method.c_str(), "ARKODE_ERK_NONE");
             }
         }
@@ -172,10 +172,10 @@ private:
             amrex::Print() << "SUNDIALS IMEX time integrator\n";
             arkode_mem = ARKStepCreate(SundialsUserFun::fe, SundialsUserFun::fi, time, y_data, sunctx);
 
+            amrex::Print() << "SUNDIALS IMEX method " << method_i << " and "
+                           << method_e << "\n";
             if (method_e != "DEFAULT" && method_i != "DEFAULT")
             {
-                amrex::Print() << "SUNDIALS IMEX method " << method_i << " and "
-                               << method_e << "\n";
                 ARKStepSetTableName(arkode_mem, method_i.c_str(), method_e.c_str());
             }
         }
@@ -199,22 +199,31 @@ private:
 
     void SetupMRI (amrex::Real time, N_Vector y_data)
     {
+        if (type == "EX-MRI") {
+            amrex::Print() << "SUNDIALS EX-MRI time integrator\n";
+        } else if (type == "IM-MRI") {
+            amrex::Print() << "SUNDIALS IM-MRI time integrator\n";
+        } else if (type == "IMEX-MRI") {
+            amrex::Print() << "SUNDIALS IMEX-MRI time integrator\n";
+        }
+        amrex::Print() << "SUNDIALS MRI method " << method << "\n";
+
         // Create the fast integrator and select method
         if (fast_type == "ERK") {
-            amrex::Print() << "SUNDIALS ERK time integrator\n";
+            amrex::Print() << "SUNDIALS MRI fast time scale ERK time integrator\n";
             arkode_fast_mem = ARKStepCreate(SundialsUserFun::ff, nullptr, time, y_data, sunctx);
 
+            amrex::Print() << "SUNDIALS MRI fast time scale ERK method " << method << "\n";
             if (fast_method != "DEFAULT") {
-                amrex::Print() << "SUNDIALS ERK method " << method << "\n";
                 ARKStepSetTableName(arkode_fast_mem, "ARKODE_DIRK_NONE", fast_method.c_str());
             }
         }
         else if (fast_type == "DIRK") {
-            amrex::Print() << "SUNDIALS DIRK time integrator\n";
+            amrex::Print() << "SUNDIALS MRI fast time scale DIRK time integrator\n";
             arkode_fast_mem = ARKStepCreate(nullptr, SundialsUserFun::ff, time, y_data, sunctx);
 
+            amrex::Print() << "SUNDIALS MRI fast time scale DIRK method " << method << "\n";
             if (fast_method != "DEFAULT") {
-                amrex::Print() << "SUNDIALS DIRK method " << method << "\n";
                 ARKStepSetTableName(arkode_fast_mem, fast_method.c_str(), "ARKODE_ERK_NONE");
             }
 
@@ -237,17 +246,14 @@ private:
 
         // Create slow integrator
         if (type == "EX-MRI") {
-            amrex::Print() << "SUNDIALS ERK time integrator\n";
             arkode_mem = MRIStepCreate(SundialsUserFun::f, nullptr, time, y_data,
                                        fast_stepper, sunctx);
         }
         else if (type == "IM-MRI") {
-            amrex::Print() << "SUNDIALS DIRK time integrator\n";
             arkode_mem = MRIStepCreate(nullptr, SundialsUserFun::f, time, y_data,
                                        fast_stepper, sunctx);
         }
         else if (type == "IMEX-MRI") {
-            amrex::Print() << "SUNDIALS IMEX time integrator\n";
             arkode_mem = MRIStepCreate(SundialsUserFun::fe, SundialsUserFun::fi,
                                        time, y_data, fast_stepper, sunctx);
         }

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -133,6 +133,10 @@ private:
     SUNLinearSolver fast_LS          = nullptr;
     SUNNonlinearSolver fast_NLS      = nullptr;
 
+    // Integrator stop time
+    bool set_stop_time = false;
+    amrex::Real stop_time = 0.0;
+
     void initialize_parameters ()
     {
         amrex::ParmParse pp("integration.sundials");
@@ -162,6 +166,8 @@ private:
 
         pp.query("linear_solver", linear_solver);
         pp.query("max_linear_iters", max_linear_iters);
+
+        set_stop_time = pp.query("stop_time", stop_time);
     }
 
     void SetupRK (amrex::Real time, N_Vector y_data)
@@ -206,6 +212,7 @@ private:
 
         // Set integrator tolerances
         if (BaseT::use_adaptive_time_step || type == "DIRK" || type == "IMEX-RK") {
+          amrex::Print() << "Adaptive time steps: " << BaseT::use_adaptive_time_step << "\n";
           amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
           amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
           flag = ARKStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
@@ -240,6 +247,13 @@ private:
         AMREX_ALWAYS_ASSERT(flag == 0);
         flag = ARKStepSetPostprocessStepFn(arkode_mem, SundialsUserFun::post_step);
         AMREX_ALWAYS_ASSERT(flag == 0);
+
+        // Set a stop time
+        if (set_stop_time) {
+          amrex::Print() << "Stop time: " << stop_time << "\n";
+          flag = ARKStepSetStopTime(arkode_mem, stop_time);
+          AMREX_ALWAYS_ASSERT(flag == 0);
+        }
     }
 
     void SetupMRI (amrex::Real time, N_Vector y_data)
@@ -278,6 +292,7 @@ private:
 
         // Set integrator tolerances
         if (BaseT::use_adaptive_fast_time_step || fast_type == "DIRK" || fast_type == "IMEX-RK") {
+          amrex::Print() << "Fast adaptive time steps: " << BaseT::use_adaptive_fast_time_step << "\n";
           amrex::Print() << "Fast relative tolerance: " << BaseT::fast_rel_tol << "\n";
           amrex::Print() << "Fast abolute tolerance: " << BaseT::fast_abs_tol << "\n";
           flag = ARKStepSStolerances(arkode_fast_mem, BaseT::fast_rel_tol, BaseT::fast_abs_tol);
@@ -329,6 +344,7 @@ private:
 
         // Set integrator tolerances
         if (BaseT::use_adaptive_time_step || fast_type == "IM-MRI" || fast_type == "IMEX-MRI") {
+          amrex::Print() << "Adaptive time steps: " << BaseT::use_adaptive_time_step << "\n";
           amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
           amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
           flag = MRIStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
@@ -348,6 +364,13 @@ private:
         AMREX_ALWAYS_ASSERT(flag == 0);
         flag = MRIStepSetPostprocessStepFn(arkode_mem, SundialsUserFun::post_step);
         AMREX_ALWAYS_ASSERT(flag == 0);
+
+        // Set a stop time
+        if (set_stop_time) {
+          amrex::Print() << "Stop time: " << stop_time << "\n";
+          flag = ARKStepSetStopTime(arkode_mem, stop_time);
+          AMREX_ALWAYS_ASSERT(flag == 0);
+        }
     }
 
     // -------------------------------------

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -105,9 +105,15 @@ private:
     std::string nonlinear_solver = "Newton";
     int max_nonlinear_iters = 0;
 
+    std::string fast_nonlinear_solver = "Newton";
+    int fast_max_nonlinear_iters = 0;
+
     // Linear solver
     std::string linear_solver = "GMRES";
     int max_linear_iters = 0;
+
+    std::string fast_linear_solver = "GMRES";
+    int fast_max_linear_iters = 0;
 
     // SUNDIALS package flags, set based on type
     bool use_ark = false;
@@ -167,8 +173,14 @@ private:
         pp.query("nonlinear_solver", nonlinear_solver);
         pp.query("max_nonlinear_iters", max_nonlinear_iters);
 
+        pp.query("fast_nonlinear_solver", fast_nonlinear_solver);
+        pp.query("fast_max_nonlinear_iters", fast_max_nonlinear_iters);
+
         pp.query("linear_solver", linear_solver);
         pp.query("max_linear_iters", max_linear_iters);
+
+        pp.query("fast_linear_solver", fast_linear_solver);
+        pp.query("fast_max_linear_iters", fast_max_linear_iters);
 
         set_stop_time = pp.query("stop_time", stop_time);
 
@@ -294,10 +306,29 @@ private:
                 AMREX_ALWAYS_ASSERT(flag == 0);
             }
 
-            fast_LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, 0, sunctx);
-            AMREX_ALWAYS_ASSERT(fast_LS != nullptr);
-            flag = ARKStepSetLinearSolver(arkode_fast_mem, fast_LS, nullptr);
+            if (amrex::Verbose()) {
+                amrex::Print() << "Fast nonlinear solver: " << fast_nonlinear_solver << "\n";
+                amrex::Print() << "Fast max nonlinear iters: " << fast_max_nonlinear_iters << "\n";
+            }
+            if (fast_nonlinear_solver == "fixed-point") {
+                NLS = SUNNonlinSol_FixedPoint(y_data, 0, sunctx);
+                AMREX_ALWAYS_ASSERT(NLS != nullptr);
+                flag = ARKStepSetNonlinearSolver(arkode_mem, NLS);
+                AMREX_ALWAYS_ASSERT(flag == 0);
+            }
+            flag = ARKStepSetMaxNonlinIters(arkode_mem, fast_max_nonlinear_iters);
             AMREX_ALWAYS_ASSERT(flag == 0);
+
+            if (fast_nonlinear_solver == "Newton") {
+                if (amrex::Verbose()) {
+                    amrex::Print() << "Linear solver: " << fast_linear_solver << "\n";
+                    amrex::Print() << "Max linear iters: " << fast_max_linear_iters << "\n";
+                }
+                LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, fast_max_linear_iters, sunctx);
+                AMREX_ALWAYS_ASSERT(LS != nullptr);
+                flag = ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
+                AMREX_ALWAYS_ASSERT(flag == 0);
+            }
         }
 
         // Attach structure with user-supplied function wrappers
@@ -373,10 +404,29 @@ private:
 
         // Create and attach linear solver
         if (type == "IM-MRI" || type == "IMEX-MRI") {
-            LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, 0, sunctx);
-            AMREX_ALWAYS_ASSERT(LS != nullptr);
-            flag = MRIStepSetLinearSolver(arkode_mem, LS, nullptr);
+            if (amrex::Verbose()) {
+                amrex::Print() << "Nonlinear solver: " << nonlinear_solver << "\n";
+                amrex::Print() << "Max nonlinear iters: " << max_nonlinear_iters << "\n";
+            }
+            if (nonlinear_solver == "fixed-point") {
+                NLS = SUNNonlinSol_FixedPoint(y_data, 0, sunctx);
+                AMREX_ALWAYS_ASSERT(NLS != nullptr);
+                flag = ARKStepSetNonlinearSolver(arkode_mem, NLS);
+                AMREX_ALWAYS_ASSERT(flag == 0);
+            }
+            flag = ARKStepSetMaxNonlinIters(arkode_mem, max_nonlinear_iters);
             AMREX_ALWAYS_ASSERT(flag == 0);
+
+            if (nonlinear_solver == "Newton") {
+                if (amrex::Verbose()) {
+                    amrex::Print() << "Linear solver: " << linear_solver << "\n";
+                    amrex::Print() << "Max linear iters: " << max_linear_iters << "\n";
+                }
+                LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, max_linear_iters, sunctx);
+                AMREX_ALWAYS_ASSERT(LS != nullptr);
+                flag = ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
+                AMREX_ALWAYS_ASSERT(flag == 0);
+            }
         }
 
         // Set post stage and step function

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -137,6 +137,9 @@ private:
     bool set_stop_time = false;
     amrex::Real stop_time = 0.0;
 
+    // Max steps between returns
+    amrex::Long max_num_steps = 0;
+
     void initialize_parameters ()
     {
         amrex::ParmParse pp("integration.sundials");
@@ -168,6 +171,8 @@ private:
         pp.query("max_linear_iters", max_linear_iters);
 
         set_stop_time = pp.query("stop_time", stop_time);
+
+        pp.query("max_num_steps", max_num_steps);
     }
 
     void SetupRK (amrex::Real time, N_Vector y_data)
@@ -254,6 +259,10 @@ private:
           flag = ARKStepSetStopTime(arkode_mem, stop_time);
           AMREX_ALWAYS_ASSERT(flag == 0);
         }
+
+        // Set max number of steps between returns
+        ARKStepSetMaxNumSteps(arkode_mem, max_num_steps);
+        AMREX_ALWAYS_ASSERT(flag == 0);
     }
 
     void SetupMRI (amrex::Real time, N_Vector y_data)
@@ -303,6 +312,10 @@ private:
         flag = ARKStepSetPostprocessStageFn(arkode_fast_mem, SundialsUserFun::post_fast_stage);
         AMREX_ALWAYS_ASSERT(flag == 0);
         flag = ARKStepSetPostprocessStepFn(arkode_fast_mem, SundialsUserFun::post_fast_step);
+        AMREX_ALWAYS_ASSERT(flag == 0);
+
+        // Set max number of steps between returns
+        ARKStepSetMaxNumSteps(arkode_fast_mem, max_num_steps);
         AMREX_ALWAYS_ASSERT(flag == 0);
 
         // Wrap fast integrator as an inner stepper
@@ -371,6 +384,10 @@ private:
           flag = ARKStepSetStopTime(arkode_mem, stop_time);
           AMREX_ALWAYS_ASSERT(flag == 0);
         }
+
+        // Set max number of steps between returns
+        ARKStepSetMaxNumSteps(arkode_mem, max_num_steps);
+        AMREX_ALWAYS_ASSERT(flag == 0);
     }
 
     // -------------------------------------

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -575,6 +575,23 @@ public:
     }
 
     virtual ~SundialsIntegrator () {
+        // Print integrator statistics
+        if (type == "EX-MRI" || type == "IM-MRI" || type == "IMEX-MRI") {
+          amrex::Print() << "Slow Time Integrator Stats\n";
+          if (ParallelDescriptor::IOProcessor()) {
+            MRIStepPrintAllStats(arkode_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
+          }
+          amrex::Print() << "Fast Time Integrator Stats\n";
+          if (ParallelDescriptor::IOProcessor()) {
+            ARKStepPrintAllStats(arkode_fast_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
+          }
+        } else {
+          amrex::Print() << "Time Integrator Stats\n";
+          if (ParallelDescriptor::IOProcessor()) {
+            ARKStepPrintAllStats(arkode_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
+          }
+        }
+
         // Clean up allocated memory
         SUNLinSolFree(LS);
         SUNLinSolFree(fast_LS);

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -177,12 +177,12 @@ private:
 
     void SetupRK (amrex::Real time, N_Vector y_data)
     {
-        amrex::Print() << "Using SUNDIALS time integrator\n";
+        if (amrex::Verbose()) { amrex::Print() << "Using SUNDIALS time integrator\n"; }
         int flag = 0;
 
         // Create integrator and select method
         if (type == "ERK") {
-            amrex::Print() << "ERK method: " << method << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "ERK method: " << method << "\n"; }
             arkode_mem = ARKStepCreate(SundialsUserFun::f, nullptr, time, y_data, sunctx);
             AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
             if (method != "DEFAULT") {
@@ -191,7 +191,7 @@ private:
             }
         }
         else if (type == "DIRK") {
-            amrex::Print() << "DIRK method: " << method << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "DIRK method: " << method << "\n"; }
             arkode_mem = ARKStepCreate(nullptr, SundialsUserFun::f, time, y_data, sunctx);
             AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
             if (method != "DEFAULT") {
@@ -200,8 +200,8 @@ private:
             }
         }
         else if (type == "IMEX-RK") {
-            amrex::Print() << "IMEX-RK method: " << method_i << " and "
-                           << method_e << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "IMEX-RK method: " << method_i << " and "
+                                    << method_e << "\n"; }
             arkode_mem = ARKStepCreate(SundialsUserFun::fe, SundialsUserFun::fi, time, y_data, sunctx);
             AMREX_ALWAYS_ASSERT(arkode_mem != 0);
             if (method_e != "DEFAULT" && method_i != "DEFAULT")
@@ -217,34 +217,39 @@ private:
 
         // Set integrator tolerances
         if (BaseT::use_adaptive_time_step || type == "DIRK" || type == "IMEX-RK") {
-          amrex::Print() << "Adaptive time steps: " << BaseT::use_adaptive_time_step << "\n";
-          amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
-          amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
-          flag = ARKStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
-          AMREX_ALWAYS_ASSERT(flag == 0);
+            if (amrex::Verbose()) {
+                amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
+                amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
+            }
+            flag = ARKStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+            AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Create and attach linear solver for implicit methods
         if (type == "DIRK" || type == "IMEX-RK") {
-          amrex::Print() << "Nonlinear solver: " << nonlinear_solver << "\n";
-          amrex::Print() << "Max nonlinear iters: " << max_nonlinear_iters << "\n";
-          if (nonlinear_solver == "fixed-point") {
-            NLS = SUNNonlinSol_FixedPoint(y_data, 4, sunctx);
-            AMREX_ALWAYS_ASSERT(NLS != nullptr);
-            flag = ARKStepSetNonlinearSolver(arkode_mem, NLS);
+            if (amrex::Verbose()) {
+                amrex::Print() << "Nonlinear solver: " << nonlinear_solver << "\n";
+                amrex::Print() << "Max nonlinear iters: " << max_nonlinear_iters << "\n";
+            }
+            if (nonlinear_solver == "fixed-point") {
+                NLS = SUNNonlinSol_FixedPoint(y_data, 0, sunctx);
+                AMREX_ALWAYS_ASSERT(NLS != nullptr);
+                flag = ARKStepSetNonlinearSolver(arkode_mem, NLS);
+                AMREX_ALWAYS_ASSERT(flag == 0);
+            }
+            flag = ARKStepSetMaxNonlinIters(arkode_mem, max_nonlinear_iters);
             AMREX_ALWAYS_ASSERT(flag == 0);
-          }
-          flag = ARKStepSetMaxNonlinIters(arkode_mem, max_nonlinear_iters);
-          AMREX_ALWAYS_ASSERT(flag == 0);
 
-          if (nonlinear_solver == "Newton") {
-            amrex::Print() << "Linear solver: " << linear_solver << "\n";
-            amrex::Print() << "Max linear iters: " << max_linear_iters << "\n";
-            LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, max_linear_iters, sunctx);
-            AMREX_ALWAYS_ASSERT(LS != nullptr);
-            flag = ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
-            AMREX_ALWAYS_ASSERT(flag == 0);
-          }
+            if (nonlinear_solver == "Newton") {
+                if (amrex::Verbose()) {
+                    amrex::Print() << "Linear solver: " << linear_solver << "\n";
+                    amrex::Print() << "Max linear iters: " << max_linear_iters << "\n";
+                }
+                LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, max_linear_iters, sunctx);
+                AMREX_ALWAYS_ASSERT(LS != nullptr);
+                flag = ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
+                AMREX_ALWAYS_ASSERT(flag == 0);
+            }
         }
 
         // Set post stage and step function
@@ -255,7 +260,7 @@ private:
 
         // Set a stop time
         if (set_stop_time) {
-          amrex::Print() << "Stop time: " << stop_time << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "Stop time: " << stop_time << "\n"; }
           flag = ARKStepSetStopTime(arkode_mem, stop_time);
           AMREX_ALWAYS_ASSERT(flag == 0);
         }
@@ -267,12 +272,12 @@ private:
 
     void SetupMRI (amrex::Real time, N_Vector y_data)
     {
-        amrex::Print() << "Using SUNDIALS multirate time integrator\n";
+        if (amrex::Verbose()) { amrex::Print() << "Using SUNDIALS multirate time integrator\n"; }
         int flag = 0;
 
         // Create the fast integrator and select method
         if (fast_type == "ERK") {
-            amrex::Print() << "Fast ERK method: " << method << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "Fast ERK method: " << method << "\n"; }
             arkode_fast_mem = ARKStepCreate(SundialsUserFun::ff, nullptr, time, y_data, sunctx);
             AMREX_ALWAYS_ASSERT(arkode_fast_mem != nullptr);
             if (fast_method != "DEFAULT") {
@@ -281,7 +286,7 @@ private:
             }
         }
         else if (fast_type == "DIRK") {
-            amrex::Print() << "Fast DIRK method: " << method << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "Fast DIRK method: " << method << "\n"; }
             arkode_fast_mem = ARKStepCreate(nullptr, SundialsUserFun::ff, time, y_data, sunctx);
             AMREX_ALWAYS_ASSERT(arkode_fast_mem != nullptr);
             if (fast_method != "DEFAULT") {
@@ -301,9 +306,10 @@ private:
 
         // Set integrator tolerances
         if (BaseT::use_adaptive_fast_time_step || fast_type == "DIRK" || fast_type == "IMEX-RK") {
-          amrex::Print() << "Fast adaptive time steps: " << BaseT::use_adaptive_fast_time_step << "\n";
-          amrex::Print() << "Fast relative tolerance: " << BaseT::fast_rel_tol << "\n";
-          amrex::Print() << "Fast abolute tolerance: " << BaseT::fast_abs_tol << "\n";
+            if (amrex::Verbose()) {
+                amrex::Print() << "Fast relative tolerance: " << BaseT::fast_rel_tol << "\n";
+                amrex::Print() << "Fast abolute tolerance: " << BaseT::fast_abs_tol << "\n";
+            }
           flag = ARKStepSStolerances(arkode_fast_mem, BaseT::fast_rel_tol, BaseT::fast_abs_tol);
           AMREX_ALWAYS_ASSERT(flag == 0);
         }
@@ -324,19 +330,19 @@ private:
 
         // Create slow integrator
         if (type == "EX-MRI") {
-            amrex::Print() << "EX-MRI method: " << method << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "EX-MRI method: " << method << "\n"; }
             arkode_mem = MRIStepCreate(SundialsUserFun::f, nullptr, time, y_data,
                                        fast_stepper, sunctx);
             AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
         }
         else if (type == "IM-MRI") {
-            amrex::Print() << "IM-MRI method: " << method << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "IM-MRI method: " << method << "\n"; }
             arkode_mem = MRIStepCreate(nullptr, SundialsUserFun::f, time, y_data,
                                        fast_stepper, sunctx);
             AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
         }
         else if (type == "IMEX-MRI") {
-            amrex::Print() << "IMEX-MRI method: " << method << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "IMEX-MRI method: " << method << "\n"; }
             arkode_mem = MRIStepCreate(SundialsUserFun::fe, SundialsUserFun::fi,
                                        time, y_data, fast_stepper, sunctx);
             AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
@@ -357,11 +363,12 @@ private:
 
         // Set integrator tolerances
         if (BaseT::use_adaptive_time_step || fast_type == "IM-MRI" || fast_type == "IMEX-MRI") {
-          amrex::Print() << "Adaptive time steps: " << BaseT::use_adaptive_time_step << "\n";
-          amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
-          amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
-          flag = MRIStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
-          AMREX_ALWAYS_ASSERT(flag == 0);
+            if (amrex::Verbose()) {
+                amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
+                amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
+            }
+            flag = MRIStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+            AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Create and attach linear solver
@@ -380,7 +387,7 @@ private:
 
         // Set a stop time
         if (set_stop_time) {
-          amrex::Print() << "Stop time: " << stop_time << "\n";
+            if (amrex::Verbose()) { amrex::Print() << "Stop time: " << stop_time << "\n"; }
           flag = ARKStepSetStopTime(arkode_mem, stop_time);
           AMREX_ALWAYS_ASSERT(flag == 0);
         }
@@ -648,20 +655,22 @@ public:
 
     virtual ~SundialsIntegrator () {
         // Print integrator statistics
-        if (type == "EX-MRI" || type == "IM-MRI" || type == "IMEX-MRI") {
-          amrex::Print() << "Slow Time Integrator Stats\n";
-          if (ParallelDescriptor::IOProcessor()) {
-            MRIStepPrintAllStats(arkode_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
-          }
-          amrex::Print() << "Fast Time Integrator Stats\n";
-          if (ParallelDescriptor::IOProcessor()) {
-            ARKStepPrintAllStats(arkode_fast_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
-          }
-        } else {
-          amrex::Print() << "Time Integrator Stats\n";
-          if (ParallelDescriptor::IOProcessor()) {
-            ARKStepPrintAllStats(arkode_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
-          }
+        if (amrex::Verbose()) {
+            if (type == "EX-MRI" || type == "IM-MRI" || type == "IMEX-MRI") {
+                amrex::Print() << "Slow Time Integrator Stats\n";
+                if (ParallelDescriptor::IOProcessor()) {
+                    MRIStepPrintAllStats(arkode_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
+                }
+                amrex::Print() << "Fast Time Integrator Stats\n";
+                if (ParallelDescriptor::IOProcessor()) {
+                    ARKStepPrintAllStats(arkode_fast_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
+                }
+            } else {
+                amrex::Print() << "Time Integrator Stats\n";
+                if (ParallelDescriptor::IOProcessor()) {
+                    ARKStepPrintAllStats(arkode_mem, stdout, SUN_OUTPUTFORMAT_TABLE);
+                }
+            }
         }
 
         // Clean up allocated memory

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -150,136 +150,172 @@ private:
     void SetupRK (amrex::Real time, N_Vector y_data)
     {
         amrex::Print() << "Using SUNDIALS time integrator\n";
+        int flag = 0;
 
         // Create integrator and select method
         if (type == "ERK") {
             amrex::Print() << "ERK method: " << method << "\n";
             arkode_mem = ARKStepCreate(SundialsUserFun::f, nullptr, time, y_data, sunctx);
+            AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
             if (method != "DEFAULT") {
-                ARKStepSetTableName(arkode_mem, "ARKODE_DIRK_NONE", method.c_str());
+                flag = ARKStepSetTableName(arkode_mem, "ARKODE_DIRK_NONE", method.c_str());
+                AMREX_ALWAYS_ASSERT(flag == 0);
             }
         }
         else if (type == "DIRK") {
             amrex::Print() << "DIRK method: " << method << "\n";
             arkode_mem = ARKStepCreate(nullptr, SundialsUserFun::f, time, y_data, sunctx);
+            AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
             if (method != "DEFAULT") {
-                ARKStepSetTableName(arkode_mem, method.c_str(), "ARKODE_ERK_NONE");
+                flag = ARKStepSetTableName(arkode_mem, method.c_str(), "ARKODE_ERK_NONE");
+                AMREX_ALWAYS_ASSERT(flag == 0);
             }
         }
         else if (type == "IMEX-RK") {
             amrex::Print() << "IMEX-RK method: " << method_i << " and "
                            << method_e << "\n";
             arkode_mem = ARKStepCreate(SundialsUserFun::fe, SundialsUserFun::fi, time, y_data, sunctx);
+            AMREX_ALWAYS_ASSERT(arkode_mem != 0);
             if (method_e != "DEFAULT" && method_i != "DEFAULT")
             {
-                ARKStepSetTableName(arkode_mem, method_i.c_str(), method_e.c_str());
+                flag = ARKStepSetTableName(arkode_mem, method_i.c_str(), method_e.c_str());
+                AMREX_ALWAYS_ASSERT(flag == 0);
             }
         }
 
         // Attach structure with user-supplied function wrappers
-        ARKStepSetUserData(arkode_mem, &udata);
+        flag = ARKStepSetUserData(arkode_mem, &udata);
+        AMREX_ALWAYS_ASSERT(flag == 0);
 
         // Set integrator tolerances
         if (BaseT::use_adaptive_time_step || type == "DIRK" || type == "IMEX-RK") {
           amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
           amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
-          ARKStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+          flag = ARKStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+          AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Create and attach linear solver for implicit methods
         if (type == "DIRK" || type == "IMEX-RK") {
             LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, 0, sunctx);
-            ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
+            AMREX_ALWAYS_ASSERT(LS != nullptr);
+            flag = ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
+            AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Set post stage and step function
-        ARKStepSetPostprocessStageFn(arkode_mem, SundialsUserFun::post_stage);
-        ARKStepSetPostprocessStepFn(arkode_mem, SundialsUserFun::post_step);
+        flag = ARKStepSetPostprocessStageFn(arkode_mem, SundialsUserFun::post_stage);
+        AMREX_ALWAYS_ASSERT(flag == 0);
+        flag = ARKStepSetPostprocessStepFn(arkode_mem, SundialsUserFun::post_step);
+        AMREX_ALWAYS_ASSERT(flag == 0);
     }
 
     void SetupMRI (amrex::Real time, N_Vector y_data)
     {
         amrex::Print() << "Using SUNDIALS multirate time integrator\n";
+        int flag = 0;
 
         // Create the fast integrator and select method
         if (fast_type == "ERK") {
             amrex::Print() << "Fast ERK method: " << method << "\n";
             arkode_fast_mem = ARKStepCreate(SundialsUserFun::ff, nullptr, time, y_data, sunctx);
+            AMREX_ALWAYS_ASSERT(arkode_fast_mem != nullptr);
             if (fast_method != "DEFAULT") {
-                ARKStepSetTableName(arkode_fast_mem, "ARKODE_DIRK_NONE", fast_method.c_str());
+                flag = ARKStepSetTableName(arkode_fast_mem, "ARKODE_DIRK_NONE", fast_method.c_str());
+                AMREX_ALWAYS_ASSERT(flag == 0);
             }
         }
         else if (fast_type == "DIRK") {
             amrex::Print() << "Fast DIRK method: " << method << "\n";
             arkode_fast_mem = ARKStepCreate(nullptr, SundialsUserFun::ff, time, y_data, sunctx);
+            AMREX_ALWAYS_ASSERT(arkode_fast_mem != nullptr);
             if (fast_method != "DEFAULT") {
-                ARKStepSetTableName(arkode_fast_mem, fast_method.c_str(), "ARKODE_ERK_NONE");
+                flag = ARKStepSetTableName(arkode_fast_mem, fast_method.c_str(), "ARKODE_ERK_NONE");
+                AMREX_ALWAYS_ASSERT(flag == 0);
             }
 
             fast_LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, 0, sunctx);
-            ARKStepSetLinearSolver(arkode_fast_mem, fast_LS, nullptr);
+            AMREX_ALWAYS_ASSERT(fast_LS != nullptr);
+            flag = ARKStepSetLinearSolver(arkode_fast_mem, fast_LS, nullptr);
+            AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Attach structure with user-supplied function wrappers
-        ARKStepSetUserData(arkode_fast_mem, &udata);
+        flag = ARKStepSetUserData(arkode_fast_mem, &udata);
+        AMREX_ALWAYS_ASSERT(flag == 0);
 
         // Set integrator tolerances
         if (BaseT::use_adaptive_fast_time_step || fast_type == "DIRK" || fast_type == "IMEX-RK") {
           amrex::Print() << "Fast relative tolerance: " << BaseT::fast_rel_tol << "\n";
           amrex::Print() << "Fast abolute tolerance: " << BaseT::fast_abs_tol << "\n";
-          ARKStepSStolerances(arkode_fast_mem, BaseT::fast_rel_tol, BaseT::fast_abs_tol);
+          flag = ARKStepSStolerances(arkode_fast_mem, BaseT::fast_rel_tol, BaseT::fast_abs_tol);
+          AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Set post stage and step function
-        ARKStepSetPostprocessStageFn(arkode_fast_mem, SundialsUserFun::post_fast_stage);
-        ARKStepSetPostprocessStepFn(arkode_fast_mem, SundialsUserFun::post_fast_step);
+        flag = ARKStepSetPostprocessStageFn(arkode_fast_mem, SundialsUserFun::post_fast_stage);
+        AMREX_ALWAYS_ASSERT(flag == 0);
+        flag = ARKStepSetPostprocessStepFn(arkode_fast_mem, SundialsUserFun::post_fast_step);
+        AMREX_ALWAYS_ASSERT(flag == 0);
 
         // Wrap fast integrator as an inner stepper
-        ARKStepCreateMRIStepInnerStepper(arkode_fast_mem, &fast_stepper);
+        flag = ARKStepCreateMRIStepInnerStepper(arkode_fast_mem, &fast_stepper);
+        AMREX_ALWAYS_ASSERT(flag == 0);
 
         // Create slow integrator
         if (type == "EX-MRI") {
             amrex::Print() << "EX-MRI method: " << method << "\n";
             arkode_mem = MRIStepCreate(SundialsUserFun::f, nullptr, time, y_data,
                                        fast_stepper, sunctx);
+            AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
         }
         else if (type == "IM-MRI") {
             amrex::Print() << "IM-MRI method: " << method << "\n";
             arkode_mem = MRIStepCreate(nullptr, SundialsUserFun::f, time, y_data,
                                        fast_stepper, sunctx);
+            AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
         }
         else if (type == "IMEX-MRI") {
             amrex::Print() << "IMEX-MRI method: " << method << "\n";
             arkode_mem = MRIStepCreate(SundialsUserFun::fe, SundialsUserFun::fi,
                                        time, y_data, fast_stepper, sunctx);
+            AMREX_ALWAYS_ASSERT(arkode_mem != nullptr);
         }
 
         // Set method
         if (method != "DEFAULT") {
             MRIStepCoupling MRIC = MRIStepCoupling_LoadTableByName(method.c_str());
-            MRIStepSetCoupling(arkode_mem, MRIC);
+            AMREX_ALWAYS_ASSERT(MRIC != nullptr);
+            flag = MRIStepSetCoupling(arkode_mem, MRIC);
+            AMREX_ALWAYS_ASSERT(flag == 0);
             MRIStepCoupling_Free(MRIC);
         }
 
         // Attach structure with user-supplied function wrappers
-        MRIStepSetUserData(arkode_mem, &udata);
+        flag = MRIStepSetUserData(arkode_mem, &udata);
+        AMREX_ALWAYS_ASSERT(flag == 0);
 
         // Set integrator tolerances
         if (BaseT::use_adaptive_time_step || fast_type == "IM-MRI" || fast_type == "IMEX-MRI") {
           amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
           amrex::Print() << "Abolute tolerance: " << BaseT::abs_tol << "\n";
-          MRIStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+          flag = MRIStepSStolerances(arkode_mem, BaseT::rel_tol, BaseT::abs_tol);
+          AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Create and attach linear solver
         if (type == "IM-MRI" || type == "IMEX-MRI") {
             LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, 0, sunctx);
-            MRIStepSetLinearSolver(arkode_mem, LS, nullptr);
+            AMREX_ALWAYS_ASSERT(LS != nullptr);
+            flag = MRIStepSetLinearSolver(arkode_mem, LS, nullptr);
+            AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Set post stage and step function
-        MRIStepSetPostprocessStageFn(arkode_mem, SundialsUserFun::post_stage);
-        MRIStepSetPostprocessStepFn(arkode_mem, SundialsUserFun::post_step);
+        flag = MRIStepSetPostprocessStageFn(arkode_mem, SundialsUserFun::post_stage);
+        AMREX_ALWAYS_ASSERT(flag == 0);
+        flag = MRIStepSetPostprocessStepFn(arkode_mem, SundialsUserFun::post_step);
+        AMREX_ALWAYS_ASSERT(flag == 0);
     }
 
     // -------------------------------------

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -128,8 +128,8 @@ private:
 
         pp.query("type", type);
         pp.query("method", method);
-        pp.query("method_e", method);
-        pp.query("method_i", method);
+        pp.query("method_e", method_e);
+        pp.query("method_i", method_i);
 
         pp.query("fast_type", fast_type);
         pp.query("fast_method", fast_method);


### PR DESCRIPTION
## Summary

* Check SUNDIALS return flags
* Abort if a required callback function is called but not set
* Fix selecting a specific IMEX method with SUNDIALS
* Document time integrator runtime inputs
* Read base class parameters at construction
* Add options for selecting the algebraic solvers with implicit methods
* Add option to set a stop time
* Only output settings and final statistics with verbose output is enabled

## Additional background

Various fixes and enhancements from testing methods in FerroX

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
