### PR TITLE
GNU Make: Add new option DEBUG_OPT_LEVEL

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -112,6 +112,12 @@ else
   DEBUG := FALSE
 endif
 
+ifdef DEBUG_OPT_LEVEL
+  DEBUG_OPT_LEVEL := $(strip $(DEBUG_OPT_LEVEL))
+else
+  DEBUG_OPT_LEVEL := 0
+endif
+
 ifdef USE_FFT
   USE_FFT := $(strip $(USE_FFT))
 else

--- a/Tools/GNUMake/comps/armclang.mak
+++ b/Tools/GNUMake/comps/armclang.mak
@@ -21,10 +21,10 @@ F90FLAGS =
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 -ftrapv
-  CFLAGS   += -g -O0 -ftrapv
-  FFLAGS   += -g -O0 -ftrapv
-  F90FLAGS += -g -O0 -ftrapv
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
 
 else
 

--- a/Tools/GNUMake/comps/cray.mak
+++ b/Tools/GNUMake/comps/cray.mak
@@ -34,17 +34,17 @@ endif
 ifeq ($(DEBUG),TRUE)
 
   ifeq ($(CRAY_IS_CLANG_BASED),TRUE)
-    CXXFLAGS += -g -O0
-    CFLAGS   += -g -O0
-    FFLAGS   += -g -O0 -e i -K trap=fp
-    F90FLAGS += -g -O0 -e i -K trap=fp
+    CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL)
+    CFLAGS   += -g -O$(DEBUG_OPT_LEVEL)
+    FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -e i -K trap=fp
+    F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -e i -K trap=fp
   else
     GENERIC_COMP_FLAGS += -K trap=fp
 
-    CXXFLAGS += -g -O0
-    CFLAGS   += -g -O0
-    FFLAGS   += -g -O0 -e i
-    F90FLAGS += -g -O0 -e i
+    CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL)
+    CFLAGS   += -g -O$(DEBUG_OPT_LEVEL)
+    FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -e i
+    F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -e i
   endif
 
 else

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -24,11 +24,11 @@ endif
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 #-ftrapv
-  CFLAGS   += -g -O0 #-ftrapv
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) #-ftrapv
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) #-ftrapv
 
-  FFLAGS   += -g -O0 -traceback -check bounds,uninit,pointers
-  F90FLAGS += -g -O0 -traceback -check bounds,uninit,pointers
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -traceback -check bounds,uninit,pointers
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -traceback -check bounds,uninit,pointers
 
 else
 

--- a/Tools/GNUMake/comps/gnu.mak
+++ b/Tools/GNUMake/comps/gnu.mak
@@ -83,8 +83,8 @@ CXXFLAGS += -Werror=return-type
 CFLAGS   += -Werror=return-type
 
 ifeq ($(DEBUG),TRUE)
-  CXXFLAGS += -g -O0 -ggdb -ftrapv
-  CFLAGS   += -g -O0 -ggdb -ftrapv
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -ggdb -ftrapv
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ggdb -ftrapv
 else
   CXXFLAGS += -g1 -O3
   CFLAGS   += -g1 -O3
@@ -176,8 +176,8 @@ F90FLAGS =
 
 ifeq ($(DEBUG),TRUE)
 
-  FFLAGS   += -g -O0 -ggdb -fcheck=bounds -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
-  F90FLAGS += -g -O0 -ggdb -fcheck=bounds -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ggdb -fcheck=bounds -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -ggdb -fcheck=bounds -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
 
 else
 

--- a/Tools/GNUMake/comps/hip.mak
+++ b/Tools/GNUMake/comps/hip.mak
@@ -84,11 +84,15 @@ endif  # BL_NO_FORT
 ifeq ($(HIP_COMPILER),clang)
 
   ifeq ($(DEBUG),TRUE)
-    CXXFLAGS += -g -O1 -munsafe-fp-atomics
-    CFLAGS   += -g -O0
+    ifeq ($(DEBUG_OPT_LEVEL),0)
+      CXXFLAGS += -g -O1 -munsafe-fp-atomics
+    else
+      CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -munsafe-fp-atomics
+    endif
+    CFLAGS   += -g -O$(DEBUG_OPT_LEVEL)
 
-    FFLAGS   += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
-    F90FLAGS += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
+    FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
+    F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
 
   else  # DEBUG=FALSE flags
 

--- a/Tools/GNUMake/comps/ibm.mak
+++ b/Tools/GNUMake/comps/ibm.mak
@@ -49,8 +49,8 @@ CFLAGS   =
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0
-  CFLAGS   += -g -O0
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL)
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL)
 
 else
 
@@ -104,8 +104,8 @@ F90FLAGS =
 
 ifeq ($(DEBUG),TRUE)
 
-  FFLAGS   += -g -O0
-  F90FLAGS += -g -O0
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL)
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL)
 
 else
 

--- a/Tools/GNUMake/comps/intel-classic.mak
+++ b/Tools/GNUMake/comps/intel-classic.mak
@@ -25,10 +25,10 @@ COMP_VERSION = $(intel_version)
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 -traceback -Wcheck
-  CFLAGS   += -g -O0 -traceback -Wcheck
-  FFLAGS   += -g -O0 -traceback -check bounds,uninit,pointers
-  F90FLAGS += -g -O0 -traceback -check bounds,uninit,pointers
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -traceback -Wcheck
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -traceback -Wcheck
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -traceback -check bounds,uninit,pointers
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -traceback -check bounds,uninit,pointers
 
 else
 

--- a/Tools/GNUMake/comps/intel-llvm.mak
+++ b/Tools/GNUMake/comps/intel-llvm.mak
@@ -25,10 +25,10 @@ COMP_VERSION = $(intel_version)
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 -ftrapv
-  CFLAGS   += -g -O0 -ftrapv
-  FFLAGS   += -g -O0 -ftrapuv -check bounds,pointers,uninit -traceback
-  F90FLAGS += -g -O0 -ftrapuv -check bounds,pointers,uninit -traceback
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ftrapuv -check bounds,pointers,uninit -traceback
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -ftrapuv -check bounds,pointers,uninit -traceback
 
 else
 

--- a/Tools/GNUMake/comps/llvm-flang.mak
+++ b/Tools/GNUMake/comps/llvm-flang.mak
@@ -23,11 +23,11 @@ COMP_VERSION = $(clang_version)
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -ftrapv
-  CFLAGS   += -g -O0 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -ftrapv
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -ftrapv
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -ftrapv
 
-  FFLAGS   += -g -O0 -ggdb -Wuninitialized -Wunused -ftrapv
-  F90FLAGS += -g -O0 -ggdb -Wuninitialized -Wunused -ftrapv
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ggdb -Wuninitialized -Wunused -ftrapv
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -ggdb -Wuninitialized -Wunused -ftrapv
 
 else
 

--- a/Tools/GNUMake/comps/llvm.mak
+++ b/Tools/GNUMake/comps/llvm.mak
@@ -23,11 +23,11 @@ COMP_VERSION = $(clang_version)
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 -ftrapv
-  CFLAGS   += -g -O0 -ftrapv
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
 
-  FFLAGS   += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
-  F90FLAGS += -g -O0 -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -ggdb -fbounds-check -fbacktrace -Wuninitialized -Wunused -ffpe-trap=invalid,zero -finit-real=snan -finit-integer=2147483647 -ftrapv
 
 else
 

--- a/Tools/GNUMake/comps/nag.mak
+++ b/Tools/GNUMake/comps/nag.mak
@@ -23,11 +23,11 @@ COMP_VERSION = $(gcc_version)
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 -fno-inline -ggdb -Wall -Wno-sign-compare -ftrapv
-  CFLAGS   += -g -O0 -fno-inline -ggdb -Wall -Wno-sign-compare -ftrapv
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -fno-inline -ggdb -Wall -Wno-sign-compare -ftrapv
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -fno-inline -ggdb -Wall -Wno-sign-compare -ftrapv
 
-  FFLAGS   += -g -O0 -nan -C
-  F90FLAGS += -g -O0 -nan -C
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -nan -C
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -nan -C
 
 else
 

--- a/Tools/GNUMake/comps/nec.mak
+++ b/Tools/GNUMake/comps/nec.mak
@@ -15,11 +15,11 @@ F90FLAGS =
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 -fno-inline -ftrace -Wall -Wunused
-  CFLAGS   += -g -O0 -fno-inline -ftrace -Wall -Wunused
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -fno-inline -ftrace -Wall -Wunused
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -fno-inline -ftrace -Wall -Wunused
 
-  FFLAGS   += -g -O0 -fcheck=bounds -ftrace -Wuninitialized
-  F90FLAGS += -g -O0 -fcheck=bounds -ftrace -Wuninitialized
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -fcheck=bounds -ftrace -Wuninitialized
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -fcheck=bounds -ftrace -Wuninitialized
 
 else
 

--- a/Tools/GNUMake/comps/nvcc.mak
+++ b/Tools/GNUMake/comps/nvcc.mak
@@ -111,7 +111,11 @@ ifeq ($(GPU_ERROR_CROSS_EXECUTION_SPACE_CALL),TRUE)
 endif
 
 ifeq ($(DEBUG),TRUE)
+ifeq ($(DEBUG_OPT_LEVEL),0)
   NVCC_FLAGS += -g -G
+else
+  NVCC_FLAGS += -g -lineinfo --ptxas-options=-O$(DEBUG_OPT_LEVEL)
+endif
 else
   NVCC_FLAGS += -lineinfo --ptxas-options=-O3
 endif

--- a/Tools/GNUMake/comps/nvhpc.mak
+++ b/Tools/GNUMake/comps/nvhpc.mak
@@ -76,8 +76,8 @@ NVHPC_GOPT ?= TRUE
 
 ifeq ($(DEBUG),TRUE)
 
-  CXXFLAGS += -g -O0 -Mbounds
-  CFLAGS   += -g -O0 -Mbounds
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -Mbounds
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -Mbounds
 
 else
 
@@ -142,8 +142,8 @@ F90FLAGS =
 
 ifeq ($(DEBUG),TRUE)
 
-  FFLAGS   += -g -O0 -Mbounds -Ktrap=divz,inv -Mchkptr
-  F90FLAGS += -g -O0 -Mbounds -Ktrap=divz,inv -Mchkptr
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -Mbounds -Ktrap=divz,inv -Mchkptr
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -Mbounds -Ktrap=divz,inv -Mchkptr
 
 else
 

--- a/Tools/GNUMake/comps/pgi.mak
+++ b/Tools/GNUMake/comps/pgi.mak
@@ -70,8 +70,8 @@ ifeq ($(DEBUG),TRUE)
 
   # 2016-12-02: pgi 16.10 doesn't appear to like -traceback together with c++11
 
-  CXXFLAGS += -g -O0 -Mbounds
-  CFLAGS   += -g -O0 -Mbounds
+  CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -Mbounds
+  CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -Mbounds
 
 else
 
@@ -140,8 +140,8 @@ ifeq ($(DEBUG),TRUE)
 
   # 2016-12-02: pgi 16.10 doesn't appear to like -traceback together with c++11
 
-  FFLAGS   += -g -O0 -Mbounds -Ktrap=divz,inv -Mchkptr
-  F90FLAGS += -g -O0 -Mbounds -Ktrap=divz,inv -Mchkptr
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -Mbounds -Ktrap=divz,inv -Mchkptr
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -Mbounds -Ktrap=divz,inv -Mchkptr
 
 else
 


### PR DESCRIPTION
This does not change the existing behavior, because it's 0 by default. This allows us to increase the optimization level when DEBUG=TRUE.

ERF's radiation test problem does not compile with `USE_CUDA=TRUE DEBUG=TRUE`. It fails at link time with
```
/usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/Scrt1.o: in function `_start':
(.text+0x21): relocation truncated to fit: R_X86_64_GOTPCRELX against symbol `__libc_start_main@@GLIBC_2.34' defined in .text section in /lib/x86_64-linux-gnu/libc.so.6
/usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/Scrt1.o:(.eh_frame+0x20): relocation truncated to fit: R_X86_64_PC32 against `.text'
/usr/lib/gcc/x86_64-linux-gnu/13/../../../x86_64-linux-gnu/crti.o: in function `_init':
(.init+0xb): relocation truncated to fit: R_X86_64_REX_GOTPCRELX against undefined symbol `__gmon_start__'
/usr/local/cuda/lib64/libcudart_static.a(cudart_static.o): in function `libcudart_static_a3bf49b59a3e5c73e23c76622c3ce0951724bc73':
cuda_runtime_api.cpp:(.text.startup+0x19): relocation truncated to fit: R_X86_64_PC32 against `.data'
cuda_runtime_api.cpp:(.text.startup+0x20): relocation truncated to fit: R_X86_64_PC32 against `.data'
cuda_runtime_api.cpp:(.text.startup+0x27): relocation truncated to fit: R_X86_64_PC32 against `.data'
cuda_runtime_api.cpp:(.text.startup+0x3d): relocation truncated to fit: R_X86_64_PC32 against `.data'
/usr/local/cuda/lib64/libcudart_static.a(cudart_static.o): in function `libcudart_static_7bd86af72cd50dfe63513852abf557d8ffc48b76':
cudart_global.cpp:(.text.startup+0xbb): relocation truncated to fit: R_X86_64_PC32 against `.bss'
cudart_global.cpp:(.text.startup+0xcb): relocation truncated to fit: R_X86_64_PC32 against symbol `__dso_handle' defined in .data.rel.local section in /usr/lib/gcc/x86_64-linux-gnu/13/crtbeginS.o
cudart_global.cpp:(.text.startup+0xd2): relocation truncated to fit: R_X86_64_PC32 against `.bss'
/usr/local/cuda/lib64/libcudart_static.a(cudart_static.o):(.eh_frame+0x4b18): additional relocation overflows omitted from the output
ERF3d.gnu.DEBUG.MPI.CUDA.ex: PC-relative offset overflow in PLT entry for `mlock@@GLIBC_2.2.5'
collect2: error: ld returned 1 exit status
make: *** [../../../Submodules/AMReX/Tools/GNUMake/Make.rules:64: ERF3d.gnu.DEBUG.MPI.CUDA.ex] Error 1
```

With `USE_CUDA=TRUE DEBUG=TRUE DEBUG_OPT_LEVEL=1`, it compiles.
