### PR TITLE
CMake: Fix Typo `AMReX_COMPILER_DEFAULT_INLINE`

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -86,7 +86,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
           )
     endif ()
 
-    if (NOT AMReX_COMPILER_DEFULT_INLINE)
+    if (NOT AMReX_COMPILER_DEFAULT_INLINE)
        target_link_libraries(amrex_${D}d
           PUBLIC
           $<BUILD_INTERFACE:Flags_INLINE>


### PR DESCRIPTION
## Summary

Option had no effect because it was always false.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
