### PR TITLE
`AMREX_ENUM`: Cache String Map

### DIFF
--- a/Src/Base/AMReX_Enum.H
+++ b/Src/Base/AMReX_Enum.H
@@ -52,7 +52,7 @@ namespace amrex
               std::enable_if_t<ET::value,int> = 0>
     T getEnum (std::string_view const& s)
     {
-        static auto const& kv = getEnumNameValuePairs<T>();
+        static auto const kv = getEnumNameValuePairs<T>();
         auto it = std::find_if(kv.begin(), kv.end(),
                                [&] (auto const& x) -> bool
                                    { return x.first == s; });
@@ -71,7 +71,7 @@ namespace amrex
               std::enable_if_t<ET::value,int> = 0>
     T getEnumCaseInsensitive (std::string_view const& s)
     {
-        static auto const& kv = getEnumNameValuePairs<T>();
+        static auto const kv = getEnumNameValuePairs<T>();
         std::string ls = amrex::toLower(std::string(s));
         auto it = std::find_if(kv.begin(), kv.end(),
                                [&] (auto const& x) -> bool
@@ -91,7 +91,7 @@ namespace amrex
               std::enable_if_t<ET::value,int> = 0>
     std::string getEnumNameString (T const& v)
     {
-        static auto const& kv = getEnumNameValuePairs<T>();
+        static auto const kv = getEnumNameValuePairs<T>();
         auto it = std::find_if(kv.begin(), kv.end(),
                                [&] (auto const& x) -> bool
                                    { return x.second == v; });

--- a/Src/Base/AMReX_Enum.H
+++ b/Src/Base/AMReX_Enum.H
@@ -17,9 +17,11 @@ using amrex_enum_traits = decltype(amrex_get_enum_traits(std::declval<T>()));
 
 namespace amrex
 {
+namespace detail
+{
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    std::vector<std::pair<std::string,T>> getEnumNameValuePairs ()
+    std::vector<std::pair<std::string,T>> getNewEnumNameValuePairs ()
     {
         auto tmp = amrex::split(std::string(ET::enum_names), ",");
         std::vector<std::pair<std::string,T>> r;
@@ -47,12 +49,22 @@ namespace amrex
         }
         return r;
     }
+}  // namespace detail
+
+    template <typename T, typename ET = amrex_enum_traits<T>,
+              std::enable_if_t<ET::value,int> = 0>
+    std::vector<std::pair<std::string,T>> getEnumNameValuePairs ()
+    {
+        // cache enum value strings for the whole type T
+        static auto r = detail::getNewEnumNameValuePairs<T>();
+        return r;
+    }
 
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
     T getEnum (std::string_view const& s)
     {
-        static auto const kv = getEnumNameValuePairs<T>();
+        auto const& kv = getEnumNameValuePairs<T>();
         auto it = std::find_if(kv.begin(), kv.end(),
                                [&] (auto const& x) -> bool
                                    { return x.first == s; });
@@ -71,7 +83,7 @@ namespace amrex
               std::enable_if_t<ET::value,int> = 0>
     T getEnumCaseInsensitive (std::string_view const& s)
     {
-        static auto const kv = getEnumNameValuePairs<T>();
+        auto const& kv = getEnumNameValuePairs<T>();
         std::string ls = amrex::toLower(std::string(s));
         auto it = std::find_if(kv.begin(), kv.end(),
                                [&] (auto const& x) -> bool
@@ -91,7 +103,7 @@ namespace amrex
               std::enable_if_t<ET::value,int> = 0>
     std::string getEnumNameString (T const& v)
     {
-        static auto const kv = getEnumNameValuePairs<T>();
+        auto const& kv = getEnumNameValuePairs<T>();
         auto it = std::find_if(kv.begin(), kv.end(),
                                [&] (auto const& x) -> bool
                                    { return x.second == v; });

--- a/Src/Base/AMReX_Enum.H
+++ b/Src/Base/AMReX_Enum.H
@@ -52,7 +52,7 @@ namespace amrex
               std::enable_if_t<ET::value,int> = 0>
     T getEnum (std::string_view const& s)
     {
-        auto const& kv = getEnumNameValuePairs<T>();
+        static auto const& kv = getEnumNameValuePairs<T>();
         auto it = std::find_if(kv.begin(), kv.end(),
                                [&] (auto const& x) -> bool
                                    { return x.first == s; });
@@ -71,7 +71,7 @@ namespace amrex
               std::enable_if_t<ET::value,int> = 0>
     T getEnumCaseInsensitive (std::string_view const& s)
     {
-        auto const& kv = getEnumNameValuePairs<T>();
+        static auto const& kv = getEnumNameValuePairs<T>();
         std::string ls = amrex::toLower(std::string(s));
         auto it = std::find_if(kv.begin(), kv.end(),
                                [&] (auto const& x) -> bool
@@ -91,7 +91,7 @@ namespace amrex
               std::enable_if_t<ET::value,int> = 0>
     std::string getEnumNameString (T const& v)
     {
-        auto const& kv = getEnumNameValuePairs<T>();
+        static auto const& kv = getEnumNameValuePairs<T>();
         auto it = std::find_if(kv.begin(), kv.end(),
                                [&] (auto const& x) -> bool
                                    { return x.second == v; });


### PR DESCRIPTION
## Summary

The `getEnumNameValuePairs` logic used below a lot of `AMREX_ENUM` functions is very slow for long-enough (e.g., N>70) enums.

In WarpX 1D simulations, it took up close to 50% of the runtime, as Dave Grote found.

This caches the key-value string list on first creation, because the type is known at compile-time.

A better implementation might skip the dictionary altogether for functions that just need one string, like `getEnumNameString`.

## Additional background

https://github.com/BLAST-WarpX/warpx/pull/6139

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
