### PR TITLE
Print out hypre version

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -746,15 +746,15 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 
         if (system::verbose > 0) {
 #if defined(HYPRE_DEVELOP_STRING) && defined(HYPRE_BRANCH_NAME)
-      amrex::Print() << "HYPRE (" << HYPRE_DEVELOP_STRING
-                     << " - " << HYPRE_BRANCH_NAME
-                     << " branch) initialized" << '\n';
+            amrex::Print() << "HYPRE (" << HYPRE_DEVELOP_STRING
+                           << " - " << HYPRE_BRANCH_NAME
+                           << " branch) initialized" << '\n';
 
 #elif defined(HYPRE_DEVELOP_STRING) && !defined(HYPRE_BRANCH_NAME)
-      amrex::Print() << "HYPRE (" << HYPRE_DEVELOP_STRING << ") initialized" << '\n';
+            amrex::Print() << "HYPRE (" << HYPRE_DEVELOP_STRING << ") initialized" << '\n';
 
 #elif defined(HYPRE_RELEASE_VERSION)
-      amrex::Print() << "HYPRE (" << HYPRE_RELEASE_VERSION << ") initialized" << '\n';
+            amrex::Print() << "HYPRE (" << HYPRE_RELEASE_VERSION << ") initialized" << '\n';
 #endif
         }
     }

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -744,6 +744,19 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
 #endif
 #endif
 
+        if (system::verbose > 0) {
+#if defined(HYPRE_DEVELOP_STRING) && defined(HYPRE_BRANCH_NAME)
+      amrex::Print() << "HYPRE (" << HYPRE_DEVELOP_STRING
+                     << " - " << HYPRE_BRANCH_NAME
+                     << " branch) initialized" << '\n';
+
+#elif defined(HYPRE_DEVELOP_STRING) && !defined(HYPRE_BRANCH_NAME)
+      amrex::Print() << "HYPRE (" << HYPRE_DEVELOP_STRING << ") initialized" << '\n';
+
+#elif defined(HYPRE_RELEASE_VERSION)
+      amrex::Print() << "HYPRE (" << HYPRE_RELEASE_VERSION << ") initialized" << '\n';
+#endif
+        }
     }
 #endif
 


### PR DESCRIPTION
## Summary

Prints out hypre version or git hash when available

## Additional background

Example:
```
$ mpirun -np 1 ./main3d.gnu.MPI.ex inputs-mlhypre
Initializing AMReX (82eeea53e3f0-dirty)...
MPI initialized with 1 MPI processes
MPI initialized with thread support level 0
HYPRE (v2.33.0-968-g44a173a95 - hypre-3.0 branch) initialized
AMReX (82eeea53e3f0-dirty) initialized

13 Hypre SS BoomerAMG Iterations, Relative Residual 3.028044427e-11
Level 0 max-norm error: 0.06546922279 1-norm error: 0.01697997329 2-norm error: 0.02351729526
Level 1 max-norm error: 0.04195654994 1-norm error: 0.0008741679547 2-norm error: 0.003988995123
AMReX (82eeea53e3f0-dirty) finalized
```

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
