### PR TITLE
Allow hypre and petsc in 1d build

### DIFF
--- a/Src/Extern/HYPRE/AMReX_Habec_1D_K.H
+++ b/Src/Extern/HYPRE/AMReX_Habec_1D_K.H
@@ -1,0 +1,119 @@
+#ifndef AMREX_HABEC_2D_H_
+#define AMREX_HABEC_2D_H_
+#include <AMReX_Config.H>
+
+namespace amrex {
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void habec_mat (GpuArray<Real,2*AMREX_SPACEDIM+1>& sten, int i, int j, int k,
+                Dim3 const& boxlo, Dim3 const& boxhi,
+                Real sa, Array4<Real const> const& a,
+                Real sb, GpuArray<Real,AMREX_SPACEDIM> const& dx,
+                GpuArray<Array4<Real const>, AMREX_SPACEDIM> const& b,
+                GpuArray<int,AMREX_SPACEDIM*2> const& bctype,
+                GpuArray<Real,AMREX_SPACEDIM*2> const& bcl, int bho,
+                GpuArray<Array4<int const>, AMREX_SPACEDIM*2> const& msk,
+                Array4<Real> const& diaginv)
+{
+    sten[1] = -(sb / (dx[0]*dx[0])) * b[0](i,j,k);
+    sten[2] = -(sb / (dx[0]*dx[0])) * b[0](i+1,j,k);
+    sten[0] = -(sten[1] + sten[2]);
+    if (sa != Real(0.0)) {
+        sten[0] += sa * a(i,j,k);
+    }
+
+    // xlo
+    if (i == boxlo.x) {
+        int cdir = Orientation(Direction::x, Orientation::low);
+        if (msk[cdir](i-1,j,k) > 0) {
+            Real bf1, bf2;
+            detail::comp_bf(bf1, bf2, sb, dx[0], bctype[cdir], bcl[cdir], bho);
+            sten[0] += bf1 * b[0](i,j,k);
+            sten[1] = Real(0.0);
+            sten[2] += bf2 * b[0](i,j,k);
+        }
+    }
+
+    // xhi
+    if (i == boxhi.x) {
+        int cdir = Orientation(Direction::x, Orientation::high);
+        if (msk[cdir](i+1,j,k) > 0) {
+            Real bf1, bf2;
+            detail::comp_bf(bf1, bf2, sb, dx[0], bctype[cdir], bcl[cdir], bho);
+            sten[0] += bf1 * b[0](i+1,j,k);
+            sten[1] += bf2 * b[0](i+1,j,k);
+            sten[2] = Real(0.0);
+        }
+    }
+}
+
+template <typename Int>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void habec_ijmat (GpuArray<Real,2*AMREX_SPACEDIM+1>& sten, Array4<Int> const& ncols,
+                  Array4<Real> const& diaginv, int i, int j, int k,
+                  Array4<Int const> const& cell_id,
+                  Real sa, Array4<Real const> const& a,
+                  Real sb, GpuArray<Real,AMREX_SPACEDIM> const& dx,
+                  GpuArray<Array4<Real const>, AMREX_SPACEDIM> const& b,
+                  GpuArray<int,AMREX_SPACEDIM*2> const& bctype,
+                  GpuArray<Real,AMREX_SPACEDIM*2> const& bcl, int bho,
+                  Array4<int const> const& osm)
+{
+    if (!osm || osm(i,j,k) != 0) {
+        sten[1] = -(sb / (dx[0]*dx[0])) * b[0](i,j,k);
+        sten[2] = -(sb / (dx[0]*dx[0])) * b[0](i+1,j,k);
+        sten[0] = -(sten[1] + sten[2]);
+        if (sa != Real(0.0)) {
+            sten[0] += sa * a(i,j,k);
+        }
+
+        // xlo
+        if (cell_id(i-1,j,k) < 0) {
+            int cdir = Orientation(Direction::x, Orientation::low);
+            Real bf1, bf2;
+            detail::comp_bf(bf1, bf2, sb, dx[0], bctype[cdir], bcl[cdir], bho);
+            sten[0] += bf1 * b[0](i,j,k);
+            sten[1] = Real(0.0);
+            sten[2] += bf2 * b[0](i,j,k);
+        }
+
+        // xhi
+        if (cell_id(i+1,j,k) < 0) {
+            int cdir = Orientation(Direction::x, Orientation::high);
+            Real bf1, bf2;
+            detail::comp_bf(bf1, bf2, sb, dx[0], bctype[cdir], bcl[cdir], bho);
+            sten[0] += bf1 * b[0](i+1,j,k);
+            sten[1] += bf2 * b[0](i+1,j,k);
+            sten[2] = Real(0.0);
+        }
+    } else {
+        sten[0] = Real(1.0);
+        for (int m = 1; m < 2*AMREX_SPACEDIM+1; ++m) {
+            sten[m] = Real(0.0);
+        }
+    }
+
+    diaginv(i,j,k) = Real(1.0) / sten[0];
+    sten[0] = Real(1.0);
+    for (int m = 1; m < 2*AMREX_SPACEDIM+1; ++m) {
+        sten[m] *= diaginv(i,j,k);
+    }
+
+    ncols(i,j,k) = 0;
+    for (int m = 0; m < 2*AMREX_SPACEDIM+1; ++m) {
+        ncols(i,j,k) += (sten[m] != Real(0.0));
+    }
+}
+
+template <typename Int>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void habec_cols (GpuArray<Int,2*AMREX_SPACEDIM+1>& sten, int i, int j, int /*k*/,
+                 Array4<Int const> const& cell_id)
+{
+    sten[0] = cell_id(i  ,j  ,0);
+    sten[1] = cell_id(i-1,j  ,0);
+    sten[2] = cell_id(i+1,j  ,0);
+}
+
+}
+#endif

--- a/Src/Extern/HYPRE/AMReX_Habec_K.H
+++ b/Src/Extern/HYPRE/AMReX_Habec_K.H
@@ -56,7 +56,9 @@ namespace amrex::detail {
     }
 }
 
-#if (AMREX_SPACEDIM == 2)
+#if (AMREX_SPACEDIM == 1)
+#include <AMReX_Habec_1D_K.H>
+#elif (AMREX_SPACEDIM == 2)
 #include <AMReX_Habec_2D_K.H>
 #elif (AMREX_SPACEDIM == 3)
 #include <AMReX_Habec_3D_K.H>

--- a/Src/Extern/HYPRE/AMReX_Hypre.cpp
+++ b/Src/Extern/HYPRE/AMReX_Hypre.cpp
@@ -29,8 +29,6 @@ Hypre::Hypre (const BoxArray& grids, const DistributionMapping& dmap,
     : comm(comm_),
       geom(geom_)
 {
-    static_assert(AMREX_SPACEDIM > 1, "Hypre: 1D not supported");
-
     // This is not static_assert because HypreSolver class does not require this.
     if (!std::is_same_v<Real, HYPRE_Real>) {
         amrex::Abort("amrex::Real != HYPRE_Real");

--- a/Src/Extern/HYPRE/AMReX_HypreMLABecLap_1D_K.H
+++ b/Src/Extern/HYPRE/AMReX_HypreMLABecLap_1D_K.H
@@ -1,0 +1,324 @@
+#ifndef AMREX_HYPRE_ML_ABECLAP_2D_K_H_
+#define AMREX_HYPRE_ML_ABECLAP_2D_K_H_
+
+#include <AMReX_Array.H>
+#include <AMReX_Orientation.H>
+
+namespace amrex {
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void hypmlabeclap_f2c_set_values (IntVect const& cell, Real* values,
+                                  GpuArray<Real,AMREX_SPACEDIM> const& dx, Real sb,
+                                  GpuArray<Array4<Real const>,AMREX_SPACEDIM> const& b,
+                                  GpuArray<Array4<int const>,AMREX_SPACEDIM*2> const& bmask,
+                                  IntVect const& refratio, int not_covered)
+{
+    Array2D<Real,-1,1,-1,1> tmp;
+    for (auto& x : tmp) { x = Real(0.0); }
+
+    Array2D<int,-1,1,-1,1> used;
+    for (auto& x : used) { x = 0; }
+
+    for (OrientationIter ori; ori; ++ori) {
+        auto const face = ori();
+        int const idir = face.coordDir();
+        int const idir1 = 1-idir; // the transverse direction
+        IntVect offset(0);
+        offset[idir] = face.isLow() ? -1 : +1;
+        IntVect const cell_out = cell + offset;
+        auto const& msk = bmask[face];
+        if (msk.contains(cell_out) && msk(cell_out) == not_covered) {
+            // There is a coarse cell on the other side of the face. There
+            // are three cases for the coarse cells involved. (1)
+            // Interpolation using 3 coarse cells. (2) Upward biased
+            // interpolation using 2 coarse cells. (3) Doward biased
+            // interpolation using 2 coarse cells. (Here up and down means
+            // the y-dirction, if we assume idir is the x-direction.)
+            IntVect offset_t(0);
+            offset_t[idir1] = refratio[idir1];
+            Real bcoeff = b[idir] ? b[idir](face.isLow() ? cell : cell_out) : Real(1.0); // b is on face
+            Real poly_coef[3];
+            {
+                Real xx[3] = {Real(-0.5)*Real(refratio[idir]), Real(0.5), Real(1.5)};
+                poly_interp_coeff<3>(Real(-0.5), xx, poly_coef);
+            }
+            Real fac = -(sb / (dx[idir]*dx[idir])) * bcoeff * poly_coef[0];
+            int const rr1 = refratio[idir1];
+            int const i1 = cell[idir1];
+            int const i1c = amrex::coarsen(i1, rr1);
+            Real xInt = Real(-0.5) + (i1-i1c*rr1+Real(0.5))/Real(rr1);
+            Real xc[] = {Real(-1.0), Real(0.0), Real(1.0)};
+            Real c[] = {Real(0.0), Real(0.0), Real(0.0)};
+            int cc[] = {0, 0, 0};
+            if (msk(cell_out-offset_t) == not_covered &&
+                msk(cell_out+offset_t) == not_covered)
+            {
+                poly_interp_coeff<3>(xInt, xc, c);
+                cc[0] = cc[1] = cc[2] = 1;
+            } else if (msk(cell_out+offset_t) == not_covered) {
+                poly_interp_coeff<2>(xInt, &(xc[1]), &(c[1]));
+                cc[1] = cc[2] = 1;
+            } else {
+                poly_interp_coeff<2>(xInt, xc, c);
+                cc[0] = cc[1] = 1;
+            }
+            if (face == Orientation(0, Orientation::low)) {
+                for (int m = 0; m < 3; ++m) {
+                    tmp(-1,m-1) += c[m] * fac;
+                    used(-1,m-1) += cc[m];
+                }
+            } else if (face == Orientation(0, Orientation::high)) {
+                for (int m = 0; m < 3; ++m) {
+                    tmp(1,m-1) += c[m] * fac;
+                    used(1,m-1) += cc[m];
+                }
+            } else if (face == Orientation(1, Orientation::low)) {
+                for (int m = 0; m < 3; ++m) {
+                    tmp(m-1,-1) += c[m] * fac;
+                    used(m-1,-1) += cc[m];
+                }
+            } else if (face == Orientation(1, Orientation::high)) {
+                for (int m = 0; m < 3; ++m) {
+                    tmp(m-1,1) += c[m] * fac;
+                    used(m-1,1) += cc[m];
+                }
+            }
+        }
+    }
+
+    auto const* ptmp = tmp.begin();
+    auto const* pused = used.begin();
+    for (int m = 0; m < 9; ++m) {
+        if (pused[m]) {
+            (*values) += ptmp[m];
+            ++values;
+        }
+    }
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void hypmlabeclap_c2f (int i, int j, int k,
+                       Array4<GpuArray<Real,2*AMREX_SPACEDIM+1>> const& stencil,
+                       GpuArray<HYPRE_Int,AMREX_SPACEDIM>* civ, HYPRE_Int* nentries,
+                       int* entry_offset, Real* entry_values,
+                       Array4<int const> const& offset_from,
+                       Array4<int const> const& nentries_to,
+                       Array4<int const> const& offset_to,
+                       GpuArray<Real,AMREX_SPACEDIM> const& dx, Real sb,
+                       Array4<int const> const& offset_bx,
+                       Array4<int const> const& offset_by,
+                       Real const* bx, Real const* by,
+                       Array4<int const> const& fine_mask,
+                       IntVect const& rr, Array4<int const> const& crse_mask)
+{
+    if (fine_mask(i,j,k)) {
+        // Let's set off-diagonal elements to zero
+        for (int m = 1; m < 2*AMREX_SPACEDIM+1; ++m) {
+            stencil(i,j,k)[m] = Real(0.0);
+        }
+    } else if (nentries_to(i,j,k) > 0) {
+        int const fromoff = offset_from(i,j,k);
+        civ[fromoff][0] = i;
+        civ[fromoff][1] = j;
+        nentries[fromoff] = nentries_to(i,j,k);
+        int foff = offset_to(i,j,k);
+        entry_offset[fromoff] = foff;
+
+        // We must iterate the faces in the lexicographical order of fine
+        // neighbor cells, because that's the order when non-stencil entries
+        // were added to Hypre's graph. Also note that a coarse cell will
+        // not have entries to fine cells at both ends of a direction. Thus
+        // we do not have to worry about the order between fine cells at the
+        // small and big ends of the same direction.
+
+        if (fine_mask(i,j-1,k)) {
+            stencil(i,j,k)[0] += stencil(i,j,k)[3];
+            stencil(i,j,k)[3] = Real(0.0);
+            // Reflux: sb/h^2*by(i,j,k)*(phi(i,j,k)-phi(i,j-1,k)) is replaced by
+            // sb/h*sum_{fine faces}(dphi/dy*by)/n_fine_faces
+            Real dyf = dx[1] / Real(rr[1]);
+            Real dycinv = Real(1.0) / dx[1];
+            Real dyfinv = Real(1.0) / dyf;
+            Real cc[3];
+            Real yy[3] = {dx[1]*Real(-0.5), dyf*Real(0.5), dyf*Real(1.5)};
+            poly_interp_coeff<3>(dyf*Real(-0.5), yy, cc);
+            for (int irx = 0; irx < rr[0]; ++irx) {
+                Real bym = by ? by[offset_by(i,j,k)+irx] : Real(1.0);
+                Real fac = sb*dycinv*dyfinv*bym/Real(rr[0]);
+                // int ii = i*rr[0] + irx
+                // int jj = j*rr[1]
+                // dphi/dy = (phi_interp - phi_fine(jj-1)) / dy_fine
+                //         = (phi_coarse*cc[0] + phi_fine(jj-1)*(cc[1]-1)
+                //                             + phi_fine(jj-2)* cc[2]) / dy_fine
+                // So the entry for fine cell (jj-1) is (cc[1]-1)*fac
+                //                  fine cell (jj-2) is  cc[2]   *fac
+                entry_values[foff+irx      ] += fac* cc[2];
+                entry_values[foff+irx+rr[0]] += fac*(cc[1]-Real(1.0));
+
+                // The coarse cell's stencils need updates too.
+                Real xInt = Real(-0.5) + (irx+Real(0.5))/Real(rr[0]);
+                Real xc[3] = {Real(-1.0), Real(0.0), Real(1.0)};
+                Real ct[3] = {Real(0.0), Real(0.0), Real(0.0)};
+                if ( fine_mask(i-1,j,k) ||
+                    !crse_mask(i-1,j,k))
+                {
+                    poly_interp_coeff<2>(xInt, &(xc[1]), &(ct[1]));
+                } else if ( fine_mask(i+1,j,k) ||
+                           !crse_mask(i+1,j,k))
+                {
+                    poly_interp_coeff<2>(xInt, xc, ct);
+                } else {
+                    poly_interp_coeff<3>(xInt, xc, ct);
+                }
+                // phi_coarse = ct[0]*phi(i-1) + ct[1]*phi(i) + ct[2]*phi(i+1)
+                stencil(i,j,k)[0] += (fac*cc[0])*ct[1];
+                stencil(i,j,k)[1] += (fac*cc[0])*ct[0];
+                stencil(i,j,k)[2] += (fac*cc[0])*ct[2];
+            }
+            foff += 2*rr[0];
+        }
+
+        if (fine_mask(i-1,j,k)) {
+            stencil(i,j,k)[0] += stencil(i,j,k)[1];
+            stencil(i,j,k)[1] = Real(0.0);
+            // Reflux: sb/h^2*bx(i,j,k)*(phi(i,j,k)-phi(i-1,j,k)) is replaced by
+            // sb/h*sum_{fine faces}(dphi/dx*bx).
+            Real dxf = dx[0] / Real(rr[0]);
+            Real dxcinv = Real(1.0) / dx[0];
+            Real dxfinv = Real(1.0) / dxf;
+            Real cc[3];
+            Real xx[3] = {dx[0]*Real(-0.5), dxf*Real(0.5), dxf*Real(1.5)};
+            poly_interp_coeff<3>(dxf*Real(-0.5), xx, cc);
+            for (int iry = 0; iry < rr[1]; ++iry) {
+                Real bxm = bx ? bx[offset_bx(i,j,k)+iry] : Real(1.0);
+                Real fac = sb*dxcinv*dxfinv*bxm/Real(rr[1]);
+                // int ii = i*rr[0]
+                // int jj = j*rr[1] + iry
+                // dphi/dx = (phi_interp - phi_fine(ii-1)) / dx_fine
+                //         = (phi_coarse*cc[0] + phi_fine(ii-1)*(cc[1]-1)
+                //                             + phi_fine(ii-2)* cc[2]) / dx_fine
+                // So the entry for fine cell(ii-1) is (cc[1]-1)*fac
+                //                  fine cell(ii-2) is  cc[2]   *fac
+                entry_values[foff++] = fac* cc[2];
+                entry_values[foff++] = fac*(cc[1] - Real(1.0));
+
+                // The coarse cell's stencils need updates too.
+                Real yInt = Real(-0.5) + (iry+Real(0.5))/Real(rr[1]);
+                Real yc[3] = {Real(-1.0), Real(0.0), Real(1.0)};
+                Real ct[3] = {Real(0.0), Real(0.0), Real(0.0)};
+                if ( fine_mask(i,j-1,k) ||
+                    !crse_mask(i,j-1,k))
+                {
+                    poly_interp_coeff<2>(yInt, &(yc[1]), &(ct[1]));
+                } else if ( fine_mask(i,j+1,k) ||
+                           !crse_mask(i,j+1,k))
+                {
+                    poly_interp_coeff<2>(yInt, yc, ct);
+                } else {
+                    poly_interp_coeff<3>(yInt, yc, ct);
+                }
+                // phi_coarse = ct[0]*phi(j-1) + ct[1]*phi(j) + ct[2]*phi(j+1)
+                stencil(i,j,k)[0] += (fac*cc[0])*ct[1];
+                stencil(i,j,k)[3] += (fac*cc[0])*ct[0];
+                stencil(i,j,k)[4] += (fac*cc[0])*ct[2];
+            }
+        }
+
+        if (fine_mask(i+1,j,k)) {
+            stencil(i,j,k)[0] += stencil(i,j,k)[2];
+            stencil(i,j,k)[2] = Real(0.0);
+            // Reflux: sb/h^2*bx(i+1,j,k)*(phi(i,j,k)-phi(i+1,j,k)) is replaced by
+            // sb/h*sum_{fine faces}(-dphi/dx*bx).
+            Real dxf = dx[0] / Real(rr[0]);
+            Real dxcinv = Real(1.0) / dx[0];
+            Real dxfinv = Real(1.0) / dxf;
+            Real cc[3];
+            Real xx[3] = {dx[0]*Real(-0.5), dxf*Real(0.5), dxf*Real(1.5)};
+            poly_interp_coeff<3>(dxf*Real(-0.5), xx, cc);
+            for (int iry = 0; iry < rr[1]; ++iry) {
+                Real bxp = bx ? bx[offset_bx(i+1,j,k)+iry] : Real(1.0);
+                Real fac = sb*dxcinv*dxfinv*bxp/Real(rr[1]);
+                // int ii = i*rr[0] + (rr[0]-1)
+                // int jj = j*rr[1] + iry
+                // -dphi/dx = (phi_interp - phi_fine(ii+1)) / dx_fine
+                //          = (phi_coarse*cc[0] + phi_fine(ii+1)*(cc[1]-1)
+                //                              + phi_fine(ii+2)* cc[2]) / dx_fine
+                // So the entry for fine cell(ii+1) is (cc[1]-1)*fac
+                //                  fine cell(ii+2) is  cc[2]   *fac
+                entry_values[foff++] = fac*(cc[1] - Real(1.0));
+                entry_values[foff++] = fac* cc[2];
+
+                // The coarse cell's stencils need updates too.
+                Real yInt = Real(-0.5) + (iry+Real(0.5))/Real(rr[1]);
+                Real yc[3] = {Real(-1.0), Real(0.0), Real(1.0)};
+                Real ct[3] = {Real(0.0), Real(0.0), Real(0.0)};
+                if ( fine_mask(i,j-1,k) ||
+                    !crse_mask(i,j-1,k))
+                {
+                    poly_interp_coeff<2>(yInt, &(yc[1]), &(ct[1]));
+                } else if ( fine_mask(i,j+1,k) ||
+                           !crse_mask(i,j+1,k))
+                {
+                    poly_interp_coeff<2>(yInt, yc, ct);
+                } else {
+                    poly_interp_coeff<3>(yInt, yc, ct);
+                }
+                // phi_coarse = ct[0]*phi(j-1) + ct[1]*phi(j) + ct[2]*phi(j+1)
+                stencil(i,j,k)[0] += (fac*cc[0])*ct[1];
+                stencil(i,j,k)[3] += (fac*cc[0])*ct[0];
+                stencil(i,j,k)[4] += (fac*cc[0])*ct[2];
+            }
+        }
+
+        if (fine_mask(i,j+1,k)) {
+            stencil(i,j,k)[0] += stencil(i,j,k)[4];
+            stencil(i,j,k)[4] = Real(0.0);
+            // Reflux: sb/h^2*by(i,j+1,k)*(phi(i,j,k)-phi(i,j+1,k)) is replaced by
+            // sb/h*sum_{fine faces}(-dphi/dy*by)
+            Real dyf = dx[1] / Real(rr[1]);
+            Real dycinv = Real(1.0) / dx[1];
+            Real dyfinv = Real(1.0) / dyf;
+            Real cc[3];
+            Real yy[3] = {dx[1]*Real(-0.5), dyf*Real(0.5), dyf*Real(1.5)};
+            poly_interp_coeff<3>(dyf*Real(-0.5), yy, cc);
+            for (int irx = 0; irx < rr[0]; ++irx) {
+                Real byp = by ? by[offset_by(i,j+1,k)+irx] : Real(1.0);
+                Real fac = sb*dycinv*dyfinv*byp/Real(rr[0]);
+                // int ii = i*rr[0] + irx
+                // int jj = j*rr[1] + (rr[1]-1)
+                // -dphi/dy = (phi_interp - phi_fine(jj+1)) / dy_fine
+                //          = (phi_coarse*cc[0] + phi_fine(jj+1)*(cc[1]-1)
+                //                              + phi_fine(jj+2)* cc[2]) / dy_fine
+                // So the entry for fine cell (jj+1) is (cc[1]-1)*fac
+                //                  fine cell (jj+2) is  cc[2]   *fac
+                entry_values[foff+irx      ] += fac*(cc[1]-Real(1.0));
+                entry_values[foff+irx+rr[0]] += fac* cc[2];
+
+                // The coarse cell's stencils need updates too.
+                Real xInt = Real(-0.5) + (irx+Real(0.5))/Real(rr[0]);
+                Real xc[3] = {Real(-1.0), Real(0.0), Real(1.0)};
+                Real ct[3] = {Real(0.0), Real(0.0), Real(0.0)};
+                if ( fine_mask(i-1,j,k) ||
+                    !crse_mask(i-1,j,k))
+                {
+                    poly_interp_coeff<2>(xInt, &(xc[1]), &(ct[1]));
+                } else if ( fine_mask(i+1,j,k) ||
+                           !crse_mask(i+1,j,k))
+                {
+                    poly_interp_coeff<2>(xInt, xc, ct);
+                } else {
+                    poly_interp_coeff<3>(xInt, xc, ct);
+                }
+                // phi_coarse = ct[0]*phi(i-1) + ct[1]*phi(i) + ct[2]*phi(i+1)
+                stencil(i,j,k)[0] += (fac*cc[0])*ct[1];
+                stencil(i,j,k)[1] += (fac*cc[0])*ct[0];
+                stencil(i,j,k)[2] += (fac*cc[0])*ct[2];
+            }
+            // not needed: foff += 2*rr[0];
+        }
+    }
+}
+
+}
+
+#endif

--- a/Src/Extern/HYPRE/AMReX_HypreMLABecLap_K.H
+++ b/Src/Extern/HYPRE/AMReX_HypreMLABecLap_K.H
@@ -295,7 +295,9 @@ void hypmlabeclap_rhs (int i, int j, int k, Dim3 const& boxlo, Dim3 const& boxhi
 
 }
 
-#if (AMREX_SPACEDIM == 2)
+#if (AMREX_SPACEDIM == 1)
+#include <AMReX_HypreMLABecLap_1D_K.H>
+#elif (AMREX_SPACEDIM == 2)
 #include <AMReX_HypreMLABecLap_2D_K.H>
 #else
 #include <AMReX_HypreMLABecLap_3D_K.H>

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
@@ -19,7 +19,6 @@ HypreNodeLap::HypreNodeLap (const BoxArray& grids_, const DistributionMapping& d
       comm(comm_), linop(linop_), verbose(verbose_),
       options_namespace(std::move(options_namespace_))
 {
-    static_assert(AMREX_SPACEDIM > 1, "HypreNodeLap: 1D not supported");
     static_assert(std::is_same_v<Real, HYPRE_Real>, "amrex::Real != HYPRE_Real");
 
     int num_procs, myid;

--- a/Src/Extern/HYPRE/CMakeLists.txt
+++ b/Src/Extern/HYPRE/CMakeLists.txt
@@ -1,11 +1,6 @@
 add_amrex_define(AMREX_USE_HYPRE NO_LEGACY NO_1D IF AMReX_HYPRE)
 
 foreach(D IN LISTS AMReX_SPACEDIM)
-    if (D EQUAL 1)
-        message(WARNING "HYPRE interfaces are not supported for 1D builds (skipping)")
-        continue()
-    endif ()
-
     #
     # This file gets processed if either AMReX_PETSC or AMReX_HYPRE are ON
     # If only AMReX_PETSC is ON, we just need to include this directory

--- a/Src/Extern/HYPRE/Make.package
+++ b/Src/Extern/HYPRE/Make.package
@@ -1,6 +1,4 @@
 
-ifneq ($(DIM), 1)
-
 CEXE_sources += AMReX_HypreABecLap.cpp AMReX_HypreABecLap2.cpp AMReX_HypreABecLap3.cpp AMReX_Hypre.cpp AMReX_HypreMLABecLap.cpp
 
 CEXE_headers += AMReX_HypreABecLap.H AMReX_HypreABecLap2.H AMReX_HypreABecLap3.H AMReX_Hypre.H AMReX_HypreMLABecLap.H
@@ -15,5 +13,3 @@ CEXE_headers += AMReX_HypreSolver.H
 
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
-
-endif

--- a/Src/Extern/PETSc/AMReX_PETSc.cpp
+++ b/Src/Extern/PETSc/AMReX_PETSc.cpp
@@ -63,7 +63,6 @@ PETScABecLap::PETScABecLap (const BoxArray& grids, const DistributionMapping& dm
     : comm(comm_),
       geom(geom_)
 {
-    static_assert(AMREX_SPACEDIM > 1, "PETScABecLap: 1D not supported");
     static_assert(std::is_same_v<Real, PetscScalar>, "amrex::Real != PetscScalar");
 
     const int ncomp = 1;

--- a/Src/Extern/PETSc/CMakeLists.txt
+++ b/Src/Extern/PETSc/CMakeLists.txt
@@ -1,11 +1,6 @@
 add_amrex_define(AMREX_USE_PETSC NO_LEGACY NO_1D IF AMReX_PETSC)
 
 foreach(D IN LISTS AMReX_SPACEDIM)
-    if (D EQUAL 1)
-       message(STATUS "PETSc interfaces are not supported for 1D builds (skipping)")
-       continue()
-    endif ()
-
     target_include_directories(amrex_${D}d
        PUBLIC
        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)


### PR DESCRIPTION
The solvers at amrex/Src/Extern/Hypre and amrex/Src/Extern/PETSc may not work. But this allows WarpX to use amrex's build system in 1D.