### PR TITLE
add dummy argument to CreateLike for particlecontainers to match the …

### DIFF
--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -22,7 +22,7 @@ template<class T>
 struct IntegratorOps<T, std::enable_if_t<std::is_base_of_v<amrex::ParticleContainerBase, T> > >
 {
 
-    static void CreateLike (amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool dummy = false)
+  static void CreateLike (amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool /*dummy*/ = false)
     {
         // Emplace a new T in V with the same size as Other and get a reference
         V.emplace_back(std::make_unique<T>(Other.Geom(0), Other.ParticleDistributionMap(0), Other.ParticleBoxArray(0)));

--- a/Src/Base/AMReX_IntegratorBase.H
+++ b/Src/Base/AMReX_IntegratorBase.H
@@ -22,7 +22,7 @@ template<class T>
 struct IntegratorOps<T, std::enable_if_t<std::is_base_of_v<amrex::ParticleContainerBase, T> > >
 {
 
-    static void CreateLike (amrex::Vector<std::unique_ptr<T> >& V, const T& Other)
+    static void CreateLike (amrex::Vector<std::unique_ptr<T> >& V, const T& Other, bool dummy = false)
     {
         // Emplace a new T in V with the same size as Other and get a reference
         V.emplace_back(std::make_unique<T>(Other.Geom(0), Other.ParticleDistributionMap(0), Other.ParticleBoxArray(0)));


### PR DESCRIPTION
…signature for multifabs

## Summary
Modify the CreateLike function in IntegratorBase so all template specializations have the same function signature.

## Additional background
Used in initialize_stages called in, for example RKIntegrator.
Addresses #4656 I think.

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
