### PR TITLE
fix atomicSetID wrapper access

### DIFF
--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -434,11 +434,13 @@ struct alignas(sizeof(double)) Particle
         ParticleIDWrapper wrapper(tmp);
         wrapper = id;
 #if defined(AMREX_USE_OMP)
-#pragma omp atomic write
-        this->m_idcpu = wrapper.m_idata;
+    #pragma omp critical
+    {
+        this->m_idcpu = wrapper.m_idata[0];
+    }
 #else
         auto *old_ptr = reinterpret_cast<unsigned long long*>(&(this->m_idcpu));
-        amrex::Gpu::Atomic::Exch(old_ptr, (unsigned long long) wrapper.m_idata);
+        amrex::Gpu::Atomic::Exch(old_ptr, (unsigned long long) wrapper.m_idata[0]);
 #endif
     }
 

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -434,13 +434,11 @@ struct alignas(sizeof(double)) Particle
         ParticleIDWrapper wrapper(tmp);
         wrapper = id;
 #if defined(AMREX_USE_OMP)
-    #pragma omp critical
-    {
-        this->m_idcpu = wrapper.m_idata[0];
-    }
+    #pragma omp atomic write
+        this->m_idcpu = *(wrapper.m_idata);
 #else
         auto *old_ptr = reinterpret_cast<unsigned long long*>(&(this->m_idcpu));
-        amrex::Gpu::Atomic::Exch(old_ptr, (unsigned long long) wrapper.m_idata[0]);
+        amrex::Gpu::Atomic::Exch(old_ptr, (unsigned long long) (*wrapper.m_idata));
 #endif
     }
 

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -434,7 +434,7 @@ struct alignas(sizeof(double)) Particle
         ParticleIDWrapper wrapper(tmp);
         wrapper = id;
 #if defined(AMREX_USE_OMP)
-    #pragma omp atomic write
+#pragma omp atomic write
         this->m_idcpu = *(wrapper.m_idata);
 #else
         auto *old_ptr = reinterpret_cast<unsigned long long*>(&(this->m_idcpu));

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -230,15 +230,23 @@ public:
                         auto old_id = p.id();
                         auto new_id = 5000 + p.id();
                         p.atomicSetID(new_id);
+#ifndef AMREX_USE_GPU
                         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(p.id() == new_id,
                                                          "atomicSetID failed: expected " +
                                                          std::to_string(new_id) + " but got " +
                                                          std::to_string(p.id()));
+#else
+                        AMREX_ALWAYS_ASSERT(p.id() == new_id);
+#endif
                         p.atomicSetID(new_id - 5000);
+#ifndef AMREX_USE_GPU
                         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(p.id() == old_id,
                                                          "atomicSetID failed: expected " +
                                                          std::to_string(old_id) + " but got " +
                                                          std::to_string(p.id()));
+#else
+                        AMREX_ALWAYS_ASSERT(p.id() == old_id);
+#endif
                     });
             }
         }

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -222,6 +222,24 @@ public:
 #endif
                     });
                 }
+
+                amrex::ParallelFor(np,
+                    [=] AMREX_GPU_DEVICE (size_t i) noexcept
+                    {
+                        ParticleType& p = pstruct[i];
+                        auto old_id = p.id();
+                        auto new_id = 5000 + p.id();
+                        p.atomicSetID(new_id);
+                        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(p.id() == new_id,
+                                                         "atomicSetID failed: expected " +
+                                                         std::to_string(new_id) + " but got " +
+                                                         std::to_string(p.id()));
+                        p.atomicSetID(new_id - 5000);
+                        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(p.id() == old_id,
+                                                         "atomicSetID failed: expected " +
+                                                         std::to_string(old_id) + " but got " +
+                                                         std::to_string(p.id()));
+                    });
             }
         }
     }


### PR DESCRIPTION
## Summary

- added dereference needed for using ParticleIDWrapper object
- added assertions to a test for checking

## Additional background

- Originally seen as the following error while debugging Artemis CI:
```
error: invalid conversion from ‘long unsigned int*’ to ‘uint64_t’ {aka ‘long unsigned int’} [-fpermissive]
  436 |         this->m_idcpu = wrapper.m_idata;
      |                         ~~~~~~~~^~~~~~~
      |                                 |
      |                                 long unsigned int*
```

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
