### PR TITLE
CMake: `AMReX::Flags_FASTMATH` Interface Helper Target

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -443,7 +443,7 @@ The list of available options is reported in the :ref:`table <tab:cmakevar>` bel
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_BUILD_SHARED_LIBS      |  Build as shared C++ library                    | NO (unless xSDK)        | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
-   | AMReX_FASTMATH               |  Enable fast-math optimizations                 | NO (CPU), YES (CUDA)    | YES, NO               |
+   | AMReX_FASTMATH               |  Enable fast-math optimizations                 | NO (CUDA is ON)          | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+
    | AMReX_FORTRAN                |  Enable Fortran language                        | NO                      | YES, NO               |
    +------------------------------+-------------------------------------------------+-------------------------+-----------------------+

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -79,6 +79,10 @@ foreach(D IN LISTS AMReX_SPACEDIM)
           )
     endif ()
 
+    if (AMReX_FASTMATH)
+        target_link_libraries(amrex_${D}d PUBLIC AMReX::Flags_FASTMATH)
+    endif ()
+
     if (AMReX_FPE)
        target_link_libraries(amrex_${D}d
           PUBLIC

--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -4,6 +4,7 @@
 #
 #   Flags_CXX                 --> Optional flags for C++ code
 #   Flags_Fortran             --> Optional flags for Fortran code
+#   Flags_FASTMATH            --> Optional flags for fast-math (floating-point)
 #   Flags_FPE                 --> Floating-Point Exception flags for both C++ and Fortran
 #   Flags_INLINE              --> Optional flags for inlining
 #
@@ -21,15 +22,15 @@ include_guard(GLOBAL)
 #
 # for every combination of
 #
-#     <lang> = cxx,fortran
-#     <id>   = gnu,intel,pgi,cray,clang,appleclang,intelllvm,msvc
+#     <lang> = cxx,fortran,cuda
+#     <id>   = gnu,intel,pgi,cray,clang,appleclang,crayclang,ibmclang,intelllvm,msvc,nvidia,nvhpc,xlclang
 #
 if (CMAKE_VERSION VERSION_LESS 3.20)
-   foreach (_language CXX Fortran )
+   foreach (_language CXX Fortran CUDA )
       set(_comp_lang   "$<COMPILE_LANGUAGE:${_language}>")
       string(TOLOWER "${_language}" _lang)
 
-      foreach (_comp GNU Intel PGI Cray Clang AppleClang IntelLLVM MSVC )
+      foreach (_comp GNU Intel PGI Cray Clang AppleClang CrayClang IBMClang IntelLLVM MSVC NVIDIA NVHPC XLClang )
          string(TOLOWER "${_comp}" _id)
          # Define variables
          set(_comp_id              "$<${_language}_COMPILER_ID:${_comp}>")
@@ -44,10 +45,10 @@ if (CMAKE_VERSION VERSION_LESS 3.20)
       unset(_lang)
    endforeach ()
 else ()
-   foreach (_language CXX Fortran )
+   foreach (_language CXX Fortran CUDA )
       string(TOLOWER "${_language}" _lang)
 
-      foreach (_comp GNU Intel PGI Cray Clang AppleClang IntelLLVM MSVC )
+      foreach (_comp GNU Intel PGI Cray Clang AppleClang CrayClang IBMClang IntelLLVM MSVC NVIDIA NVHPC XLClang )
          string(TOLOWER "${_comp}" _id)
          # Define variables
          set(_${_lang}_${_id}      "$<COMPILE_LANG_AND_ID:${_language},${_comp}>")
@@ -125,6 +126,35 @@ target_compile_options( Flags_Fortran
    $<${_fortran_cray_dbg}:-O0 -e i>
    $<${_fortran_cray_rel}:>
    )
+
+
+#
+# Fast-Math (for floating point)
+#
+add_library(Flags_FASTMATH INTERFACE)
+add_library(AMReX::Flags_FASTMATH ALIAS Flags_FASTMATH)
+
+target_compile_options( Flags_FASTMATH
+   INTERFACE
+      $<${_cuda_nvidia}:--use_fast_math>
+      $<${_cuda_nvhpc}:-fast>
+      $<${_fortran_gnu}:-ffast-math>
+      $<${_cxx_gnu}:-ffast-math>
+      $<${_fortran_intel}:-ffast-math>
+      $<${_cxx_intel}:-ffast-math>
+      $<${_fortran_pgi}:-ffast-math>
+      $<${_cxx_pgi}:-ffast-math>
+      $<${_fortran_cray}:-ffast-math>
+      $<${_cxx_cray}:-ffast-math>
+      $<${_fortran_clang}:-ffast-math>
+      $<${_cxx_clang}:-ffast-math>
+      $<${_cxx_appleclang}:-ffast-math>
+      $<${_cxx_crayclang}:-ffast-math>
+      $<${_cxx_ibmclang}:-ffast-math>
+      $<${_cxx_intelllvm}:-ffast-math>
+      $<${_cxx_xlclang}:-ffast-math>
+      $<${_cxx_msvc}:/fp:fast>
+)
 
 
 #

--- a/Tools/CMake/AMReXOptions.cmake
+++ b/Tools/CMake/AMReXOptions.cmake
@@ -256,14 +256,8 @@ print_option(AMReX_GPU_RDC)
 #
 # Fast Math    ================================================================
 #
-set(_FASTMATH_default OFF)
-if(AMReX_GPU_BACKEND STREQUAL CUDA)  # note: historic settings
-# if(NOT AMReX_GPU_BACKEND STREQUAL NONE)  # note: this would be more consistent for GPUs
-    set(_FASTMATH_default ON)
-endif()
-option(AMReX_FASTMATH  "Enable fast-math optimizations" ${_FASTMATH_default})
+option(AMReX_FASTMATH  "Enable fast-math optimizations" OFF)
 print_option(AMReX_FASTMATH)
-unset(_FASTMATH_default)
 
 #
 # Parallel backends    ========================================================

--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -217,11 +217,6 @@ if (AMReX_SYCL)
    include(AMReXSYCL)
    foreach(D IN LISTS AMReX_SPACEDIM)
       target_link_libraries(amrex_${D}d PUBLIC SYCL)
-
-       # fast math
-       if(AMReX_FASTMATH)
-           target_compile_options(amrex_${D}d PUBLIC -ffast-math)
-       endif()
    endforeach()
 endif ()
 
@@ -366,11 +361,6 @@ if (AMReX_HIP)
 
    foreach(D IN LISTS AMReX_SPACEDIM)
        target_compile_options(amrex_${D}d PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-m64>)
-
-       # fast math
-       if(AMReX_FASTMATH)
-           target_compile_options(amrex_${D}d PUBLIC -ffast-math)
-       endif()
 
        # ROCm 4.5: use unsafe floating point atomics, otherwise atomicAdd is much slower
        # 

--- a/Tools/CMake/AMReX_Config.cmake
+++ b/Tools/CMake/AMReX_Config.cmake
@@ -13,6 +13,13 @@
 function (configure_amrex AMREX_TARGET)
 
    #
+   # Include the required modules
+   #
+   include( AMReX_ThirdPartyProfilers )
+   include( AMReXGenexHelpers )
+   include( AMReXFlagsTargets )
+
+   #
    # Check if target "amrex" has been defined before
    # calling this macro
    #
@@ -24,15 +31,10 @@ function (configure_amrex AMREX_TARGET)
    # Check that needed options have already been defined
    #
    if ( ( NOT ( DEFINED AMReX_MPI ) ) OR ( NOT (DEFINED AMReX_OMP) )
-	 OR ( NOT (DEFINED AMReX_PIC) ) OR (NOT (DEFINED AMReX_FPE)))
+	 OR ( NOT (DEFINED AMReX_PIC) ) OR (NOT (DEFINED AMReX_FASTMATH))
+     OR (NOT (DEFINED AMReX_FPE)))
       message ( AUTHOR_WARNING "Required options are not defined" )
    endif ()
-
-   #
-   # Include the required modules
-   #
-   include( AMReX_ThirdPartyProfilers )
-   include( AMReXGenexHelpers )
 
    #
    # Setup compilers
@@ -147,19 +149,7 @@ function (configure_amrex AMREX_TARGET)
 
    # fast math
    if (AMReX_FASTMATH)
-       # GPU specific backends set in AMReXParallelBackends.cmake
-       if (AMReX_GPU_BACKEND STREQUAL NONE)
-           # See https://cmake.org/cmake/help/v4.1/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID
-           target_compile_options(${AMREX_TARGET} PUBLIC
-               $<$<CXX_COMPILER_ID:AppleClang,Clang,CrayClang,GNU,IBMClang,IntelLLVM,XLClang>:-ffast-math>
-               $<${_cxx_msvc}:"/fp:fast">  # MSVC
-           )
-           if (CMAKE_Fortran_COMPILER_LOADED)
-               target_compile_options(${AMREX_TARGET} PUBLIC
-                   $<$<Fortran_COMPILER_ID:AppleClang,Clang,CrayClang,GNU,IBMClang,IntelLLVM,XLClang>:-ffast-math>
-               )
-           endif ()
-       endif()
+       target_link_libraries(${AMREX_TARGET} PUBLIC AMReX::Flags_FASTMATH)
    endif()
 
    #


### PR DESCRIPTION
## Summary

This PR _changes no defaults_. It just refactors #4545 a bit further prior to adding the option `AMReX_FASTMATH` in a first AMReX release, providing a better internal implementation and a user-friendly helper target (fully optional).

Add an interface target for the fast-math flags. This makes it easier to re-use them downstream when AMReX is pre-compiled w/o fast-math (default in all of our current package managers), but the main code wants to still use fast-math on the side of the application code.

## Additional background

Follow-up to #4545, see comment https://github.com/AMReX-Codes/amrex/pull/4545#discussion_r2245683394

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
