### PR TITLE
Add ParallelForOMP

### DIFF
--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -245,7 +245,7 @@ namespace amrex {
 
 #if defined(AMREX_USE_GPU) || !defined(AMREX_USE_OMP)
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelForOMP (T n, L const& f) noexcept
 {
     ParallelFor(n, f);
@@ -257,7 +257,7 @@ void ParallelForOMP (Box const& box, L const& f) noexcept
     ParallelFor(box, f);
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelForOMP (Box const& box, T ncomp, L const& f) noexcept
 {
     ParallelFor(box, ncomp, f);
@@ -265,7 +265,7 @@ void ParallelForOMP (Box const& box, T ncomp, L const& f) noexcept
 
 #else /* !defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP) */
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 AMREX_ATTRIBUTE_FLATTEN_FOR
 void ParallelForOMP (T n, L const& f) noexcept
 {
@@ -307,7 +307,7 @@ void ParallelForOMP (Box const& box, L const& f) noexcept
 #endif
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 AMREX_ATTRIBUTE_FLATTEN_FOR
 void ParallelForOMP (Box const& box, T ncomp, L const& f) noexcept
 {

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -241,4 +241,113 @@ namespace Gpu {
 
 #include <AMReX_CTOParallelForImpl.H>
 
+namespace amrex {
+
+#if defined(AMREX_USE_GPU) || !defined(AMREX_USE_OMP)
+
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void ParallelForOMP (T n, L const& f) noexcept
+{
+    ParallelFor(n, f);
+}
+
+template <typename L>
+void ParallelForOMP (Box const& box, L const& f) noexcept
+{
+    ParallelFor(box, f);
+}
+
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+void ParallelForOMP (Box const& box, T ncomp, L const& f) noexcept
+{
+    ParallelFor(box, ncomp, f);
+}
+
+#else /* !defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP) */
+
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+AMREX_ATTRIBUTE_FLATTEN_FOR
+void ParallelForOMP (T n, L const& f) noexcept
+{
+#pragma omp parallel for
+    for (T i = 0; i < n; ++i) {
+        f(i);
+    }
+}
+
+template <typename L>
+AMREX_ATTRIBUTE_FLATTEN_FOR
+void ParallelForOMP (Box const& box, L const& f) noexcept
+{
+    auto lo = amrex::lbound(box);
+    auto hi = amrex::ubound(box);
+#if (AMREX_SPACEDIM == 1)
+#pragma omp parallel for
+    for (int i = lo.x; i <= hi.x; ++i) {
+        f(i,0,0);
+    }
+#elif (AMREX_SPACEDIM == 2)
+#pragma omp parallel for
+    for     (int j = lo.y; j <= hi.y; ++j) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            f(i,j,0);
+        }
+    }
+#else
+#pragma omp parallel for collapse(2)
+    for         (int k = lo.z; k <= hi.z; ++k) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+                f(i,j,k);
+            }
+        }
+    }
+#endif
+}
+
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+AMREX_ATTRIBUTE_FLATTEN_FOR
+void ParallelForOMP (Box const& box, T ncomp, L const& f) noexcept
+{
+    auto lo = amrex::lbound(box);
+    auto hi = amrex::ubound(box);
+#if (AMREX_SPACEDIM == 1)
+#pragma omp parallel for collspase(2)
+    for (T n = 0; n < ncomp; ++n) {
+        AMREX_PRAGMA_SIMD
+        for (int i = lo.x; i <= hi.x; ++i) {
+            f(i,0,0,n);
+        }
+    }
+#elif (AMREX_SPACEDIM == 2)
+#pragma omp parallel for collapse(2)
+    for (T n = 0; n < ncomp; ++n) {
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+                f(i,j,0,n);
+            }
+        }
+    }
+#else
+#pragma omp parallel for collapse(3)
+    for (T n = 0; n < ncomp; ++n) {
+        for         (int k = lo.z; k <= hi.z; ++k) {
+            for     (int j = lo.y; j <= hi.y; ++j) {
+                AMREX_PRAGMA_SIMD
+                for (int i = lo.x; i <= hi.x; ++i) {
+                    f(i,j,k,n);
+                }
+            }
+        }
+    }
+#endif
+}
+
+#endif
+
+}
+
 #endif

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -314,7 +314,7 @@ void ParallelForOMP (Box const& box, T ncomp, L const& f) noexcept
     auto lo = amrex::lbound(box);
     auto hi = amrex::ubound(box);
 #if (AMREX_SPACEDIM == 1)
-#pragma omp parallel for collspase(2)
+#pragma omp parallel for collapse(2)
     for (T n = 0; n < ncomp; ++n) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -277,7 +277,7 @@ void launch (T const& n, L const& f) noexcept
     }
 }
 
-template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelFor (Gpu::KernelInfo const& info, T n, L const& f) noexcept
 {
     if (amrex::isEmpty(n)) { return; }
@@ -376,7 +376,7 @@ void ParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, L const& f
     }
 }
 
-template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L const& f) noexcept
 {
     if (amrex::isEmpty(box)) { return; }
@@ -428,7 +428,7 @@ void ParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L
     }
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelForRNG (T n, L const& f) noexcept
 {
     if (amrex::isEmpty(n)) { return; }
@@ -497,7 +497,7 @@ void ParallelForRNG (BoxND<dim> const& box, L const& f) noexcept
     }
 }
 
-template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelForRNG (BoxND<dim> const& box, T ncomp, L const& f) noexcept
 {
     if (amrex::isEmpty(box)) { return; }
@@ -615,8 +615,8 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
 }
 
 template <int MT, typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void ParallelFor (Gpu::KernelInfo const& /*info*/,
                   BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                   BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
@@ -656,9 +656,9 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
 }
 
 template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void ParallelFor (Gpu::KernelInfo const& /*info*/,
                   BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                   BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
@@ -788,7 +788,7 @@ void launch (BoxND<dim> const& box, L const& f) noexcept
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Gpu::KernelInfo const&, T n, L const& f) noexcept
 {
@@ -835,7 +835,7 @@ ParallelFor (Gpu::KernelInfo const&, BoxND<dim> const& box, L const& f) noexcept
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Gpu::KernelInfo const&, BoxND<dim> const& box, T ncomp, L const& f) noexcept
 {
@@ -858,7 +858,7 @@ ParallelFor (Gpu::KernelInfo const&, BoxND<dim> const& box, T ncomp, L const& f)
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeDeviceRunnable<L>::value>
 ParallelForRNG (T n, L const& f) noexcept
 {
@@ -902,7 +902,7 @@ ParallelForRNG (BoxND<dim> const& box, L const& f) noexcept
     AMREX_GPU_ERROR_CHECK();
 }
 
-template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeDeviceRunnable<L>::value>
 ParallelForRNG (BoxND<dim> const& box, T ncomp, L const& f) noexcept
 {
@@ -986,8 +986,8 @@ ParallelFor (Gpu::KernelInfo const&,
 }
 
 template <int MT, typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
 ParallelFor (Gpu::KernelInfo const&,
              BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
@@ -1016,9 +1016,9 @@ ParallelFor (Gpu::KernelInfo const&,
 }
 
 template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value && MaybeDeviceRunnable<L3>::value>
 ParallelFor (Gpu::KernelInfo const&,
              BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
@@ -1066,7 +1066,7 @@ void launch (T const& n, L&& f) noexcept
     launch<AMREX_GPU_MAX_THREADS>(n, std::forward<L>(f));
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
@@ -1080,7 +1080,7 @@ ParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, L&& f) noexcept
     ParallelFor<AMREX_GPU_MAX_THREADS>(info, box, std::forward<L>(f));
 }
 
-template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeDeviceRunnable<L>::value>
 ParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
@@ -1107,8 +1107,8 @@ ParallelFor (Gpu::KernelInfo const& info,
 }
 
 template <typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value>
 ParallelFor (Gpu::KernelInfo const& info,
              BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
@@ -1119,9 +1119,9 @@ ParallelFor (Gpu::KernelInfo const& info,
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 std::enable_if_t<MaybeDeviceRunnable<L1>::value && MaybeDeviceRunnable<L2>::value && MaybeDeviceRunnable<L3>::value>
 ParallelFor (Gpu::KernelInfo const& info,
              BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
@@ -1133,13 +1133,13 @@ ParallelFor (Gpu::KernelInfo const& info,
                                              box3, ncomp3, std::forward<L3>(f3));
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void For (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
     ParallelFor<AMREX_GPU_MAX_THREADS>(info, n,std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void For (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
     ParallelFor<MT>(info, n,std::forward<L>(f));
@@ -1157,13 +1157,13 @@ void For (Gpu::KernelInfo const& info, BoxND<dim> const& box, L&& f) noexcept
     ParallelFor<MT>(info, box,std::forward<L>(f));
 }
 
-template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void For (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     ParallelFor<AMREX_GPU_MAX_THREADS>(info,box,ncomp,std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void For (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     ParallelFor<MT>(info,box,ncomp,std::forward<L>(f));
@@ -1200,8 +1200,8 @@ void For (Gpu::KernelInfo const& info,
 }
 
 template <typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void For (Gpu::KernelInfo const& info,
           BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
           BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
@@ -1210,8 +1210,8 @@ void For (Gpu::KernelInfo const& info,
 }
 
 template <int MT, typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void For (Gpu::KernelInfo const& info,
           BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
           BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
@@ -1220,9 +1220,9 @@ void For (Gpu::KernelInfo const& info,
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void For (Gpu::KernelInfo const& info,
           BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
           BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
@@ -1235,9 +1235,9 @@ void For (Gpu::KernelInfo const& info,
 }
 
 template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void For (Gpu::KernelInfo const& info,
           BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
           BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
@@ -1249,13 +1249,13 @@ void For (Gpu::KernelInfo const& info,
                 box3,ncomp3,std::forward<L3>(f3));
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelFor (T n, L&& f) noexcept
 {
     ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{}, n, std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelFor (T n, L&& f) noexcept
 {
     ParallelFor<MT>(Gpu::KernelInfo{}, n, std::forward<L>(f));
@@ -1273,13 +1273,13 @@ void ParallelFor (BoxND<dim> const& box, L&& f) noexcept
     ParallelFor<MT>(Gpu::KernelInfo{}, box, std::forward<L>(f));
 }
 
-template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelFor (BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelFor (BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     ParallelFor<MT>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
@@ -1312,8 +1312,8 @@ void ParallelFor (BoxND<dim> const& box1, BoxND<dim> const& box2, BoxND<dim> con
 }
 
 template <typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void ParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                   BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
 {
@@ -1321,8 +1321,8 @@ void ParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <int MT, typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void ParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                   BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
 {
@@ -1330,9 +1330,9 @@ void ParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void ParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                   BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
                   BoxND<dim> const& box3, T3 ncomp3, L3&& f3) noexcept
@@ -1344,9 +1344,9 @@ void ParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void ParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                   BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
                   BoxND<dim> const& box3, T3 ncomp3, L3&& f3) noexcept
@@ -1357,13 +1357,13 @@ void ParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                 box3,ncomp3,std::forward<L3>(f3));
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void For (T n, L&& f) noexcept
 {
     ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{}, n,std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void For (T n, L&& f) noexcept
 {
     ParallelFor<MT>(Gpu::KernelInfo{}, n,std::forward<L>(f));
@@ -1381,13 +1381,13 @@ void For (BoxND<dim> const& box, L&& f) noexcept
     ParallelFor<MT>(Gpu::KernelInfo{}, box,std::forward<L>(f));
 }
 
-template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void For (BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     ParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void For (BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     ParallelFor<MT>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
@@ -1420,8 +1420,8 @@ void For (BoxND<dim> const& box1, BoxND<dim> const& box2, BoxND<dim> const& box3
 }
 
 template <typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void For (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
           BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
 {
@@ -1429,8 +1429,8 @@ void For (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <int MT, typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void For (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
           BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
 {
@@ -1438,9 +1438,9 @@ void For (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void For (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
           BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
           BoxND<dim> const& box3, T3 ncomp3, L3&& f3) noexcept
@@ -1452,9 +1452,9 @@ void For (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void For (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
           BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
           BoxND<dim> const& box3, T3 ncomp3, L3&& f3) noexcept
@@ -1465,7 +1465,7 @@ void For (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                 box3,ncomp3,std::forward<L3>(f3));
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
@@ -1481,7 +1481,7 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
     }
 }
 
-template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
@@ -1497,14 +1497,14 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
     }
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (T n, L&& f) noexcept
 {
     HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{}, n, std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (T n, L&& f) noexcept
 {
@@ -1541,7 +1541,7 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, L&& f
     }
 }
 
-template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
@@ -1556,7 +1556,7 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, T nco
     }
 }
 
-template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
@@ -1626,8 +1626,8 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
 }
 
 template <typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
@@ -1646,8 +1646,8 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
 }
 
 template <int MT, typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
@@ -1666,9 +1666,9 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value && MaybeHostDeviceRunnable<L3>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
@@ -1692,9 +1692,9 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
 }
 
 template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 std::enable_if_t<MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value && MaybeHostDeviceRunnable<L3>::value>
 HostDeviceParallelFor (Gpu::KernelInfo const& info,
                        BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
@@ -1717,13 +1717,13 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
     }
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void HostDeviceFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
     HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(info,n,std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void HostDeviceFor (Gpu::KernelInfo const& info, T n, L&& f) noexcept
 {
     HostDeviceParallelFor<MT>(info,n,std::forward<L>(f));
@@ -1741,13 +1741,13 @@ void HostDeviceFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, L&& f) n
     HostDeviceParallelFor<MT>(info,box,std::forward<L>(f));
 }
 
-template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void HostDeviceFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(info,box,ncomp,std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void HostDeviceFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     HostDeviceParallelFor<MT>(info,box,ncomp,std::forward<L>(f));
@@ -1786,8 +1786,8 @@ void HostDeviceFor (Gpu::KernelInfo const& info,
 }
 
 template <typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void HostDeviceFor (Gpu::KernelInfo const& info,
                     BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                     BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
@@ -1796,8 +1796,8 @@ void HostDeviceFor (Gpu::KernelInfo const& info,
 }
 
 template <int MT, typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void HostDeviceFor (Gpu::KernelInfo const& info,
                     BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                     BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
@@ -1806,9 +1806,9 @@ void HostDeviceFor (Gpu::KernelInfo const& info,
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void HostDeviceFor (Gpu::KernelInfo const& info,
                     BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                     BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
@@ -1821,9 +1821,9 @@ void HostDeviceFor (Gpu::KernelInfo const& info,
 }
 
 template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void HostDeviceFor (Gpu::KernelInfo const& info,
                     BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                     BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
@@ -1835,13 +1835,13 @@ void HostDeviceFor (Gpu::KernelInfo const& info,
                           box3,ncomp3,std::forward<L3>(f3));
 }
 
-template <typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void HostDeviceParallelFor (T n, L&& f) noexcept
 {
     HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},n,std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void HostDeviceParallelFor (T n, L&& f) noexcept
 {
     HostDeviceParallelFor<MT>(Gpu::KernelInfo{},n,std::forward<L>(f));
@@ -1859,13 +1859,13 @@ void HostDeviceParallelFor (BoxND<dim> const& box, L&& f) noexcept
     HostDeviceParallelFor<MT>(Gpu::KernelInfo{},box,std::forward<L>(f));
 }
 
-template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void HostDeviceParallelFor (BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     HostDeviceParallelFor<AMREX_GPU_MAX_THREADS>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
 }
 
-template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral<T>::value> >
+template <int MT, typename T, typename L, int dim, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void HostDeviceParallelFor (BoxND<dim> const& box, T ncomp, L&& f) noexcept
 {
     HostDeviceParallelFor<MT>(Gpu::KernelInfo{},box,ncomp,std::forward<L>(f));
@@ -1900,8 +1900,8 @@ void HostDeviceParallelFor (BoxND<dim> const& box1, BoxND<dim> const& box2, BoxN
 }
 
 template <typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void HostDeviceParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                             BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
 {
@@ -1909,8 +1909,8 @@ void HostDeviceParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <int MT, typename T1, typename T2, typename L1, typename L2, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>> >
 void HostDeviceParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                             BoxND<dim> const& box2, T2 ncomp2, L2&& f2) noexcept
 {
@@ -1918,9 +1918,9 @@ void HostDeviceParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void HostDeviceParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                             BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
                             BoxND<dim> const& box3, T3 ncomp3, L3&& f3) noexcept
@@ -1932,9 +1932,9 @@ void HostDeviceParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
 }
 
 template <int MT, typename T1, typename T2, typename T3, typename L1, typename L2, typename L3, int dim,
-          typename M1=std::enable_if_t<std::is_integral<T1>::value>,
-          typename M2=std::enable_if_t<std::is_integral<T2>::value>,
-          typename M3=std::enable_if_t<std::is_integral<T3>::value> >
+          typename M1=std::enable_if_t<std::is_integral_v<T1>>,
+          typename M2=std::enable_if_t<std::is_integral_v<T2>>,
+          typename M3=std::enable_if_t<std::is_integral_v<T3>> >
 void HostDeviceParallelFor (BoxND<dim> const& box1, T1 ncomp1, L1&& f1,
                             BoxND<dim> const& box2, T2 ncomp2, L2&& f2,
                             BoxND<dim> const& box3, T3 ncomp3, L3&& f3) noexcept

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -182,7 +182,7 @@ struct ReduceOpLogicalAnd
 #ifdef AMREX_USE_SYCL
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    std::enable_if_t<std::is_integral<T>::value>
+    std::enable_if_t<std::is_integral_v<T>>
     parallel_update (T& d, T s, Gpu::Handler const& h) const noexcept {
         T r = Gpu::blockReduceLogicalAnd(s,h);
         if (h.threadIdx() == 0) { d = d && r; }
@@ -190,7 +190,7 @@ struct ReduceOpLogicalAnd
 #else
     template <typename T, int MT=AMREX_GPU_MAX_THREADS>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    std::enable_if_t<std::is_integral<T>::value>
+    std::enable_if_t<std::is_integral_v<T>>
     parallel_update (T& d, T s) const noexcept {
         T r = Gpu::blockReduceLogicalAnd<MT>(s);
         if (threadIdx.x == 0) { d = d && r; }
@@ -214,7 +214,7 @@ struct ReduceOpLogicalOr
 #ifdef AMREX_USE_SYCL
     template <typename T>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    std::enable_if_t<std::is_integral<T>::value>
+    std::enable_if_t<std::is_integral_v<T>>
     parallel_update (T& d, T s, Gpu::Handler const& h) const noexcept {
         T r = Gpu::blockReduceLogicalOr(s,h);
         if (h.threadIdx() == 0) { d = d || r; }
@@ -222,7 +222,7 @@ struct ReduceOpLogicalOr
 #else
     template <typename T, int MT=AMREX_GPU_MAX_THREADS>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    std::enable_if_t<std::is_integral<T>::value>
+    std::enable_if_t<std::is_integral_v<T>>
     parallel_update (T& d, T s) const noexcept {
         T r = Gpu::blockReduceLogicalOr<MT>(s);
         if (threadIdx.x == 0) { d = d || r; }
@@ -541,7 +541,7 @@ public:
     }
 
     template <typename N, typename D, typename F,
-              typename M=std::enable_if_t<std::is_integral<N>::value> >
+              typename M=std::enable_if_t<std::is_integral_v<N>> >
     void eval (Box const& box, N ncomp, D & reduce_data, F const& f)
     {
         using ReduceTuple = typename D::Type;
@@ -601,7 +601,7 @@ public:
     }
 
     template <typename N, typename D, typename F,
-              typename M=std::enable_if_t<std::is_integral<N>::value> >
+              typename M=std::enable_if_t<std::is_integral_v<N>> >
     void eval (N n, D & reduce_data, F const& f)
     {
         if (n <= 0) { return; }
@@ -742,7 +742,7 @@ public:
 
 namespace Reduce {
 
-template <typename T, typename N, typename M=std::enable_if_t<std::is_integral<N>::value> >
+template <typename T, typename N, typename M=std::enable_if_t<std::is_integral_v<N>> >
 T Sum (N n, T const* v, T init_val = 0)
 {
     ReduceOps<ReduceOpSum> reduce_op;
@@ -754,7 +754,7 @@ T Sum (N n, T const* v, T init_val = 0)
 }
 
 template <typename T, typename N, typename F,
-          typename M=std::enable_if_t<std::is_integral<N>::value> >
+          typename M=std::enable_if_t<std::is_integral_v<N>> >
 T Sum (N n, F const& f, T init_val = 0)
 {
     ReduceOps<ReduceOpSum> reduce_op;
@@ -765,7 +765,7 @@ T Sum (N n, F const& f, T init_val = 0)
     return amrex::get<0>(hv) + init_val;
 }
 
-template <typename T, typename N, typename M=std::enable_if_t<std::is_integral<N>::value> >
+template <typename T, typename N, typename M=std::enable_if_t<std::is_integral_v<N>> >
 T Min (N n, T const* v, T init_val = std::numeric_limits<T>::max())
 {
     ReduceOps<ReduceOpMin> reduce_op;
@@ -777,7 +777,7 @@ T Min (N n, T const* v, T init_val = std::numeric_limits<T>::max())
 }
 
 template <typename T, typename N, typename F,
-          typename M=std::enable_if_t<std::is_integral<N>::value> >
+          typename M=std::enable_if_t<std::is_integral_v<N>> >
 T Min (N n, F const& f, T init_val = std::numeric_limits<T>::max())
 {
     ReduceOps<ReduceOpMin> reduce_op;
@@ -788,7 +788,7 @@ T Min (N n, F const& f, T init_val = std::numeric_limits<T>::max())
     return std::min(amrex::get<0>(hv),init_val);
 }
 
-template <typename T, typename N, typename M=std::enable_if_t<std::is_integral<N>::value> >
+template <typename T, typename N, typename M=std::enable_if_t<std::is_integral_v<N>> >
 T Max (N n, T const* v, T init_val = std::numeric_limits<T>::lowest())
 {
     ReduceOps<ReduceOpMax> reduce_op;
@@ -800,7 +800,7 @@ T Max (N n, T const* v, T init_val = std::numeric_limits<T>::lowest())
 }
 
 template <typename T, typename N, typename F,
-          typename M=std::enable_if_t<std::is_integral<N>::value> >
+          typename M=std::enable_if_t<std::is_integral_v<N>> >
 T Max (N n, F const& f, T init_val = std::numeric_limits<T>::lowest())
 {
     ReduceOps<ReduceOpMax> reduce_op;
@@ -811,7 +811,7 @@ T Max (N n, F const& f, T init_val = std::numeric_limits<T>::lowest())
     return std::max(amrex::get<0>(hv),init_val);
 }
 
-template <typename T, typename N, typename M=std::enable_if_t<std::is_integral<N>::value> >
+template <typename T, typename N, typename M=std::enable_if_t<std::is_integral_v<N>> >
 std::pair<T,T> MinMax (N n, T const* v)
 {
     ReduceOps<ReduceOpMin,ReduceOpMax> reduce_op;
@@ -825,7 +825,7 @@ std::pair<T,T> MinMax (N n, T const* v)
 }
 
 template <typename T, typename N, typename F,
-          typename M=std::enable_if_t<std::is_integral<N>::value> >
+          typename M=std::enable_if_t<std::is_integral_v<N>> >
 std::pair<T,T> MinMax (N n, F const& f)
 {
     ReduceOps<ReduceOpMin,ReduceOpMax> reduce_op;
@@ -839,7 +839,7 @@ std::pair<T,T> MinMax (N n, F const& f)
     return std::make_pair(amrex::get<0>(hv), amrex::get<1>(hv));
 }
 
-template <typename T, typename N, typename P, typename M=std::enable_if_t<std::is_integral<N>::value> >
+template <typename T, typename N, typename P, typename M=std::enable_if_t<std::is_integral_v<N>> >
 bool AnyOf (N n, T const* v, P const& pred)
 {
     Gpu::LaunchSafeGuard lsg(true);

--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -385,7 +385,7 @@ T PrefixSum_mp (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum)
 #endif
 
 template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
-          typename M=std::enable_if_t<std::is_integral<N>::value &&
+          typename M=std::enable_if_t<std::is_integral_v<N> &&
                                       (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
                                        std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
 T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE type, RetSum a_ret_sum = retSum)
@@ -624,7 +624,7 @@ T PrefixSum (N n, FIN && fin, FOUT && fout, TYPE type, RetSum a_ret_sum = retSum
 #elif defined(AMREX_USE_HIP)
 
 template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
-          typename M=std::enable_if_t<std::is_integral<N>::value &&
+          typename M=std::enable_if_t<std::is_integral_v<N> &&
                                       (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
                                        std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
 T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = retSum)
@@ -787,7 +787,7 @@ T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = ret
 #elif defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
 
 template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
-          typename M=std::enable_if_t<std::is_integral<N>::value &&
+          typename M=std::enable_if_t<std::is_integral_v<N> &&
                                       (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
                                        std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
 T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = retSum)
@@ -926,7 +926,7 @@ T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = ret
 #else
 
 template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
-          typename M=std::enable_if_t<std::is_integral<N>::value &&
+          typename M=std::enable_if_t<std::is_integral_v<N> &&
                                       (std::is_same<std::decay_t<TYPE>,Type::Inclusive>::value ||
                                        std::is_same<std::decay_t<TYPE>,Type::Exclusive>::value)> >
 T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = retSum)
@@ -1170,7 +1170,7 @@ T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = ret
 #endif
 
 // The return value is the total sum if a_ret_sum is true.
-template <typename N, typename T, typename M=std::enable_if_t<std::is_integral<N>::value> >
+template <typename N, typename T, typename M=std::enable_if_t<std::is_integral_v<N>> >
 T InclusiveSum (N n, T const* in, T * out, RetSum a_ret_sum = retSum)
 {
 #if defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
@@ -1231,7 +1231,7 @@ T InclusiveSum (N n, T const* in, T * out, RetSum a_ret_sum = retSum)
 }
 
 // The return value is the total sum if a_ret_sum is true.
-template <typename N, typename T, typename M=std::enable_if_t<std::is_integral<N>::value> >
+template <typename N, typename T, typename M=std::enable_if_t<std::is_integral_v<N>> >
 T ExclusiveSum (N n, T const* in, T * out, RetSum a_ret_sum = retSum)
 {
     if (n <= 0) { return 0; }

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -751,7 +751,7 @@ struct Plan
             int norig = n;
             Long nelems = Long(nex)*howmany;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -766,7 +766,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -786,7 +786,7 @@ struct Plan
             int norig = n;
             Long nelems = Long(nex)*howmany;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -809,7 +809,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -837,7 +837,7 @@ struct Plan
             int norig = n;
             Long nelems = Long(nex)*howmany;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -860,7 +860,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -888,7 +888,7 @@ struct Plan
             int norig = n;
             Long nelems = Long(nex)*howmany;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -907,7 +907,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -931,7 +931,7 @@ struct Plan
             int norig = n;
             Long nelems = Long(nex)*howmany;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -950,7 +950,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(nex);
                     auto i = int(ielem - batch*nex);
@@ -982,7 +982,7 @@ struct Plan
         if (kind == Kind::r2r_oo_f) {
             int istride = n+1;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -993,7 +993,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1005,7 +1005,7 @@ struct Plan
         } else if (kind == Kind::r2r_oo_b) {
             int istride = 2*n+1;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1016,7 +1016,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1028,7 +1028,7 @@ struct Plan
         } else if (kind == Kind::r2r_ee_f) {
             int istride = n+1;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1039,7 +1039,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1051,7 +1051,7 @@ struct Plan
         } else if (kind == Kind::r2r_ee_b) {
             int istride = 2*n+1;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1061,7 +1061,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1072,7 +1072,7 @@ struct Plan
         } else if (kind == Kind::r2r_eo) {
             int istride = 2*n+1;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1083,7 +1083,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1095,7 +1095,7 @@ struct Plan
         } else if (kind == Kind::r2r_oe) {
             int istride = 2*n+1;
             if (r2r_data_is_complex) {
-                ParallelFor(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems/2, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);
@@ -1106,7 +1106,7 @@ struct Plan
                     }
                 });
             } else {
-                ParallelFor(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
+                ParallelForOMP(nelems, [=] AMREX_GPU_DEVICE (Long ielem)
                 {
                     auto batch = ielem / Long(norig);
                     auto k = int(ielem - batch*norig);

--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -97,7 +97,7 @@ void OpenBCSolver<T>::setGreensFunction (F const& greens_function)
         }
         AMREX_ASSERT(nimages[0] == 2);
         box.shift(-lo);
-        amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        amrex::ParallelForOMP(box, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             T G;
             if (i == len[0] || j == len[1] || k == len[2]) {
@@ -191,7 +191,7 @@ void OpenBCSolver<T>::solve (MF& phi, MF const& rho)
                 AMREX_ASSERT(leng == rhobox.numPts());
             }
 #endif
-            amrex::ParallelFor(rhobox.numPts(), [=] AMREX_GPU_DEVICE (Long i)
+            amrex::ParallelForOMP(rhobox.numPts(), [=] AMREX_GPU_DEVICE (Long i)
             {
 #if (AMREX_SPACEDIM == 3)
                 Long isrc = i % leng;

--- a/Src/FFT/AMReX_FFT_R2C.H
+++ b/Src/FFT/AMReX_FFT_R2C.H
@@ -1193,7 +1193,7 @@ void R2C<T,D,C>::post_forward_doit_1 (F const& post_forward)
             auto* spectral_fab = detail::get_fab(m_cz);
             if (spectral_fab) {
                 auto const& a = spectral_fab->array(); // m_cz's ordering is z,x,y
-                ParallelFor(spectral_fab->box(),
+                ParallelForOMP(spectral_fab->box(),
                 [=] AMREX_GPU_DEVICE (int iz, int jx, int ky)
                 {
                     post_forward(jx,ky,iz,a(iz,jx,ky));
@@ -1203,7 +1203,7 @@ void R2C<T,D,C>::post_forward_doit_1 (F const& post_forward)
             auto* spectral_fab = detail::get_fab(m_cy);
             if (spectral_fab) {
                 auto const& a = spectral_fab->array(); // m_cy's ordering is y,x,z
-                ParallelFor(spectral_fab->box(),
+                ParallelForOMP(spectral_fab->box(),
                 [=] AMREX_GPU_DEVICE (int iy, int jx, int k)
                 {
                     post_forward(jx,iy,k,a(iy,jx,k));
@@ -1213,7 +1213,7 @@ void R2C<T,D,C>::post_forward_doit_1 (F const& post_forward)
             auto* spectral_fab = detail::get_fab(m_cx);
             if (spectral_fab) {
                 auto const& a = spectral_fab->array();
-                ParallelFor(spectral_fab->box(),
+                ParallelForOMP(spectral_fab->box(),
                 [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     post_forward(i,j,k,a(i,j,k));

--- a/Src/FFT/AMReX_FFT_R2X.H
+++ b/Src/FFT/AMReX_FFT_R2X.H
@@ -1026,7 +1026,7 @@ void R2X<T>::post_forward_doit (FAB* fab, F const& f)
     }
     if (fab) {
         auto const& a = fab->array();
-        ParallelFor(fab->box(),
+        ParallelForOMP(fab->box(),
         [f=f,a=a] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             if constexpr (dim == 0) {


### PR DESCRIPTION
ParallelFor does not do any OMP threading, because we do coarse-grained OMP threading at the MFIter level with tiling. But there are cases we use ParallelFor outside MFIter and they could benefit from OMP threading. Thus, we add new ParallelForOMP functions in this PR. Note that OMP threading is used only for CPU builds with OMP, otherwise the new ParallelForOMP functions are equivalent to ParallelFor functions.
