### PR TITLE
Fix Assert in `ReduceToPlaneMF`

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -1292,7 +1292,7 @@ FA reduce_to_plane (int direction, Box const& domain, FA const& mf, F const& f)
     Box const ndomain = amrex::convert(domain, mf.ixType());
 
     auto npts = amrex::convert(mf.boxArray(),IntVect(0)).numPts();
-    if (npts != ndomain.numPts()) {
+    if (npts != amrex::convert(domain, amrex::IntVect(0)).numPts()) {
         amrex::Abort("ReduceToPlaneMF: mf's BoxArray must have a rectangular domain.");
     }
 


### PR DESCRIPTION
## Summary

Fix an assert in `reduce_to_plane`, making sure the same staggering is used for the number-of-node-points assert.

## Additional background

Follow-up to #4384

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
