### PR TITLE
Allow std::string "name" arguments for ParmParse methods

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -354,18 +354,18 @@ public:
                         std::string parser_prefix = std::string());
 
     //! Returns true if name is in table.
-    [[nodiscard]] bool contains (const char* name) const;
+    [[nodiscard]] bool contains (std::string_view name) const;
     /**
     * \brief Returns the number of values associated with nth occurrence of
     * name (prepended with the prefix) in the table.  n == -1 implies
     * the last occurrence.
     */
-    [[nodiscard]] int countval (const char* name, int n = LAST) const;
+    [[nodiscard]] int countval (std::string_view name, int n = LAST) const;
     /**
     * \brief Returns the number of times the given name (prepended with
     * prefix) appears in the table.
     */
-    [[nodiscard]] int countname (const std::string& name) const;
+    [[nodiscard]] int countname (std::string_view name) const;
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
     * If successful, the value is converted to a bool and stored
@@ -373,18 +373,18 @@ public:
     * ival'th value does not exist, or if the printed representation
     * of the value cannot be converted to an bool, an error message is
     * output and the program halts.   Note that ival == 0 is the first
-    * value in the list.  ParmParse converte the value 'true', and non-zero
+    * value in the list.  ParmParse converts the value 'true', and non-zero
     * integers or floats to bool(true), and bool(false) for 'false'
     * or zero integer or float values.
     */
-    void getkth (const char* name,
-                 int         k,
-                 bool&       ref,
-                 int         ival = FIRST) const;
+    void getkth (std::string_view name,
+                 int              k,
+                 bool&            ref,
+                 int              ival = FIRST) const;
     //! Same as getkth() but searches for the last occurrence of name.
-    void get (const char* name,
-              bool&       ref,
-              int         ival = FIRST) const;
+    void get (std::string_view name,
+              bool&            ref,
+              int              ival = FIRST) const;
     /**
     * \brief Similar to getkth() but returns 0 if there is no kth occurrence
     * of name.  If successful, it returns 1 and stores the value in
@@ -392,34 +392,34 @@ public:
     * occurrence does not, or if there is a type mismatch, then the
     * program signals an error and halts.
     */
-    int querykth (const char* name,
-                  int         k,
-                  bool&       ref,
-                  int         ival = FIRST) const;
+    int querykth (std::string_view name,
+                  int              k,
+                  bool&            ref,
+                  int              ival = FIRST) const;
     //! Same as querykth() but searches for the last occurrence of name.
-    int query (const char* name,
-               bool&       ref,
-               int         ival = FIRST) const;
-    //! Add a key 'name'with value 'ref' to the end of the PP table.
-    void add (const char* name, bool val);
+    int query (std::string_view name,
+               bool&            ref,
+               int              ival = FIRST) const;
+    //! Add a key 'name' with value 'val' to the end of the PP table.
+    void add (std::string_view name, bool val);
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
     * If successful, the value is converted to an int and stored
     * in reference ref.  If the kth occurrence does not exist or
     * ival'th value does not exist, or if the printed representation
     * of the value cannot be converted to an int, an error message is
-    * output and the program halts.   Note that ival == 0 is the first
+    * output and the program halts.  Note that ival == 0 is the first
     * value in the list.
     */
-    void getkth (const char* name,
-                 int         k,
-                 int&        ref,
-                 int         ival = FIRST) const;
+    void getkth (std::string_view name,
+                 int              k,
+                 int&             ref,
+                 int              ival = FIRST) const;
 
     //! Same as getkth() but searches for the last occurrence of name.
-    void get (const char* name,
-              int&        ref,
-              int         ival = FIRST) const;
+    void get (std::string_view name,
+              int&             ref,
+              int              ival = FIRST) const;
     /**
     * Similar to getkth() but returns 0 if there is no kth occurrence
     * of name.  If successful, it returns 1 and stores the value in
@@ -427,16 +427,50 @@ public:
     * occurrence does not, or if there is a type mismatch, then the
     * program signals an error and halts.
     */
-    int querykth (const char* name,
-                  int         k,
-                  int&        ref,
-                  int         ival = FIRST) const;
+    int querykth (std::string_view name,
+                  int              k,
+                  int&             ref,
+                  int              ival = FIRST) const;
     //! Same as querykth() but searches for the last occurrence of name.
-    int query (const char* name,
-               int&        ref,
-               int         ival = FIRST) const;
-    //! Add a key 'name'with value 'ref' to the end of the PP table.
-    void add (const char* name, int  val);
+    int query (std::string_view name,
+               int&             ref,
+               int              ival = FIRST) const;
+    //! Add a key 'name' with value 'val' to the end of the PP table.
+    void add (std::string_view name, int val);
+    /**
+    * \brief Get the ival'th value of kth occurrence of the requested name.
+    * If successful, the value is converted to an int and stored
+    * in reference ref.  If the kth occurrence does not exist or
+    * ival'th value does not exist, or if the printed representation
+    * of the value cannot be converted to an int, an error message is
+    * output and the program halts.  Note that ival == 0 is the first
+    * value in the list.
+    */
+    void getkth (std::string_view name,
+                 int              k,
+                 long&            ref,
+                 int              ival = FIRST) const;
+    //! Same as getkth() but searches for the last occurrence of name.
+    void get (std::string_view name,
+              long&            ref,
+              int              ival = FIRST) const;
+    /**
+    * \brief Similar to getkth() but returns 0 if there is no kth occurrence
+    * of name.  If successful, it returns 1 and stores the value in
+    * ref.  If the kth occurrence exists, but ival'th value of that
+    * occurrence does not, or if there is a type mismatch, then the
+    * program signals an error and halts.
+    */
+    int querykth (std::string_view name,
+                  int              k,
+                  long&            ref,
+                  int              ival = FIRST) const;
+    //! Same as querykth() but searches for the last occurrence of name.
+    int query (std::string_view name,
+               long&            ref,
+               int              ival = FIRST) const;
+    //! Add a key 'name' with value 'val' to the end of the PP table.
+    void add (std::string_view name, long val);
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
     * If successful, the value is converted to an int and stored
@@ -446,14 +480,14 @@ public:
     * output and the program halts.   Note that ival == 0 is the first
     * value in the list.
     */
-    void getkth (const char* name,
-                 int         k,
-                 long&       ref,
-                 int         ival = FIRST) const;
+    void getkth (std::string_view name,
+                 int              k,
+                 long long&       ref,
+                 int              ival = FIRST) const;
     //! Same as getkth() but searches for the last occurrence of name.
-    void get (const char* name,
-              long&       ref,
-              int         ival = FIRST) const;
+    void get (std::string_view name,
+              long long&       ref,
+              int              ival = FIRST) const;
     /**
     * \brief Similar to getkth() but returns 0 if there is no kth occurrence
     * of name.  If successful, it returns 1 and stores the value in
@@ -461,50 +495,16 @@ public:
     * occurrence does not, or if there is a type mismatch, then the
     * program signals an error and halts.
     */
-    int querykth (const char* name,
-                  int         k,
-                  long&       ref,
-                  int         ival = FIRST) const;
+    int querykth (std::string_view name,
+                  int              k,
+                  long long&       ref,
+                  int              ival = FIRST) const;
     //! Same as querykth() but searches for the last occurrence of name.
-    int query (const char* name,
-               long&        ref,
-               int         ival = FIRST) const;
-    //! Add a key 'name'with value 'ref' to the end of the PP table.
-    void add (const char* name, long  val);
-    /**
-    * \brief Get the ival'th value of kth occurrence of the requested name.
-    * If successful, the value is converted to an int and stored
-    * in reference ref.  If the kth occurrence does not exist or
-    * ival'th value does not exist, or if the printed representation
-    * of the value cannot be converted to an int, an error message is
-    * output and the program halts.   Note that ival == 0 is the first
-    * value in the list.
-    */
-    void getkth (const char* name,
-                 int         k,
-                 long long&  ref,
-                 int         ival = FIRST) const;
-    //! Same as getkth() but searches for the last occurrence of name.
-    void get (const char* name,
-              long long&  ref,
-              int         ival = FIRST) const;
-    /**
-    * \brief Similar to getkth() but returns 0 if there is no kth occurrence
-    * of name.  If successful, it returns 1 and stores the value in
-    * ref.  If the kth occurrence exists, but ival'th value of that
-    * occurrence does not, or if there is a type mismatch, then the
-    * program signals an error and halts.
-    */
-    int querykth (const char* name,
-                  int         k,
-                  long long&  ref,
-                  int         ival = FIRST) const;
-    //! Same as querykth() but searches for the last occurrence of name.
-    int query (const char* name,
-               long long&  ref,
-               int         ival = FIRST) const;
-    //! Add a key 'name'with value 'ref' to the end of the PP table.
-    void add (const char* name, long long  val);
+    int query (std::string_view name,
+               long long&       ref,
+               int              ival = FIRST) const;
+    //! Add a key 'name' with value 'val' to the end of the PP table.
+    void add (std::string_view name, long long  val);
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
     * If successful, the value is converted to a float and stored
@@ -514,14 +514,14 @@ public:
     * is output and the program halts.   Note that ival == 0 is the
     * first value in the list.
     */
-    void getkth (const char* name,
-                 int         k,
-                 float&      ref,
-                 int         ival = FIRST) const;
+    void getkth (std::string_view name,
+                 int              k,
+                 float&           ref,
+                 int              ival = FIRST) const;
     //! Same as getkth() but searches for the last occurrence of name.
-    void get (const char* name,
-              float&      ref,
-              int         ival = FIRST) const;
+    void get (std::string_view name,
+              float&           ref,
+              int              ival = FIRST) const;
     /**
     * \brief Similar to getkth() but returns 0 if there is no kth occurrence
     * of name.  If successful, it returns 1 and stores the value in
@@ -529,16 +529,16 @@ public:
     * occurrence does not, or if there is a type mismatch, then the
     * program signals an error and halts.
     */
-    int querykth (const char* name,
-                  int         k,
-                  float&      ref,
-                  int         ival = FIRST) const;
+    int querykth (std::string_view name,
+                  int              k,
+                  float&           ref,
+                  int              ival = FIRST) const;
     //! Same as querykth() but searches for the last occurrence of name.
-    int query (const char* name,
-               float&      ref,
-               int         ival = FIRST) const;
-    //! Add a key 'name'with value 'ref' to the end of the PP table.
-    void add (const char* name, float  val);
+    int query (std::string_view name,
+               float&           ref,
+               int              ival = FIRST) const;
+    //! Add a key 'name' with value 'val' to the end of the PP table.
+    void add (std::string_view name, float  val);
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
     * If successful, the value is converted to a double and stored
@@ -548,14 +548,14 @@ public:
     * is output and the program halts.   Note that ival = 0 is the
     * first value in the list.
     */
-    void getkth (const char* name,
+    void getkth (std::string_view name,
                  int         k,
                  double&     ref,
                  int         ival = FIRST) const;
     //! Same as getkth() but searches for the last occurrence of name.
-    void get (const char* name,
-              double&     ref,
-              int         ival = FIRST) const;
+    void get (std::string_view name,
+              double&          ref,
+              int              ival = FIRST) const;
     /**
     * \brief Similar to getkth() but returns 0 if there is no kth occurrence
     * of name.  If successful, it returns 1 and stores the value in
@@ -563,16 +563,16 @@ public:
     * occurrence does not, or if there is a type mismatch, then the
     * program signals an error and halts.
     */
-    int querykth (const char* name,
-                  int         k,
-                  double&     ref,
-                  int         ival = FIRST) const;
+    int querykth (std::string_view name,
+                  int              k,
+                  double&          ref,
+                  int              ival = FIRST) const;
     //! Same as querykth() but searches for the last occurrence of name.
-    int query (const char* name,
-               double&     ref,
-               int         ival = FIRST) const;
-    //! Add a key 'name'with value 'ref' to the end of the PP table.
-    void add (const char* name, double val);
+    int query (std::string_view name,
+               double&          ref,
+               int              ival = FIRST) const;
+    //! Add a key 'name' with value 'val' to the end of the PP table.
+    void add (std::string_view name, double val);
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
     * If successful, the value is converted to a std::string and stored
@@ -582,15 +582,15 @@ public:
     * is output and the program halts.   Note that ival = 0 is the
     * first value in the list.
     */
-    void getkth (const char*  name,
-                 int          k,
-                 std::string& ref,
-                 int          ival = FIRST) const;
+    void getkth (std::string_view name,
+                 int              k,
+                 std::string&     ref,
+                 int              ival = FIRST) const;
 
     //! Same as getkth() but searches for the last occurrence of name.
-    void get (const char*  name,
-              std::string& ref,
-              int          ival = FIRST) const;
+    void get (std::string_view name,
+              std::string&     ref,
+              int              ival = FIRST) const;
     /**
     * \brief Similar to getkth() but returns 0 if there is no kth occurrence
     * of name.  If successful, it returns 1 and stores the value in
@@ -598,16 +598,16 @@ public:
     * occurrence does not, or if there is a type mismatch, then the
     * program signals an error and halts.
     */
-    int querykth (const char*  name,
-                  int          k,
-                  std::string& ref,
-                  int          ival = FIRST) const;
+    int querykth (std::string_view name,
+                  int              k,
+                  std::string&     ref,
+                  int              ival = FIRST) const;
     //! Same as querykth() but searches for the last occurrence of name.
-    int query (const char*  name,
-               std::string& ref,
-               int          ival = FIRST) const;
-    //! Add a key 'name'with value 'ref' to the end of the PP table.
-    void add (const char* name, const std::string& val);
+    int query (std::string_view name,
+               std::string&     ref,
+               int              ival = FIRST) const;
+    //! Add a key 'name' with value 'val' to the end of the PP table.
+    void add (std::string_view name, const std::string& val);
 
 
     //! Similar to get() but store the whole line including empty spaces in
@@ -618,7 +618,7 @@ public:
     //! of empty spaces, because of how ParmParse parses the line. For
     //! example, `a b  c` with two spaces between `b` and `c` will become "a
     //! b c".
-    void getline (const char* name, std::string& ref) const;
+    void getline (std::string_view name, std::string& ref) const;
 
     //! Similar to query() but store the whole line including empty spaces
     //! in the middle if present as a single string. For example, `foo = a b
@@ -628,7 +628,7 @@ public:
     //! of empty spaces, because of how ParmParse parses the line. For
     //! example, `a b  c` with two spaces between `b` and `c` will become "a
     //! b c".
-    int queryline (const char* name, std::string& ref) const;
+    int queryline (std::string_view name, std::string& ref) const;
 
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
@@ -639,14 +639,14 @@ public:
     * is output and the program halts.   Note that ival = 0 is the
     * first value in the list.
     */
-    void getkth (const char* name,
-                 int         k,
-                 IntVect&    ref,
-                 int         ival = FIRST) const;
+    void getkth (std::string_view name,
+                 int              k,
+                 IntVect&         ref,
+                 int              ival = FIRST) const;
     //! Same as getkth() but searches for the last occurrence of name.
-    void get (const char* name,
-              IntVect&    ref,
-              int         ival = FIRST) const;
+    void get (std::string_view name,
+              IntVect&         ref,
+              int              ival = FIRST) const;
     /**
     * \brief Similar to getkth() but returns 0 if there is no kth occurrence
     * of name.  If successful, it returns 1 and stores the value in
@@ -654,16 +654,16 @@ public:
     * occurrence does not, or if there is a type mismatch, then the
     * program signals an error and halts.
     */
-    int querykth (const char* name,
-                  int         k,
-                  IntVect&    ref,
-                  int         ival = FIRST) const;
+    int querykth (std::string_view name,
+                  int              k,
+                  IntVect&         ref,
+                  int              ival = FIRST) const;
     //! Same as querykth() but searches for the last occurrence of name.
-    int query (const char* name,
-               IntVect&    ref,
-               int         ival = FIRST) const;
-    //! Add a key 'name'with value 'ref' to the end of the PP table.
-    void add (const char* name, const IntVect& val);
+    int query (std::string_view name,
+               IntVect&         ref,
+               int              ival = FIRST) const;
+    //! Add a key 'name' with value 'val' to the end of the PP table.
+    void add (std::string_view name, const IntVect& val);
     /**
     * \brief Get the ival'th value of kth occurrence of the requested name.
     * If successful, the value is converted to a Box and stored
@@ -673,14 +673,14 @@ public:
     * is output and the program halts.   Note that ival = 0 is the
     * first value in the list.
     */
-    void getkth (const char* name,
-                 int         k,
-                 Box&        ref,
-                 int         ival = FIRST) const;
+    void getkth (std::string_view name,
+                 int              k,
+                 Box&             ref,
+                 int              ival = FIRST) const;
     //! Same as getkth() but searches for the last occurrence of name.
-    void get (const char* name,
-              Box&        ref,
-              int         ival = FIRST) const;
+    void get (std::string_view name,
+              Box&             ref,
+              int              ival = FIRST) const;
     /**
     * \brief Similar to getkth() but returns 0 if there is no kth occurrence
     * of name.  If successful, it returns 1 and stores the value in
@@ -688,16 +688,16 @@ public:
     * occurrence does not, or if there is a type mismatch, then the
     * program signals an error and halts.
     */
-    int querykth (const char* name,
-                  int         k,
-                  Box&        ref,
-                  int         ival = FIRST) const;
+    int querykth (std::string_view name,
+                  int              k,
+                  Box&             ref,
+                  int              ival = FIRST) const;
     //! Same as querykth() but searches for the last occurrence of name.
-    int query (const char* name,
-               Box&        ref,
-               int         ival = FIRST) const;
-    //! Add a key 'name'with value 'ref' to the end of the PP table.
-    void add (const char* name, const Box& val);
+    int query (std::string_view name,
+               Box&             ref,
+               int              ival = FIRST) const;
+    //! Add a key 'name' with value 'val' to the end of the PP table.
+    void add (std::string_view name, const Box& val);
     /**
     * \brief Gets an std::vector\<int\> of num_val values from kth occurrence of
     * given name.  If successful, the values are converted to an int
@@ -710,29 +710,29 @@ public:
     * converted to an int, an error message is reported and the
     * program halts.
     */
-    void getktharr (const char*       name,
+    void getktharr (std::string_view  name,
                     int               k,
                     std::vector<int>& ref,
                     int               start_ix = FIRST,
                     int               num_val = ALL) const;
     //! Same as getktharr() but searches for last occurrence of name.
-    void getarr (const char*       name,
+    void getarr (std::string_view  name,
                  std::vector<int>& ref,
                  int               start_ix = FIRST,
                  int               num_val = ALL) const;
     //! queryktharr() is to querykth() as getktharr() is to getkth().
-    int queryktharr (const char*       name,
+    int queryktharr (std::string_view  name,
                      int               k,
                      std::vector<int>& ref,
                      int               start_ix = FIRST,
                      int               num_val = ALL) const;
     //! Same as queryktharr() but searches for last occurrence of name.
-    int queryarr (const char*       name,
+    int queryarr (std::string_view  name,
                   std::vector<int>& ref,
                   int               start_ix = FIRST,
                   int               num_val = ALL) const;
     //! Add a key 'name' with vector of values 'ref' to the end of the PP table.
-    void addarr (const char* name, const std::vector<int>& ref);
+    void addarr (std::string_view name, const std::vector<int>& ref);
 
     /**
     * \brief Gets an std::vector\<long\> of num_val values from kth occurrence of
@@ -746,29 +746,29 @@ public:
     * converted to a long, an error message is reported and the
     * program halts.
     */
-    void getktharr (const char*        name,
+    void getktharr (std::string_view   name,
                     int                k,
                     std::vector<long>& ref,
                     int                start_ix = FIRST,
                     int                num_val = ALL) const;
     //! Same as getktharr() but searches for last occurrence of name.
-    void getarr (const char*        name,
+    void getarr (std::string_view   name,
                  std::vector<long>& ref,
                  int                start_ix = FIRST,
                  int                num_val = ALL) const;
     //! queryktharr() is to querykth() as getktharr() is to getkth().
-    int queryktharr (const char*        name,
+    int queryktharr (std::string_view   name,
                      int                k,
                      std::vector<long>& ref,
                      int                start_ix = FIRST,
                      int                num_val = ALL) const;
     //! Same as queryktharr() but searches for last occurrence of name.
-    int queryarr (const char*        name,
+    int queryarr (std::string_view   name,
                   std::vector<long>& ref,
                   int                start_ix = FIRST,
                   int                num_val = ALL) const;
     //! Add a key 'name' with vector of values 'ref' to the end of the PP table.
-    void addarr (const char* name, const std::vector<long>& ref);
+    void addarr (std::string_view name, const std::vector<long>& ref);
 
     /**
     * \brief Gets an std::vector\<long long\> of num_val values from kth occurrence of
@@ -782,29 +782,29 @@ public:
     * converted to a long long, an error message is reported and the
     * program halts.
     */
-    void getktharr (const char*             name,
+    void getktharr (std::string_view        name,
                     int                     k,
                     std::vector<long long>& ref,
                     int                     start_ix = FIRST,
                     int                     num_val = ALL) const;
     //! Same as getktharr() but searches for last occurrence of name.
-    void getarr (const char*             name,
+    void getarr (std::string_view        name,
                  std::vector<long long>& ref,
                  int                     start_ix = FIRST,
                  int                     num_val = ALL) const;
     //! queryktharr() is to querykth() as getktharr() is to getkth().
-    int queryktharr (const char*             name,
+    int queryktharr (std::string_view        name,
                      int                     k,
                      std::vector<long long>& ref,
                      int                     start_ix = FIRST,
                      int                     num_val = ALL) const;
     //! Same as queryktharr() but searches for last occurrence of name.
-    int queryarr (const char*             name,
+    int queryarr (std::string_view        name,
                   std::vector<long long>& ref,
                   int                     start_ix = FIRST,
                   int                     num_val = ALL) const;
     //! Add a key 'name' with vector of values 'ref' to the end of the PP table.
-    void addarr (const char* name, const std::vector<long long>& ref);
+    void addarr (std::string_view name, const std::vector<long long>& ref);
 
     /**
     * \brief Gets an std::vector\<float\> of num_val values from kth occurrence of
@@ -818,29 +818,29 @@ public:
     * values cannot be converted to a float, an error message is
     * reported and the program halts.
     */
-    void getktharr (const char*         name,
+    void getktharr (std::string_view    name,
                     int                 k,
                     std::vector<float>& ref,
                     int                 start_ix = FIRST,
                     int                 num_val = ALL) const;
     //! Same as getktharr() but searches for last occurrence of name.
-    void getarr (const char*         name,
+    void getarr (std::string_view    name,
                  std::vector<float>& ref,
                  int                 start_ix = FIRST,
                  int                 num_val = ALL) const;
     //! queryktharr() is to querykth() as getktharr() is to getkth().
-    int queryktharr (const char*         name,
+    int queryktharr (std::string_view    name,
                      int                 k,
                      std::vector<float>& ref,
                      int                 start_ix = FIRST,
                      int                 num_val = ALL) const;
     //! Same as queryktharr() but searches for last occurrence of name.
-    int queryarr (const char*         name,
+    int queryarr (std::string_view    name,
                   std::vector<float>& ref,
                   int                 start_ix = FIRST,
                   int                 num_val = ALL) const;
     //! Add a key 'name' with vector of values 'ref' to the end of the PP table.
-    void addarr (const char* name, const std::vector<float>& ref);
+    void addarr (std::string_view name, const std::vector<float>& ref);
     /**
     * \brief Gets an std::vector\<double\> of num_val values from kth occurrence of
     * given name.  If successful, the values are converted to a double
@@ -853,29 +853,29 @@ public:
     * values cannot be converted to a double, an error message is
     * reported and the program halts.
     */
-    void getktharr (const char*          name,
+    void getktharr (std::string_view     name,
                     int                  k,
                     std::vector<double>& ref,
                     int                  start_ix = FIRST,
                     int                  num_val = ALL) const;
     //! Same as getktharr() but searches for last occurrence of name.
-    void getarr (const char*          name,
+    void getarr (std::string_view     name,
                  std::vector<double>& ref,
                  int                  start_ix = FIRST,
                  int                  num_val = ALL) const;
     //! queryktharr() is to querykth() as getktharr() is to getkth().
-    int queryktharr (const char*          name,
+    int queryktharr (std::string_view     name,
                      int                  k,
                      std::vector<double>& ref,
                      int                  start_ix = FIRST,
                      int                  num_val = ALL) const;
     //! Same as queryktharr() but searches for last occurrence of name.
-    int queryarr (const char*          name,
+    int queryarr (std::string_view     name,
                   std::vector<double>& ref,
                   int                  start_ix = FIRST,
                   int                  num_val = ALL) const;
     //! Add a key 'name' with vector of values 'ref' to the end of the PP table.
-    void addarr (const char* name, const std::vector<double>& ref);
+    void addarr (std::string_view name, const std::vector<double>& ref);
     /**
     * \brief Gets an std::vector<std::string> of num_val values from kth occurrence of
     * given name.  If successful, the values are converted to an
@@ -888,29 +888,29 @@ public:
     * values cannot be converted to an std::string, an error message is
     * reported and the program halts.
     */
-    void getktharr (const char*               name,
+    void getktharr (std::string_view          name,
                     int                       k,
                     std::vector<std::string>& ref,
                     int                       start_ix = FIRST,
                     int                       num_val = ALL) const;
     //! Same as getktharr() but searches for last occurrence of name.
-    void getarr (const char*               name,
+    void getarr (std::string_view          name,
                  std::vector<std::string>& ref,
                  int                       start_ix = FIRST,
                  int                       num_val = ALL) const;
     //! queryktharr() is to querykth() as getktharr() is to getkth().
-    int queryktharr (const char*               name,
+    int queryktharr (std::string_view          name,
                      int                       k,
                      std::vector<std::string>& ref,
                      int                       start_ix = FIRST,
                      int                       num_val = ALL) const;
     //! Same as queryktharr() but searches for last occurrence of name.2
-    int queryarr (const char*               name,
+    int queryarr (std::string_view          name,
                   std::vector<std::string>& ref,
                   int                       start_ix = FIRST,
                   int                       num_val = ALL) const;
     //! Add a key 'name' with vector of values 'ref' to the end of the PP table.
-    void addarr (const char* name, const std::vector<std::string>& ref);
+    void addarr (std::string_view name, const std::vector<std::string>& ref);
     /**
     * \brief Gets an std::vector\<IntVect\> of num_val values from kth occurrence of
     * given name.  If successful, the values are converted to an
@@ -923,29 +923,29 @@ public:
     * values cannot be converted to an IntVect, an error message is
     * reported and the program halts.
     */
-    void getktharr (const char*           name,
+    void getktharr (std::string_view      name,
                     int                   k,
                     std::vector<IntVect>& ref,
                     int                   start_ix = FIRST,
                     int                   num_val = ALL) const;
     //! Same as getktharr() but searches for last occurrence of name.
-    void getarr (const char*           name,
+    void getarr (std::string_view      name,
                  std::vector<IntVect>& ref,
                  int                   start_ix = FIRST,
                  int                   num_val = ALL) const;
     //! queryktharr() is to querykth() as getktharr() is to getkth().
-    int queryktharr (const char*           name,
+    int queryktharr (std::string_view      name,
                      int                   k,
                      std::vector<IntVect>& ref,
                      int                   start_ix = FIRST,
                      int                   num_val = ALL) const;
     //! Same as queryktharr() but searches for last occurrence of name.2
-    int queryarr (const char*           name,
+    int queryarr (std::string_view      name,
                   std::vector<IntVect>& ref,
                   int                   start_ix = FIRST,
                   int                   num_val = ALL) const;
     //! Add a key 'name' with vector of values 'ref' to the end of the PP table.
-    void addarr (const char* name, const std::vector<IntVect>& ref);
+    void addarr (std::string_view name, const std::vector<IntVect>& ref);
     /**
     * \brief Gets an std::vector\<Box\> of num_val values from kth occurrence of
     * given name.  If successful, the values are converted to an
@@ -958,29 +958,29 @@ public:
     * values cannot be converted to an Box, an error message is
     * reported and the program halts.
     */
-    void getktharr (const char*       name,
+    void getktharr (std::string_view  name,
                     int               k,
                     std::vector<Box>& ref,
                     int               start_ix = FIRST,
                     int               num_val = ALL) const;
     //! Same as getktharr() but searches for last occurrence of name.
-    void getarr (const char*       name,
+    void getarr (std::string_view  name,
                  std::vector<Box>& ref,
                  int               start_ix = FIRST,
                  int               num_val = ALL) const;
     //! queryktharr() is to querykth() as getktharr() is to getkth().
-    int queryktharr (const char*       name,
+    int queryktharr (std::string_view  name,
                      int               k,
                      std::vector<Box>& ref,
                      int               start_ix = FIRST,
                      int               num_val = ALL) const;
     //! Same as queryktharr() but searches for last occurrence of name.2
-    int queryarr (const char*       name,
+    int queryarr (std::string_view  name,
                   std::vector<Box>& ref,
                   int               start_ix = FIRST,
                   int               num_val = ALL) const;
     //! Add a key 'name' with vector of values 'ref' to the end of the PP table.
-    void addarr (const char* name, const std::vector<Box>& refd);
+    void addarr (std::string_view name, const std::vector<Box>& ref);
 
     /*
      * \brief Query IntVect from array
@@ -988,7 +988,7 @@ public:
      * This reads IntVect from an array (e.g., `8 16 8`), not the format
      * using parentheses (e.g., `(8,16,8)`).
      */
-    int queryarr (const char* name, IntVect& ref) const;
+    int queryarr (std::string_view name, IntVect& ref) const;
 
     /*
      * \brief Get IntVect from array
@@ -996,16 +996,16 @@ public:
      * This reads IntVect from an array (e.g., `8 16 8`), not the format
      * using parentheses (e.g., `(8,16,8)`).
      */
-    void getarr (const char* name, IntVect& ref) const;
+    void getarr (std::string_view name, IntVect& ref) const;
 
     //! Query RealVect from array
-    int queryarr (const char* name, RealVect& ref) const;
+    int queryarr (std::string_view name, RealVect& ref) const;
 
     //! Get RealVect from array
-    void getarr (const char* name, RealVect& ref) const;
+    void getarr (std::string_view name, RealVect& ref) const;
 
     template <typename T, std::size_t N>
-    void get (const char* name, std::array<T,N>& ref) const {
+    void get (std::string_view name, std::array<T,N>& ref) const {
         std::vector<T> v;
         this->getarr(name, v);
         AMREX_ALWAYS_ASSERT(v.size() >= N);
@@ -1015,7 +1015,7 @@ public:
     }
 
     template <typename T, std::size_t N>
-    int query (const char* name, std::array<T,N>& ref) const {
+    int query (std::string_view name, std::array<T,N>& ref) const {
         std::vector<T> v;
         int exist = this->queryarr(name, v);
         if (exist) {
@@ -1034,7 +1034,7 @@ public:
      * existed previously.
      */
     template <typename T, std::enable_if_t<!IsStdVector<T>::value, int> = 0>
-    int queryAdd (const char* name, T& ref) {
+    int queryAdd (std::string_view name, T& ref) {
         int exist = this->query(name, ref);
         if (!exist) {
             this->add(name, ref);
@@ -1042,7 +1042,7 @@ public:
         return exist;
     }
 
-    int queryAdd (const char* name, std::string& ref) {
+    int queryAdd (std::string_view name, std::string& ref) {
         int exist = this->query(name, ref);
         if (!exist && !ref.empty()) {
             this->add(name, ref);
@@ -1060,7 +1060,7 @@ public:
      * (and resized) according to the number of values in the inputs.
      */
     template <typename T>
-    int queryAdd (const char* name, std::vector<T>& ref) {
+    int queryAdd (std::string_view name, std::vector<T>& ref) {
         std::vector<T> empty;
         int exist = this->queryarr(name, empty);
         if (exist) {
@@ -1079,7 +1079,7 @@ public:
      * existed previously.
      */
     template <typename T>
-    int queryAdd (const char* name, std::vector<T>& ref, int num_val) {
+    int queryAdd (std::string_view name, std::vector<T>& ref, int num_val) {
         int exist = this->queryarr(name, ref, 0, num_val);
         if (!exist) {
             this->addarr(name, ref);
@@ -1094,7 +1094,7 @@ public:
      * existed previously.
      */
     template <typename T, std::size_t N>
-    int queryAdd (const char* name, std::array<T,N>& ref) {
+    int queryAdd (std::string_view name, std::array<T,N>& ref) {
         std::vector<T> v;
         int exist = this->queryarr(name, v);
         if (exist) {
@@ -1118,12 +1118,12 @@ public:
      * scalar. The return value indicates whether it's found. Note that
      * queryWithParser will be used recursively for unresolved symbols.
      */
-    int queryWithParser (const char* name, bool& ref) const;
-    int queryWithParser (const char* name, int& ref) const;
-    int queryWithParser (const char* name, long& ref) const;
-    int queryWithParser (const char* name, long long& ref) const;
-    int queryWithParser (const char* name, float& ref) const;
-    int queryWithParser (const char* name, double& ref) const;
+    int queryWithParser (std::string_view name, bool& ref) const;
+    int queryWithParser (std::string_view name, int& ref) const;
+    int queryWithParser (std::string_view name, long& ref) const;
+    int queryWithParser (std::string_view name, long long& ref) const;
+    int queryWithParser (std::string_view name, float& ref) const;
+    int queryWithParser (std::string_view name, double& ref) const;
 
     /**
      * \brief Query with Parser. The return value indicates whether it's
@@ -1131,19 +1131,19 @@ public:
      * symbols. If the number of elements in the input does not equal to
      * `nvals`, it's a runtime error.
      */
-    int queryarrWithParser (const char* name, int nvals, bool* ref) const;
-    int queryarrWithParser (const char* name, int nvals, int* ref) const;
-    int queryarrWithParser (const char* name, int nvals, long* ref) const;
-    int queryarrWithParser (const char* name, int nvals, long long* ref) const;
-    int queryarrWithParser (const char* name, int nvals, float* ref) const;
-    int queryarrWithParser (const char* name, int nvals, double* ref) const;
+    int queryarrWithParser (std::string_view name, int nvals, bool* ref) const;
+    int queryarrWithParser (std::string_view name, int nvals, int* ref) const;
+    int queryarrWithParser (std::string_view name, int nvals, long* ref) const;
+    int queryarrWithParser (std::string_view name, int nvals, long long* ref) const;
+    int queryarrWithParser (std::string_view name, int nvals, float* ref) const;
+    int queryarrWithParser (std::string_view name, int nvals, double* ref) const;
     template <typename T, std::enable_if_t<std::is_same_v<T,bool> ||
                                            std::is_same_v<T,int> ||
                                            std::is_same_v<T,long> ||
                                            std::is_same_v<T,long long> ||
                                            std::is_same_v<T,float> ||
                                            std::is_same_v<T,double>,int> = 0>
-    int queryarrWithParser (const char* name, int nvals, std::vector<T>& ref) const
+    int queryarrWithParser (std::string_view name, int nvals, std::vector<T>& ref) const
     {
         if (this->contains(name)) {
             if (int(ref.size()) < nvals) { ref.resize(nvals); }
@@ -1165,7 +1165,7 @@ public:
                                            std::is_same_v<T,long long> ||
                                            std::is_same_v<T,float> ||
                                            std::is_same_v<T,double>,int> = 0>
-    int queryAddWithParser (const char* name, T& ref)
+    int queryAddWithParser (std::string_view name, T& ref)
     {
         int exist = this->queryWithParser(name, ref);
         if (!exist) {
@@ -1185,11 +1185,11 @@ public:
                                            std::is_same_v<T,long long> ||
                                            std::is_same_v<T,float> ||
                                            std::is_same_v<T,double>,int> = 0>
-    void getWithParser (const char* name, T& ref) const
+    void getWithParser (std::string_view name, T& ref) const
     {
         int exist = this->queryWithParser(name, ref);
         if (!exist) {
-            amrex::Error(std::string("ParmParse::getWithParser: failed to get ")+name);
+            amrex::Error(std::string("ParmParse::getWithParser: failed to get ")+std::string(name));
         }
     }
 
@@ -1204,11 +1204,11 @@ public:
                                            std::is_same_v<T,long long> ||
                                            std::is_same_v<T,float> ||
                                            std::is_same_v<T,double>,int> = 0>
-    void getarrWithParser (const char* name, int nvals, T* ref) const
+    void getarrWithParser (std::string_view name, int nvals, T* ref) const
     {
         int exist = this->queryarrWithParser(name, nvals, ref);
         if (!exist) {
-            amrex::Error(std::string("ParmParse::getarrWithParser: failed to get ")+name);
+            amrex::Error(std::string("ParmParse::getarrWithParser: failed to get ")+std::string(name));
         }
     }
 
@@ -1223,11 +1223,11 @@ public:
                                            std::is_same_v<T,long long> ||
                                            std::is_same_v<T,float> ||
                                            std::is_same_v<T,double>,int> = 0>
-    void getarrWithParser (const char* name, int nvals, std::vector<T>& ref) const
+    void getarrWithParser (std::string_view name, int nvals, std::vector<T>& ref) const
     {
         int exist = this->queryarrWithParser(name, nvals, ref);
         if (!exist) {
-            amrex::Error(std::string("ParmParse::getarrWithParser: failed to get ")+name);
+            amrex::Error(std::string("ParmParse::getarrWithParser: failed to get ")+std::string(name));
         }
     }
 
@@ -1297,7 +1297,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    int query (const char* name, T& ref, int ival = FIRST) const
+    int query (std::string_view name, T& ref, int ival = FIRST) const
     {
         std::string s;
         int exist = this->query(name, s, ival);
@@ -1325,7 +1325,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    void get (const char* name, T& ref, int ival = FIRST) const
+    void get (std::string_view name, T& ref, int ival = FIRST) const
     {
         std::string s;
         this->get(name, s, ival);
@@ -1343,7 +1343,7 @@ public:
     //! Query an array of enum values using given name.
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    int queryarr (const char* name,
+    int queryarr (std::string_view name,
                   std::vector<T>& ref,
                   int start_ix = FIRST,
                   int num_val = ALL) const
@@ -1370,7 +1370,7 @@ public:
     //! Get an array of enum values using given name.
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    void getarr (const char* name,
+    void getarr (std::string_view name,
                  std::vector<T>& ref,
                  int start_ix = FIRST,
                  int num_val = ALL) const
@@ -1403,7 +1403,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    int query_enum_case_insensitive (const char* name, T& ref, int ival = FIRST) const
+    int query_enum_case_insensitive (std::string_view name, T& ref, int ival = FIRST) const
     {
         std::string s;
         int exist = this->query(name, s, ival);
@@ -1433,7 +1433,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    void get_enum_case_insensitive (const char* name, T& ref, int ival = FIRST) const
+    void get_enum_case_insensitive (std::string_view name, T& ref, int ival = FIRST) const
     {
         int exist = this->query_enum_case_insensitive(name, ref, ival);
         if (!exist) {
@@ -1458,7 +1458,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    int query_enum_sloppy (const char* name, T& ref, std::string_view const& ignores,
+    int query_enum_sloppy (std::string_view name, T& ref, std::string_view const& ignores,
                            int ival = FIRST) const
     {
         std::string s;
@@ -1495,7 +1495,7 @@ public:
      */
     template <typename T, typename ET = amrex_enum_traits<T>,
               std::enable_if_t<ET::value,int> = 0>
-    void get_enum_sloppy (const char* name, T& ref, std::string_view const& ignores,
+    void get_enum_sloppy (std::string_view name, T& ref, std::string_view const& ignores,
                           int ival = FIRST) const
     {
         int exist = this->query_enum_sloppy(name, ref, ignores, ival);
@@ -1516,7 +1516,7 @@ public:
      * std::optional of arithmetic type.
      */
     template <typename T, std::enable_if_t<ppdetail::IsArithmeticOptional_v<T>, int> = 0>
-    int queryAsDouble (const char* name, T& ref) const
+    int queryAsDouble (std::string_view name, T& ref) const
     {
         using value_type = ppdetail::underlying_type_t<T>;
         double dref;
@@ -1545,7 +1545,7 @@ public:
      * std::optional of arithmetic type.
      */
     template <typename T, std::enable_if_t<ppdetail::IsArithmeticOptional_v<T>, int> = 0>
-    int queryarrAsDouble (const char* name, int nvals, T* ref) const
+    int queryarrAsDouble (std::string_view name, int nvals, T* ref) const
     {
         using value_type = ppdetail::underlying_type_t<T>;
         std::vector<double> dref(nvals);
@@ -1576,11 +1576,11 @@ public:
      * std::optional of arithmetic type.
      */
     template <typename T, std::enable_if_t<ppdetail::IsArithmeticOptional_v<T>, int> = 0>
-    void getAsDouble (const char* name, T& ref) const
+    void getAsDouble (std::string_view name, T& ref) const
     {
         int exist = this->queryAsDouble(name, ref);
         if (!exist) {
-            amrex::Error(std::string("ParmParse::getAsDouble: failed to get ")+name);
+            amrex::Error(std::string("ParmParse::getAsDouble: failed to get ")+std::string(name));
         }
     }
 
@@ -1593,16 +1593,16 @@ public:
      * std::optional of arithmetic type.
      */
     template <typename T, std::enable_if_t<ppdetail::IsArithmeticOptional_v<T>, int> = 0>
-    void getarrAsDouble (const char* name, int nvals, T* ref) const
+    void getarrAsDouble (std::string_view name, int nvals, T* ref) const
     {
         int exist = this->queryarrAsDouble(name, nvals, ref);
         if (!exist) {
-            amrex::Error(std::string("ParmParse::getarrAsDouble: failed to get ")+name);
+            amrex::Error(std::string("ParmParse::getarrAsDouble: failed to get ")+std::string(name));
         }
     }
 
     //! Remove given name from the table.
-    int remove (const char* name);
+    int remove (std::string_view name);
 
     //! Make Parser using given string `func` as function body and `vars` as
     //! variable names. Constants known to ParmParse will be set. It's a
@@ -1621,9 +1621,9 @@ public:
      * it's found. The table (i.e., vector of vector) is in the format of
      * `{{a00, a01, a02...} {a10, a11, a12...} ...}`.
      */
-    int querytable (const char* name, std::vector<std::vector<double>>& ref) const;
-    int querytable (const char* name, std::vector<std::vector<float>>& ref) const;
-    int querytable (const char* name, std::vector<std::vector<int>>& ref) const;
+    int querytable (std::string_view name, std::vector<std::vector<double>>& ref) const;
+    int querytable (std::string_view name, std::vector<std::vector<float>>& ref) const;
+    int querytable (std::string_view name, std::vector<std::vector<int>>& ref) const;
 
     /**
      * \brief Get vector of vector. It's an error if it is not found.  The
@@ -1631,7 +1631,7 @@ public:
      * `{{a00, a01, * a02...} {a10, a11, a12...} ...}`.
      */
     template <typename T>
-    void gettable (const char* name, std::vector<std::vector<T>>& ref) const
+    void gettable (std::string_view name, std::vector<std::vector<T>>& ref) const
     {
         if (this->querytable(name, ref) == 0) {
             amrex::ErrorStream() << "ParmParse::gettable: " << name

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1723,7 +1723,7 @@ public:
 
     [[nodiscard]] std::string const& getPrefix () const;
 
-    [[nodiscard]] std::string prefixedName (const std::string_view& str) const;
+    [[nodiscard]] std::string prefixedName (std::string_view str) const;
 
 protected:
 

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1131,12 +1131,12 @@ public:
      * symbols. If the number of elements in the input does not equal to
      * `nvals`, it's a runtime error.
      */
-    int queryarrWithParser (std::string_view name, int nvals, bool* ref) const;
-    int queryarrWithParser (std::string_view name, int nvals, int* ref) const;
-    int queryarrWithParser (std::string_view name, int nvals, long* ref) const;
-    int queryarrWithParser (std::string_view name, int nvals, long long* ref) const;
-    int queryarrWithParser (std::string_view name, int nvals, float* ref) const;
-    int queryarrWithParser (std::string_view name, int nvals, double* ref) const;
+    int queryarrWithParser (std::string_view name, int nvals, bool* ptr) const;
+    int queryarrWithParser (std::string_view name, int nvals, int* ptr) const;
+    int queryarrWithParser (std::string_view name, int nvals, long* ptr) const;
+    int queryarrWithParser (std::string_view name, int nvals, long long* ptr) const;
+    int queryarrWithParser (std::string_view name, int nvals, float* ptr) const;
+    int queryarrWithParser (std::string_view name, int nvals, double* ptr) const;
     template <typename T, std::enable_if_t<std::is_same_v<T,bool> ||
                                            std::is_same_v<T,int> ||
                                            std::is_same_v<T,long> ||
@@ -1204,9 +1204,9 @@ public:
                                            std::is_same_v<T,long long> ||
                                            std::is_same_v<T,float> ||
                                            std::is_same_v<T,double>,int> = 0>
-    void getarrWithParser (std::string_view name, int nvals, T* ref) const
+    void getarrWithParser (std::string_view name, int nvals, T* ptr) const
     {
-        int exist = this->queryarrWithParser(name, nvals, ref);
+        int exist = this->queryarrWithParser(name, nvals, ptr);
         if (!exist) {
             amrex::Error(std::string("ParmParse::getarrWithParser: failed to get ")+std::string(name));
         }
@@ -1545,7 +1545,7 @@ public:
      * std::optional of arithmetic type.
      */
     template <typename T, std::enable_if_t<ppdetail::IsArithmeticOptional_v<T>, int> = 0>
-    int queryarrAsDouble (std::string_view name, int nvals, T* ref) const
+    int queryarrAsDouble (std::string_view name, int nvals, T* ptr) const
     {
         using value_type = ppdetail::underlying_type_t<T>;
         std::vector<double> dref(nvals);
@@ -1561,7 +1561,7 @@ public:
                         amrex::Abort("ParmParse:: queryarrAsDouble is not safe");
                     }
                 }
-                ref[i] = vref;
+                ptr[i] = vref;
             }
         }
         return exist;
@@ -1593,9 +1593,9 @@ public:
      * std::optional of arithmetic type.
      */
     template <typename T, std::enable_if_t<ppdetail::IsArithmeticOptional_v<T>, int> = 0>
-    void getarrAsDouble (std::string_view name, int nvals, T* ref) const
+    void getarrAsDouble (std::string_view name, int nvals, T* ptr) const
     {
-        int exist = this->queryarrAsDouble(name, nvals, ref);
+        int exist = this->queryarrAsDouble(name, nvals, ptr);
         if (!exist) {
             amrex::Error(std::string("ParmParse::getarrAsDouble: failed to get ")+std::string(name));
         }

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1649,6 +1649,9 @@ public:
     * those derived from argv to the table.
     */
     static void Initialize (int argc, char** argv, const char* parfile);
+    static void Initialize (int argc, char** argv, const std::string& parfile) {
+        return Initialize(argc, argv, parfile.c_str());
+    }
     /**
     * \brief The destructor.  The internal static table will only be deleted
     * if there are no other ParmParse objects in existence.

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -2237,7 +2237,7 @@ bool squeryarrWithParser (const ParmParse::Table& table,
                           const std::string&      parser_prefix,
                           const std::string&      name,
                           int                     nvals,
-                          T*                      ref)
+                          T*                      ptr)
 {
     std::vector<std::string> vals;
     bool exist = squeryarr(table, parser_prefix, name, vals,
@@ -2246,7 +2246,7 @@ bool squeryarrWithParser (const ParmParse::Table& table,
 
     AMREX_ALWAYS_ASSERT(int(vals.size()) == nvals);
     for (int ival = 0; ival < nvals; ++ival) {
-        bool r = pp_parser(table, parser_prefix, name, vals[ival], ref[ival], true);
+        bool r = pp_parser(table, parser_prefix, name, vals[ival], ptr[ival], true);
         if (!r) { return false; }
     }
     return true;
@@ -2290,39 +2290,39 @@ ParmParse::queryWithParser (std::string_view name, double& ref) const
 }
 
 int
-ParmParse::queryarrWithParser (std::string_view name, int nvals, bool* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, bool* ptr) const
 {
-    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ptr);
 }
 
 int
-ParmParse::queryarrWithParser (std::string_view name, int nvals, int* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, int* ptr) const
 {
-    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ptr);
 }
 
 int
-ParmParse::queryarrWithParser (std::string_view name, int nvals, long* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, long* ptr) const
 {
-    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ptr);
 }
 
 int
-ParmParse::queryarrWithParser (std::string_view name, int nvals, long long* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, long long* ptr) const
 {
-    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ptr);
 }
 
 int
-ParmParse::queryarrWithParser (std::string_view name, int nvals, float* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, float* ptr) const
 {
-    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ptr);
 }
 
 int
-ParmParse::queryarrWithParser (std::string_view name, int nvals, double* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, double* ptr) const
 {
-    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
+    return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ptr);
 }
 
 Parser

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1352,8 +1352,8 @@ ParmParse::prettyPrintUsedInputs (std::ostream& os)
 }
 
 int
-ParmParse::countval (const char* name,
-                     int         n) const
+ParmParse::countval (std::string_view name,
+                     int              n) const
 {
     //
     // First find n'th occurrence of name in table.
@@ -1364,107 +1364,129 @@ ParmParse::countval (const char* name,
 
 // BOOL
 void
-ParmParse::getkth (const char* name,
-                   int         k,
-                   bool&       ref,
-                   int         ival) const
+ParmParse::getkth (std::string_view name,
+                   int              k,
+                   bool&            ref,
+                   int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 void
-ParmParse::get (const char* name,
-                bool&       ref,
-                int ival) const
+ParmParse::get (std::string_view name,
+                bool&            ref,
+                int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 int
-ParmParse::querykth (const char* name,
-                     int         k,
-                     bool&       ref,
-                     int         ival) const
+ParmParse::querykth (std::string_view name,
+                     int              k,
+                     bool&            ref,
+                     int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 int
-ParmParse::query (const char* name,
-                  bool&       ref,
-                  int         ival) const
+ParmParse::query (std::string_view name,
+                  bool&            ref,
+                  int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 void
-ParmParse::add (const char* name, // NOLINT(readability-make-member-function-const)
-                const bool  val)
+ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
+                const bool       val)
 {
     saddval(prefixedName(name),val);
 }
 
 // INT
 void
-ParmParse::getkth (const char* name, int k, int& ref, int ival) const
+ParmParse::getkth (std::string_view name,
+                   int              k,
+                   int&             ref,
+                   int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 void
-ParmParse::get (const char* name, int& ref, int ival) const
+ParmParse::get (std::string_view name,
+                int&             ref,
+                int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 int
-ParmParse::querykth (const char* name, int k, int& ref, int ival) const
+ParmParse::querykth (std::string_view name,
+                     int              k,
+                     int&             ref,
+                     int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 int
-ParmParse::query (const char* name, int& ref, int ival) const
+ParmParse::query (std::string_view name,
+                  int&             ref,
+                  int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 void
-ParmParse::add (const char* name, const int val) // NOLINT(readability-make-member-function-const)
+ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
+                const int        val)
 {
     saddval(prefixedName(name),val);
 }
 
 void
-ParmParse::getktharr (const char* name, int k, std::vector<int>& ref,
-                      int start_ix, int num_val) const
+ParmParse::getktharr (std::string_view  name,
+                      int               k,
+                      std::vector<int>& ref,
+                      int               start_ix,
+                      int               num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 void
-ParmParse::getarr (const char* name, std::vector<int>& ref, int start_ix,
-                   int num_val) const
+ParmParse::getarr (std::string_view  name,
+                   std::vector<int>& ref,
+                   int               start_ix,
+                   int               num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 int
-ParmParse::queryktharr (const char* name, int k, std::vector<int>& ref,
-                        int start_ix, int num_val) const
+ParmParse::queryktharr (std::string_view  name,
+                        int               k,
+                        std::vector<int>& ref,
+                        int               start_ix,
+                        int               num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 int
-ParmParse::queryarr (const char* name, std::vector<int>& ref, int start_ix,
-                     int num_val) const
+ParmParse::queryarr (std::string_view  name,
+                     std::vector<int>& ref,
+                     int               start_ix,
+                     int               num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<int>& ref) // NOLINT(readability-make-member-function-const)
+ParmParse::addarr (std::string_view        name, // NOLINT(readability-make-member-function-const)
+                   const std::vector<int>& ref)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1472,196 +1494,260 @@ ParmParse::addarr (const char* name, const std::vector<int>& ref) // NOLINT(read
 
 // LONG
 void
-ParmParse::getkth (const char* name, int k, long& ref, int ival) const
+ParmParse::getkth (std::string_view name,
+                   int              k,
+                   long&            ref,
+                   int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 void
-ParmParse::get (const char* name, long& ref, int ival) const
+ParmParse::get (std::string_view name,
+                long&            ref,
+                int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 int
-ParmParse::querykth (const char* name, int k, long& ref, int ival) const
+ParmParse::querykth (std::string_view name,
+                     int              k,
+                     long&            ref,
+                     int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 int
-ParmParse::query (const char* name, long& ref, int ival) const
+ParmParse::query (std::string_view name,
+                  long&            ref,
+                  int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 void
-ParmParse::add (const char* name, // NOLINT(readability-make-member-function-const)
-                const long  val)
+ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
+                const long       val)
 {
     saddval(prefixedName(name),val);
 }
 
 void
-ParmParse::getktharr (const char* name, int k, std::vector<long>& ref,
-                      int start_ix, int num_val) const
+ParmParse::getktharr (std::string_view   name,
+                      int                k,
+                      std::vector<long>& ref,
+                      int                start_ix,
+                      int                num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 void
-ParmParse::getarr (const char* name, std::vector<long>& ref, int start_ix,
-                   int num_val) const
+ParmParse::getarr (std::string_view   name,
+                   std::vector<long>& ref,
+                   int                start_ix,
+                   int                num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 int
-ParmParse::queryktharr (const char* name, int k, std::vector<long>& ref,
-                        int start_ix, int num_val) const
+ParmParse::queryktharr (std::string_view   name,
+                        int                k,
+                        std::vector<long>& ref,
+                        int                start_ix,
+                        int                num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 int
-ParmParse::queryarr (const char* name, std::vector<long>& ref, int start_ix,
-                     int num_val) const
+ParmParse::queryarr (std::string_view   name,
+                     std::vector<long>& ref,
+                     int                start_ix,
+                     int                num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<long>& ref) // NOLINT(readability-make-member-function-const)
+ParmParse::addarr (std::string_view name, const std::vector<long>& ref) // NOLINT(readability-make-member-function-const)
 {
     saddarr(prefixedName(name),ref);
 }
 
 // long long
 void
-ParmParse::getkth (const char* name, int k, long long& ref, int ival) const
+ParmParse::getkth (std::string_view name,
+                   int              k,
+                   long long&       ref,
+                   int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 void
-ParmParse::get (const char* name, long long& ref, int ival) const
+ParmParse::get (std::string_view name,
+                long long&       ref,
+                int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 int
-ParmParse::querykth (const char* name, int k, long long& ref, int ival) const
+ParmParse::querykth (std::string_view name,
+                     int              k,
+                     long long&       ref,
+                     int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 int
-ParmParse::query (const char* name, long long& ref, int ival) const
+ParmParse::query (std::string_view name,
+                  long long&       ref,
+                  int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 void
-ParmParse::add (const char* name, const long long val) // NOLINT(readability-make-member-function-const)
+ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
+                const long long  val)
 {
     saddval(prefixedName(name),val);
 }
 
 void
-ParmParse::getktharr (const char* name, int k, std::vector<long long>& ref,
-                      int start_ix, int num_val) const
+ParmParse::getktharr (std::string_view        name,
+                      int                     k,
+                      std::vector<long long>& ref,
+                      int                     start_ix,
+                      int                     num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 void
-ParmParse::getarr (const char* name, std::vector<long long>& ref, int start_ix,
-                   int num_val) const
+ParmParse::getarr (std::string_view        name,
+                   std::vector<long long>& ref,
+                   int                     start_ix,
+                   int                     num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 int
-ParmParse::queryktharr (const char* name, int k, std::vector<long long>& ref,
-                        int start_ix, int num_val) const
+ParmParse::queryktharr (std::string_view        name,
+                        int                     k,
+                        std::vector<long long>& ref,
+                        int                     start_ix,
+                        int                     num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 int
-ParmParse::queryarr (const char* name, std::vector<long long>& ref, int start_ix,
-                     int num_val) const
+ParmParse::queryarr (std::string_view        name,
+                     std::vector<long long>& ref,
+                     int                     start_ix,
+                     int                     num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<long long>& ref) // NOLINT(readability-make-member-function-const)
+ParmParse::addarr (std::string_view              name, // NOLINT(readability-make-member-function-const)
+                   const std::vector<long long>& ref)
 {
     saddarr(prefixedName(name),ref);
 }
 
 // FLOAT
 void
-ParmParse::getkth (const char* name, int k, float& ref, int ival) const
+ParmParse::getkth (std::string_view name,
+                   int              k,
+                   float&           ref,
+                   int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 void
-ParmParse::get (const char* name, float& ref, int ival) const
+ParmParse::get (std::string_view name,
+                float&           ref,
+                int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 int
-ParmParse::querykth (const char* name, int k, float& ref, int ival) const
+ParmParse::querykth (std::string_view name,
+                     int              k,
+                     float&           ref,
+                     int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 int
-ParmParse::query (const char* name, float& ref, int ival) const
+ParmParse::query (std::string_view name,
+                  float&           ref,
+                  int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 void
-ParmParse::add (const char* name, const float val) // NOLINT(readability-make-member-function-const)
+ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
+                const float      val)
 {
     saddval(prefixedName(name),val);
 }
 
 void
-ParmParse::getktharr (const char* name, int k, std::vector<float>& ref,
-                      int start_ix, int num_val) const
+ParmParse::getktharr (std::string_view    name,
+                      int                 k,
+                      std::vector<float>& ref,
+                      int                 start_ix,
+                      int                 num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 void
-ParmParse::getarr (const char* name, std::vector<float>& ref, int start_ix,
-                   int num_val) const
+ParmParse::getarr (std::string_view    name,
+                   std::vector<float>& ref,
+                   int                 start_ix,
+                   int                 num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 int
-ParmParse::queryktharr (const char* name, int k, std::vector<float>& ref,
-                        int start_ix, int num_val) const
+ParmParse::queryktharr (std::string_view    name,
+                        int                 k,
+                        std::vector<float>& ref,
+                        int                 start_ix,
+                        int                 num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix, num_val,k);
 }
 
 int
-ParmParse::queryarr (const char* name, std::vector<float>& ref, int start_ix,
-                     int num_val) const
+ParmParse::queryarr (std::string_view    name,
+                     std::vector<float>& ref,
+                     int                 start_ix,
+                     int                 num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<float>& ref) // NOLINT(readability-make-member-function-const)
+ParmParse::addarr (std::string_view          name, // NOLINT(readability-make-member-function-const)
+                   const std::vector<float>& ref)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1670,65 +1756,87 @@ ParmParse::addarr (const char* name, const std::vector<float>& ref) // NOLINT(re
 
 // DOUBLE
 void
-ParmParse::getkth (const char* name, int k, double& ref, int ival) const
+ParmParse::getkth (std::string_view name,
+                   int              k,
+                   double&          ref,
+                   int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 void
-ParmParse::get (const char* name, double& ref, int ival) const
+ParmParse::get (std::string_view name,
+                double&          ref,
+                int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 int
-ParmParse::querykth (const char* name, int k, double& ref, int ival) const
+ParmParse::querykth (std::string_view name,
+                     int              k,
+                     double&          ref,
+                     int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 int
-ParmParse::query (const char* name, double& ref, int ival) const
+ParmParse::query (std::string_view name,
+                  double&          ref,
+                  int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 void
-ParmParse::add (const char* name, const double val) // NOLINT(readability-make-member-function-const)
+ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
+                const double     val)
 {
     saddval(prefixedName(name),val);
 }
 
 void
-ParmParse::getktharr (const char* name, int k, std::vector<double>& ref,
-                      int start_ix, int num_val) const
+ParmParse::getktharr (std::string_view     name,
+                      int                  k,
+                      std::vector<double>& ref,
+                      int                  start_ix,
+                      int                  num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 void
-ParmParse::getarr (const char* name, std::vector<double>& ref, int start_ix,
-                   int num_val) const
+ParmParse::getarr (std::string_view     name,
+                   std::vector<double>& ref,
+                   int                  start_ix,
+                   int                  num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 int
-ParmParse::queryktharr (const char* name, int k, std::vector<double>& ref,
-                        int start_ix, int num_val) const
+ParmParse::queryktharr (std::string_view     name,
+                        int                  k,
+                        std::vector<double>& ref,
+                        int                  start_ix,
+                        int                  num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix, num_val,k);
 }
 
 int
-ParmParse::queryarr (const char* name, std::vector<double>& ref, int start_ix,
-                     int num_val) const
+ParmParse::queryarr (std::string_view     name,
+                     std::vector<double>& ref,
+                     int                  start_ix,
+                     int                  num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<double>& ref) // NOLINT(readability-make-member-function-const)
+ParmParse::addarr (std::string_view           name, // NOLINT(readability-make-member-function-const)
+                   const std::vector<double>& ref)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1737,65 +1845,87 @@ ParmParse::addarr (const char* name, const std::vector<double>& ref) // NOLINT(r
 
 // STRING
 void
-ParmParse::getkth (const char* name, int k, std::string& ref, int ival) const
+ParmParse::getkth (std::string_view name,
+                   int              k,
+                   std::string&     ref,
+                   int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 void
-ParmParse::get (const char* name, std::string& ref, int ival) const
+ParmParse::get (std::string_view name,
+                std::string&     ref,
+                int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 int
-ParmParse::querykth (const char* name, int k, std::string& ref, int ival) const
+ParmParse::querykth (std::string_view name,
+                     int              k,
+                     std::string&     ref,
+                     int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 int
-ParmParse::query (const char* name, std::string& ref, int ival) const
+ParmParse::query (std::string_view name,
+                  std::string&     ref,
+                  int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 void
-ParmParse::add (const char* name, const std::string& val) // NOLINT(readability-make-member-function-const)
+ParmParse::add (std::string_view   name, // NOLINT(readability-make-member-function-const)
+                const std::string& val)
 {
     saddval(prefixedName(name),val);
 }
 
 void
-ParmParse::getktharr (const char* name, int k, std::vector<std::string>& ref,
-                      int start_ix, int num_val) const
+ParmParse::getktharr (std::string_view          name,
+                      int                       k,
+                      std::vector<std::string>& ref,
+                      int                       start_ix,
+                      int                       num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 void
-ParmParse::getarr (const char* name, std::vector<std::string>& ref,
-                   int start_ix, int num_val) const
+ParmParse::getarr (std::string_view          name,
+                   std::vector<std::string>& ref,
+                   int                       start_ix,
+                   int                       num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 int
-ParmParse::queryktharr (const char* name, int k, std::vector<std::string>& ref,
-                        int start_ix, int num_val) const
+ParmParse::queryktharr (std::string_view          name,
+                        int                       k,
+                        std::vector<std::string>& ref,
+                        int                       start_ix,
+                        int                       num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix, num_val,k);
 }
 
 int
-ParmParse::queryarr (const char* name, std::vector<std::string>& ref,
-                     int start_ix, int num_val) const
+ParmParse::queryarr (std::string_view          name,
+                     std::vector<std::string>& ref,
+                     int                       start_ix,
+                     int                       num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<std::string>& ref) // NOLINT(readability-make-member-function-const)
+ParmParse::addarr (std::string_view                name, // NOLINT(readability-make-member-function-const)
+                   const std::vector<std::string>& ref)
 {
     saddarr(prefixedName(name),ref);
 }
@@ -1804,137 +1934,182 @@ ParmParse::addarr (const char* name, const std::vector<std::string>& ref) // NOL
 
 // INTVECT
 void
-ParmParse::getkth (const char* name, int k, IntVect& ref, int ival) const
+ParmParse::getkth (std::string_view name,
+                   int              k,
+                   IntVect&         ref,
+                   int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 void
-ParmParse::get (const char* name, IntVect& ref, int ival) const
+ParmParse::get (std::string_view name,
+                IntVect&         ref,
+                int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 int
-ParmParse::querykth (const char* name, int k, IntVect& ref, int ival) const
+ParmParse::querykth (std::string_view name,
+                     int              k,
+                     IntVect&         ref,
+                     int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 int
-ParmParse::query (const char* name, IntVect& ref, int ival) const
+ParmParse::query (std::string_view name,
+                  IntVect&         ref,
+                  int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 void
-ParmParse::add (const char* name, const IntVect& val) // NOLINT(readability-make-member-function-const)
+ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
+                const IntVect&   val)
 {
     saddval(prefixedName(name),val);
 }
 
 void
-ParmParse::getktharr (const char* name, int k, std::vector<IntVect>& ref,
-                      int start_ix, int num_val) const
+ParmParse::getktharr (std::string_view      name,
+                      int                   k,
+                      std::vector<IntVect>& ref,
+                      int                   start_ix,
+                      int                   num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 void
-ParmParse::getarr (const char* name, std::vector<IntVect>& ref,
-                   int start_ix, int num_val) const
+ParmParse::getarr (std::string_view      name,
+                   std::vector<IntVect>& ref,
+                   int                   start_ix,
+                   int                   num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 int
-ParmParse::queryktharr (const char* name, int k, std::vector<IntVect>& ref,
-                        int start_ix, int num_val) const
+ParmParse::queryktharr (std::string_view      name,
+                        int                   k,
+                        std::vector<IntVect>& ref,
+                        int                   start_ix,
+                        int                   num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix, num_val,k);
 }
 
 int
-ParmParse::queryarr (const char* name, std::vector<IntVect>& ref,
-                     int start_ix, int num_val) const
+ParmParse::queryarr (std::string_view      name,
+                     std::vector<IntVect>& ref,
+                     int                   start_ix,
+                     int                   num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<IntVect>& ref) // NOLINT(readability-make-member-function-const)
+ParmParse::addarr (std::string_view            name, // NOLINT(readability-make-member-function-const)
+                   const std::vector<IntVect>& ref)
 {
     saddarr(prefixedName(name),ref);
 }
 
 // BOX
 void
-ParmParse::getkth (const char* name, int k, Box& ref, int ival) const
+ParmParse::getkth (std::string_view name,
+                   int              k,
+                   Box&             ref,
+                   int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 void
-ParmParse::get (const char* name, Box& ref, int ival) const
+ParmParse::get (std::string_view name,
+                Box&             ref,
+                int              ival) const
 {
     sgetval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 int
-ParmParse::querykth (const char* name, int k, Box& ref, int ival) const
+ParmParse::querykth (std::string_view name,
+                     int              k,
+                     Box&             ref,
+                     int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival,k);
 }
 
 int
-ParmParse::query (const char* name, Box& ref, int ival) const
+ParmParse::query (std::string_view name,
+                  Box&             ref,
+                  int              ival) const
 {
     return squeryval(*m_table,m_parser_prefix, prefixedName(name),ref,ival, LAST);
 }
 
 void
-ParmParse::add (const char* name, const Box& val) // NOLINT(readability-make-member-function-const)
+ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
+                const Box&       val)
 {
     saddval(prefixedName(name),val);
 }
 
 void
-ParmParse::getktharr (const char* name, int k, std::vector<Box>& ref,
-                      int start_ix, int num_val) const
+ParmParse::getktharr (std::string_view  name,
+                      int               k,
+                      std::vector<Box>& ref,
+                      int               start_ix,
+                      int               num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val,k);
 }
 
 void
-ParmParse::getarr (const char* name, std::vector<Box>& ref,
-                   int start_ix, int num_val) const
+ParmParse::getarr (std::string_view  name,
+                   std::vector<Box>& ref,
+                   int               start_ix,
+                   int               num_val) const
 {
     sgetarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 int
-ParmParse::queryktharr (const char* name, int k, std::vector<Box>& ref,
-                        int start_ix, int num_val) const
+ParmParse::queryktharr (std::string_view  name,
+                        int               k,
+                        std::vector<Box>& ref,
+                        int               start_ix,
+                        int               num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix, num_val,k);
 }
 
 int
-ParmParse::queryarr (const char* name, std::vector<Box>& ref,
-                     int start_ix, int num_val) const
+ParmParse::queryarr (std::string_view  name,
+                     std::vector<Box>& ref,
+                     int               start_ix,
+                     int               num_val) const
 {
     return squeryarr(*m_table,m_parser_prefix, prefixedName(name),ref,start_ix,num_val, LAST);
 }
 
 void
-ParmParse::addarr (const char* name, const std::vector<Box>& ref) // NOLINT(readability-make-member-function-const)
+ParmParse::addarr (std::string_view        name, // NOLINT(readability-make-member-function-const)
+                   const std::vector<Box>& ref)
 {
     saddarr(prefixedName(name),ref);
 }
 
 
 int
-ParmParse::queryarr (const char* name, IntVect& ref) const
+ParmParse::queryarr (std::string_view name,
+                     IntVect&         ref) const
 {
     std::vector<int> v;
     int exist = this->queryarr(name, v);
@@ -1946,7 +2121,7 @@ ParmParse::queryarr (const char* name, IntVect& ref) const
 }
 
 void
-ParmParse::getarr (const char* name, IntVect& ref) const
+ParmParse::getarr (std::string_view name, IntVect& ref) const
 {
     std::vector<int> v;
     this->getarr(name, v);
@@ -1955,7 +2130,7 @@ ParmParse::getarr (const char* name, IntVect& ref) const
 }
 
 int
-ParmParse::queryarr (const char* name, RealVect& ref) const
+ParmParse::queryarr (std::string_view name, RealVect& ref) const
 {
     std::vector<Real> v;
     int exist = this->queryarr(name, v);
@@ -1967,7 +2142,7 @@ ParmParse::queryarr (const char* name, RealVect& ref) const
 }
 
 void
-ParmParse::getarr (const char* name, RealVect& ref) const
+ParmParse::getarr (std::string_view name, RealVect& ref) const
 {
     std::vector<Real> v;
     this->getarr(name, v);
@@ -1976,7 +2151,7 @@ ParmParse::getarr (const char* name, RealVect& ref) const
 }
 
 void
-ParmParse::getline (const char* name, std::string& ref) const
+ParmParse::getline (std::string_view name, std::string& ref) const
 {
     std::vector<std::string> tmp;
     getarr(name, tmp);
@@ -1984,7 +2159,7 @@ ParmParse::getline (const char* name, std::string& ref) const
 }
 
 int
-ParmParse::queryline (const char* name, std::string& ref) const
+ParmParse::queryline (std::string_view name, std::string& ref) const
 {
     std::vector<std::string> tmp;
     auto r = queryarr(name, tmp);
@@ -1999,7 +2174,7 @@ ParmParse::queryline (const char* name, std::string& ref) const
 //
 
 int
-ParmParse::countname (const std::string& name) const
+ParmParse::countname (std::string_view name) const
 {
     auto pname = prefixedName(name);
     auto found = m_table->find(pname);
@@ -2015,7 +2190,7 @@ ParmParse::countname (const std::string& name) const
 //
 
 bool
-ParmParse::contains (const char* name) const
+ParmParse::contains (std::string_view name) const
 {
     auto pname = prefixedName(name);
     auto found = m_table->find(pname);
@@ -2031,7 +2206,7 @@ ParmParse::contains (const char* name) const
 }
 
 int
-ParmParse::remove (const char* name)
+ParmParse::remove (std::string_view name)
 {
     auto const pname = prefixedName(name);
     auto n = m_table->erase(pname);
@@ -2079,73 +2254,73 @@ bool squeryarrWithParser (const ParmParse::Table& table,
 }
 
 int
-ParmParse::queryWithParser (const char* name, bool& ref) const
+ParmParse::queryWithParser (std::string_view name, bool& ref) const
 {
     return squeryWithParser(*m_table,m_parser_prefix,prefixedName(name),ref);
 }
 
 int
-ParmParse::queryWithParser (const char* name, int& ref) const
+ParmParse::queryWithParser (std::string_view name, int& ref) const
 {
     return squeryWithParser(*m_table,m_parser_prefix,prefixedName(name),ref);
 }
 
 int
-ParmParse::queryWithParser (const char* name, long& ref) const
+ParmParse::queryWithParser (std::string_view name, long& ref) const
 {
     return squeryWithParser(*m_table,m_parser_prefix,prefixedName(name),ref);
 }
 
 int
-ParmParse::queryWithParser (const char* name, long long& ref) const
+ParmParse::queryWithParser (std::string_view name, long long& ref) const
 {
     return squeryWithParser(*m_table,m_parser_prefix,prefixedName(name),ref);
 }
 
 int
-ParmParse::queryWithParser (const char* name, float& ref) const
+ParmParse::queryWithParser (std::string_view name, float& ref) const
 {
     return squeryWithParser(*m_table,m_parser_prefix,prefixedName(name),ref);
 }
 
 int
-ParmParse::queryWithParser (const char* name, double& ref) const
+ParmParse::queryWithParser (std::string_view name, double& ref) const
 {
     return squeryWithParser(*m_table,m_parser_prefix,prefixedName(name),ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, bool* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, bool* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, int* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, int* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, long* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, long* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, long long* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, long long* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, float* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, float* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
 
 int
-ParmParse::queryarrWithParser (const char* name, int nvals, double* ref) const
+ParmParse::queryarrWithParser (std::string_view name, int nvals, double* ref) const
 {
     return squeryarrWithParser(*m_table,m_parser_prefix,prefixedName(name),nvals,ref);
 }
@@ -2233,7 +2408,7 @@ void read_table (std::vector<std::vector<T>>& ref, std::string const& str)
 }
 }
 
-int ParmParse::querytable (const char* name, std::vector<std::vector<double>>& ref) const
+int ParmParse::querytable (std::string_view name, std::vector<std::vector<double>>& ref) const
 {
     std::string table_s;
     int r = query(name, table_s);
@@ -2243,7 +2418,7 @@ int ParmParse::querytable (const char* name, std::vector<std::vector<double>>& r
     return r;
 }
 
-int ParmParse::querytable (const char* name, std::vector<std::vector<float>>& ref) const
+int ParmParse::querytable (std::string_view name, std::vector<std::vector<float>>& ref) const
 {
     std::string table_s;
     int r = query(name, table_s);
@@ -2253,7 +2428,7 @@ int ParmParse::querytable (const char* name, std::vector<std::vector<float>>& re
     return r;
 }
 
-int ParmParse::querytable (const char* name, std::vector<std::vector<int>>& ref) const
+int ParmParse::querytable (std::string_view name, std::vector<std::vector<int>>& ref) const
 {
     std::string table_s;
     int r = query(name, table_s);

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1098,7 +1098,7 @@ ParmParse::getPrefix () const
 }
 
 std::string
-ParmParse::prefixedName (const std::string_view& str) const
+ParmParse::prefixedName (std::string_view str) const
 {
     AMREX_ASSERT( ! str.empty() );
 

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -24,9 +24,9 @@ struct HypreOptParse
     template <typename F>
     void operator() (const std::string& key, F&& func)
     {
-        if (pp.contains(key.c_str())) {
+        if (pp.contains(key)) {
             int val;
-            pp.query(key.c_str(), val);
+            pp.query(key, val);
             std::forward<F>(func)(solver, val);
         }
     }
@@ -35,7 +35,7 @@ struct HypreOptParse
     void operator() (const std::string& key, F&& func, T default_val)
     {
         T val = default_val;
-        pp.queryAdd(key.c_str(), val);
+        pp.queryAdd(key, val);
         std::forward<F>(func)(solver, val);
     }
 
@@ -43,16 +43,16 @@ struct HypreOptParse
     void operator() (const std::string& key, F&& func, T default_val, int index)
     {
         T val = default_val;
-        pp.queryAdd(key.c_str(), val);
+        pp.queryAdd(key, val);
         std::forward<F>(func)(solver, val, index);
     }
 
     template <typename T, typename F>
     void set (const std::string& key, F&& func)
     {
-        if (pp.contains(key.c_str())) {
+        if (pp.contains(key)) {
             T val;
-            pp.query(key.c_str(), val);
+            pp.query(key, val);
             std::forward<F>(func)(solver, val);
         }
     }

--- a/Tests/EB/CNS/Source/CNS.cpp
+++ b/Tests/EB/CNS/Source/CNS.cpp
@@ -404,9 +404,9 @@ CNS::read_params ()
 
     int irefbox = 0;
     Vector<Real> refboxlo, refboxhi;
-    while (pp.queryarr(("refine_box_lo_"+std::to_string(irefbox)).c_str(), refboxlo))
+    while (pp.queryarr("refine_box_lo_"+std::to_string(irefbox), refboxlo))
     {
-        pp.getarr(("refine_box_hi_"+std::to_string(irefbox)).c_str(), refboxhi);
+        pp.getarr("refine_box_hi_"+std::to_string(irefbox), refboxhi);
         refine_boxes.emplace_back(refboxlo.data(), refboxhi.data());
         ++irefbox;
     }

--- a/Tests/EB_CNS/Source/CNS.cpp
+++ b/Tests/EB_CNS/Source/CNS.cpp
@@ -415,7 +415,7 @@ CNS::read_params ()
     Vector<Real> refboxlo, refboxhi;
     while (pp.queryarr("refine_box_lo_"+std::to_string(irefbox), refboxlo))
     {
-        pp.getarr("refine_box_hi_"+std::to_string(irefbox).c_str(), refboxhi);
+        pp.getarr("refine_box_hi_"+std::to_string(irefbox), refboxhi);
         refine_boxes.emplace_back(refboxlo.data(), refboxhi.data());
         ++irefbox;
     }

--- a/Tests/EB_CNS/Source/CNS.cpp
+++ b/Tests/EB_CNS/Source/CNS.cpp
@@ -413,9 +413,9 @@ CNS::read_params ()
 
     int irefbox = 0;
     Vector<Real> refboxlo, refboxhi;
-    while (pp.queryarr(("refine_box_lo_"+std::to_string(irefbox)).c_str(), refboxlo))
+    while (pp.queryarr("refine_box_lo_"+std::to_string(irefbox), refboxlo))
     {
-        pp.getarr(("refine_box_hi_"+std::to_string(irefbox)).c_str(), refboxhi);
+        pp.getarr("refine_box_hi_"+std::to_string(irefbox).c_str(), refboxhi);
         refine_boxes.emplace_back(refboxlo.data(), refboxhi.data());
         ++irefbox;
     }


### PR DESCRIPTION
## Summary
The `ParmParse` constructor accepts argument `prefix == std::string`.  But once the object is created, methods on it require `char *` objects for the `name` argument, leading to code like:
```
std::string prefix = "prefix";
std::string name = "name";
ParmParse pp(prefix);
pp.get(name.c_str(), input);
```

The proposed patch adds wrappers to allow arguments to `ParmParse` methods `get`, `query`, etc, to allow the `name` argument to be a `std::string`, so the `c_str()` is not needed and the interface is consistent.  It also fixes a few mismatches between comments and code.

## Additional background
Wrappers are provided for all methods except one.  It was not possible to add a `std::string` interface for the two-name version of `get`:
```
    void get (const char* new_name, const char* old_name, T& ref)
```
because with `string` values for the first two arguments and an `int` value for the third, this creates an ambiguity with the standard `get`:
```    
     void get (const std::string&  name,
              std::string& ref,
              int          ival = FIRST)
```
For this reason, a wrapper is not provided for the two-name version of `get`. 
Currently the only thing that disambiguates this template from the standard `get` is that in the two-name version both names are `char*` and in the template the second argument `ref` is `std::string`, allowing the first argument to be `string` breaks this. This is an unforunate feature of the API design.
Furthermore I believe this function is somewhat obscure and it should possibly be deprecated or renamed to `get_with_fallback` or `get2` or similar.


## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
