### PR TITLE
[WIP] OpenBC SIMD

### DIFF
--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -341,7 +341,28 @@ void ParallelForOMP (T n, L const& f) noexcept
 template <typename L>
 void ParallelForOMP (Box const& box, L const& f) noexcept
 {
-    ParallelFor(box, f);
+    constexpr int WIDTH = amrex::simd::native_simd_size_real;
+    if constexpr (std::is_invocable_v<L const&, SIMDindex<WIDTH, int>, int, int>) {
+        // CPU + SIMD without OpenMP threading: serial SIMD-chunked loop along
+        // the contiguous i-direction, with a scalar (width 1) remainder.
+        // (On GPU AMREX_USE_SIMD is off, so no kernel is SIMD-invocable and
+        //  this branch is never instantiated; the #else forwards to ParallelFor.)
+        auto lo = amrex::lbound(box);
+        auto hi = amrex::ubound(box);
+        for         (int k = lo.z; k <= hi.z; ++k) {
+            for     (int j = lo.y; j <= hi.y; ++j) {
+                int i = lo.x;
+                for (; i + WIDTH <= hi.x + 1; i += WIDTH) {
+                    f(SIMDindex<WIDTH, int>{i}, j, k);
+                }
+                for (; i <= hi.x; ++i) {
+                    f(SIMDindex<1, int>{i}, j, k);
+                }
+            }
+        }
+    } else {
+        ParallelFor(box, f);
+    }
 }
 
 /**
@@ -376,31 +397,75 @@ void ParallelForOMP (Box const& box, L const& f) noexcept
 {
     auto lo = amrex::lbound(box);
     auto hi = amrex::ubound(box);
+
+    // Dispatch: a SIMD-aware kernel takes an amrex::SIMDindex<WIDTH> as its
+    // running index (instead of a plain int) and is processed in SIMD-width
+    // chunks along the contiguous i-direction, with a scalar (width 1)
+    // remainder. All other (scalar) kernels keep the original (int,int,int)
+    // contract. The decision is made at compile time, so unrelated scalar
+    // callers are unaffected.
+    constexpr int WIDTH = amrex::simd::native_simd_size_real;
+    constexpr bool simd_invocable =
+        std::is_invocable_v<L const&, SIMDindex<WIDTH, int>, int, int>;
+
 #if (AMREX_SPACEDIM == 1)
+    if constexpr (simd_invocable) {
+        int i = lo.x;
+        for (; i + WIDTH <= hi.x + 1; i += WIDTH) {
+            f(SIMDindex<WIDTH, int>{i}, 0, 0);
+        }
+        for (; i <= hi.x; ++i) {
+            f(SIMDindex<1, int>{i}, 0, 0);
+        }
+    } else {
 #pragma omp parallel for
-    for (int i = lo.x; i <= hi.x; ++i) {
-        f(i,0,0);
+        for (int i = lo.x; i <= hi.x; ++i) {
+            f(i,0,0);
+        }
     }
 #elif (AMREX_SPACEDIM == 2)
+    if constexpr (simd_invocable) {
 #pragma omp parallel for
-    for     (int j = lo.y; j <= hi.y; ++j) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            f(i,j,0);
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            int i = lo.x;
+            for (; i + WIDTH <= hi.x + 1; i += WIDTH) {
+                f(SIMDindex<WIDTH, int>{i}, j, 0);
+            }
+            for (; i <= hi.x; ++i) {
+                f(SIMDindex<1, int>{i}, j, 0);
+            }
+        }
+    } else {
+#pragma omp parallel for
+        for     (int j = lo.y; j <= hi.y; ++j) {
+            AMREX_PRAGMA_SIMD
+            for (int i = lo.x; i <= hi.x; ++i) {
+                f(i,j,0);
+            }
         }
     }
 #else
+    if constexpr (simd_invocable) {
 #pragma omp parallel for collapse(2)
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            constexpr int WIDTH = amrex::simd::native_simd_size_real;
-            int i = lo.x;
-            for (; i + WIDTH <= hi.x; i+=WIDTH) {
-                f(SIMDindex<WIDTH, int>{i}, j, k);
+        for         (int k = lo.z; k <= hi.z; ++k) {
+            for     (int j = lo.y; j <= hi.y; ++j) {
+                int i = lo.x;
+                for (; i + WIDTH <= hi.x + 1; i += WIDTH) {
+                    f(SIMDindex<WIDTH, int>{i}, j, k);
+                }
+                for (; i <= hi.x; ++i) {
+                    f(SIMDindex<1, int>{i}, j, k);
+                }
             }
-            for (; i <= hi.x; ++i) {
-                // TODO: template, etc.
-                f(SIMDindex<1, int>{i}, j, k);
+        }
+    } else {
+#pragma omp parallel for collapse(2)
+        for         (int k = lo.z; k <= hi.z; ++k) {
+            for     (int j = lo.y; j <= hi.y; ++j) {
+                AMREX_PRAGMA_SIMD
+                for (int i = lo.x; i <= hi.x; ++i) {
+                    f(i,j,k);
+                }
             }
         }
     }

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -393,9 +393,14 @@ void ParallelForOMP (Box const& box, L const& f) noexcept
 #pragma omp parallel for collapse(2)
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
-            AMREX_PRAGMA_SIMD
-            for (int i = lo.x; i <= hi.x; ++i) {
-                f(i,j,k);
+            constexpr int WIDTH = amrex::simd::native_simd_size_real;
+            int i = lo.x;
+            for (; i + WIDTH <= hi.x; i+=WIDTH) {
+                f(SIMDindex<WIDTH, int>{i}, j, k);
+            }
+            for (; i <= hi.x; ++i) {
+                // TODO: template, etc.
+                //f(SIMDindex<1, int>{i}, j, k);
             }
         }
     }

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -400,7 +400,7 @@ void ParallelForOMP (Box const& box, L const& f) noexcept
             }
             for (; i <= hi.x; ++i) {
                 // TODO: template, etc.
-                //f(SIMDindex<1, int>{i}, j, k);
+                f(SIMDindex<1, int>{i}, j, k);
             }
         }
     }

--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -2,28 +2,9 @@
 #define AMREX_GPU_LAUNCH_FUNCTS_C_H_
 #include <AMReX_Config.H>
 
-#include <AMReX_SIMD.H>
-
 namespace amrex {
 
-/** Helper type to store/access the SIMD width in ParallelForSIMD lambdas
- *
- * Use instead of int as the running index i. Used to pass the
- * SIMD WIDTH as compile-time meta-data into a called function/method.
- *
- * @tparam WIDTH SIMD width in elements
- * @tparam N index type (integer)
- */
-template<int WIDTH=simd::native_simd_size_real, class N=int>
-struct SIMDindex
-{
-    /** SIMD width in elements */
-    static constexpr int width = WIDTH;
-
-    /** The linear loop index of ParallelFor(SIMD) */
-    N index = 0;
-};
-
+/// \cond DOXYGEN_IGNORE
 namespace detail {
 
     // call_f_scalar_handler

--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -2,9 +2,28 @@
 #define AMREX_GPU_LAUNCH_FUNCTS_C_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_SIMD.H>
+
 namespace amrex {
 
-/// \cond DOXYGEN_IGNORE
+/** Helper type to store/access the SIMD width in ParallelForSIMD lambdas
+ *
+ * Use instead of int as the running index i. Used to pass the
+ * SIMD WIDTH as compile-time meta-data into a called function/method.
+ *
+ * @tparam WIDTH SIMD width in elements
+ * @tparam N index type (integer)
+ */
+template<int WIDTH=simd::native_simd_size_real, class N=int>
+struct SIMDindex
+{
+    /** SIMD width in elements */
+    static constexpr int width = WIDTH;
+
+    /** The linear loop index of ParallelFor(SIMD) */
+    N index = 0;
+};
+
 namespace detail {
 
     // call_f_scalar_handler

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -11,6 +11,7 @@
 #   include <vir/simd.h>  // includes SIMD TS2 header <experimental/simd>
 #   if __cplusplus >= 202002L
 #       include <vir/simd_cvt.h>
+#       include <vir/simd_iota.h>
 #   endif
 #endif
 
@@ -27,6 +28,7 @@ namespace amrex::simd
         using namespace vir::stdx;
 #   if __cplusplus >= 202002L
         using vir::cvt;
+        using vir::iota_v;
 #   endif
 
         /** Vectorized ternary operator: select(mask, true_val, false_val)

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -180,6 +180,56 @@ namespace amrex::simd
     using SIMDIdCpu = std::uint64_t;
 #endif
 
+    /** Number of SIMD lanes represented by a type
+     *
+     * Returns 1 for a scalar arithmetic type (int, amrex::Real, ...) and the
+     * SIMD width for a stdx::simd type. Use to deduce the SIMD width from a
+     * kernel's index argument type, e.g. for kernels that may be called with
+     * either a scalar int (GPU / non-SIMD CPU) or a SIMD int register (CPU
+     * with SIMD).
+     *
+     * @tparam T a scalar arithmetic type or a stdx::simd type
+     */
+    template <typename T>
+    struct lane_count : std::integral_constant<int, 1> {};
+
+#ifdef AMREX_USE_SIMD
+    template <typename U, typename Abi>
+    struct lane_count<stdx::simd<U, Abi>>
+        : std::integral_constant<int, static_cast<int>(stdx::simd<U, Abi>::size())> {};
+#endif
+
+    template <typename T>
+    inline constexpr int lane_count_v = lane_count<std::decay_t<T>>::value;
+
+    /** Build a real value (SIMD register or scalar) from an integer index
+     *
+     * For a scalar integer idx this returns ST(idx). For a SIMD integer
+     * register it returns a static_simd_cast to the SIMD real type ST. This
+     * mirrors the dual scalar/SIMD calling convention of SIMD-capable grid
+     * kernels, where the index argument is either a scalar int (GPU / non-SIMD
+     * CPU) or a SIMD int register (CPU with SIMD).
+     *
+     * @tparam ST the target real type: amrex::Real or a SIMDReal<WIDTH>
+     * @tparam Idx the index type: an integer or a stdx::simd integer
+     * @param idx the integer index (scalar or SIMD)
+     * @return the index value converted to the real type ST
+     */
+    template <typename ST, typename Idx>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    ST index_to_real (Idx const& idx)
+    {
+        if constexpr (std::is_arithmetic_v<Idx>) {
+            return static_cast<ST>(idx);
+        } else {
+#ifdef AMREX_USE_SIMD
+            return stdx::static_simd_cast<ST>(idx);
+#else
+            return static_cast<ST>(idx);
+#endif
+        }
+    }
+
     /// \cond DOXYGEN_IGNORE
     namespace detail {
         struct InternalVectorized {};

--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -176,10 +176,10 @@ void OpenBCSolver<T>::setGreensFunction (F const& greens_function)
         }
         AMREX_ASSERT(nimages[0] == 2);
         box.shift(-lo);
-        amrex::ParallelForOMP(box, [=] AMREX_GPU_DEVICE (amrex::SIMDindex<> i, int j, int k)
+        amrex::ParallelForOMP(box, [=]<int WIDTH> AMREX_GPU_DEVICE (amrex::SIMDindex<WIDTH> i, int j, int k)
         {
             using SIMD_T = simd::stdx::fixed_size_simd<T, i.width>;
-            using SIMD_int = simd::stdx::rebind_simd_t<int, SIMD_T>;
+            using SIMD_int = simd::stdx::fixed_size_simd<int, i.width>; // simd::stdx::rebind_simd_t<int, SIMD_T>;
 
             SIMD_T G = 0;
             if (j != len[1] && k != len[2])
@@ -190,7 +190,7 @@ void OpenBCSolver<T>::setGreensFunction (F const& greens_function)
 
                 auto const i_bound = ii == len[0];
                 simd::stdx::where(simd::stdx::cvt(i_bound), G) = 0.0;
-                simd::stdx::where(simd::stdx::cvt(!i_bound), G) = greens_function(ii+lo3.x,jj+lo3.y,kk+lo3.z);
+                simd::stdx::where(simd::stdx::cvt(!i_bound), G) = greens_function.template operator()<WIDTH>(ii+lo3.x,jj+lo3.y,kk+lo3.z);
             }
 
             for (int koff = 0; koff < nimages[2]; ++koff) {

--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -176,17 +176,23 @@ void OpenBCSolver<T>::setGreensFunction (F const& greens_function)
         }
         AMREX_ASSERT(nimages[0] == 2);
         box.shift(-lo);
-        amrex::ParallelForOMP(box, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        amrex::ParallelForOMP(box, [=] AMREX_GPU_DEVICE (amrex::SIMDindex<> i, int j, int k)
         {
-            T G;
-            if (i == len[0] || j == len[1] || k == len[2]) {
-                G = 0;
-            } else {
-                auto ii = i;
+            using SIMD_T = simd::stdx::fixed_size_simd<T, i.width>;
+            using SIMD_int = simd::stdx::rebind_simd_t<int, SIMD_T>;
+
+            SIMD_T G = 0;
+            if (j != len[1] && k != len[2])
+            {
+                SIMD_int ii = simd::stdx::iota_v<SIMD_int> + i.index;
                 auto jj = (j > len[1]) ? 2*len[1]-j : j;
                 auto kk = (k > len[2]) ? 2*len[2]-k : k;
-                G = greens_function(ii+lo3.x,jj+lo3.y,kk+lo3.z);
+
+                auto const i_bound = ii == len[0];
+                simd::stdx::where(simd::stdx::cvt(i_bound), G) = 0.0;
+                simd::stdx::where(simd::stdx::cvt(!i_bound), G) = greens_function(ii+lo3.x,jj+lo3.y,kk+lo3.z);
             }
+
             for (int koff = 0; koff < nimages[2]; ++koff) {
                 int k2 = (koff == 0) ?  k : 2*len[2]-k;
                 if ((k2 == 2*len[2]) || (koff == 1 && k == len[2])) {
@@ -198,11 +204,14 @@ void OpenBCSolver<T>::setGreensFunction (F const& greens_function)
                         continue;
                     }
                     for (int ioff = 0; ioff < nimages[0]; ++ioff) {
-                        int i2 = (ioff == 0) ?  i : 2*len[0]-i;
-                        if ((i2 == 2*len[0]) || (ioff == 1 && i == len[0])) {
-                            continue;
+                        for (int iw = i.index; iw < i.index+i.width; ++iw) {
+                            int i2 = (ioff == 0) ?  iw : 2*len[0]-iw;
+                            if ((i2 == 2*len[0]) || (ioff == 1 && iw == len[0])) {
+                                continue;
+                            }
+                            // TODO: SIMD-assign N values
+                            a(i2+lo3.x,j2+lo3.y,k2+lo3.z) = G[iw];
                         }
-                        a(i2+lo3.x,j2+lo3.y,k2+lo3.z) = G;
                     }
                 }
             }

--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -2,6 +2,10 @@
 #define AMREX_FFT_OPENBC_SOLVER_H_
 
 #include <AMReX_FFT_R2C.H>
+#include <AMReX_GpuLaunch.H>
+#include <AMReX_SIMD.H>
+
+#include <type_traits>
 
 namespace amrex::FFT
 {
@@ -176,46 +180,97 @@ void OpenBCSolver<T>::setGreensFunction (F const& greens_function)
         }
         AMREX_ASSERT(nimages[0] == 2);
         box.shift(-lo);
-        amrex::ParallelForOMP(box, [=]<int WIDTH> AMREX_GPU_DEVICE (amrex::SIMDindex<WIDTH> i, int j, int k)
+#ifdef AMREX_USE_SIMD
+        // A SIMD-capable Green's function can be evaluated on a whole vector of
+        // i-indices at once. We detect this by checking whether it is callable
+        // with a SIMD integer register; scalar Green's functions (e.g. the one
+        // in PoissonOpenBC) take the scalar path in the #else branch below.
+        if constexpr (std::is_invocable_v<F const&,
+            simd::stdx::fixed_size_simd<int, simd::native_simd_size_real>, int, int>)
         {
-            using SIMD_T = simd::stdx::fixed_size_simd<T, i.width>;
-            using SIMD_int = simd::stdx::fixed_size_simd<int, i.width>; // simd::stdx::rebind_simd_t<int, SIMD_T>;
-
-            SIMD_T G = 0;
-            if (j != len[1] && k != len[2])
+            amrex::ParallelForOMP(box, [=]<int WIDTH> AMREX_GPU_DEVICE (amrex::SIMDindex<WIDTH> i, int j, int k)
             {
-                SIMD_int ii = simd::stdx::iota_v<SIMD_int> + i.index;
-                auto jj = (j > len[1]) ? 2*len[1]-j : j;
-                auto kk = (k > len[2]) ? 2*len[2]-k : k;
+                using SIMD_T   = simd::stdx::fixed_size_simd<T, WIDTH>;
+                using SIMD_int = simd::stdx::fixed_size_simd<int, WIDTH>;
 
-                auto const i_bound = ii == len[0];
-                simd::stdx::where(simd::stdx::cvt(i_bound), G) = 0.0;
-                simd::stdx::where(simd::stdx::cvt(!i_bound), G) = greens_function.template operator()<WIDTH>(ii+lo3.x,jj+lo3.y,kk+lo3.z);
-            }
+                // The fill mirrors the scalar version below, but evaluates G on
+                // the WIDTH lanes [i.index, i.index+WIDTH) at once.
+                SIMD_T G = 0;
+                if (j != len[1] && k != len[2])
+                {
+                    SIMD_int const ii = simd::stdx::iota_v<SIMD_int> + i.index;
+                    auto const jj = (j > len[1]) ? 2*len[1]-j : j;
+                    auto const kk = (k > len[2]) ? 2*len[2]-k : k;
 
-            for (int koff = 0; koff < nimages[2]; ++koff) {
-                int k2 = (koff == 0) ?  k : 2*len[2]-k;
-                if ((k2 == 2*len[2]) || (koff == 1 && k == len[2])) {
-                    continue;
+                    // lanes on the i-boundary (ii == len[0]) stay zero
+                    auto const i_interior = ii != len[0];
+                    simd::stdx::where(simd::stdx::cvt(i_interior), G) =
+                        greens_function(ii+lo3.x, jj+lo3.y, kk+lo3.z);
                 }
-                for (int joff = 0; joff < nimages[1]; ++joff) {
-                    int j2 = (joff == 0) ?  j : 2*len[1]-j;
-                    if ((j2 == 2*len[1]) || (joff == 1 && j == len[1])) {
+
+                for (int koff = 0; koff < nimages[2]; ++koff) {
+                    int k2 = (koff == 0) ?  k : 2*len[2]-k;
+                    if ((k2 == 2*len[2]) || (koff == 1 && k == len[2])) {
                         continue;
                     }
-                    for (int ioff = 0; ioff < nimages[0]; ++ioff) {
-                        for (int iw = i.index; iw < i.index+i.width; ++iw) {
-                            int i2 = (ioff == 0) ?  iw : 2*len[0]-iw;
-                            if ((i2 == 2*len[0]) || (ioff == 1 && iw == len[0])) {
-                                continue;
+                    for (int joff = 0; joff < nimages[1]; ++joff) {
+                        int j2 = (joff == 0) ?  j : 2*len[1]-j;
+                        if ((j2 == 2*len[1]) || (joff == 1 && j == len[1])) {
+                            continue;
+                        }
+                        for (int ioff = 0; ioff < nimages[0]; ++ioff) {
+                            // the i-mirror image and boundary skips are per
+                            // lane, so scatter the WIDTH lanes individually
+                            // (lane index iw in [0, WIDTH), global i = i.index+iw)
+                            for (int iw = 0; iw < WIDTH; ++iw) {
+                                int const il = i.index + iw;
+                                int i2 = (ioff == 0) ?  il : 2*len[0]-il;
+                                if ((i2 == 2*len[0]) || (ioff == 1 && il == len[0])) {
+                                    continue;
+                                }
+                                a(i2+lo3.x,j2+lo3.y,k2+lo3.z) = G[iw];
                             }
-                            // TODO: SIMD-assign N values
-                            a(i2+lo3.x,j2+lo3.y,k2+lo3.z) = G[iw];
                         }
                     }
                 }
-            }
-        });
+            });
+        }
+        else
+#endif
+        {
+            // scalar Green's function fill (also used on GPU and non-SIMD CPU)
+            amrex::ParallelForOMP(box, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                T G;
+                if (i == len[0] || j == len[1] || k == len[2]) {
+                    G = 0;
+                } else {
+                    auto ii = i;
+                    auto jj = (j > len[1]) ? 2*len[1]-j : j;
+                    auto kk = (k > len[2]) ? 2*len[2]-k : k;
+                    G = greens_function(ii+lo3.x,jj+lo3.y,kk+lo3.z);
+                }
+                for (int koff = 0; koff < nimages[2]; ++koff) {
+                    int k2 = (koff == 0) ?  k : 2*len[2]-k;
+                    if ((k2 == 2*len[2]) || (koff == 1 && k == len[2])) {
+                        continue;
+                    }
+                    for (int joff = 0; joff < nimages[1]; ++joff) {
+                        int j2 = (joff == 0) ?  j : 2*len[1]-j;
+                        if ((j2 == 2*len[1]) || (joff == 1 && j == len[1])) {
+                            continue;
+                        }
+                        for (int ioff = 0; ioff < nimages[0]; ++ioff) {
+                            int i2 = (ioff == 0) ?  i : 2*len[0]-i;
+                            if ((i2 == 2*len[0]) || (ioff == 1 && i == len[0])) {
+                                continue;
+                            }
+                            a(i2+lo3.x,j2+lo3.y,k2+lo3.z) = G;
+                        }
+                    }
+                }
+            });
+        }
     }
 
     if (m_info.twod_mode) {


### PR DESCRIPTION
## Summary

Enable SIMD acceleration (CPU) in `OpenBCSolver<T>::setGreensFunction`.

- [ ] debug
- [ ] generalize

## Additional background

See https://github.com/BLAST-WarpX/warpx/issues/6090

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
