### PR TITLE
generalize the average_*_to_cellcenter routines to take IntVect ngrow…

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -916,7 +916,7 @@ void average_face_to_cellcenter (CMF& cc, int dcomp,
                                  const Array<const FMF*,AMREX_SPACEDIM>& fc,
                                  int ngrow)
 {
-   IntVect ng_vect = IntVect(AMREX_D_DECL(ngrow,ngrow,ngrow));
+   IntVect ng_vect(ngrow);
    average_face_to_cellcenter(cc, dcomp, fc, ng_vect);
 }
 

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -32,12 +32,18 @@ namespace amrex
     void average_face_to_cellcenter (MultiFab& cc, int dcomp,
                                      const Vector<const MultiFab*>& fc,
                                      int ngrow = 0);
+    //! Average face-based MultiFab onto cell-centered MultiFab.
+    void average_face_to_cellcenter (MultiFab& cc, int dcomp,
+                                     const Vector<const MultiFab*>& fc,
+                                     IntVect ngrow = IntVect::TheZeroVector());
+
     //! Average face-based FabArray onto cell-centered FabArray.
     template <typename CMF, typename FMF,
               std::enable_if_t<IsFabArray_v<CMF> && IsFabArray_v<FMF>, int> = 0>
     void average_face_to_cellcenter (CMF& cc, int dcomp,
                                      const Array<const FMF*,AMREX_SPACEDIM>& fc,
                                      int ngrow = 0);
+
     //! Average face-based MultiFab onto cell-centered MultiFab with geometric weighting.
     void average_face_to_cellcenter (MultiFab& cc,
                                      const Vector<const MultiFab*>& fc,
@@ -888,10 +894,20 @@ NormHelper (const MMF& mask,
 }
 
 template <typename CMF, typename FMF,
-          std::enable_if_t<IsFabArray_v<CMF> && IsFabArray_v<FMF>, int> FOO>
+          std::enable_if_t<IsFabArray_v<CMF> && IsFabArray_v<FMF>, IntVect> FOO>
 void average_face_to_cellcenter (CMF& cc, int dcomp,
                                  const Array<const FMF*,AMREX_SPACEDIM>& fc,
                                  int ngrow)
+{
+   IntVect ng_vect = IntVect(AMREX_D_DECL(ngrow,ngrow,ngrow));
+   average_face_to_cellcenter(cc, dcomp, fc, ng_vect);
+}
+
+template <typename CMF, typename FMF,
+          std::enable_if_t<IsFabArray_v<CMF> && IsFabArray_v<FMF>, int> FOO>
+void average_face_to_cellcenter (CMF& cc, int dcomp,
+                                 const Array<const FMF*,AMREX_SPACEDIM>& fc,
+                                 IntVect ngrow)
 {
     AMREX_ASSERT(cc.nComp() >= dcomp + AMREX_SPACEDIM);
     AMREX_ASSERT(fc[0]->nComp() == 1);
@@ -902,7 +918,7 @@ void average_face_to_cellcenter (CMF& cc, int dcomp,
         AMREX_D_TERM(auto const& fxma = fc[0]->const_arrays();,
                      auto const& fyma = fc[1]->const_arrays();,
                      auto const& fzma = fc[2]->const_arrays(););
-        ParallelFor(cc, IntVect(ngrow),
+        ParallelFor(cc, ngrow,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
         {
 #if (AMREX_SPACEDIM == 1)

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -59,7 +59,7 @@ namespace amrex
               std::enable_if_t<IsFabArray_v<CMF> && IsFabArray_v<FMF>, int> = 0>
     void average_face_to_cellcenter (CMF& cc, int dcomp,
                                      const Array<const FMF*,AMREX_SPACEDIM>& fc,
-                                     IntVect const& ngrow);
+                                     IntVect const& ng_vect);
 
     //! Average face-based MultiFab onto cell-centered MultiFab with geometric weighting.
     void average_face_to_cellcenter (MultiFab& cc,

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -18,24 +18,35 @@ namespace amrex
     void average_node_to_cellcenter (MultiFab& cc, int dcomp,
                                      const MultiFab& nd, int scomp,
                                      int ncomp, int ngrow = 0);
+    void average_node_to_cellcenter (MultiFab& cc, int dcomp,
+                                     const MultiFab& nd, int scomp,
+                                     int ncomp, IntVect const& ng_vect);
 
     /**
      * \brief Average edge-based MultiFab onto cell-centered MultiFab.
      *
-     * This fills in \p ngrow ghost cells in the cell-centered MultiFab. Both cell centered and
-     * edge centered MultiFabs need to have \p ngrow ghost values.
+     * This fills in \p ngrow ghost cells in the cell-centered MultiFab. Both cell-centered and
+     * edge-centered MultiFabs need to have \p ngrow ghost values.
      */
     void average_edge_to_cellcenter (MultiFab& cc, int dcomp,
                                      const Vector<const MultiFab*>& edge,
                                      int ngrow = 0);
-    //! Average face-based MultiFab onto cell-centered MultiFab.
+    void average_edge_to_cellcenter (MultiFab& cc, int dcomp,
+                                     const Vector<const MultiFab*>& edge,
+                                     IntVect const& ng_vect);
+
+    /**
+     * \brief Average face-based MultiFab onto cell-centered MultiFab.
+     *
+     * This fills in \p ngrow ghost cells in the cell-centered MultiFab. Both cell-centered and
+     * face-centered MultiFabs need to have \p ngrow ghost values.
+     */
     void average_face_to_cellcenter (MultiFab& cc, int dcomp,
                                      const Vector<const MultiFab*>& fc,
                                      int ngrow = 0);
-    //! Average face-based MultiFab onto cell-centered MultiFab.
     void average_face_to_cellcenter (MultiFab& cc, int dcomp,
                                      const Vector<const MultiFab*>& fc,
-                                     IntVect ngrow = IntVect::TheZeroVector());
+                                     IntVect const& ng_vect);
 
     //! Average face-based FabArray onto cell-centered FabArray.
     template <typename CMF, typename FMF,
@@ -43,6 +54,12 @@ namespace amrex
     void average_face_to_cellcenter (CMF& cc, int dcomp,
                                      const Array<const FMF*,AMREX_SPACEDIM>& fc,
                                      int ngrow = 0);
+
+    template <typename CMF, typename FMF,
+              std::enable_if_t<IsFabArray_v<CMF> && IsFabArray_v<FMF>, int> = 0>
+    void average_face_to_cellcenter (CMF& cc, int dcomp,
+                                     const Array<const FMF*,AMREX_SPACEDIM>& fc,
+                                     IntVect const& ngrow);
 
     //! Average face-based MultiFab onto cell-centered MultiFab with geometric weighting.
     void average_face_to_cellcenter (MultiFab& cc,
@@ -894,7 +911,7 @@ NormHelper (const MMF& mask,
 }
 
 template <typename CMF, typename FMF,
-          std::enable_if_t<IsFabArray_v<CMF> && IsFabArray_v<FMF>, IntVect> FOO>
+          std::enable_if_t<IsFabArray_v<CMF> && IsFabArray_v<FMF>, int> FOO>
 void average_face_to_cellcenter (CMF& cc, int dcomp,
                                  const Array<const FMF*,AMREX_SPACEDIM>& fc,
                                  int ngrow)
@@ -907,7 +924,7 @@ template <typename CMF, typename FMF,
           std::enable_if_t<IsFabArray_v<CMF> && IsFabArray_v<FMF>, int> FOO>
 void average_face_to_cellcenter (CMF& cc, int dcomp,
                                  const Array<const FMF*,AMREX_SPACEDIM>& fc,
-                                 IntVect ngrow)
+                                 IntVect const& ng_vect)
 {
     AMREX_ASSERT(cc.nComp() >= dcomp + AMREX_SPACEDIM);
     AMREX_ASSERT(fc[0]->nComp() == 1);
@@ -918,7 +935,7 @@ void average_face_to_cellcenter (CMF& cc, int dcomp,
         AMREX_D_TERM(auto const& fxma = fc[0]->const_arrays();,
                      auto const& fyma = fc[1]->const_arrays();,
                      auto const& fzma = fc[2]->const_arrays(););
-        ParallelFor(cc, ngrow,
+        ParallelFor(cc, ng_vect,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
         {
 #if (AMREX_SPACEDIM == 1)
@@ -945,7 +962,7 @@ void average_face_to_cellcenter (CMF& cc, int dcomp,
 #endif
         for (MFIter mfi(cc,TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            const Box bx = mfi.growntilebox(ngrow);
+            const Box bx = mfi.growntilebox(ng_vect);
             auto const& ccarr = cc.array(mfi);
             AMREX_D_TERM(auto const& fxarr = fc[0]->const_array(mfi);,
                          auto const& fyarr = fc[1]->const_array(mfi);,

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -62,11 +62,18 @@ namespace amrex
     void average_node_to_cellcenter (MultiFab& cc, int dcomp,
          const MultiFab& nd, int scomp, int ncomp, int ngrow)
     {
+        IntVect ng_vect(ngrow);
+        average_node_to_cellcenter (cc, dcomp, nd, scomp, ncomp, ng_vect);
+    }
+
+    void average_node_to_cellcenter (MultiFab& cc, int dcomp,
+         const MultiFab& nd, int scomp, int ncomp, IntVect& ngrow)
+    {
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion() && cc.isFusingCandidate()) {
             auto const& ccma = cc.arrays();
             auto const& ndma = nd.const_arrays();
-            ParallelFor(cc, IntVect(ngrow), ncomp,
+            ParallelFor(cc, ngrow, ncomp,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
                 amrex_avg_nd_to_cc(i, j, k, n, ccma[box_no], ndma[box_no], dcomp, scomp);
@@ -97,6 +104,13 @@ namespace amrex
     void average_edge_to_cellcenter (MultiFab& cc, int dcomp,
         const Vector<const MultiFab*>& edge, int ngrow)
     {
+        IntVect ng_vect(ng);
+        average_edge_to_cellcenter (cc, dcomp, edge, ng_vect);
+    }
+
+    void average_edge_to_cellcenter (MultiFab& cc, int dcomp,
+        const Vector<const MultiFab*>& edge, IntVect& ngrow)
+    {
         AMREX_ASSERT(cc.nComp() >= dcomp + AMREX_SPACEDIM);
         AMREX_ASSERT(edge.size() == AMREX_SPACEDIM);
         AMREX_ASSERT(edge[0]->nComp() == 1);
@@ -106,7 +120,7 @@ namespace amrex
             AMREX_D_TERM(auto const& exma = edge[0]->const_arrays();,
                          auto const& eyma = edge[1]->const_arrays();,
                          auto const& ezma = edge[2]->const_arrays(););
-            ParallelFor(cc, IntVect(ngrow),
+            ParallelFor(cc, ngrow,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
             {
                 amrex_avg_eg_to_cc(i, j, k, ccma[box_no],
@@ -136,6 +150,14 @@ namespace amrex
                 });
             }
         }
+    }
+
+    void average_face_to_cellcenter (MultiFab& cc, int dcomp,
+        const Vector<const MultiFab*>& fc, IntVect& ngrow)
+    {
+        average_face_to_cellcenter(cc, dcomp,
+            Array<MultiFab const*,AMREX_SPACEDIM>{{AMREX_D_DECL(fc[0],fc[1],fc[2])}},
+            ngrow);
     }
 
     void average_face_to_cellcenter (MultiFab& cc, int dcomp,

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -67,13 +67,13 @@ namespace amrex
     }
 
     void average_node_to_cellcenter (MultiFab& cc, int dcomp,
-         const MultiFab& nd, int scomp, int ncomp, IntVect& ngrow)
+         const MultiFab& nd, int scomp, int ncomp, IntVect const& ng_vect)
     {
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion() && cc.isFusingCandidate()) {
             auto const& ccma = cc.arrays();
             auto const& ndma = nd.const_arrays();
-            ParallelFor(cc, ngrow, ncomp,
+            ParallelFor(cc, ng_vect, ncomp,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
             {
                 amrex_avg_nd_to_cc(i, j, k, n, ccma[box_no], ndma[box_no], dcomp, scomp);
@@ -89,7 +89,7 @@ namespace amrex
 #endif
             for (MFIter mfi(cc,TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
-                const Box bx = mfi.growntilebox(ngrow);
+                const Box bx = mfi.growntilebox(ng_vect);
                 Array4<Real> const& ccarr = cc.array(mfi);
                 Array4<Real const> const& ndarr = nd.const_array(mfi);
 
@@ -104,12 +104,12 @@ namespace amrex
     void average_edge_to_cellcenter (MultiFab& cc, int dcomp,
         const Vector<const MultiFab*>& edge, int ngrow)
     {
-        IntVect ng_vect(ng);
+        IntVect ng_vect(ngrow);
         average_edge_to_cellcenter (cc, dcomp, edge, ng_vect);
     }
 
     void average_edge_to_cellcenter (MultiFab& cc, int dcomp,
-        const Vector<const MultiFab*>& edge, IntVect& ngrow)
+        const Vector<const MultiFab*>& edge, IntVect const& ng_vect)
     {
         AMREX_ASSERT(cc.nComp() >= dcomp + AMREX_SPACEDIM);
         AMREX_ASSERT(edge.size() == AMREX_SPACEDIM);
@@ -120,7 +120,7 @@ namespace amrex
             AMREX_D_TERM(auto const& exma = edge[0]->const_arrays();,
                          auto const& eyma = edge[1]->const_arrays();,
                          auto const& ezma = edge[2]->const_arrays(););
-            ParallelFor(cc, ngrow,
+            ParallelFor(cc, ng_vect,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
             {
                 amrex_avg_eg_to_cc(i, j, k, ccma[box_no],
@@ -138,7 +138,7 @@ namespace amrex
 #endif
             for (MFIter mfi(cc,TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
-                const Box bx = mfi.growntilebox(ngrow);
+                const Box bx = mfi.growntilebox(ng_vect);
                 Array4<Real> const& ccarr = cc.array(mfi);
                 AMREX_D_TERM(Array4<Real const> const& exarr = edge[0]->const_array(mfi);,
                              Array4<Real const> const& eyarr = edge[1]->const_array(mfi);,
@@ -153,11 +153,11 @@ namespace amrex
     }
 
     void average_face_to_cellcenter (MultiFab& cc, int dcomp,
-        const Vector<const MultiFab*>& fc, IntVect& ngrow)
+        const Vector<const MultiFab*>& fc, IntVect const& ng_vect)
     {
         average_face_to_cellcenter(cc, dcomp,
             Array<MultiFab const*,AMREX_SPACEDIM>{{AMREX_D_DECL(fc[0],fc[1],fc[2])}},
-            ngrow);
+            ng_vect);
     }
 
     void average_face_to_cellcenter (MultiFab& cc, int dcomp,


### PR DESCRIPTION
… rather than int ngrow

## Summary
This PR adds new interfaces to the average_face_to_cellcenter, average_edge_to_cellcenter and average_node_to_cellcenter routines so that there is the option to pass "ngrow" as an IntVect rather than as a single integer.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
