### PR TITLE
Add ToString function for array and tuple

### DIFF
--- a/Src/Base/AMReX_Utility.H
+++ b/Src/Base/AMReX_Utility.H
@@ -24,8 +24,10 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <ostream>
 #include <sstream>
 #include <string>
+#include <tuple>
 #include <typeinfo>
 #include <type_traits>
 
@@ -220,6 +222,24 @@ namespace amrex
     template<typename T> void hash_combine (uint64_t & seed, const T & val) noexcept;
     template<typename T> uint64_t hash_vector (const Vector<T> & vec, uint64_t seed = 0xDEADBEEFDEADBEEF) noexcept;
 
+    template <class T>
+    std::ostream& ToString(std::ostream& os,
+                           const T& t,
+                           const char* symbol_begin = "[",
+                           const char* symbol_delim = ", ",
+                           const char* symbol_end = "]",
+                           const char* symbol_str = "\"",
+                           int limit = 100);
+
+    template <class T>
+    std::string ToString(const T& t,
+                         const char* symbol_begin = "[",
+                         const char* symbol_delim = ", ",
+                         const char* symbol_end = "]",
+                         const char* symbol_str = "\"",
+                         int limit = 100,
+                         std::ostringstream ss = {});
+
 }
 
 template <typename T>
@@ -379,5 +399,102 @@ amrex::hash_vector (const Vector<T> & vec, uint64_t seed) noexcept
     }
     return seed;
 }
+
+
+namespace amrex::detail {
+
+    // Determine if type has .begin() and .end() member functions
+    template <class T>
+    constexpr decltype((T{}.begin(), T{}.end(), true)) HasBeginEnd() {
+        return true;
+    }
+    template <class T, class... Args>
+    constexpr bool HasBeginEnd(Args...) {
+        return false;
+    }
+
+    // Determine if type has a specialization for std::tuple_size
+    template <class T>
+    constexpr decltype((std::tuple_size<T>::value, true)) HasTupleSize() {
+        return true;
+    }
+    template <class T, class... Args>
+    constexpr bool HasTupleSize(Args...) {
+        return false;
+    }
+
+    // Helper for tuple unpacking
+    template <class T, std::size_t... idx>
+    void ToStringTupleImp(std::index_sequence<idx...>, std::ostream& os, const T& t,
+                          const char* symbol_begin, const char* symbol_delim,
+                          const char* symbol_end, const char* symbol_str, int limit) {
+        os << symbol_begin;
+        Long count = 0;
+        auto op = [&](auto& value) {
+            if (count > 0 && (count <= limit || limit < 0)) {
+                os << symbol_delim;
+            }
+            if (count < limit || limit < 0) {
+                ToString(os, value, symbol_begin, symbol_delim, symbol_end,
+                        symbol_str, limit);
+            } else if (count == limit) {
+                os << "...";
+            }
+            ++count;
+        };
+        (op(std::get<idx>(t)), ...);
+        os << symbol_end;
+    }
+}
+
+template <class T>
+std::ostream& amrex::ToString(std::ostream& os, const T& t, const char* symbol_begin,
+                              const char* symbol_delim, const char* symbol_end,
+                              const char* symbol_str, int limit)
+{
+    if constexpr (std::is_same_v<std::string, T> ||
+                  std::is_same_v<char*, std::decay_t<T>> ||
+                  std::is_same_v<const char*, T>) {
+        // String-like types
+        os << symbol_str << t << symbol_str;
+    } else if constexpr (detail::HasBeginEnd<T>() || std::is_array_v<T>) {
+        // Array-like types
+        os << symbol_begin;
+        Long count = 0;
+        for (auto& value : t) {
+            if (count > 0) {
+                os << symbol_delim;
+            }
+            if (count < limit || limit < 0) {
+                ToString(os, value, symbol_begin, symbol_delim, symbol_end,
+                         symbol_str, limit);
+            } else if (count == limit) {
+                os << "...";
+                break;
+            }
+            ++count;
+        }
+        os << symbol_end;
+    } else if constexpr (detail::HasTupleSize<T>()) {
+        // Tuple-like types
+        detail::ToStringTupleImp(std::make_index_sequence<std::tuple_size_v<T>>{},
+                                 os, t, symbol_begin, symbol_delim, symbol_end,
+                                 symbol_str, limit);
+    } else {
+        // Scalar types
+        os << t;
+    }
+    return os;
+}
+
+template <class T>
+std::string amrex::ToString(const T& t, const char* symbol_begin, const char* symbol_delim,
+                            const char* symbol_end, const char* symbol_str,
+                            int limit, std::ostringstream ss)
+{
+    ToString(ss, t, symbol_begin, symbol_delim, symbol_end, symbol_str, limit);
+    return ss.str();
+}
+
 
 #endif /*BL_UTILITY_H*/

--- a/Src/Base/AMReX_Utility.H
+++ b/Src/Base/AMReX_Utility.H
@@ -30,6 +30,7 @@
 #include <tuple>
 #include <typeinfo>
 #include <type_traits>
+#include <utility>
 
 namespace amrex
 {
@@ -405,7 +406,7 @@ namespace amrex::detail {
 
     // Determine if type has .begin() and .end() member functions
     template <class T>
-    constexpr decltype((T{}.begin(), T{}.end(), true)) HasBeginEnd() {
+    constexpr decltype((std::declval<T>().begin(), std::declval<T>().end(), true)) HasBeginEnd() {
         return true;
     }
     template <class T, class... Args>

--- a/Src/Base/AMReX_Utility.H
+++ b/Src/Base/AMReX_Utility.H
@@ -27,6 +27,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <typeinfo>
 #include <type_traits>
@@ -454,10 +455,18 @@ std::ostream& amrex::ToString(std::ostream& os, const T& t, const char* symbol_b
                               const char* symbol_str, int limit)
 {
     if constexpr (std::is_same_v<std::string, T> ||
+                  std::is_same_v<std::string_view, T> ||
                   std::is_same_v<char*, std::decay_t<T>> ||
                   std::is_same_v<const char*, T>) {
         // String-like types
         os << symbol_str << t << symbol_str;
+    } else if constexpr (std::is_same_v<signed char, T> ||
+                         std::is_same_v<unsigned char, T>) {
+        // Buffer-like types, don't print as char
+        os << static_cast<int>(t);
+    } else if constexpr (std::is_pointer_v<T>) {
+        // Pointer types, don't print char* as string
+        os << static_cast<const void*>(t);
     } else if constexpr (detail::HasBeginEnd<T>() || std::is_array_v<T>) {
         // Array-like types
         os << symbol_begin;


### PR DESCRIPTION
## Summary

This PR adds a `ToString` function that can be used with scalars, arrays and tuples to write error messages or when debugging.

TODO: write a doc comment for `ToString`

It might be useful to add compatibility for BaseFab and PODVector with automatic dtoh memcpy.

Example (https://godbolt.org/z/vsn6Krbsj)
```C++
std::vector v{4., 7., 23., 0.000001, 7.123456789123456789, 8., 3., 0.0000011};
std::tuple t{443, 0.234423, 244.4f, "Test tuple"};
std::array a{4., 7., 23., 0.000001, 7.12345, 8., 3., 0.0000011};
std::map<int, std::vector<double>> m{{0, {32.42, 1.000324}},
                                        {4, {12.3, 2.65775, 3.24}}};
int b[]{2, 3, 65, 3, 6, 54};
const char* c = "Test char *";
char e[] = "Test char array";

std::cout << amrex::ToString(v) << '\n';
std::cout << amrex::ToString(t, "[", ",", "]", "'", 100,std::ostringstream{} << std::setprecision(4)) << '\n';
std::cout << amrex::ToString(a, "{", " ; ", "}", "\"", 3, std::ostringstream{} << std::setprecision(10)) << '\n';
std::cout << amrex::ToString(m, "<", " | ", ">", "\"", 100, std::ostringstream{} << std::setprecision(10))<< '\n';
std::cout << amrex::ToString(b) << '\n';
std::cout << amrex::ToString(c) << '\n';
std::cout << amrex::ToString(e) << '\n';
std::cout << amrex::ToString("Test direct string") << '\n';
std::cout << amrex::ToString(std::string("Test string")) << '\n';
std::cout << amrex::ToString(std::array{"awdawd", "43tf4", "awd4t45"})  << '\n';
std::cout << amrex::ToString(std::array{'t', 'e', 's', 't'}) << '\n';

std::cout << '\n';

amrex::ToString(std::cout, v) << '\n';
amrex::ToString(std::cout << std::setprecision(4), t, "[", ",", "]", "'", 100) << '\n';
amrex::ToString(std::cout << std::setprecision(10), a, "{", " ; ", "}", "\"", 3) << '\n';
amrex::ToString(std::cout << std::setprecision(10), m, "<", " | ", ">", "\"", 100) << '\n';
amrex::ToString(std::cout, b) << '\n';
amrex::ToString(std::cout, c) << '\n';
amrex::ToString(std::cout, e) << '\n';
amrex::ToString(std::cout, "Test direct string") << '\n';
amrex::ToString(std::cout, std::string("Test string")) << '\n';
amrex::ToString(std::cout, std::array{"awdawd", "43tf4", "awd4t45"}) << '\n';
amrex::ToString(std::cout, std::array{'t', 'e', 's', 't'}) << '\n';
```
Prints
```python
[4, 7, 23, 1e-06, 7.12345, 8, 3, 1.1e-06]
[443,0.2344,244.4,'Test tuple']
{4 ; 7 ; 23 ; ...}
<<0 | <32.42 | 1.000324>> | <4 | <12.3 | 2.65775 | 3.24>>>
[2, 3, 65, 3, 6, 54]
"Test char *"
"Test char array"
"Test direct string"
"Test string"
["awdawd", "43tf4", "awd4t45"]
[t, e, s, t]

[4, 7, 23, 1e-06, 7.12345, 8, 3, 1.1e-06]
[443,0.2344,244.4,'Test tuple']
{4 ; 7 ; 23 ; ...}
<<0 | <32.42 | 1.000324>> | <4 | <12.3 | 2.65775 | 3.24>>>
[2, 3, 65, 3, 6, 54]
"Test char *"
"Test char array"
"Test direct string"
"Test string"
["awdawd", "43tf4", "awd4t45"]
[t, e, s, t]
```

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
