### PR TITLE
Delete outdated statement in Particle documentation

### DIFF
--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -758,9 +758,6 @@ The following runtime parameters affect the behavior of virtual particles in Nyx
 |                   | boundary in which no aggregation should be performed.                 |             |             |
 +-------------------+-----------------------------------------------------------------------+-------------+-------------+
 
-Finally, the `amrex.use_gpu_aware_mpi` switch can also affect the behavior of the particle communication routines when
-running on GPU platforms like Summit. We recommend leaving it off.
-
 .. [1]
    Particles default to double precision for their real data. To use single precision, compile your code with ``USE_SINGLE_PRECISION_PARTICLES=TRUE``.
 


### PR DESCRIPTION
## Summary
Delete an outdated sentence about GPU-aware MPI in the particle documentation.

The up-to-date information about GPU-awareness is located in `Docs/sphinx_documentation/source/GPU.rst`. See in particular https://amrex-codes.github.io/amrex/docs_html/GPU.html#particle-support and https://amrex-codes.github.io/amrex/docs_html/GPU.html#inputs-parameters.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
