### PR TITLE
AMReX Enum: Underlying Value

### DIFF
--- a/Src/Base/AMReX_Enum.H
+++ b/Src/Base/AMReX_Enum.H
@@ -135,7 +135,7 @@ namespace amrex
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    constexpr auto getEnumUnderlyingValue (T v) noexcept
+    constexpr auto toUnderlying (T v) noexcept
     {
         return static_cast<std::underlying_type_t<T>>(v);
     }

--- a/Src/Base/AMReX_Enum.H
+++ b/Src/Base/AMReX_Enum.H
@@ -128,6 +128,17 @@ namespace amrex
     {
         return std::string(ET::class_name);
     }
+
+    /** Return the underlying (u)int of an enum value
+     *
+     * Useful when building bitmasks.
+     */
+    template <typename T, typename ET = amrex_enum_traits<T>,
+              std::enable_if_t<ET::value,int> = 0>
+    constexpr auto getEnumUnderlyingValue (T v) noexcept
+    {
+        return static_cast<std::underlying_type_t<T>>(v);
+    }
 }
 
 #define AMREX_ENUM(CLASS, ...) \


### PR DESCRIPTION
## Summary

Sometimes one needs the underlying (u)int value of an `enum class`, e.g., when building bitmasks. This adds a helper function to `AMREX_ENUM`.

## Additional background

https://github.com/BLAST-ImpactX/impactx/pull/1104

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
