### PR TITLE
HIP CI: Switch to 7.0 in two tests

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v5
     - name: Dependencies
       run: |
-        .github/workflows/dependencies/dependencies_hip.sh 6.3.2
+        .github/workflows/dependencies/dependencies_hip.sh 7.0
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v4
@@ -165,7 +165,7 @@ jobs:
     - uses: actions/checkout@v5
     - name: Dependencies
       run: |
-        .github/workflows/dependencies/dependencies_hip.sh
+        .github/workflows/dependencies/dependencies_hip.sh 7.0
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v4

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -59,7 +59,7 @@ namespace {
 }
 #endif
 
-#ifdef AMREX_USE_HIP
+#if defined(AMREX_USE_HIP) && defined(HIP_VERSION_MAJOR) && (HIP_VERSION_MAJOR <= 6)
 namespace {
     __host__ __device__ void amrex_check_wavefront_size () {
 #ifdef __HIP_DEVICE_COMPILE__
@@ -363,7 +363,7 @@ Device::Initialize (bool minimal)
     nvtxRangePop();
 #endif
 
-#if defined(AMREX_USE_HIP)
+#if defined(AMREX_USE_HIP) && defined(HIP_VERSION_MAJOR) && (HIP_VERSION_MAJOR <= 6)
     if (num_devices_used < 0) {
         // This test is always false, but it makes the compiler no longer
         // complain about unused function, amrex_check_wavefront_size.

--- a/Src/Base/AMReX_parmparse_mod.F90
+++ b/Src/Base/AMReX_parmparse_mod.F90
@@ -20,13 +20,8 @@ module amrex_parmparse_module
      generic :: assignment(=) => amrex_parmparse_assign  ! shallow copy
      generic :: get           => get_int, get_real, get_logical, get_string
      generic :: query         => query_int, query_real, query_logical, query_string
-#if defined(__GFORTRAN__) && (__GNUC__ <= 4)
-     generic :: getarr        => get_intarr, get_realarr
-     generic :: queryarr      => query_intarr, query_realarr
-#else
      generic :: getarr        => get_intarr, get_realarr, get_stringarr
      generic :: queryarr      => query_intarr, query_realarr, query_stringarr
-#endif
      generic :: add           => add_int, add_real, add_logical, add_string
      generic :: addarr        => add_intarr, add_realarr, add_stringarr
      procedure, private :: amrex_parmparse_assign
@@ -51,9 +46,7 @@ module amrex_parmparse_module
      procedure, private :: add_intarr
      procedure, private :: add_realarr
      procedure, private :: add_stringarr
-#if (!defined(__GFORTRAN__) || (__GNUC__ > 4)) && (!defined(__ibmxl__))
      final :: amrex_parmparse_destroy
-#endif
   end type amrex_parmparse
 
   ! interfaces to cpp functions

--- a/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_mod.F90
@@ -35,9 +35,7 @@ module amrex_flash_fluxregister_module
      procedure, private :: amrex_flash_fluxregister_store
      procedure, private :: amrex_flash_fluxregister_store_area
      procedure, private :: amrex_flash_fluxregister_store_area_ifd
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_flash_fluxregister_destroy
-#endif
   end type amrex_flash_fluxregister
 
   interface

--- a/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
@@ -26,9 +26,7 @@ module amrex_fluxregister_module
      procedure, private :: amrex_fluxregister_assign
      procedure, private :: amrex_fluxregister_fineadd
      procedure, private :: amrex_fluxregister_fineadd_1fab
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_fluxregister_destroy
-#endif
   end type amrex_fluxregister
 
   interface

--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -32,9 +32,7 @@ module amrex_boxarray_module
      procedure, private :: amrex_boxarray_maxsize_int3
      procedure, private :: amrex_boxarray_maxsize_iv
      procedure, private :: amrex_boxarray_intersects_box
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_boxarray_destroy
-#endif
   end type amrex_boxarray
 
   interface operator(==)

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -21,9 +21,7 @@ module amrex_distromap_module
      procedure :: get_pmap      => amrex_distromap_get_pmap ! fill caller-owned array of PEs
      procedure, private :: amrex_distromap_assign
      procedure, private :: amrex_distromap_install
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_distromap_destroy
-#endif
   end type amrex_distromap
 
   interface operator(==)

--- a/Src/F_Interfaces/Base/AMReX_fab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_fab_mod.F90
@@ -32,9 +32,7 @@ module amrex_fab_module
      procedure, private :: amrex_fab_resize
      procedure, private :: amrex_fab_norminf
      procedure, private :: amrex_fab_reset_omp_private
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_fab_destroy
-#endif
   end type amrex_fab
 
   interface amrex_fab_build

--- a/Src/F_Interfaces/Base/AMReX_geometry_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_geometry_mod.F90
@@ -35,9 +35,7 @@ module amrex_geometry_module
      procedure :: get_physical_location => amrex_geometry_get_ploc
      procedure, private :: amrex_geometry_assign
      procedure, private :: amrex_geometry_install
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_geometry_destroy
-#endif
   end type amrex_geometry
 
   ! interfaces to c++ functions

--- a/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
@@ -91,9 +91,7 @@ module amrex_multifab_module
      procedure, private :: amrex_multifab_sum_boundary
      procedure, private :: amrex_multifab_sum_boundary_c
      procedure, private :: amrex_multifab_average_sync
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_multifab_destroy
-#endif
   end type amrex_multifab
 
   interface amrex_multifab_build
@@ -123,9 +121,7 @@ module amrex_multifab_module
      procedure, private :: amrex_imultifab_assign
      procedure, private :: amrex_imultifab_setval_gv
      procedure, private :: amrex_imultifab_setval
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_imultifab_destroy
-#endif
   end type amrex_imultifab
 
   interface amrex_imultifab_build
@@ -153,9 +149,7 @@ module amrex_multifab_module
      procedure :: validbox         => amrex_mfiter_validbox
      procedure :: fabbox           => amrex_mfiter_fabbox
      procedure, private :: amrex_mfiter_assign
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_mfiter_destroy
-#endif
   end type amrex_mfiter
 
   interface amrex_mfiter_build

--- a/Src/F_Interfaces/Base/AMReX_physbc_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_physbc_mod.F90
@@ -17,9 +17,7 @@ module amrex_physbc_module
    contains
      generic :: assignment(=) => amrex_physbc_assign  ! shallow copy
      procedure, private :: amrex_physbc_assign
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_physbc_destroy
-#endif
   end type amrex_physbc
 
   interface

--- a/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_mod.F90
@@ -15,9 +15,7 @@ module amrex_abeclaplacian_module
      procedure :: set_acoeffs => amrex_abeclaplacian_set_acoeffs
      procedure :: set_bcoeffs => amrex_abeclaplacian_set_bcoeffs
      procedure, private :: amrex_abeclaplacian_assign
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_abeclaplacian_destroy
-#endif
   end type amrex_abeclaplacian
 
   interface

--- a/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
@@ -46,9 +46,7 @@ module amrex_multigrid_module
      procedure, private :: amrex_multigrid_set_always_use_bnorm
      procedure, private :: amrex_multigrid_set_final_fill_bc
 
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_multigrid_destroy
-#endif
   end type amrex_multigrid
 
   ! interfaces to C++ functions

--- a/Src/F_Interfaces/LinearSolvers/AMReX_poisson_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_poisson_mod.F90
@@ -12,9 +12,7 @@ module amrex_poisson_module
    contains
      generic :: assignment(=) => amrex_poisson_assign   ! shallow copy
      procedure, private :: amrex_poisson_assign
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_poisson_destroy
-#endif
   end type amrex_poisson
 
   ! interfaces to C++ functions

--- a/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
+++ b/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
@@ -36,9 +36,7 @@ module amrex_particlecontainer_module
      procedure, private :: amrex_get_particles_i
      procedure, private :: amrex_num_particles_i
      procedure, private :: amrex_add_particle_i
-#if !defined(__GFORTRAN__) || (__GNUC__ > 4)
      final :: amrex_particlecontainer_destroy
-#endif
   end type amrex_particlecontainer
 
   interface

--- a/Src/LinearSolvers/AMReX_SpMV.H
+++ b/Src/LinearSolvers/AMReX_SpMV.H
@@ -125,6 +125,11 @@ void SpMV (AlgVector<T>& y, SpMatrix<T> const& A, AlgVector<T> const& x)
     T alpha = T(1.0);
     T beta = T(0.0);
 
+#if (HIP_VERSION_MAJOR >= 7)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
     std::size_t buffer_size;
     rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
                    &beta, y_descr, data_type, rocsparse_spmv_alg_default,
@@ -147,6 +152,11 @@ void SpMV (AlgVector<T>& y, SpMatrix<T> const& A, AlgVector<T> const& x)
                    rocsparse_spmv_stage_compute,
 #endif
                    &buffer_size, pbuffer);
+
+#if (HIP_VERSION_MAJOR >= 7)
+// xxxxx HIP TODO: rocsparse_spmv has been deprecated.
+#pragma clang diagnostic pop
+#endif
 
     Gpu::streamSynchronize();
 


### PR DESCRIPTION
* Fix warning about the deprecation of `__AMDGCN_WAVEFRONT_SIZE`.

* No need to support gfortran <= 4. This also avoids a flang warning on finalizer.

* Work around -Werror for the deprecation of rocsparse_spmv
