### PR TITLE
fix spelling, remove misspelled words from .codespell-ignore-words

### DIFF
--- a/.codespell-ignore-words
+++ b/.codespell-ignore-words
@@ -10,7 +10,6 @@ cant
 ccache
 clen
 compex
-couldnt
 fromm
 frop
 geometrys
@@ -22,7 +21,6 @@ inout
 ist
 lsit
 nd
-nineth
 parm
 parms
 pres

--- a/.codespell-ignore-words
+++ b/.codespell-ignore-words
@@ -21,6 +21,7 @@ inout
 ist
 lsit
 nd
+nineth
 parm
 parms
 pres

--- a/Src/Base/AMReX_constants_mod.f90
+++ b/Src/Base/AMReX_constants_mod.f90
@@ -27,7 +27,7 @@ module amrex_constants_module
   real(kind = amrex_real), parameter :: SIXTH   = ONE/SIX
   real(kind = amrex_real), parameter :: SEVENTH = ONE/SEVEN
   real(kind = amrex_real), parameter :: EIGHTH  = 0.125_amrex_real
-  real(kind = amrex_real), parameter :: NINETH  = ONE/NINE
+  real(kind = amrex_real), parameter :: NINTH  = ONE/NINE
   real(kind = amrex_real), parameter :: TENTH   = 0.10_amrex_real
   real(kind = amrex_real), parameter :: TWELFTH = ONE/TWELVE
 

--- a/Src/Base/AMReX_constants_mod.f90
+++ b/Src/Base/AMReX_constants_mod.f90
@@ -27,7 +27,7 @@ module amrex_constants_module
   real(kind = amrex_real), parameter :: SIXTH   = ONE/SIX
   real(kind = amrex_real), parameter :: SEVENTH = ONE/SEVEN
   real(kind = amrex_real), parameter :: EIGHTH  = 0.125_amrex_real
-  real(kind = amrex_real), parameter :: NINTH  = ONE/NINE
+  real(kind = amrex_real), parameter :: NINTH   = ONE/NINE
   real(kind = amrex_real), parameter :: NINETH  = ONE/NINE ! compatibility
   real(kind = amrex_real), parameter :: TENTH   = 0.10_amrex_real
   real(kind = amrex_real), parameter :: TWELFTH = ONE/TWELVE

--- a/Src/Base/AMReX_constants_mod.f90
+++ b/Src/Base/AMReX_constants_mod.f90
@@ -28,6 +28,7 @@ module amrex_constants_module
   real(kind = amrex_real), parameter :: SEVENTH = ONE/SEVEN
   real(kind = amrex_real), parameter :: EIGHTH  = 0.125_amrex_real
   real(kind = amrex_real), parameter :: NINTH  = ONE/NINE
+  real(kind = amrex_real), parameter :: NINETH  = ONE/NINE ! compatibility
   real(kind = amrex_real), parameter :: TENTH   = 0.10_amrex_real
   real(kind = amrex_real), parameter :: TWELFTH = ONE/TWELVE
 

--- a/Src/EB/AMReX_EB_StateRedistItracker.cpp
+++ b/Src/EB/AMReX_EB_StateRedistItracker.cpp
@@ -213,10 +213,10 @@ MakeITracker ( Box const& bx,
            if (sum_vol < target_volfrac)
            {
 #if 0
-             amrex::Print() << "Couldnt merge with enough cells to raise volume at " <<
+             amrex::Print() << "Couldn't merge with enough cells to raise volume at " <<
                                IntVect(i,j) << " so stuck with sum_vol " << sum_vol << '\n';
 #endif
-             amrex::Abort("Couldnt merge with enough cells to raise volume greater than target_volfrac");
+             amrex::Abort("Couldn't merge with enough cells to raise volume greater than target_volfrac");
            }
        }
     });
@@ -724,10 +724,10 @@ MakeITracker ( Box const& bx,
            if (sum_vol < target_volfrac)
            {
 #if 0
-             amrex::Print() << "Couldnt merge with enough cells to raise volume at " <<
+             amrex::Print() << "Couldn't merge with enough cells to raise volume at " <<
                                IntVect(i,j,k) << " so stuck with sum_vol " << sum_vol << '\n';
 #endif
-             amrex::Abort("Couldnt merge with enough cells to raise volume greater than target_volfrac");
+             amrex::Abort("Couldn't merge with enough cells to raise volume greater than target_volfrac");
            }
        }
     });


### PR DESCRIPTION
## Summary
Remove misspelled words "couldnt" and "nineth" from .codespell-ignore-words, fix in source

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
