### PR TITLE
avoid nullptr deref within TinyProfiler for no mpi

### DIFF
--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -775,7 +775,7 @@ TinyProfiler::PrintMemStats (std::map<std::string, MemStat>& memstats,
         std::vector<Long> avgmem_vec(nprocs);
         std::vector<Long> maxmem_vec(nprocs);
 
-        if (nprocs == 1)
+        if (ParallelDescriptor::NProcs() == 1)
         {
             nalloc_vec[0] = nalloc;
             nfree_vec[0] = nfree;


### PR DESCRIPTION
## Summary

Compiling with TinyProfiler but no MPI results in a warning about a potential nullptr dereference in the TinyProfiler code. This should never actually happen in serial because nprocs is always 1, but the warning can be avoided.

## Additional background

To reproduce the error that this avoids:
```
./configure --dim=2 --with-mpi=no --enable-particle=no --with-fortran=no --enable-linear-solver=no --enable-fortran-api=no --prefix=./ --enable-tiny-profile=yes --comp=gnu --with-cuda=no
make -j WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-unused-parameter"
```

Results in:
```
In file included from /home/bperry/PelePhysics/Submodules/amrex/Src/Base/AMReX_TinyProfiler.cpp:5:
In function ‘void amrex::ParallelDescriptor::Gather(const T*, size_t, T1*, size_t, int) [with T = long int; T1 = long int]’,
    inlined from ‘static void amrex::TinyProfiler::PrintMemStats(std::map<std::__cxx11::basic_string<char>, amrex::MemStat>&, const std::string&, double, double, std::ostream*)’ at /home/bperry/PelePhysics/Submodules/amrex/Src/Base/AMReX_TinyProfiler.cpp:789:39:
/home/bperry/PelePhysics/Submodules/amrex/Src/Base/AMReX_ParallelDescriptor.H:1188:38: error: null pointer dereference [-Werror=null-dereference]
 1188 |     for (int j=0; j<sc; ++j) { t1[j] = t[j]; }
      |                                ~~~~~~^~~~
```


## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
