### PR TITLE
ParmParse: Remove two Aborts

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -616,10 +616,6 @@ bldTable (const char*& str, ParmParse::Table& tab)
         }
         case pEQ_sign:
         {
-            if ( cur_name.empty() )
-            {
-                amrex::Abort("ParmParse::bldTable() EQ with no current defn");
-            }
             if ( !cur_list.empty() )
             {
                 //
@@ -658,12 +654,6 @@ bldTable (const char*& str, ParmParse::Table& tab)
         }
         case pValue:
         {
-            if ( cur_name.empty() )
-            {
-                std::string msg("ParmParse::bldTable(): value with no defn: ");
-                msg += tokname;
-                amrex::Abort(msg.c_str());
-            }
             cur_list.push_back(std::move(tokname));
             cur_linefeeds.push_back(num_linefeeds);
             break;

--- a/Tests/ParmParse/inputs
+++ b/Tests/ParmParse/inputs
@@ -1,3 +1,4 @@
+dAx_x/dx(x,y,t,zeval) = 12
 
 amrex.signal_handling = 0
 amrex.throw_exception = 1

--- a/Tests/ParmParse/main.cpp
+++ b/Tests/ParmParse/main.cpp
@@ -24,6 +24,12 @@ int main(int argc, char* argv[])
     }
     {
         ParmParse pp;
+        int val;
+        pp.query("dAx_x/dx(x,y,t,zeval)", val);
+        AMREX_ALWAYS_ASSERT(val == 12);
+    }
+    {
+        ParmParse pp;
 
         std::string name;
         pp.query("name", name);


### PR DESCRIPTION
ParmParse now supports names containing special characters such as `/`, `(`, `)`, and `,` except for white space and `=` (e.g., `dAx_x/dx(x,y,t,zeval) = 12`). In fact, even before this PR, such names were already supported as long as they are not the first entry, due to the way input parsing was implemented. With this PR, these names are now allowed as the first entry as well.
