### PR TITLE
Fallback to default `CUDA_ARCH` if `nvidia-smi` fails

### DIFF
--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -98,13 +98,7 @@ ifeq ($(USE_CUDA),TRUE)
   endif
   ifneq ($(cuda_device_query_result),)
      TEMP_CUDA_ARCH = $(lastword $(cuda_device_query_result))
-#      CUDA_ARCH = $(subst .,,$(TEMP_CUDA_ARCH))
-     # We do this because pgfortran does not support all cuda arches.
-     ifeq ($(TEMP_CUDA_ARCH),3.5)
-         CUDA_ARCH = 35
-     else
-         CUDA_ARCH = $(firstword $(subst ., ,$(TEMP_CUDA_ARCH)))0
-     endif
+     CUDA_ARCH = $(subst .,,$(TEMP_CUDA_ARCH))
   endif
 endif
 endif

--- a/Tools/GNUMake/sites/Make.unknown
+++ b/Tools/GNUMake/sites/Make.unknown
@@ -94,7 +94,7 @@ ifeq ($(USE_CUDA),TRUE)
      cuda_device_query_result := $(shell $(CUDA_HOME)/extras/demo_suite/deviceQuery | grep "CUDA Capability")
   else
      # try nvidia-smi, as deviceQuery is no longer distributed with CUDA 12 and up
-     cuda_device_query_result := $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader)
+     cuda_device_query_result := $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader || echo $(CUDA_ARCH))
   endif
   ifneq ($(cuda_device_query_result),)
      TEMP_CUDA_ARCH = $(lastword $(cuda_device_query_result))


### PR DESCRIPTION
## Summary

Fallback to `$(CUDA_ARCH)` if the `nvidia-smi` shell command fails. Also simplifies the `CUDA_ARCH` extraction process since [`pgfortran` is no longer a concern anymore](https://github.com/AMReX-Codes/amrex/issues/4621#issuecomment-3208242650).

## Additional background

Fixes #4621

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
