### PR TITLE
Remove no-op Fortran *_destroy blocks (#4666)

### DIFF
--- a/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
@@ -101,9 +101,11 @@ module amrex_fluxregister_module
      end subroutine amrex_fi_fluxregister_overwrite
   end interface
 
+#ifdef __NVCOMPILER
   interface amrex_fluxregister_destroy
      module procedure amrex_fluxregister_destroy
   end interface amrex_fluxregister_destroy
+#endif
 
 contains
 

--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -48,9 +48,11 @@ module amrex_boxarray_module
      module procedure amrex_boxarray_print
   end interface amrex_print
 
+#ifdef __NVCOMPILER
   interface amrex_boxarray_destroy
      module procedure amrex_boxarray_destroy
   end interface amrex_boxarray_destroy
+#endif
 
   ! interfaces to cpp functions
 

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -37,9 +37,11 @@ module amrex_distromap_module
      module procedure amrex_distromap_print
   end interface amrex_print
 
+#ifdef __NVCOMPILER
   interface amrex_distromap_destroy
      module procedure amrex_distromap_destroy
   end interface amrex_distromap_destroy
+#endif
 
   ! interfaces to cpp functions
 

--- a/Src/F_Interfaces/Base/AMReX_fab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_fab_mod.F90
@@ -40,9 +40,11 @@ module amrex_fab_module
      module procedure amrex_fab_build_install
   end interface amrex_fab_build
 
+#ifdef __NVCOMPILER
   interface amrex_fab_destroy
      module procedure amrex_fab_destroy
   end interface amrex_fab_destroy
+#endif
 
 contains
 

--- a/Src/F_Interfaces/Base/AMReX_geometry_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_geometry_mod.F90
@@ -74,9 +74,11 @@ module amrex_geometry_module
      end subroutine amrex_fi_geometry_get_intdomain
   end interface
 
+#ifdef __NVCOMPILER
   interface amrex_geometry_destroy
      module procedure amrex_geometry_destroy
   end interface amrex_geometry_destroy
+#endif
 
 contains
 

--- a/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
@@ -99,9 +99,11 @@ module amrex_multifab_module
      module procedure amrex_multifab_build_a
   end interface amrex_multifab_build
 
+#ifdef __NVCOMPILER
   interface amrex_multifab_destroy
     module procedure amrex_multifab_destroy
   end interface amrex_multifab_destroy
+#endif
 
   type, public   :: amrex_imultifab
      logical               :: owner = .false.
@@ -129,9 +131,11 @@ module amrex_multifab_module
      module procedure amrex_imultifab_build_a
   end interface amrex_imultifab_build
 
+#ifdef __NVCOMPILER
   interface amrex_imultifab_destroy
     module procedure amrex_imultifab_destroy
   end interface amrex_imultifab_destroy
+#endif
 
   type, public :: amrex_mfiter
      type(c_ptr)      :: p       = c_null_ptr
@@ -161,9 +165,11 @@ module amrex_multifab_module
      module procedure amrex_mfiter_build_badm_s
   end interface amrex_mfiter_build
 
+#ifdef __NVCOMPILER
   interface amrex_mfiter_destroy
     module procedure amrex_mfiter_destroy
   end interface amrex_mfiter_destroy
+#endif
 
   ! interfaces to c++ functions
 

--- a/Src/F_Interfaces/Base/AMReX_physbc_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_physbc_mod.F90
@@ -45,9 +45,11 @@ module amrex_physbc_module
      end subroutine amrex_fi_delete_physbc
   end interface
 
+#ifdef __NVCOMPILER
   interface amrex_physbc_destroy
     module procedure amrex_physbc_destroy
   end interface amrex_physbc_destroy
+#endif
 
 contains
 

--- a/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_mod.F90
@@ -56,9 +56,11 @@ module amrex_abeclaplacian_module
      end subroutine amrex_fi_abeclap_set_bcoeffs
   end interface
 
+#ifdef __NVCOMPILER
   interface amrex_abeclaplacian_destroy
      module procedure amrex_abeclaplacian_destroy
   end interface amrex_abeclaplacian_destroy
+#endif
 
 contains
 

--- a/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
@@ -152,9 +152,11 @@ module amrex_multigrid_module
      end subroutine amrex_fi_multigrid_set_final_fill_bc
   end interface
 
+#ifdef __NVCOMPILER
   interface amrex_multigrid_destroy
      module procedure amrex_multigrid_destroy
   end interface amrex_multigrid_destroy
+#endif
 
 contains
 

--- a/Src/F_Interfaces/LinearSolvers/AMReX_poisson_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_poisson_mod.F90
@@ -33,9 +33,11 @@ module amrex_poisson_module
      end subroutine amrex_fi_delete_linop
   end interface
 
+#ifdef __NVCOMPILER
   interface amrex_poisson_destroy
      module procedure amrex_poisson_destroy
   end interface amrex_poisson_destroy
+#endif
 
 contains
 

--- a/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
+++ b/Src/F_Interfaces/Particle/AMReX_particlecontainer_mod.F90
@@ -161,9 +161,11 @@ module amrex_particlecontainer_module
 
   end interface
 
+#ifdef __NVCOMPILER
   interface amrex_particlecontainer_destroy
      module procedure amrex_particlecontainer_destroy
   end interface amrex_particlecontainer_destroy
+#endif
 
 contains
 


### PR DESCRIPTION
## Summary
Resolves #4666.

I was able to build my code on ifx without triggering ICE by removing these blocks. Turns out the ICE is triggered not just by finalizers, but any type-bound procedure which is also in an interface block and made independently public from the module, but fortunately I didn't find any such procedures in AMReX.

These blocks are no-ops and completely harmless to remove since they only contain single procedures each and don't rename anything. However if you prefer, since they are valid Fortran, we could wrap them in ifdefs so Intel compilers don't see them.

## Additional background
These interface blocks trigger an ifx ICE on user codes which invoke `use ..., only:` on AMReX modules.

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
