### PR TITLE
Enable zero-sized Type in TypeMultiplier

### DIFF
--- a/Src/Base/AMReX_TypeList.H
+++ b/Src/Base/AMReX_TypeList.H
@@ -151,6 +151,12 @@ constexpr auto CartesianProduct (Ls...) {
     return (TypeList<TypeList<>>{} * ... * Ls{});
 }
 
+template <class T, std::size_t N>
+struct TypeArray {
+    using Type = T;
+    static constexpr std::size_t size () noexcept { return N; }
+};
+
 namespace detail {
     // return TypeList<T, T, T, T, ... (N times)> by using the fast power algorithm
     template <class T, std::size_t N>
@@ -173,6 +179,14 @@ namespace detail {
         return SingleTypeMultiplier_impl<T, N>();
     }
 
+    // overload of SingleTypeMultiplier for multiple types:
+    // convert TypeArray<T,N> to  T, T, T, T, ... (N times with N >= 0)
+    // Note that only this overload works with N = 0
+    template <class T, std::size_t N>
+    constexpr auto SingleTypeMultiplier (TypeArray<T, N>) {
+        return SingleTypeMultiplier_impl<T, N>();
+    }
+
     // overload of SingleTypeMultiplier for one regular type
     template <class T>
     constexpr auto SingleTypeMultiplier (T) {
@@ -189,13 +203,14 @@ namespace detail {
 /**
  * \brief Return the first template argument with the later arguments applied to it.
  * Types of the form T[N] are expanded to T, T, T, T, ... (N times with N >= 1).
+ * Types of the form TypeArray<T,N> are expanded to T, T, T, T, ... (N times with N >= 0).
  *
  * For example, TypeMultiplier<ReduceData, Real[4], int[2], Long>
  * is an alias to the type ReduceData<Real, Real, Real, Real, int, int, Long>.
  */
 template <template <class...> class TParam, class... Types>
 using TypeMultiplier = TypeAt<0, decltype(detail::TApply<TParam>(
-    (TypeList<>{} + ... + detail::SingleTypeMultiplier(Types{}))
+    (TypeList<>{} + ... + detail::SingleTypeMultiplier(std::declval<Types>()))
 ))>;
 
 }


### PR DESCRIPTION
## Summary

In C++ it is not allowed to make a zero-sized array type like `int[0]` so a more verbose way using `amrex::TypeArray<int, 0>` needs to be used. Additionally, `std::declval` is now used instead of `Types{}`.

## Additional background

Zero-variants in https://github.com/BLAST-ImpactX/impactx/pull/1104

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
