### PR TITLE
Curl Curl Solver: Support for 1D spherical and 1D cylindrical

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.H
@@ -36,12 +36,14 @@ public:
     MLCurlCurl (const Vector<Geometry>& a_geom,
                 const Vector<BoxArray>& a_grids,
                 const Vector<DistributionMapping>& a_dmap,
-                const LPInfo& a_info = LPInfo());
+                const LPInfo& a_info = LPInfo(),
+                int a_coord = 0);
 
     void define (const Vector<Geometry>& a_geom,
                  const Vector<BoxArray>& a_grids,
                  const Vector<DistributionMapping>& a_dmap,
-                 const LPInfo& a_info = LPInfo());
+                 const LPInfo& a_info = LPInfo(),
+                 int a_coord = 0);
 
     void setScalars (RT a_alpha, RT a_beta) noexcept;
 
@@ -89,6 +91,8 @@ public:
 
     void prepareForSolve () override;
 
+    void preparePrecond () override;
+
     [[nodiscard]] bool isSingular (int /*amrlev*/) const override { return false; }
     [[nodiscard]] bool isBottomSingular () const override { return false; }
 
@@ -134,6 +138,10 @@ private:
     [[nodiscard]] CurlCurlSymmetryInfo getSymmetryInfo (int amrlev, int mglev) const;
 
     void update_lusolver ();
+
+    void set_curvilinear_domain_bc ();
+
+    int m_coord = 0;
 
     RT m_alpha = std::numeric_limits<RT>::lowest();
     RT m_beta  = std::numeric_limits<RT>::lowest();

--- a/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.cpp
@@ -5,17 +5,29 @@ namespace amrex {
 MLCurlCurl::MLCurlCurl (const Vector<Geometry>& a_geom,
                         const Vector<BoxArray>& a_grids,
                         const Vector<DistributionMapping>& a_dmap,
-                        const LPInfo& a_info)
+                        const LPInfo& a_info, int a_coord)
 {
-    define(a_geom, a_grids, a_dmap, a_info);
+    define(a_geom, a_grids, a_dmap, a_info, a_coord);
 }
 
 void MLCurlCurl::define (const Vector<Geometry>& a_geom,
                          const Vector<BoxArray>& a_grids,
                          const Vector<DistributionMapping>& a_dmap,
-                         const LPInfo& a_info)
+                         const LPInfo& a_info, int a_coord)
 {
     MLLinOpT<MF>::define(a_geom, a_grids, a_dmap, a_info, {});
+
+    m_coord = a_coord;
+#if (AMREX_SPACEDIM == 2)
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_coord == 0,
+                                     "CurlCurl: In 2D, only Cartesian is supported.");
+#elif (AMREX_SPACEDIM == 3)
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_coord == 0,
+                                     "CurlCurl: In 3D, only Cartesian is supported.");
+#endif
+    if (m_coord == 1 || m_coord == 2) {
+        AMREX_ALWAYS_ASSERT(a_geom[0].ProbLo(0) == 0);
+    }
 
     m_dotmask.resize(this->m_num_amr_levels);
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
@@ -120,8 +132,9 @@ void MLCurlCurl::setDirichletNodesToZero (int amrlev, int mglev, MF& a_mf) const
     mfi_info.DisableDeviceSync();
 #endif
 
-    for (auto& mf : a_mf)
+    for (int imf = 0; imf < 3; ++imf)
     {
+        auto& mf = a_mf[imf];
         auto const idxtype = mf.ixType();
         Box const domain = amrex::convert(m_geom[amrlev][mglev].Domain(), idxtype);
 
@@ -137,6 +150,11 @@ void MLCurlCurl::setDirichletNodesToZero (int amrlev, int mglev, MF& a_mf) const
                 bool is_dirichlet = face.isLow()
                     ? m_lobc[0][idim] == LinOpBCType::Dirichlet
                     : m_hibc[0][idim] == LinOpBCType::Dirichlet;
+#if (AMREX_SPACEDIM == 1)
+                if (m_coord == 1 && imf == 2 && face.isLow()) {
+                    is_dirichlet = false; // Ez in 1d cyl is not Dirichlet at r=0.
+                }
+#endif
                 if (is_dirichlet && domain[face] == vbx[face] &&
                     idxtype.nodeCentered(idim))
                 {
@@ -247,6 +265,8 @@ MLCurlCurl::apply (int amrlev, int mglev, MF& out, MF& in, BCMode /*bc_mode*/,
     auto const b = m_beta;
 
     auto dinfo = getDirichletInfo(amrlev,mglev);
+    auto coord = m_coord;
+    amrex::ignore_unused(coord);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -280,7 +300,11 @@ MLCurlCurl::apply (int amrlev, int mglev, MF& out, MF& in, BCMode /*bc_mode*/,
                 if (dinfo.is_dirichlet_y_edge(i,j,k)) {
                     yout(i,j,k) = Real(0.0);
                 } else {
-                    mlcurlcurl_adotx_y(i,j,k,yout,xin,yin,zin,bcy(i,j,k),adxinv);
+                    mlcurlcurl_adotx_y(i,j,k,yout,xin,yin,zin,bcy(i,j,k),adxinv
+#if (AMREX_SPACEDIM < 3)
+                                       ,coord
+#endif
+                                      );
                 }
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k)
@@ -288,7 +312,11 @@ MLCurlCurl::apply (int amrlev, int mglev, MF& out, MF& in, BCMode /*bc_mode*/,
                 if (dinfo.is_dirichlet_z_edge(i,j,k)) {
                     zout(i,j,k) = Real(0.0);
                 } else {
-                    mlcurlcurl_adotx_z(i,j,k,zout,xin,yin,zin,bcz(i,j,k),adxinv);
+                    mlcurlcurl_adotx_z(i,j,k,zout,xin,yin,zin,bcz(i,j,k),adxinv
+#if (AMREX_SPACEDIM < 3)
+                                       ,coord
+#endif
+                                      );
                 }
             });
         } else {
@@ -306,7 +334,11 @@ MLCurlCurl::apply (int amrlev, int mglev, MF& out, MF& in, BCMode /*bc_mode*/,
                 if (dinfo.is_dirichlet_y_edge(i,j,k)) {
                     yout(i,j,k) = Real(0.0);
                 } else {
-                    mlcurlcurl_adotx_y(i,j,k,yout,xin,yin,zin,b,adxinv);
+                    mlcurlcurl_adotx_y(i,j,k,yout,xin,yin,zin,b,adxinv
+#if (AMREX_SPACEDIM < 3)
+                                       ,coord
+#endif
+                                      );
                 }
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k)
@@ -314,7 +346,11 @@ MLCurlCurl::apply (int amrlev, int mglev, MF& out, MF& in, BCMode /*bc_mode*/,
                 if (dinfo.is_dirichlet_z_edge(i,j,k)) {
                     zout(i,j,k) = Real(0.0);
                 } else {
-                    mlcurlcurl_adotx_z(i,j,k,zout,xin,yin,zin,b,adxinv);
+                    mlcurlcurl_adotx_z(i,j,k,zout,xin,yin,zin,b,adxinv
+#if (AMREX_SPACEDIM < 3)
+                                       ,coord
+#endif
+                                      );
                 }
             });
         }
@@ -369,6 +405,8 @@ void MLCurlCurl::smooth1D (int amrlev, int mglev, MF& sol, MF const& rhs,
 
     int xhi = this->m_geom[amrlev][mglev].Domain().bigEnd(0);
 
+    auto coord = m_coord;
+
     MultiFab nmf(amrex::convert(rhs[0].boxArray(),IntVect(1)),
                  rhs[0].DistributionMap(), 1, 0, MFInfo().SetAlloc(false));
 
@@ -379,18 +417,18 @@ void MLCurlCurl::smooth1D (int amrlev, int mglev, MF& sol, MF const& rhs,
         ParallelFor( nmf, [=] AMREX_GPU_DEVICE(int bno, int i, int j, int k)
         {
             bool valid_x = i <= xhi; // x is cell-centered, not nodal
-            mlcurlcurl_1D(i,j,k,ex[bno],ey[bno],ez[bno],
-                          rhsx[bno],rhsy[bno],rhsz[bno],
-                          bcx[bno],bcy[bno],bcz[bno],
-                          adxinv,color,dinfo,valid_x);
+            mlcurlcurl_smooth_1d(i,j,k,ex[bno],ey[bno],ez[bno],
+                                 rhsx[bno],rhsy[bno],rhsz[bno],
+                                 bcx[bno],bcy[bno],bcz[bno],
+                                 adxinv,color,dinfo,valid_x,coord);
         });
     } else {
         ParallelFor( nmf, [=] AMREX_GPU_DEVICE(int bno, int i, int j, int k)
         {
             bool valid_x = i <= xhi; // x is cell-centered, not nodal
-            mlcurlcurl_1D(i,j,k,ex[bno],ey[bno],ez[bno],
-                          rhsx[bno],rhsy[bno],rhsz[bno],
-                          b,adxinv,color,dinfo,valid_x);
+            mlcurlcurl_smooth_1d(i,j,k,ex[bno],ey[bno],ez[bno],
+                                 rhsx[bno],rhsy[bno],rhsz[bno],
+                                 b,adxinv,color,dinfo,valid_x,coord);
         });
     }
     Gpu::streamSynchronize();
@@ -616,7 +654,24 @@ void MLCurlCurl::update_lusolver ()
 
 void MLCurlCurl::prepareForSolve ()
 {
+    set_curvilinear_domain_bc();
     update_lusolver();
+}
+
+void MLCurlCurl::preparePrecond ()
+{
+    set_curvilinear_domain_bc();
+}
+
+void MLCurlCurl::set_curvilinear_domain_bc ()
+{
+#if (AMREX_SPACEDIM == 1)
+    if (m_coord > 0) {
+        // Even though it's not exactly Dirichlet, setting this to Dirichlet
+        // will skip ghost cell filling at the axis.
+        m_lobc[0][0] = LinOpBCType::Dirichlet;
+    }
+#endif
 }
 
 Real MLCurlCurl::xdoty (int amrlev, int mglev, const MF& x, const MF& y,
@@ -876,7 +931,6 @@ iMultiFab const& MLCurlCurl::getDotMask (int amrlev, int mglev, int idim) const
 
 CurlCurlDirichletInfo MLCurlCurl::getDirichletInfo (int amrlev, int mglev) const
 {
-
     auto helper = [&] (int idim, int face) -> int
     {
 #if (AMREX_SPACEDIM == 2)
@@ -888,6 +942,7 @@ CurlCurlDirichletInfo MLCurlCurl::getDirichletInfo (int amrlev, int mglev) const
             return std::numeric_limits<int>::lowest();
         }
 #endif
+        // The code above is to avoid compiler warnings. It has no meanning.
 
         if (face == 0) {
             if (m_lobc[0][idim] == LinOpBCType::Dirichlet) {
@@ -909,12 +964,15 @@ CurlCurlDirichletInfo MLCurlCurl::getDirichletInfo (int amrlev, int mglev) const
                                                       helper(2,0))),
                                  IntVect(AMREX_D_DECL(helper(0,1),
                                                       helper(1,1),
-                                                      helper(2,1)))};
+                                                      helper(2,1)))
+#if (AMREX_SPACEDIM < 3)
+                                 ,m_coord
+#endif
+                                };
 }
 
 CurlCurlSymmetryInfo MLCurlCurl::getSymmetryInfo (int amrlev, int mglev) const
 {
-
     auto helper = [&] (int idim, int face) -> int
     {
 #if (AMREX_SPACEDIM == 2)
@@ -926,6 +984,7 @@ CurlCurlSymmetryInfo MLCurlCurl::getSymmetryInfo (int amrlev, int mglev) const
             return std::numeric_limits<int>::lowest();
         }
 #endif
+        // The code above is to avoid compiler warnings. It has no meaning.
 
         if (face == 0) {
             if (m_lobc[0][idim] == LinOpBCType::symmetry) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl_K.H
@@ -185,6 +185,9 @@ struct CurlCurlDirichletInfo
 {
     IntVect dirichlet_lo;
     IntVect dirichlet_hi;
+#if (AMREX_SPACEDIM < 3)
+    int coord = 0;
+#endif
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool is_dirichlet_node (int i, int j, int k) const
@@ -235,7 +238,11 @@ struct CurlCurlDirichletInfo
     {
 #if (AMREX_SPACEDIM == 1)
         amrex::ignore_unused(j);
-        return (i == dirichlet_lo[0]) || (i == dirichlet_hi[0]);
+        if ((i == 0) && (coord == 1)) {
+            return false; // Ez in 1d cyl is not dirichlet
+        } else {
+            return (i == dirichlet_lo[0]) || (i == dirichlet_hi[0]);
+        }
 #else
         return (i == dirichlet_lo[0]) || (i == dirichlet_hi[0])
             || (j == dirichlet_lo[1]) || (j == dirichlet_hi[1]);
@@ -373,16 +380,33 @@ void mlcurlcurl_adotx_y (int i, int j, int k, Array4<Real> const& Ay,
                          Array4<Real const> const& ex,
                          Array4<Real const> const& ey,
                          Array4<Real const> const& ez,
-                         Real beta, GpuArray<Real,AMREX_SPACEDIM> const& adxinv)
+                         Real beta, GpuArray<Real,AMREX_SPACEDIM> const& adxinv
+#if (AMREX_SPACEDIM < 3)
+                         , int coord
+#endif
+                        )
 {
 #if (AMREX_SPACEDIM == 1)
     amrex::ignore_unused(ex,ez);
-    Real dxx = adxinv[0] * adxinv[0];
-    Real ccey =  ey(i  ,j  ,k  ) * dxx * Real(2.0)
-        - dxx * (ey(i-1,j  ,k  ) +
-                 ey(i+1,j  ,k  ));
+    Real ccey;
+    if (coord == 0) {
+        ccey =  ey(i  ,j,k) * Real(2.0)
+            -   ey(i-1,j,k)
+            -   ey(i+1,j,k);
+    } else if (coord == 1) {
+        // i=0 won't get here
+        ccey =  ey(i  ,j,k) * (Real( 1.0)/(Real(i)*Real(i)) + Real(2.0))
+            +   ey(i-1,j,k) * (Real( 0.5)/Real(i) - Real(1.0))
+            +   ey(i+1,j,k) * (Real(-0.5)/Real(i) - Real(1.0));
+    } else {
+        // i=0 won't get here
+        ccey =  ey(i  ,j,k) * Real(2.0)
+            +   ey(i-1,j,k) * (Real( 1.0)/Real(i) - Real(1.0))
+            +   ey(i+1,j,k) * (Real(-1.0)/Real(i) - Real(1.0));
+    }
+    ccey *= adxinv[0] * adxinv[0];
 #elif (AMREX_SPACEDIM == 2)
-    amrex::ignore_unused(ez);
+    amrex::ignore_unused(ez,coord);
     Real dxx = adxinv[0] * adxinv[0];
     Real dxy = adxinv[0] * adxinv[1];
     Real ccey =  ey(i  ,j  ,k  ) * dxx * Real(2.0)
@@ -419,16 +443,35 @@ void mlcurlcurl_adotx_z (int i, int j, int k, Array4<Real> const& Az,
                          Array4<Real const> const& ex,
                          Array4<Real const> const& ey,
                          Array4<Real const> const& ez,
-                         Real beta, GpuArray<Real,AMREX_SPACEDIM> const& adxinv)
+                         Real beta, GpuArray<Real,AMREX_SPACEDIM> const& adxinv
+#if (AMREX_SPACEDIM < 3)
+                         , int coord
+#endif
+                        )
 {
 #if (AMREX_SPACEDIM == 1)
     amrex::ignore_unused(ex,ey);
-    Real dxx = adxinv[0] * adxinv[0];
-    Real ccez =  ez(i  ,j  ,k  ) * dxx*Real(2.0)
-        - dxx * (ez(i-1,j  ,k  ) +
-                 ez(i+1,j  ,k  ));
+    Real ccez;
+    if (coord == 0) {
+        ccez =  ez(i  ,j,k) * Real(2.0)
+            -   ez(i-1,j,k)
+            -   ez(i+1,j,k);
+    } else if (coord == 1) {
+        if (i == 0) {
+            ccez = Real(4.0) * (ez(0,0,0) - ez(1,0,0));
+        } else {
+            ccez =  ez(i  ,j,k) * Real(2.0)
+                +   ez(i-1,j,k) * (Real( 0.5)/Real(i) - Real(1.0))
+                +   ez(i+1,j,k) * (Real(-0.5)/Real(i) - Real(1.0));
+        }
+    } else {
+        ccez =  ez(i  ,j,k) * Real(2.0)
+            +   ez(i-1,j,k) * (Real( 1.0)/Real(i) - Real(1.0))
+            +   ez(i+1,j,k) * (Real(-1.0)/Real(i) - Real(1.0));
+    }
+    ccez *= adxinv[0] * adxinv[0];
 #elif (AMREX_SPACEDIM == 2)
-    amrex::ignore_unused(ex,ey);
+    amrex::ignore_unused(ex,ey,coord);
     Real dxx = adxinv[0] * adxinv[0];
     Real dyy = adxinv[1] * adxinv[1];
     Real ccez =  ez(i  ,j  ,k  ) * (dxx+dyy)*Real(2.0)
@@ -460,20 +503,19 @@ void mlcurlcurl_adotx_z (int i, int j, int k, Array4<Real> const& Az,
 
 #if (AMREX_SPACEDIM == 1)
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void mlcurlcurl_1D (int i, int j, int k,
-                    Array4<Real> const& ex,
-                    Array4<Real> const& ey,
-                    Array4<Real> const& ez,
-                    Array4<Real const> const& rhsx,
-                    Array4<Real const> const& rhsy,
-                    Array4<Real const> const& rhsz,
-                    Real beta,
-                    GpuArray<Real,AMREX_SPACEDIM> const& adxinv,
-                    int color,
-                    CurlCurlDirichletInfo const& dinfo, bool valid_x)
+void mlcurlcurl_smooth_1d (int i, int j, int k,
+                           Array4<Real> const& ex,
+                           Array4<Real> const& ey,
+                           Array4<Real> const& ez,
+                           Array4<Real const> const& rhsx,
+                           Array4<Real const> const& rhsy,
+                           Array4<Real const> const& rhsz,
+                           Real beta,
+                           GpuArray<Real,AMREX_SPACEDIM> const& adxinv,
+                           int color,
+                           CurlCurlDirichletInfo const& dinfo, bool valid_x,
+                           int coord)
 {
-    if (dinfo.is_dirichlet_node(i,j,k)) {return; }
-
     Real dxx = adxinv[0] * adxinv[0];
 
     int my_color = i%2;
@@ -484,37 +526,83 @@ void mlcurlcurl_1D (int i, int j, int k,
             ex(i,j,k) = rhsx(i,j,k) / beta;
         }
 
-        Real gamma_y = dxx * Real(2.0) + beta;
-        Real ccey = - dxx * (ey(i-1,j  ,k  ) +
-                             ey(i+1,j  ,k  ) );
-        Real res_y = rhsy(i,j,k) - ( gamma_y * ey(i,j,k) + ccey );
-        ey(i,j,k) += res_y/gamma_y;
+        if (coord == 0)
+        {
+            if (dinfo.is_dirichlet_node(i,j,k)) { return; }
 
-        Real gamma_z = dxx * Real(2.0) + beta;
-        Real ccez = -dxx * (ez(i-1,j  ,k  ) +
-                            ez(i+1,j  ,k  ) );
-        Real res_z = rhsz(i,j,k) - ( gamma_z * ez(i,j,k) + ccez );
-        ez(i,j,k) += res_z/gamma_z;
+            Real cm = -dxx;
+            Real cp = -dxx;
+
+            Real gamma = dxx * Real(2.0) + beta;
+
+            Real ccey = cm * ey(i-1,j,k) + cp * ey(i+1,j,k);
+            Real res_y = rhsy(i,j,k) - ( gamma * ey(i,j,k) + ccey );
+            ey(i,j,k) += res_y/gamma;
+
+            Real ccez = cm * ez(i-1,j,k) + cp * ez(i+1,j,k);
+            Real res_z = rhsz(i,j,k) - ( gamma * ez(i,j,k) + ccez );
+            ez(i,j,k) += res_z/gamma;
+        }
+        else if (coord == 1)
+        {
+            if ((i > 0) && ! dinfo.is_dirichlet_node(i,j,k)) {
+                Real cm = dxx * (Real( 0.5)/Real(i) - Real(1.0));
+                Real cp = dxx * (Real(-0.5)/Real(i) - Real(1.0));
+
+                Real gamma = dxx * (Real(1.0)/(Real(i)*Real(i)) + Real(2.0)) + beta;
+
+                Real ccey = cm * ey(i-1,j,k) + cp * ey(i+1,j,k);
+                Real res_y = rhsy(i,j,k) - ( gamma * ey(i,j,k) + ccey );
+                ey(i,j,k) += res_y/gamma;
+
+                gamma = dxx * Real(2.0) + beta;
+
+                Real ccez = cm * ez(i-1,j,k) + cp * ez(i+1,j,k);
+                Real res_z = rhsz(i,j,k) - ( gamma * ez(i,j,k) + ccez );
+                ez(i,j,k) += res_z/gamma;
+            }
+            if ((i == 0) || (i == 1)) {
+                ez(0,0,0) = (rhsz(0,0,0) + Real(4.0)*dxx*ez(1,0,0))
+                    / (beta + Real(4.0)*dxx);
+            }
+        }
+        else
+        {
+            if (i == 0 || dinfo.is_dirichlet_node(i,j,k)) { return; }
+
+            Real cm = dxx * (Real( 1.0)/Real(i) - Real(1.0));
+            Real cp = dxx * (Real(-1.0)/Real(i) - Real(1.0));
+
+            Real gamma = dxx * Real(2.0) + beta;
+
+            Real ccey = cm * ey(i-1,j,k) + cp * ey(i+1,j,k);
+            Real res_y = rhsy(i,j,k) - ( gamma * ey(i,j,k) + ccey );
+            ey(i,j,k) += res_y/gamma;
+
+            Real ccez = cm * ez(i-1,j,k) + cp * ez(i+1,j,k);
+            Real res_z = rhsz(i,j,k) - ( gamma * ez(i,j,k) + ccez );
+            ez(i,j,k) += res_z/gamma;
+        }
     }
 }
 
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-void mlcurlcurl_1D (int i, int j, int k,
-                    Array4<Real> const& ex,
-                    Array4<Real> const& ey,
-                    Array4<Real> const& ez,
-                    Array4<Real const> const& rhsx,
-                    Array4<Real const> const& rhsy,
-                    Array4<Real const> const& rhsz,
-                    Array4<Real const> const& betax,
-                    Array4<Real const> const& betay,
-                    Array4<Real const> const& betaz,
-                    GpuArray<Real,AMREX_SPACEDIM> const& adxinv,
-                    int color,
-                    CurlCurlDirichletInfo const& dinfo, bool valid_x)
+void mlcurlcurl_smooth_1d (int i, int j, int k,
+                           Array4<Real> const& ex,
+                           Array4<Real> const& ey,
+                           Array4<Real> const& ez,
+                           Array4<Real const> const& rhsx,
+                           Array4<Real const> const& rhsy,
+                           Array4<Real const> const& rhsz,
+                           Array4<Real const> const& betax,
+                           Array4<Real const> const& betay,
+                           Array4<Real const> const& betaz,
+                           GpuArray<Real,AMREX_SPACEDIM> const& adxinv,
+                           int color,
+                           CurlCurlDirichletInfo const& dinfo, bool valid_x,
+                           int coord)
 {
-    if (dinfo.is_dirichlet_node(i,j,k)) {return; }
     Real dxx = adxinv[0] * adxinv[0];
 
     int my_color = i%2;
@@ -525,17 +613,66 @@ void mlcurlcurl_1D (int i, int j, int k,
             ex(i,j,k) = rhsx(i,j,k) / betax(i,j,k);
         }
 
-        Real gamma_y = dxx * Real(2.0) + betay(i,j,k);
-        Real ccey = - dxx * (ey(i-1,j  ,k  ) +
-                             ey(i+1,j  ,k  ) );
-        Real res_y = rhsy(i,j,k) - ( gamma_y * ey(i,j,k) + ccey );
-        ey(i,j,k) += res_y/gamma_y;
+        if (coord == 0)
+        {
+            if (dinfo.is_dirichlet_node(i,j,k)) { return; }
 
-        Real gamma_z = dxx * Real(2.0) + betaz(i,j,k);
-        Real ccez = -dxx * (ez(i-1,j  ,k  ) +
-                            ez(i+1,j  ,k  ) );
-        Real res_z = rhsz(i,j,k) - ( gamma_z * ez(i,j,k) + ccez );
-        ez(i,j,k) += res_z/gamma_z;
+            Real cm = -dxx;
+            Real cp = -dxx;
+
+            Real gamma_y = dxx * Real(2.0) + betay(i,j,k);
+            Real ccey = cm * ey(i-1,j,k) + cp * ey(i+1,j,k);
+            Real res_y = rhsy(i,j,k) - ( gamma_y * ey(i,j,k) + ccey );
+            ey(i,j,k) += res_y/gamma_y;
+
+            Real gamma_z = dxx * Real(2.0) + betaz(i,j,k);
+            Real ccez = cm * ez(i-1,j,k) + cp * ez(i+1,j,k);
+            Real res_z = rhsz(i,j,k) - ( gamma_z * ez(i,j,k) + ccez );
+            ez(i,j,k) += res_z/gamma_z;
+        }
+        else if (coord == 1)
+        {
+            if ((i > 0) && ! dinfo.is_dirichlet_node(i,j,k)) {
+                Real cm = dxx * (Real( 0.5)/Real(i) - Real(1.0));
+                Real cp = dxx * (Real(-0.5)/Real(i) - Real(1.0));
+
+                Real gamma = dxx * (Real(1.0)/(Real(i)*Real(i)) + Real(2.0)) + betay(i,j,k);
+
+                Real ccey = cm * ey(i-1,j,k) + cp * ey(i+1,j,k);
+                Real res_y = rhsy(i,j,k) - ( gamma * ey(i,j,k) + ccey );
+                ey(i,j,k) += res_y/gamma;
+            }
+
+            if (i == 0) {
+                ez(0,0,0) = (rhsz(0,0,0) + Real(4.0)*dxx*ez(1,0,0)) / (betaz(0,0,0) + Real(4.0)*dxx);
+            } else if (! dinfo.is_dirichlet_node(i,j,k)) {
+                Real cm = dxx * (Real( 0.5)/Real(i) - Real(1.0));
+                Real cp = dxx * (Real(-0.5)/Real(i) - Real(1.0));
+
+                Real gamma = dxx * Real(2.0) + betaz(i,j,k);
+
+                Real ccez = cm * ez(i-1,j,k) + cp * ez(i+1,j,k);
+                Real res_z = rhsz(i,j,k) - ( gamma * ez(i,j,k) + ccez );
+                ez(i,j,k) += res_z/gamma;
+            }
+        }
+        else
+        {
+            if (dinfo.is_dirichlet_node(i,j,k)) { return; }
+
+            Real cm = dxx * (Real( 1.0)/Real(i) - Real(1.0));
+            Real cp = dxx * (Real(-1.0)/Real(i) - Real(1.0));
+
+            Real gamma_y = dxx * Real(2.0) + betay(i,j,k);
+            Real ccey = cm * ey(i-1,j,k) + cp * ey(i+1,j,k);
+            Real res_y = rhsy(i,j,k) - ( gamma_y * ey(i,j,k) + ccey );
+            ey(i,j,k) += res_y/gamma_y;
+
+            Real gamma_z = dxx * Real(2.0) + betaz(i,j,k);
+            Real ccez = cm * ez(i-1,j,k) + cp * ez(i+1,j,k);
+            Real res_z = rhsz(i,j,k) - ( gamma_z * ez(i,j,k) + ccez );
+            ez(i,j,k) += res_z/gamma_z;
+        }
     }
 }
 
@@ -1195,6 +1332,8 @@ void mlcurlcurl_restriction (int dir, int i, int j, int k,
 #elif (AMREX_SPACEDIM == 1)
         if (dir == 0) {
             crse(i,0,0) = Real(0.5) * (fine(ii,0,0) + fine(ii+1,0,0));
+        } else if (i == 0 && dir == 2 && dinfo.coord == 1) {
+            crse(0,0,0) = Real(0.5) * (fine(0,0,0) + fine(1,0,0));
         } else {
             crse(i,0,0) = Real(0.25) * (fine(ii-1,0,0)             +
                                         fine(ii  ,0,0) * Real(2.0) +

--- a/Tests/LinearSolvers/CurlCurl/MyTest.H
+++ b/Tests/LinearSolvers/CurlCurl/MyTest.H
@@ -19,6 +19,7 @@ private:
     void readParameters ();
     void initData ();
 
+    int coord = 0;
     int n_cell = 128;
     int max_grid_size = 64;
 

--- a/Tests/LinearSolvers/CurlCurl/MyTest.cpp
+++ b/Tests/LinearSolvers/CurlCurl/MyTest.cpp
@@ -23,7 +23,7 @@ MyTest::solve ()
     info.setConsolidation(consolidation);
     info.setMaxCoarseningLevel(max_coarsening_level);
 
-    MLCurlCurl mlcc({geom}, {grids}, {dmap}, info);
+    MLCurlCurl mlcc({geom}, {grids}, {dmap}, info, coord);
 
     mlcc.setDomainBC({AMREX_D_DECL(LinOpBCType::symmetry,
                                    LinOpBCType::Dirichlet,
@@ -92,6 +92,13 @@ void
 MyTest::readParameters ()
 {
     ParmParse pp;
+    pp.query("coord", coord);
+#if (AMREX_SPACEDIM == 3)
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coord == 0, "Only Cartesian is supported in 3D");
+#elif (AMREX_SPACEDIM == 2)
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coord != 2, "Spherical coordinates not supported in 2D");
+#endif
+
     pp.query("n_cell", n_cell);
     pp.query("max_grid_size", max_grid_size);
 

--- a/Tests/LinearSolvers/CurlCurl/initProb.cpp
+++ b/Tests/LinearSolvers/CurlCurl/initProb.cpp
@@ -11,6 +11,26 @@ MyTest::initProb ()
     const auto dx      = geom.CellSizeArray();
     const auto a = alpha;
     const auto b = beta;
+    const auto ndhi = geom.Domain().bigEnd()+1;
+
+    enum class CoordID { Cartesian, Cyl1D, Cyl2D, Sph1D };
+    auto cid = CoordID::Cartesian;
+#if (AMREX_SPACEDIM == 1)
+    if (this->coord == 1) {
+        cid = CoordID::Cyl1D;
+        AMREX_ALWAYS_ASSERT(prob_lo[0] == 0);
+    } else if (this->coord == 2) {
+        cid = CoordID::Sph1D;
+        AMREX_ALWAYS_ASSERT(prob_lo[0] == 0);
+    }
+#elif (AMREX_SPACEDIM == 2)
+    if (this->coord == 1) {
+        amrex::Abort("2D Cylindrical support will be added later");
+    }
+#endif
+
+    amrex::ignore_unused(cid,ndhi);
+
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
@@ -26,7 +46,16 @@ MyTest::initProb ()
         amrex::ParallelFor(gbx,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            actual_init_prob(i,j,k,rhsfab,solfab,prob_lo,dx,a,b);
+#if (AMREX_SPACEDIM == 1)
+            if (cid == CoordID::Sph1D) {
+                actual_init_prob_sph1d(i,j,k,rhsfab,solfab,prob_lo,dx,a,b,ndhi);
+            } else if (cid == CoordID::Cyl1D) {
+                actual_init_prob_cyl1d(i,j,k,rhsfab,solfab,prob_lo,dx,a,b,ndhi);
+            } else
+#endif
+            {
+                actual_init_prob(i,j,k,rhsfab,solfab,prob_lo,dx,a,b);
+            }
         });
     }
 }

--- a/Tests/LinearSolvers/CurlCurl/initProb_K.H
+++ b/Tests/LinearSolvers/CurlCurl/initProb_K.H
@@ -127,4 +127,135 @@ void actual_init_prob (int i, int j, int k,
     }
 }
 
+#if (AMREX_SPACEDIM == 1)
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void actual_init_prob_sph1d (int i, int j, int k,
+                             amrex::GpuArray<amrex::Array4<amrex::Real>,3> const& rhs,
+                             amrex::GpuArray<amrex::Array4<amrex::Real>,3> const& sol,
+                             amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& problo,
+                             amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
+                             amrex::Real alpha, amrex::Real beta,
+                             amrex::IntVect const& ndhi)
+{
+    using namespace amrex;
+
+    constexpr Real pi = amrex::Math::pi<Real>();
+
+    Real xnd = problo[0] + Real(i)*dx[0];
+    Real xcc = xnd + Real(0.5)*dx[0];
+
+    if (sol[0].contains(i,j,k)) {
+        Real x = xcc;
+        Real Ex = std::sin(pi*x);
+        sol[0](i,j,k) = Ex;
+    }
+
+    if (sol[1].contains(i,j,k)) {
+        Real x = xnd;
+        Real Ey = std::sin(Real(2.0)*pi*x);
+        sol[1](i,j,k) = Ey;
+    }
+
+    if (sol[2].contains(i,j,k)) {
+        Real x = xnd;
+        Real Ez = std::sin(Real(3.0)*pi*x);
+        sol[2](i,j,k) = Ez;
+    }
+
+    if (rhs[0].contains(i,j,k)) {
+        rhs[0](i,j,k) = beta*sol[0](i,j,k);
+    }
+
+    if (rhs[1].contains(i,j,k)) {
+        Real x = xnd;
+        if ((x == 0) || (i == ndhi[0])) {
+            rhs[1](i,j,k) = 0;
+        } else {
+            auto s = Real(2.0)*pi;
+            Real cce = -Real(2.0)*s*std::cos(s*x)/x + s*s*std::sin(s*x);
+            rhs[1](i,j,k) = alpha*cce + beta*sol[1](i,j,k);
+        }
+    }
+
+    if (rhs[2].contains(i,j,k)) {
+        Real x = xnd;
+        if ((x == 0) || (i == ndhi[0])) {
+            rhs[2](i,j,k) = 0;
+        } else {
+            auto s = Real(3.0)*pi;
+            Real cce = -Real(2.0)*s*std::cos(s*x)/x + s*s*std::sin(s*x);
+            rhs[2](i,j,k) = alpha*cce + beta*sol[2](i,j,k);
+        }
+    }
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void actual_init_prob_cyl1d (int i, int j, int k,
+                             amrex::GpuArray<amrex::Array4<amrex::Real>,3> const& rhs,
+                             amrex::GpuArray<amrex::Array4<amrex::Real>,3> const& sol,
+                             amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& problo,
+                             amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
+                             amrex::Real alpha, amrex::Real beta,
+                             amrex::IntVect const& ndhi)
+{
+    using namespace amrex;
+
+    constexpr Real pi = amrex::Math::pi<Real>();
+
+    Real xnd = problo[0] + Real(i)*dx[0];
+    Real xcc = xnd + Real(0.5)*dx[0];
+
+    if (sol[0].contains(i,j,k)) {
+        Real x = xcc;
+        Real Ex = std::sin(pi*x);
+        sol[0](i,j,k) = Ex;
+    }
+
+    if (sol[1].contains(i,j,k)) {
+        Real x = xnd;
+        Real Ey = std::sin(Real(2.0)*pi*x);
+        sol[1](i,j,k) = Ey;
+    }
+
+    if (sol[2].contains(i,j,k)) {
+        Real x = xnd;
+        Real Ez = std::cos(Real(2.5)*pi*x);
+        sol[2](i,j,k) = Ez;
+    }
+
+    if (rhs[0].contains(i,j,k)) {
+        rhs[0](i,j,k) = beta*sol[0](i,j,k);
+    }
+
+    if (rhs[1].contains(i,j,k)) {
+        Real x = xnd;
+        if ((x == 0) || (i == ndhi[0])) {
+            rhs[1](i,j,k) = 0;
+        } else {
+            auto s = Real(2.0)*pi;
+            Real cce = std::sin(s*x)*(s*s+Real(1.0)/(x*x)) - std::cos(s*x)*s/x;
+            rhs[1](i,j,k) = alpha*cce + beta*sol[1](i,j,k);
+        }
+    }
+
+    if (rhs[2].contains(i,j,k)) {
+        if (i == ndhi[0]) {
+            rhs[2](i,j,k) = 0;
+        } else {
+            Real x = xnd;
+            Real s = Real(2.5)*pi;
+            Real cce;
+            if (x == 0) {
+                cce = 2*s*s;
+            } else {
+                cce = std::sin(s*x)*s/x + std::cos(s*x)*s*s;
+            }
+            rhs[2](i,j,k) = alpha*cce + beta*sol[2](i,j,k);
+        }
+    }
+}
+
+#endif
+
 #endif

--- a/Tests/LinearSolvers/CurlCurl/inputs
+++ b/Tests/LinearSolvers/CurlCurl/inputs
@@ -1,4 +1,6 @@
 
+coord = 0 # 0: cartesian, 1: cylindrical, 2: spherical
+
 n_cell = 128
 max_grid_size = 64
 


### PR DESCRIPTION
This PR adds support for 1D spherical and 1D cylindrical. Note that the curl of curl of E is zero in the radial direction. For 1D spherical coordinates, E_theta and E_phi have reflect-odd symmetry, and are thus zero at R = 0. For 1D cylindrical coordinates, E_theta has reflect-odd symmetry, and is thus zero at r = 0. E_z has reflect-even symmetry at r = 0, where the curl-curl is -4(Ez(1)-Ez(0))/dr^2 in the z-direction.
