### PR TITLE
ParmParse: Add prettyPrintUsedInputs and prettyPrintUnusedInputs

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1654,9 +1654,17 @@ public:
     //! Write the contents of the table in ASCII to the ostream.
     static void dumpTable (std::ostream& os, bool prettyPrint = false);
 
-    //! Write the table in a pretty way to the ostream. If there are
+    //! Write all entried in the table in a pretty way to the ostream. If there are
     //! duplicates, only the last one is printed.
     static void prettyPrintTable (std::ostream& os);
+
+    //! Write unused inputs in a pretty way to the ostream. If there are
+    //! duplicates, only the last one is printed.
+    static void prettyPrintUnusedInputs (std::ostream& os);
+
+    //! Write used inputs in a pretty way to the ostream. If there are
+    //! duplicates, only the last one is printed.
+    static void prettyPrintUsedInputs (std::ostream& os);
 
     //! Add keys and values from a file to the end of the PP table.
     static void addfile (std::string const& filename);

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1654,7 +1654,7 @@ public:
     //! Write the contents of the table in ASCII to the ostream.
     static void dumpTable (std::ostream& os, bool prettyPrint = false);
 
-    //! Write all entried in the table in a pretty way to the ostream. If there are
+    //! Write all entries in the table in a pretty way to the ostream. If there are
     //! duplicates, only the last one is printed.
     static void prettyPrintTable (std::ostream& os);
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1294,13 +1294,24 @@ ParmParse::dumpTable (std::ostream& os, bool prettyPrint)
     }
 }
 
-void
-ParmParse::prettyPrintTable (std::ostream& os)
+namespace {
+
+enum class PPFlag { all, unused, used };
+
+void pretty_print_table (std::ostream& os, PPFlag pp_flag)
 {
     std::vector<std::string> sorted_names;
     sorted_names.reserve(g_table.size());
     for (auto const& [name, entry] : g_table) {
-        sorted_names.push_back(name);
+        bool to_print;
+        if (pp_flag == PPFlag::used) {
+            to_print = (entry.m_count > 0);
+        } else if (pp_flag == PPFlag::unused) {
+            to_print = (entry.m_count == 0);
+        } else {
+            to_print = true;
+        }
+        if (to_print) { sorted_names.push_back(name); }
     }
     std::sort(sorted_names.begin(), sorted_names.end());
 
@@ -1318,6 +1329,26 @@ ParmParse::prettyPrintTable (std::ostream& os)
             }
         }
     }
+}
+
+}
+
+void
+ParmParse::prettyPrintTable (std::ostream& os)
+{
+    pretty_print_table(os, PPFlag::all);
+}
+
+void
+ParmParse::prettyPrintUnusedInputs (std::ostream& os)
+{
+    pretty_print_table(os, PPFlag::unused);
+}
+
+void
+ParmParse::prettyPrintUsedInputs (std::ostream& os)
+{
+    pretty_print_table(os, PPFlag::used);
 }
 
 int


### PR DESCRIPTION
Add two new functions to ParmParse. The existing function prettyPrintTable prints all entries. We can now use prettyPrintUsedInputs to print used inputs, and use prettyPrintUnusedInputs to print unused inputs.
