### PR TITLE
SIMD: Remove Unnecessary Namespaces

### DIFF
--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -17,12 +17,9 @@
 namespace amrex::simd
 {
     // TODO make SIMD provider configurable: VIR (C++17 TS2) or C++26 (later)
-    //namespace stdx = std::experimental;
     // for https://en.cppreference.com/w/cpp/experimental/simd/simd_cast.html
     namespace stdx {
 #ifdef AMREX_USE_SIMD
-        using namespace std::experimental;
-        using namespace std::experimental::__proposed;
         using namespace vir::stdx;
 #else
         // fallback implementations for functions that are commonly used in portable code paths
@@ -36,21 +33,21 @@ namespace amrex::simd
 
 #ifdef AMREX_USE_SIMD
     // TODO: not sure why std::experimental::simd_abi::native<T> does not work, so we use this long version
-    constexpr auto native_simd_size_real = std::experimental::native_simd<amrex::Real>::size();
-    constexpr auto native_simd_size_particlereal = std::experimental::native_simd<amrex::ParticleReal>::size();
+    constexpr auto native_simd_size_real = stdx::native_simd<amrex::Real>::size();
+    constexpr auto native_simd_size_particlereal = stdx::native_simd<amrex::ParticleReal>::size();
 
     // Note: to make use of not only vector registers but also ILP, user might want to use * 2 or more of the native size
     //       for selected compute kernels.
     // TODO Check if a default with * 2 or similar is sensible.
     template<int SIMD_WIDTH = native_simd_size_real>
-    using SIMDReal = std::experimental::fixed_size_simd<amrex::Real, SIMD_WIDTH>;
+    using SIMDReal = stdx::fixed_size_simd<amrex::Real, SIMD_WIDTH>;
 
     template<int SIMD_WIDTH = native_simd_size_particlereal>
-    using SIMDParticleReal = std::experimental::fixed_size_simd<amrex::ParticleReal, SIMD_WIDTH>;
+    using SIMDParticleReal = stdx::fixed_size_simd<amrex::ParticleReal, SIMD_WIDTH>;
 
     // Type that has the same amount of IdCpu SIMD elements as the SIMDParticleReal type
     template<typename T_ParticleReal = SIMDParticleReal<>>
-    using SIMDIdCpu = std::experimental::rebind_simd_t<std::uint64_t, T_ParticleReal>;
+    using SIMDIdCpu = stdx::rebind_simd_t<std::uint64_t, T_ParticleReal>;
 #else
     constexpr auto native_simd_size_real = 1;
     constexpr auto native_simd_size_particlereal = 1;


### PR DESCRIPTION
## Summary

With `vir-simd`, we do not need these namespaces anymore. They are in fact not available on macOS/Windows by default.

## Additional background

https://github.com/conda-forge/amrex-feedstock/pull/60

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
