### PR TITLE
Add GNUMake changes for building on Tuolumne (LLNL)

### DIFF
--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1139,7 +1139,7 @@ ifeq ($(USE_SYCL),TRUE)
 else ifeq ($(USE_HIP),TRUE)
 
     LINKFLAGS = $(HIPCC_FLAGS)
-    AMREX_LINKER = hipcc
+    AMREX_LINKER ?= hipcc
 
     ifdef AMREX_AMD_ARCH
       AMD_ARCH = $(AMREX_AMD_ARCH)

--- a/Tools/GNUMake/Make.machines
+++ b/Tools/GNUMake/Make.machines
@@ -54,6 +54,11 @@ ifeq ($(findstring alcf.anl.gov, $(host_name)),alcf.anl.gov)
   endif
 endif
 
+ifeq ($(findstring tuolumne, $(host_name)), tuolumne)
+  which_site := llnl
+  which_computer := tuolumne
+endif
+
 ifeq ($(findstring sierra, $(host_name)), sierra)
   which_site := llnl
   which_computer := sierra

--- a/Tools/GNUMake/sites/Make.llnl
+++ b/Tools/GNUMake/sites/Make.llnl
@@ -2,7 +2,7 @@
 # For ray and rzmanta at LLNL
 #
 
-LLNL_MACHINES := ray rzmanta rzansel sierra butte lassen
+LLNL_MACHINES := ray rzmanta rzansel sierra butte lassen tuolumne
 
 ifneq ($(which_computer), $(findstring $(which_computer), $(LLNL_MACHINES)))
   $(error Unknown LLNL computer, $(which_computer))
@@ -106,5 +106,39 @@ ifeq ($(which_computer),$(filter $(which_computer),sierra butte rzansel lassen))
   ifeq ($(lowercase_comp),ibm)
        override XTRALIBS += -L$(XLF_ROOT)/lib -L$(XLC_ROOT)/lib
   endif
+
+endif
+
+ifeq ($(which_computer),$(filter $(which_computer),tuolumne))
+
+  # This assumes these modules (or newer):
+  # module load rocmcc/6.4.2-magic
+  # module load cray-mpich/9.0.1
+
+  ifeq ($(USE_MPI),TRUE)
+
+    CC = $(shell which mpiamdclang)
+    CXX = $(shell which mpiamdclang++)
+    FC = $(shell which mpiamdflang)
+    HIPCXX = $(CXX)
+
+  else
+
+    CC = $(shell which amdclang)
+    CXX = $(shell which amdclang++)
+    FC = $(shell which amdflang)
+    HIPCXX = $(CXX)
+
+  endif
+
+  ifeq ($(USE_HIP),TRUE)
+    # MI250X chip set
+    AMD_ARCH=gfx942
+    DEFINES += -D__HIP_PLATFORM_AMD__
+    CXXFLAGS += -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -I/opt/rocm-6.1.2/include --rocm-path=/opt/rocm-6.1.2 -x hip -fhip-new-launch-api --driver-mode=g++
+    LDFLAGS += --hip-link
+  endif
+
+  AMREX_LINKER = $(CXX)
 
 endif


### PR DESCRIPTION
## Summary
This adds the changes needed in the GNUMake files to build on Tuolumne (at LLNL). This is an AMD GPU system.

## Additional background
These changes assume that the rocmcc module was loaded (as noted in the comments in the file).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
