### PR TITLE
Workaround CUDA 12.9 / CMake 3.30: Ignore SM 10.0+

### DIFF
--- a/Tools/CMake/AMReXUtils.cmake
+++ b/Tools/CMake/AMReXUtils.cmake
@@ -222,15 +222,22 @@ endfunction ()
 function (convert_cuda_archs  _cuda_archs)
 
    foreach (_item IN LISTS ${_cuda_archs})
+      # remove -real suffixes
+      string(REGEX REPLACE "\\-real$" "" _item "${_item}")
+
       string(REGEX MATCH "\\." _has_decimal "${_item}")
       string(REGEX MATCH "[0-9]+" _is_number "${_item}")
 
       if (NOT _has_decimal AND _is_number)
          math(EXPR _int "${_item}/10" OUTPUT_FORMAT DECIMAL)
          math(EXPR _mod "${_item}%10" OUTPUT_FORMAT DECIMAL)
-         list(APPEND _tmp "${_int}.${_mod}")
+         if(_int LESS 10)  # CMake 3.30 does not support SM 10.0+ in cuda_select_nvcc_arch_flags
+             list(APPEND _tmp "${_int}.${_mod}")
+         endif()
       else ()
-         list(APPEND _tmp ${_item})
+         if(_item LESS 10)  # CMake 3.30 does not support SM 10.0+ in cuda_select_nvcc_arch_flags
+            list(APPEND _tmp ${_item})
+        endif()
       endif()
    endforeach ()
 


### PR DESCRIPTION
## Summary

The legacy CMake logic we have fails the moment that CUDA Toolkit advertises SMs >= 10.0. While we work on a modernization #4572, the current `development` breaks **all CUDA builds** in CUDA 12.9, even for older SMs.

Exclude newer SMs for now from our build logic.

## Additional background

Seen with
```
$ cmake --version
cmake version 3.30.4

CMake suite maintained and supported by Kitware (kitware.com/cmake).

$ nvcc --version
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2025 NVIDIA Corporation
Built on Tue_May_27_02:21:03_PDT_2025
Cuda compilation tools, release 12.9, V12.9.86
Build cuda_12.9.r12.9/compiler.36037853_0
```

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
