### PR TITLE
Add explanatory comment to ParticleReduce

### DIFF
--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -217,6 +217,8 @@ ReduceSum (PC const& pc, int lev_min, int lev_max, F const& f)
                 grid_tile_ids.push_back(kv.first);
                 ptile_ptrs.push_back(&(kv.second));
             }
+
+            // We avoid ParIter here to allow reductions after grids change but prior to calling Redistribute()
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for if (!system::regtest_reduction) reduction(+:sm)
 #endif
@@ -418,6 +420,8 @@ ReduceMax (PC const& pc, int lev_min, int lev_max, F const& f)
                 grid_tile_ids.push_back(kv.first);
                 ptile_ptrs.push_back(&(kv.second));
             }
+
+            // We avoid ParIter here to allow reductions after grids change but prior to calling Redistribute()
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for if (!system::regtest_reduction) reduction(max:r)
 #endif
@@ -619,6 +623,8 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F const& f)
                 grid_tile_ids.push_back(kv.first);
                 ptile_ptrs.push_back(&(kv.second));
             }
+
+            // We avoid ParIter here to allow reductions after grids change but prior to calling Redistribute()
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for if (!system::regtest_reduction) reduction(min:r)
 #endif
@@ -815,6 +821,8 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F const& f)
                 grid_tile_ids.push_back(kv.first);
                 ptile_ptrs.push_back(&(kv.second));
             }
+
+            // We avoid ParIter here to allow reductions after grids change but prior to calling Redistribute()
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for if (!system::regtest_reduction) reduction(&&:r)
 #endif
@@ -1012,6 +1020,8 @@ ReduceLogicalOr (PC const& pc, int lev_min, int lev_max, F const& f)
                 grid_tile_ids.push_back(kv.first);
                 ptile_ptrs.push_back(&(kv.second));
             }
+
+            // We avoid ParIter here to allow reductions after grids change but prior to calling Redistribute()
 #ifdef AMREX_USE_OMP
 #pragma omp parallel for if (!system::regtest_reduction) reduction(||:r)
 #endif
@@ -1247,6 +1257,8 @@ ParticleReduce (PC const& pc, int lev_min, int lev_max, F const& f, ReduceOps& r
             grid_tile_ids.push_back(kv.first);
             ptile_ptrs.push_back(&(kv.second));
         }
+
+        // We avoid ParIter here to allow reductions after grids change but prior to calling Redistribute()
 #if !defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP)
 #pragma omp parallel for
 #endif


### PR DESCRIPTION
Explain why we don't use ParIter in the ParticleReduce methods.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
