### PR TITLE
add support for make flags to the build info script

### DIFF
--- a/Tools/C_scripts/AMReX_buildInfo.H
+++ b/Tools/C_scripts/AMReX_buildInfo.H
@@ -21,6 +21,7 @@ const char* buildInfoGetCXXFlags();
 const char* buildInfoGetFFlags();
 const char* buildInfoGetLinkFlags();
 const char* buildInfoGetLibraries();
+const char* buildInfoGetMakeFlags();
 const char* buildInfoGetAux(int i);
 int buildInfoGetNumModules();
 const char* buildInfoGetModuleName(int i);

--- a/Tools/C_scripts/makebuildinfo_C.py
+++ b/Tools/C_scripts/makebuildinfo_C.py
@@ -96,6 +96,12 @@ const char* buildInfoGetLibraries() {
   return libraries;
 }
 
+const char* buildInfoGetMakeFlags() {
+
+  static const char make_flags[] = "@@make_flags@@";
+  return make_flags;
+}
+
 const char* buildInfoGetAux(int i) {
 
   //static const char AUX1[] = "${AUX[1]}";
@@ -237,6 +243,10 @@ if __name__ == "__main__":
     parser.add_argument("--link_flags", help="linker flags", type=str, default="")
 
     parser.add_argument("--libraries", help="libraries linked", type=str, default="")
+
+    parser.add_argument("--make_flags",
+                        help="the options provided to the make command",
+                        type=str, default="")
 
     parser.add_argument("--AUX",
                         help="auxiliary information (EOS, network path) (deprecated)",


### PR DESCRIPTION
we can capture any flags provided to "make" via the $(MAKEFLAGS) variable and pass them into the build info generator.  This allows us to store the command line overrides in a job_info

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
