### PR TITLE
CUDA CI: Add -Werror=deprecated-declarations

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -215,7 +215,7 @@ jobs:
         # /home/runner/work/amrex/amrex/Src/Base/AMReX_GpuLaunchGlobal.H:16:41: error: unused parameter ‘f0’ [-Werror=unused-parameter]
         #    16 |     AMREX_GPU_GLOBAL void launch_global (L f0) { f0(); }
         #
-        make -j4 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-unused-parameter" CCACHE=ccache CUDA_ARCH="8.0 9.0"
+        make -j4 WARN_ALL=TRUE WARN_ERROR=TRUE XTRA_CXXFLAGS="-fno-operator-names -Wno-unused-parameter -Werror=deprecated-declarations" CCACHE=ccache CUDA_ARCH="8.0 9.0"
         make install
 
         ccache -s


### PR DESCRIPTION
This helps us detect the use of deprecated features earlier.

Note that we only added it to the CUDA 13 CI. The CUDA 12 CIs would fail due to our simple logic of handing the CUB version.