### PR TITLE
Make `CUDA_ARCH` assignment conditional to respect user-specified value

### DIFF
--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -98,12 +98,12 @@ ifeq ($(USE_CUDA),TRUE)
   endif
   ifneq ($(cuda_device_query_result),)
      TEMP_CUDA_ARCH = $(lastword $(cuda_device_query_result))
-#      CUDA_ARCH = $(subst .,,$(TEMP_CUDA_ARCH))
+#      CUDA_ARCH ?= $(subst .,,$(TEMP_CUDA_ARCH))
      # We do this because pgfortran does not support all cuda arches.
      ifeq ($(TEMP_CUDA_ARCH),3.5)
-         CUDA_ARCH = 35
+         CUDA_ARCH ?= 35
      else
-         CUDA_ARCH = $(firstword $(subst ., ,$(TEMP_CUDA_ARCH)))0
+         CUDA_ARCH ?= $(firstword $(subst ., ,$(TEMP_CUDA_ARCH)))0
      endif
   endif
 endif


### PR DESCRIPTION
## Summary

Change the `CUDA_ARCH` assignment in `Tools/GNUMake/sites/Make.unknown` from a hard "=" to a conditional "?=" so that if the user has already set `CUDA_ARCH` (e.g., in `GNUMakefile`), it won’t be clobbered.

## Additional background

Fixes #4621 

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
