### PR TITLE
Use `p.id().is_valid()` consistently

### DIFF
--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -68,7 +68,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           compression,
                           [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i) -> int
                           {
-                              return ptd.id(i) > 0;
+                              return ptd.id(i).is_valid();
                           }, true);
 }
 
@@ -104,7 +104,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           compression,
                           [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i) -> int
                           {
-                              return ptd.id(i) > 0;
+                              return ptd.id(i).is_valid();
                           });
 }
 
@@ -140,7 +140,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           compression,
                           [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
-                              return ptd.id(i) > 0;
+                              return ptd.id(i).is_valid();
                           });
 }
 
@@ -168,7 +168,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           compression,
                           [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
-                              return ptd.id(i) > 0;
+                              return ptd.id(i).is_valid();
                           });
 }
 
@@ -202,7 +202,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           compression,
                           [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
-                              return ptd.id(i) > 0;
+                              return ptd.id(i).is_valid();
                           });
 }
 
@@ -240,7 +240,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                           compression,
                           [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
-                              return ptd.id(i) > 0;
+                              return ptd.id(i).is_valid();
                           });
 }
 
@@ -263,7 +263,7 @@ WritePlotFileHDF5 (const std::string& dir, const std::string& name,
                           compression,
                           [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, int i)
                           {
-                              return ptd.id(i) > 0;
+                              return ptd.id(i).is_valid();
                           });
 }
 
@@ -461,7 +461,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             const auto& aos = kv.second.GetArrayOfStructs();
             for (int k = 0; k < aos.numParticles(); ++k) {
                 const ParticleType& p = aos[k];
-                if (p.id() > 0) {
+                if (p.id().is_valid()) {
                     //
                     // Only count (and checkpoint) valid particles.
                     //
@@ -1465,7 +1465,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             ++iptr;
         }
 
-        AMREX_ASSERT(p.id() > 0);
+        AMREX_ASSERT(p.id().is_valid());
 
         AMREX_D_TERM(p.pos(0) = ParticleReal(rptr[0]);,
                      p.pos(1) = ParticleReal(rptr[1]);,

--- a/Src/Extern/SENSEI/AMReX_ParticleDataAdaptorI.H
+++ b/Src/Extern/SENSEI/AMReX_ParticleDataAdaptorI.H
@@ -589,7 +589,7 @@ int ParticleDataAdaptor<ParticleType, NArrayReal, NArrayInt>::GetMeshMetadata(
         for (long long i = 0; i < numReal; ++i)
         {
           const auto &part = ptd[i];
-          if (part.id() > 0)
+          if (part.id().is_valid())
           {
 #if (AMREX_SPACEDIM == 1)
             bounds[0] = bounds[0] > part.pos(0) ? part.pos(0) : bounds[0];
@@ -690,8 +690,8 @@ svtkPolyData* ParticleDataAdaptor<ParticleType, NArrayReal, NArrayInt>::BuildPar
 
       for (long long i = 0; i < numReal; ++i)
       {
-        const auto& part = make_particle<ParticleType>{}(ptd, i);
-        if (part.id() > 0)
+        const auto& part = ptd[i];
+        if (part.id().is_valid())
         {
           // add a vertex type cell
           vertex->InsertNextCell(1);
@@ -757,10 +757,9 @@ int ParticleDataAdaptor<ParticleType, NArrayReal, NArrayInt>::AddParticlesIDArra
       auto numReal = pti.numParticles();
       for (long long i = 0; i < numReal; ++i)
       {
-        const auto &part = make_particle<ParticleType>{}(ptd, i);
-        if (part.id() > 0)
+        if (ptd.id(i).is_valid())
         {
-          partIds[i] = part.id();
+          partIds[i] = ptd.id(i);
         }
       }
       partIds += numReal;
@@ -801,10 +800,9 @@ int ParticleDataAdaptor<ParticleType, NArrayReal, NArrayInt>::AddParticlesCPUArr
       auto numReal = pti.numParticles();
       for (long long i = 0; i < numReal; ++i)
       {
-        const auto &part = make_particle<ParticleType>{}(ptd, i);
-        if (part.id() > 0)
+        if (ptd.id(i).is_valid())
         {
-          partCpu[i] = part.cpu();
+          partCpu[i] = ptd.cpu(i);
         }
       }
       partCpu += numReal;
@@ -882,7 +880,7 @@ int ParticleDataAdaptor<ParticleType, NArrayReal, NArrayInt>::AddParticlesSOARea
         for (long long i = 0; i < numReal; ++i)
         {
           const auto &part = ptd[i];
-          if (part.id() > 0)
+          if (part.id().is_valid())
           {
             pData[i*nComps + j] = realData[i];
           }
@@ -954,7 +952,7 @@ int ParticleDataAdaptor<ParticleType, NArrayReal, NArrayInt>::AddParticlesSOAInt
       for (long long i = 0; i < numReal; ++i)
       {
         const auto &part = ptd[i];
-        if (part.id() > 0)
+        if (part.id().is_valid())
         {
           pData[i] = intData[i];
         }
@@ -1041,7 +1039,7 @@ int ParticleDataAdaptor<ParticleType, NArrayReal, NArrayInt>::AddParticlesAOSRea
         for (long long i = 0; i < numReal; ++i)
         {
           const auto &part = aos[i];
-          if (part.id() > 0)
+          if (part.id().is_valid())
           {
             pData[i*nComps + j] = part.rdata(indices[j]);
           }
@@ -1114,7 +1112,7 @@ int ParticleDataAdaptor<ParticleType, NArrayReal, NArrayInt>::AddParticlesAOSInt
       for (long long i = 0; i < numReal; ++i)
       {
         const auto &part = aos[i];
-        if (part.id() > 0)
+        if (part.id().is_valid())
         {
           pData[i] = part.idata(index);
         }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1793,7 +1793,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                     arr.push_back(soa.GetIntData(comp)[pindex]);
                                 }
 
-                                p.id().make_invlid(); // Invalidate the particle
+                                p.id().make_invalid(); // Invalidate the particle
                             }
                         }
                         else {
@@ -1821,7 +1821,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                 }
                             }
 
-                            p.id().make_invlid(); // Invalidate the particle
+                            p.id().make_invalid(); // Invalidate the particle
                         }
 
                         if (!p.id().is_valid())
@@ -1916,7 +1916,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                     arr.push_back(soa.GetIntData(comp)[pindex]);
                                 }
 
-                                ptd.id(pindex).make_invlid(); // Invalidate the particle
+                                ptd.id(pindex).make_invalid(); // Invalidate the particle
                             }
                         }
                         else {
@@ -1947,7 +1947,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                     dst += sizeof(int);
                                 }
                             }
-                            ptd.id(pindex).make_invlid(); // Invalidate the particle
+                            ptd.id(pindex).make_invalid(); // Invalidate the particle
                         }
 
                         if (!ptd.id(pindex).is_valid()){

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1740,12 +1740,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                     while (pindex <= last) {
                         ParticleType& p = aos[pindex];
 
-                        if ((remove_negative == false) && (!ptd.id(pindex).is_valid())) {
+                        if ((remove_negative == false) && (!p.id().is_valid())) {
                             ++pindex;
                             continue;
                         }
 
-                        if (!ptd.id(pindex).is_valid())
+                        if (!p.id().is_valid())
                         {
                             aos[pindex] = aos[last];
                             for (int comp = 0; comp < NumRealComps(); comp++) {
@@ -1763,7 +1763,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
                         particlePostLocate(p, pld, lev);
 
-                        if (!ptd.id(pindex).is_valid())
+                        if (!p.id().is_valid())
                         {
                             aos[pindex] = aos[last];
                             for (int comp = 0; comp < NumRealComps(); comp++) {
@@ -1793,7 +1793,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                     arr.push_back(soa.GetIntData(comp)[pindex]);
                                 }
 
-                                ptd.id(pindex).make_invlid(); // Invalidate the particle
+                                p.id().make_invlid(); // Invalidate the particle
                             }
                         }
                         else {
@@ -1821,10 +1821,10 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                 }
                             }
 
-                            ptd.id(pindex).make_invlid(); // Invalidate the particle
+                            p.id().make_invlid(); // Invalidate the particle
                         }
 
-                        if (!ptd.id(pindex).is_valid())
+                        if (!p.id().is_valid())
                         {
                             aos[pindex] = aos[last];
                             for (int comp = 0; comp < NumRealComps(); comp++) {

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -412,9 +412,9 @@ Reset (ParticleType& p,
             amrex::AllPrint()<< "Invalidating out-of-domain particle: " << p << '\n';
         }
 
-        AMREX_ASSERT(p.id() > 0);
+        AMREX_ASSERT(p.id().is_valid());
 
-        p.id() = -p.id();
+        p.id().make_invalid();
     }
 
     return pld;
@@ -454,7 +454,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         if (!success && lev_min == 0)
         {
             // The particle has left the domain; invalidate it.
-            p.id() = -p.id();
+            p.id().make_invalid();
             success = true;
         }
     }
@@ -516,7 +516,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             reduce_op.eval(np, reduce_data,
                            [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
                            {
-                               return (ptd.id(i) > 0) ? 1 : 0;
+                               return (ptd.id(i).is_valid()) ? 1 : 0;
                            });
 
             int np_valid = amrex::get<0>(reduce_data.value(reduce_op));
@@ -566,7 +566,7 @@ Long ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, Cell
             reduce_op.eval(ptile.numParticles(), reduce_data,
                            [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
                            {
-                               return (ptd.id(i) > 0) ? 1 : 0;
+                               return (ptd.id(i).is_valid()) ? 1 : 0;
                            });
         }
 
@@ -715,7 +715,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         [=] AMREX_GPU_DEVICE (const typename ParticleTileType::ConstParticleTileDataType& ptd, int ip,
                               amrex::Array4<amrex::Real> const& count)
         {
-            const auto p = make_particle<ConstParticleType>{}(ptd, ip);
+            const auto p = ptd[ip];
             CellAssignor assignor;
             IntVect iv = assignor(p, plo, dxi, domain);
             amrex::Gpu::Atomic::AddNoRet(&count(iv), 1.0_rt);
@@ -792,7 +792,7 @@ struct FilterVirt
     AMREX_GPU_HOST_DEVICE
     int operator() (const SrcData& src, int src_i) const noexcept
     {
-        auto iv = getParticleCell(src.m_aos[src_i], m_plo, m_dxi, m_domain);
+        auto iv = getParticleCell(src, src_i, m_plo, m_dxi, m_domain);
         return (m_assign_buffer_grid(iv)!=-1);
     }
 };
@@ -806,8 +806,8 @@ struct TransformerVirt
     {
         copyParticle(dst, src, src_i, dst_i);
 
-        (dst.m_aos[dst_i]).id() = LongParticleIds::VirtualParticleID;
-        (dst.m_aos[dst_i]).cpu() = 0;
+        dst.id(dst_i) = LongParticleIds::VirtualParticleID;
+        dst.cpu(dst_i) = 0;
     }
 };
 
@@ -1035,8 +1035,8 @@ struct AssignGridFilter
     AMREX_GPU_HOST_DEVICE
     int operator() (const SrcData& src, int src_i) const noexcept
     {
-        const auto tup_min = (m_assign_grid)(src.m_aos[src_i], m_lev_min, m_lev_max, m_nGrow, DefaultAssignor{});
-        const auto tup_max = (m_assign_grid)(src.m_aos[src_i], m_lev_max, m_lev_max, m_nGrow, DefaultAssignor{});
+        const auto tup_min = (m_assign_grid)(src[src_i], m_lev_min, m_lev_max, m_nGrow, DefaultAssignor{});
+        const auto tup_max = (m_assign_grid)(src[src_i], m_lev_max, m_lev_max, m_nGrow, DefaultAssignor{});
         const auto p_boxes = amrex::get<0>(tup_min);
         const auto p_boxes_max = amrex::get<0>(tup_max);
         const auto p_levs_max  = amrex::get<1>(tup_max);
@@ -1054,8 +1054,8 @@ struct TransformerGhost
     {
         copyParticle(dst, src, src_i, dst_i);
 
-        (dst.m_aos[dst_i]).id() = LongParticleIds::GhostParticleID;
-        (dst.m_aos[dst_i]).cpu() = 0;
+        dst.id(dst_i) = LongParticleIds::GhostParticleID;
+        dst.cpu(dst_i) = 0;
     }
 };
 
@@ -1497,9 +1497,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
             AMREX_FOR_1D ( num_move, i,
             {
-                const auto p = make_particle<ParticleType>{}(ptd,i + num_stay);
+                const auto p = ptd[i + num_stay];
 
-                if (p.id() < 0)
+                if (!p.id().is_valid())
                 {
                     p_boxes[i] = -1;
                     p_levs[i]  = -1;
@@ -1740,12 +1740,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                     while (pindex <= last) {
                         ParticleType& p = aos[pindex];
 
-                        if ((remove_negative == false) && (p.id() < 0)) {
+                        if ((remove_negative == false) && (!ptd.id(pindex).is_valid())) {
                             ++pindex;
                             continue;
                         }
 
-                        if (p.id() < 0)
+                        if (!ptd.id(pindex).is_valid())
                         {
                             aos[pindex] = aos[last];
                             for (int comp = 0; comp < NumRealComps(); comp++) {
@@ -1763,7 +1763,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
                         particlePostLocate(p, pld, lev);
 
-                        if (p.id() < 0)
+                        if (!ptd.id(pindex).is_valid())
                         {
                             aos[pindex] = aos[last];
                             for (int comp = 0; comp < NumRealComps(); comp++) {
@@ -1793,7 +1793,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                     arr.push_back(soa.GetIntData(comp)[pindex]);
                                 }
 
-                                p.id() = -p.id(); // Invalidate the particle
+                                ptd.id(pindex).make_invlid(); // Invalidate the particle
                             }
                         }
                         else {
@@ -1821,10 +1821,10 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                 }
                             }
 
-                            p.id() = -p.id(); // Invalidate the particle
+                            ptd.id(pindex).make_invlid(); // Invalidate the particle
                         }
 
-                        if (p.id() < 0)
+                        if (!ptd.id(pindex).is_valid())
                         {
                             aos[pindex] = aos[last];
                             for (int comp = 0; comp < NumRealComps(); comp++) {
@@ -1860,14 +1860,14 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                     Long pindex = 0;
                     auto ptd = particle_tile->getParticleTileData();
                     while (pindex <= last) {
-                        ParticleType p(ptd,pindex);
+                        ParticleType p = ptd[pindex];
 
-                        if ((remove_negative == false) && (p.id() < 0)) {
+                        if ((remove_negative == false) && (!ptd.id(pindex).is_valid())) {
                             ++pindex;
                             continue;
                         }
 
-                        if (p.id() < 0){
+                        if (!ptd.id(pindex).is_valid()){
                             soa.GetIdCPUData()[pindex] = soa.GetIdCPUData()[last];
                             for (int comp = 0; comp < NumRealComps(); comp++) {
                                 soa.GetRealData(comp)[pindex] = soa.GetRealData(comp)[last];
@@ -1884,7 +1884,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
                         particlePostLocate(p, pld, lev);
 
-                        if (p.id() < 0) {
+                        if (!ptd.id(pindex).is_valid()) {
                             soa.GetIdCPUData()[pindex] = soa.GetIdCPUData()[last];
                             for (int comp = 0; comp < NumRealComps(); comp++) {
                                 soa.GetRealData(comp)[pindex] = soa.GetRealData(comp)[last];
@@ -1916,7 +1916,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                     arr.push_back(soa.GetIntData(comp)[pindex]);
                                 }
 
-                                p.id() = -p.id(); // Invalidate the particle
+                                ptd.id(pindex).make_invlid(); // Invalidate the particle
                             }
                         }
                         else {
@@ -1947,10 +1947,10 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                     dst += sizeof(int);
                                 }
                             }
-                            p.id() = -p.id(); // Invalidate the particle
+                            ptd.id(pindex).make_invlid(); // Invalidate the particle
                         }
 
-                        if (p.id() < 0){
+                        if (!ptd.id(pindex).is_valid()){
                             soa.GetIdCPUData()[pindex] = soa.GetIdCPUData()[last];
                             for (int comp = 0; comp < NumRealComps(); comp++) {
                                 soa.GetRealData(comp)[pindex] = soa.GetRealData(comp)[last];
@@ -2504,7 +2504,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
     if (lev_max == -1) {
         lev_max = finestLevel();
-}
+    }
 
     return (numParticlesOutOfRange(*this, lev_min, lev_max, nGrow) == 0);
 }
@@ -2632,7 +2632,7 @@ AssignCellDensitySingleLevel (int rho_index,
             {
                 AMREX_HOST_DEVICE_FOR_1D( np, i,
                 {
-                    auto p = make_particle<ParticleType>{}(ptd,i);
+                    auto p = ptd[i];
                     amrex_deposit_cic(p, ncomp, rhoarr, plo, dxi);
                 });
             }
@@ -2640,7 +2640,7 @@ AssignCellDensitySingleLevel (int rho_index,
             {
                 AMREX_HOST_DEVICE_FOR_1D( np, i,
                 {
-                    auto p = make_particle<ParticleType>{}(ptd,i);
+                    auto p = ptd[i];
                     amrex_deposit_particle_dx_cic(p, ncomp, rhoarr, plo, dxi, pdxi);
                 });
             }

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -39,7 +39,7 @@ struct FilterPositiveID {
     template <typename P>
     AMREX_GPU_HOST_DEVICE
     int operator() (const P& p) const {
-        return p.id() > 0;
+        return p.id().is_valid();
     }
 };
 
@@ -456,7 +456,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             const auto& aos = kv.second.GetArrayOfStructs();
             for (int k = 0; k < aos.numParticles(); ++k) {
                 const ParticleType& p = aos[k];
-                if (p.id() > 0) {
+                if (p.id().is_valid()) {
                     //
                     // Only count (and checkpoint) valid particles.
                     //
@@ -1009,7 +1009,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             ++iptr;
         }
 
-        AMREX_ASSERT(ptemp.id() > 0);
+        AMREX_ASSERT(ptemp.id().is_valid());
 
         AMREX_D_TERM(ptemp.pos(0) = ParticleReal(rptr[0]);,
                      ptemp.pos(1) = ParticleReal(rptr[1]);,
@@ -1143,7 +1143,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             Gpu::copy(Gpu::deviceToHost, aos.begin(), aos.begin() + np, host_aos.begin());
             for (int k = 0; k < np; ++k) {
                 const ParticleType& p = host_aos[k];
-                if (p.id() > 0) {
+                if (p.id().is_valid()) {
                     //
                     // Only count (and checkpoint) valid particles.
                     //
@@ -1226,7 +1226,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                     auto np = host_aos.numParticles();
                     for (int index = 0; index < np; ++index) {
                         const ParticleType* it = &host_aos[index];
-                        if (it->id() > 0) {
+                        if (it->id().is_valid()) {
 
                             // write out the particle struct first...
                             AMREX_D_TERM(File << it->pos(0) << ' ',

--- a/Src/Particle/AMReX_ParticleReduce.H
+++ b/Src/Particle/AMReX_ParticleReduce.H
@@ -664,21 +664,21 @@ ReduceMin (PC const& pc, int lev_min, int lev_max, F const& f)
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
  *                  {
- *                      return p.id() > 0;
+ *                      return p.id().is_valid();
  *                  });
  *
  *        using SPType  = typename PC::SuperParticleType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
  *                  {
- *                      return p.id() > 0;
+ *                      return p.id().is_valid();
  *                  });
  *
  *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.id(i) > 0;
+ *                      return ptd.id(i).is_valid();
  *                  });
  *
  */
@@ -711,21 +711,21 @@ ReduceLogicalAnd (PC const& pc, F&& f)
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
  *                  {
- *                      return p.id() > 0;
+ *                      return p.id().is_valid();
  *                  });
  *
  *        using SPType  = typename PC::SuperParticleType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
  *                  {
- *                      return p.id() > 0;
+ *                      return p.id().is_valid();
  *                  });
  *
  *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.id(i) > 0;
+ *                      return ptd.id(i).is_valid();
  *                  });
  *
  */
@@ -759,21 +759,21 @@ ReduceLogicalAnd (PC const& pc, int lev, F&& f)
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
  *                  {
- *                      return p.id() > 0;
+ *                      return p.id().is_valid();
  *                  });
  *
  *        using SPType  = typename PC::SuperParticleType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
  *                  {
- *                      return p.id() > 0;
+ *                      return p.id().is_valid();
  *                  });
  *
  *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalAnd(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.id(i) > 0;
+ *                      return ptd.id(i).is_valid();
  *                  });
  *
  */
@@ -862,21 +862,21 @@ ReduceLogicalAnd (PC const& pc, int lev_min, int lev_max, F const& f)
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
  *                  {
- *                      return p.id() < 1;
+ *                      return !p.id().is_valid();
  *                  });
  *
  *        using SPType  = typename PC::SuperParticleType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
  *                  {
- *                      return p.id() < 1;
+ *                      return !p.id().is_valid();
  *                  });
  *
  *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.id(i) < 1;
+ *                      return !ptd.id(i).is_valid();
  *                  });
  *
  */
@@ -909,21 +909,21 @@ ReduceLogicalOr (PC const& pc, F&& f)
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
  *                  {
- *                      return p.id() < 1;
+ *                      return !p.id().is_valid();
  *                  });
  *
  *        using SPType  = typename PC::SuperParticleType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
  *                  {
- *                      return p.id() < 1;
+ *                      return !p.id().is_valid();
  *                  });
  *
  *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.id(i) < 1;
+ *                      return !ptd.id(i).is_valid();
  *                  });
  *
  */
@@ -957,21 +957,21 @@ ReduceLogicalOr (PC const& pc, int lev, F&& f)
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> bool
  *                  {
- *                      return p.id() < 1;
+ *                      return !p.id().is_valid();
  *                  });
  *
  *        using SPType  = typename PC::SuperParticleType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> bool
  *                  {
- *                      return p.id() < 1;
+ *                      return !p.id().is_valid();
  *                  });
  *
  *        using ConstPTDType = typename PC::ConstPTDType;
  *        auto rv = amrex::ReduceLogicalOr(pc,
  *                  [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> bool
  *                  {
- *                      return ptd.id(i) < 1;
+ *                      return !ptd.id(i).is_valid();
  *                  });
  *
  */

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -47,7 +47,7 @@ numParticlesOutOfRange (Iterator const& pti, int nGrow)
  * \param nGrow the number of grow cells allowed.
  *
  */
-template <class Iterator, std::enable_if_t<IsParticleIterator<Iterator>::value && !Iterator::ContainerType::ParticleType::is_soa_particle, int> foo = 0>
+template <class Iterator, std::enable_if_t<IsParticleIterator<Iterator>::value, int> foo = 0>
 int
 numParticlesOutOfRange (Iterator const& pti, IntVect nGrow)
 {
@@ -72,44 +72,8 @@ numParticlesOutOfRange (Iterator const& pti, IntVect nGrow)
     reduce_op.eval(np, reduce_data,
     [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
     {
-        auto p = make_particle<ParticleType>{}(ptd,i);
-        if ((p.id() < 0)) { return false; }
-        using AssignorType = typename Iterator::CellAssignor;
-        AssignorType assignor;
-        IntVect iv = assignor(p, plo, dxi, domain);
-        return !box.contains(iv);
-    });
-    int hv = amrex::get<0>(reduce_data.value(reduce_op));
-    return hv;
-}
-
-template <class Iterator, std::enable_if_t<IsParticleIterator<Iterator>::value && Iterator::ContainerType::ParticleType::is_soa_particle, int> foo = 0>
-int
-numParticlesOutOfRange (Iterator const& pti, IntVect nGrow)
-{
-    using ParticleType = typename Iterator::ContainerType::ConstParticleType;
-
-    const auto& tile = pti.GetParticleTile();
-    const auto tile_data = tile.getConstParticleTileData();
-    const auto np = tile.numParticles();
-    const auto& geom = pti.Geom(pti.GetLevel());
-
-    const auto domain = geom.Domain();
-    const auto plo = geom.ProbLoArray();
-    const auto dxi = geom.InvCellSizeArray();
-
-    Box box = pti.tilebox();
-    box.grow(nGrow);
-
-    ReduceOps<ReduceOpSum> reduce_op;
-    ReduceData<int> reduce_data(reduce_op);
-    using ReduceTuple = typename decltype(reduce_data)::Type;
-
-    reduce_op.eval(np, reduce_data,
-    [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
-    {
-        ParticleType p(tile_data,i);
-        if ((p.id() < 0)) { return false; }
+        auto p = ptd[i];
+        if (!p.id().is_valid()) { return false; }
         using AssignorType = typename Iterator::CellAssignor;
         AssignorType assignor;
         IntVect iv = assignor(p, plo, dxi, domain);
@@ -449,7 +413,7 @@ int getParticleGrid (P const& p, amrex::Array4<int> const& mask,
                      amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi,
                      const Box& domain) noexcept
 {
-    if (p.id() < 0) { return -1; }
+    if (!p.id().is_valid()) { return -1; }
     IntVect iv = getParticleCell(p, plo, dxi, domain);
     return mask(iv);
 }
@@ -870,7 +834,7 @@ void PermutationForDeposition (Gpu::DeviceVector<index_type>& perm, index_type n
     PermutationForDeposition<index_type>(perm, nitems, bx.numPts() * ref_product,
         [=] AMREX_GPU_DEVICE (index_type idx) noexcept
             {
-                const auto p = make_particle<ParticleType>{}(ptd,idx);
+                const auto p = ptd[idx];
 
                 IntVect iv = ((p.pos() - pos_offset) * dxi).round();
 

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -51,8 +51,6 @@ template <class Iterator, std::enable_if_t<IsParticleIterator<Iterator>::value, 
 int
 numParticlesOutOfRange (Iterator const& pti, IntVect nGrow)
 {
-    using ParticleType = typename Iterator::ContainerType::ParticleType;
-
     const auto& tile = pti.GetParticleTile();
     const auto np = tile.numParticles();
     const auto& ptd = tile.getConstParticleTileData();
@@ -830,7 +828,6 @@ void PermutationForDeposition (Gpu::DeviceVector<index_type>& perm, index_type n
     const IntVect ref_offset(AMREX_D_DECL(1, refine_vect[0], refine_vect[0] * refine_vect[1]));
 
     auto ptd = ptile.getConstParticleTileData();
-    using ParticleType = typename PTile::ParticleType::ConstType;
     PermutationForDeposition<index_type>(perm, nitems, bx.numPts() * ref_product,
         [=] AMREX_GPU_DEVICE (index_type idx) noexcept
             {

--- a/Src/Particle/AMReX_TracerParticles.cpp
+++ b/Src/Particle/AMReX_TracerParticles.cpp
@@ -73,7 +73,7 @@ TracerParticleContainer::AdvectWithUmac (MultiFab* umac, int lev, Real dt)
                                [=] AMREX_GPU_DEVICE (int i)
             {
                 ParticleType& p = p_pbox[i];
-                if (p.id() <= 0) { return; }
+                if (!p.id().is_valid()) { return; }
                 ParticleReal v[AMREX_SPACEDIM];
                 mac_interpolate(p, plo, dxi, umacarr, v);
                 if (ipass == 0)
@@ -151,7 +151,7 @@ TracerParticleContainer::AdvectWithUcc (const MultiFab& Ucc, int lev, Real dt)
                                [=] AMREX_GPU_DEVICE (int i)
             {
                 ParticleType& p  = p_pbox[i];
-                if (p.id() <= 0) { return; }
+                if (!p.id().is_valid()) { return; }
                 ParticleReal v[AMREX_SPACEDIM];
 
                 cic_interpolate(p, plo, dxi, uccarr, v);
@@ -298,7 +298,7 @@ TracerParticleContainer::Timestamp (const std::string&      basename,
                     {
                       const ParticleType& p = pbox[k];
 
-                      if (p.id() <= 0) { continue; }
+                      if (!p.id().is_valid()) { continue; }
 
                       const IntVect& iv = Index(p,lev);
 

--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -15,7 +15,7 @@ struct KeepValidFilter
     AMREX_GPU_HOST_DEVICE
     int operator() (const SrcData& src, int i) const noexcept
     {
-        return (src.id(i) > 0);
+        return (src.id(i).is_valid());
     }
 };
 
@@ -804,7 +804,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
             reduce_op.eval(np, reduce_data,
             [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
             {
-                return (ptd.id(i) > 0) ? 1 : 0;
+                return (ptd.id(i).is_valid()) ? 1 : 0;
             });
 
             int np_valid = amrex::get<0>(reduce_data.value(reduce_op));
@@ -1089,7 +1089,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     const auto& ptd = pbox.getConstParticleTileData();
                     for (int pindex = 0; pindex < pbox.numParticles(); ++pindex)
                     {
-                        if (ptd.id(pindex) <= 0) { continue; }
+                        if (!ptd.id(pindex).is_valid()) { continue; }
 
                         particle_detail::iPackParticleData(ptd, pindex, iptr,
                             write_int_comp.dataPtr(), is_checkpoint);
@@ -1116,7 +1116,7 @@ void WriteBinaryParticleDataAsync (PC const& pc,
                     const auto& ptd = pbox.getConstParticleTileData();
                     for (int pindex = 0; pindex < pbox.numParticles(); ++pindex)
                     {
-                        if (ptd.id(pindex) <= 0) { continue; }
+                        if (!ptd.id(pindex).is_valid()) { continue; }
 
                         particle_detail::rPackParticleData(ptd, pindex, rptr,
                             write_real_comp.dataPtr());


### PR DESCRIPTION
## Summary

This PR applies further cleaning to particles.

The largest change is the replacement of all numeric id comparisons with `id().is_valid()` and `id().make_invlid()`. Previously, `id() > 0`, `id() < 0`, `id() < 1` and `id() <= 0` with `id() = - id()` were used, making the treatment of id == 0 inconsistent (particle ids start at 1 because of this).

Both `ptd.m_aos[i]` and `make_particle<ConstParticleType>{}(ptd, ip);` were replaced with `ptd[i]` which is more concise and works with PureSoA particles.

The PureSoA specialization of numParticlesOutOfRange was removed because the other version also works with PureSoA particles.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
