### PR TITLE
Add ParamParse::getPrefix

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1700,6 +1700,8 @@ public:
 
     static std::string ParserPrefix;
 
+    [[nodiscard]] std::string const& getPrefix () const;
+
     [[nodiscard]] std::string prefixedName (const std::string_view& str) const;
 
 protected:

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1091,6 +1091,12 @@ bool pp_parser (const ParmParse::Table& table, const std::string& parser_prefix,
 
 }  // End of unnamed namespace.
 
+std::string const&
+ParmParse::getPrefix () const
+{
+    return m_prefix;
+}
+
 std::string
 ParmParse::prefixedName (const std::string_view& str) const
 {


### PR DESCRIPTION
It was removed in #4031. But it is still used by ImpactX in an assert, and it is still useful.
