### PR TITLE
Hypre & PETSc in 1d build

### DIFF
--- a/Src/Extern/HYPRE/CMakeLists.txt
+++ b/Src/Extern/HYPRE/CMakeLists.txt
@@ -1,6 +1,10 @@
-add_amrex_define(AMREX_USE_HYPRE NO_LEGACY NO_1D IF AMReX_HYPRE)
+add_amrex_define(AMREX_USE_HYPRE NO_LEGACY IF AMReX_HYPRE)
 
 foreach(D IN LISTS AMReX_SPACEDIM)
+    if (D EQUAL 1)
+        continue()
+    endif ()
+
     #
     # This file gets processed if either AMReX_PETSC or AMReX_HYPRE are ON
     # If only AMReX_PETSC is ON, we just need to include this directory

--- a/Src/Extern/HYPRE/Make.package
+++ b/Src/Extern/HYPRE/Make.package
@@ -1,4 +1,6 @@
 
+ifneq ($(DIM),1)
+
 CEXE_sources += AMReX_HypreABecLap.cpp AMReX_HypreABecLap2.cpp AMReX_HypreABecLap3.cpp AMReX_Hypre.cpp AMReX_HypreMLABecLap.cpp
 
 CEXE_headers += AMReX_HypreABecLap.H AMReX_HypreABecLap2.H AMReX_HypreABecLap3.H AMReX_Hypre.H AMReX_HypreMLABecLap.H
@@ -13,3 +15,5 @@ CEXE_headers += AMReX_HypreSolver.H
 
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
+
+endif

--- a/Src/Extern/PETSc/CMakeLists.txt
+++ b/Src/Extern/PETSc/CMakeLists.txt
@@ -1,6 +1,10 @@
-add_amrex_define(AMREX_USE_PETSC NO_LEGACY NO_1D IF AMReX_PETSC)
+add_amrex_define(AMREX_USE_PETSC NO_LEGACY IF AMReX_PETSC)
 
 foreach(D IN LISTS AMReX_SPACEDIM)
+    if (D EQUAL 1)
+        continue()
+    endif ()
+
     target_include_directories(amrex_${D}d
        PUBLIC
        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)

--- a/Src/Extern/PETSc/Make.package
+++ b/Src/Extern/PETSc/Make.package
@@ -1,4 +1,6 @@
 
+ifneq ($(DIM),1)
+
 CEXE_headers += AMReX_PETSc.H
 
 CEXE_sources += AMReX_PETSc.cpp
@@ -11,3 +13,5 @@ CEXE_headers += AMReX_Habec_K.H
 
 VPATH_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
 INCLUDE_LOCATIONS += $(AMREX_HOME)/Src/Extern/HYPRE
+
+endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -77,7 +77,7 @@ public:
     [[nodiscard]] std::unique_ptr<Hypre> makeHypre (Hypre::Interface hypre_interface) const override;
 #endif
 
-#ifdef AMREX_USE_PETSC
+#if defined(AMREX_USE_PETSC) && (AMREX_SPACEDIM > 1)
     [[nodiscard]] std::unique_ptr<PETScABecLap> makePETSc () const override;
 #endif
 
@@ -726,7 +726,7 @@ MLCellABecLapT<MF>::makeHypre (Hypre::Interface hypre_interface) const
 }
 #endif
 
-#ifdef AMREX_USE_PETSC
+#if defined(AMREX_USE_PETSC) && (AMREX_SPACEDIM > 1)
 template <typename MF>
 std::unique_ptr<PETScABecLap>
 MLCellABecLapT<MF>::makePETSc () const

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -120,7 +120,7 @@ public:
     [[nodiscard]] std::unique_ptr<Hypre> makeHypre (Hypre::Interface hypre_interface) const override;
 #endif
 
-#ifdef AMREX_USE_PETSC
+#if defined(AMREX_USE_PETSC) && (AMREX_SPACEDIM > 1)
     [[nodiscard]] std::unique_ptr<PETScABecLap> makePETSc () const override;
 #endif
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -13,7 +13,7 @@
 #include <AMReX_HypreABecLap3.H>
 #endif
 
-#ifdef AMREX_USE_PETSC
+#if defined(AMREX_USE_PETSC) && (AMREX_SPACEDIM > 1)
 #include <petscksp.h>
 #include <AMReX_PETSc.H>
 #endif
@@ -1421,7 +1421,7 @@ MLEBABecLap::makeHypre (Hypre::Interface hypre_interface) const
 }
 #endif
 
-#ifdef AMREX_USE_PETSC
+#if defined(AMREX_USE_PETSC) && (AMREX_SPACEDIM > 1)
 std::unique_ptr<PETScABecLap>
 MLEBABecLap::makePETSc () const
 {

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -1054,7 +1054,7 @@ MLMGT<MF>::prepareForSolve (Vector<AMF*> const& a_sol, Vector<AMF const*> const&
         hypre_node_solver.reset();
 #endif
 
-#ifdef AMREX_USE_PETSC
+#if defined(AMREX_USE_PETSC) && (AMREX_SPACEDIM > 1)
         petsc_solver.reset();
         petsc_bndry.reset();
 #endif


### PR DESCRIPTION
This is a follow-up on #4682. WarpX needs AMREX_USE_PETSC to be defined.
