### PR TITLE
Correction to EB volume centroid for anisotropic case

### DIFF
--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -139,21 +139,21 @@ void set_eb_data (const int i, const int j, const int k,
     Real dz2 = dz1*dz1;
     Real dz3 = dz2*dz1;
 
-    Real b1 = 0.5_rt*(axp-axm)*dx2*dy1*dz1 + 0.5_rt*(ayp*fcy(i,j+1,k,0) + aym*fcy(i,j,k,0))*dx1*dy2*dz1 + 0.5_rt*(azp*fcz(i,j,k+1,0) + azm*fcz(i,j,k,0))*dx1*dy1*dz2;
-    Real b2 = 0.5_rt*(axp*fcx(i+1,j,k,0) + axm*fcx(i,j,k,0))*dx2*dy1*dz1 + 0.5_rt*(ayp-aym)*dx1*dy2*dz1 + 0.5_rt*(azp*fcz(i,j,k+1,1) + azm*fcz(i,j,k,1))*dx1*dy1*dz2;
-    Real b3 = 0.5_rt*(axp*fcx(i+1,j,k,1) + axm*fcx(i,j,k,1))*dx2*dy1*dz1 + 0.5_rt*(ayp*fcy(i,j+1,k,1) + aym*fcy(i,j,k,1))*dx1*dy2*dz1 + 0.5_rt*(azp-azm)*dx1*dy1*dz2;
+    Real b1 = (0.5_rt*(axp-axm) + 0.5_rt*(ayp*fcy(i,j+1,k,0) + aym*fcy(i,j,k,0)) + 0.5_rt*(azp*fcz(i,j,k+1,0) + azm*fcz(i,j,k,0))) * dx2*dy1*dz1;
+    Real b2 = (0.5_rt*(axp*fcx(i+1,j,k,0) + axm*fcx(i,j,k,0)) + 0.5_rt*(ayp-aym) + 0.5_rt*(azp*fcz(i,j,k+1,1) + azm*fcz(i,j,k,1))) * dx1*dy2*dz1;
+    Real b3 = (0.5_rt*(axp*fcx(i+1,j,k,1) + axm*fcx(i,j,k,1)) + 0.5_rt*(ayp*fcy(i,j+1,k,1) + aym*fcy(i,j,k,1)) + 0.5_rt*(azp-azm)) * dx1*dy1*dz2;
     Real b4 = -nx*0.25_rt*(axp-axm)*dx2*dy1*dz1 - ny*(m2y(i,j+1,k,0) - m2y(i,j,k,0))*dx3*dz1 - nz*(m2z(i,j,k+1,0) - m2z(i,j,k,0))*dx3*dy1;
     Real b5 = -nx*(m2x(i+1,j,k,0) - m2x(i,j,k,0))*dy3*dz1 - ny*0.25_rt*(ayp-aym)*dx1*dy2*dz1 - nz*(m2z(i,j,k+1,1) - m2z(i,j,k,1))*dx1*dy3;
     Real b6 = -nx*(m2x(i+1,j,k,1) - m2x(i,j,k,1))*dy1*dz3 - ny*(m2y(i,j+1,k,1) - m2y(i,j,k,1))*dx1*dz3 - nz*0.25_rt*(azp-azm)*dx1*dy1*dz2;
-    Real b7 = -nx*0.5_rt*(axp*fcx(i+1,j,k,0) + axm*fcx(i,j,k,0))*dx2*dy1*dz1
-              -ny*0.5_rt*(ayp*fcy(i,j+1,k,0) + aym*fcy(i,j,k,0))*dx1*dy2*dz1
+    Real b7 = -nx*0.5_rt*(axp*fcx(i+1,j,k,0) + axm*fcx(i,j,k,0))*dx1*dy2*dz1
+              -ny*0.5_rt*(ayp*fcy(i,j+1,k,0) + aym*fcy(i,j,k,0))*dx2*dy1*dz1
               -nz*(m2z(i,j,k+1,2) - m2z(i,j,k,2))*dx2*dy2;
-    Real b8 = -nx*0.5_rt*(axp*fcx(i+1,j,k,1) + axm*fcx(i,j,k,1))*dx2*dy1*dz1
+    Real b8 = -nx*0.5_rt*(axp*fcx(i+1,j,k,1) + axm*fcx(i,j,k,1))*dx1*dy1*dz2
               -ny*(m2y(i,j+1,k,2) - m2y(i,j,k,2))*dx2*dz2
-              -nz*0.5_rt*(azp*fcz(i,j,k+1,0) + azm*fcz(i,j,k,0))*dx1*dy1*dz2;
+              -nz*0.5_rt*(azp*fcz(i,j,k+1,0) + azm*fcz(i,j,k,0))*dx2*dy1*dz1;
     Real b9 = -nx*(m2x(i+1,j,k,2) - m2x(i,j,k,2))*dy2*dz2
-              -ny*0.5_rt*(ayp*fcy(i,j+1,k,1) + aym*fcy(i,j,k,1))*dx1*dy2*dz1
-              -nz*0.5_rt*(azp*fcz(i,j,k+1,1) + azm*fcz(i,j,k,1))*dx1*dy1*dz2;
+              -ny*0.5_rt*(ayp*fcy(i,j+1,k,1) + aym*fcy(i,j,k,1))*dx1*dy1*dz2
+              -nz*0.5_rt*(azp*fcz(i,j,k+1,1) + azm*fcz(i,j,k,1))*dx1*dy2*dz1;
 
     Real ny2 = ny *ny;
     Real ny3 = ny2*ny;


### PR DESCRIPTION
## Summary
Based on the observation by @skang67, correction for the EB volume centroid for anisotropic meshes is made.

In `cut_face_2d`, the face centroid locations -`fcx(i,j,k,0)` is normalized w.r.t `dy` and `fcx(i,j,k,1)` is w.r.t. `dz`. This derivation makes the volume centroid consistent with this normalization. The updated derivation is in the pdf linked below.

[EB_anisotropic_volume_centroid.pdf](https://github.com/user-attachments/files/21498252/EB_anisotropic_volume_centroid.pdf)

The volume of the cell needs to be corrected as well. @skang67 will submit the PR for that.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
