### PR TITLE
OpenBC FFT Solver: Fix 2d mode bug

### DIFF
--- a/Src/FFT/AMReX_FFT_R2C.H
+++ b/Src/FFT/AMReX_FFT_R2C.H
@@ -1228,12 +1228,8 @@ T R2C<T,D,C>::scalingFactor () const
 {
 #if (AMREX_SPACEDIM == 3)
     if (m_info.twod_mode) {
-        if (m_real_domain.length(2) > 1) {
-            return T(1)/T(Long(m_real_domain.length(0)) *
-                          Long(m_real_domain.length(1)));
-        } else {
-            return T(1)/T(m_real_domain.length(0));
-        }
+        return T(1)/T(Long(m_real_domain.length(0)) *
+                      Long(m_real_domain.length(1)));
     } else
 #endif
     {

--- a/Src/FFT/AMReX_FFT_R2X.H
+++ b/Src/FFT/AMReX_FFT_R2X.H
@@ -187,14 +187,7 @@ R2X<T>::R2X (Box const& domain,
     } // else: x-fft: r2r(m_rx)
 
 #if (AMREX_SPACEDIM >= 2)
-
-#if (AMREX_SPACEDIM == 2)
-    bool batch_on_y = false;
-#else
-    bool batch_on_y = m_info.twod_mode && (m_dom_0.length(2) == 1);
-#endif
-
-    if ((domain.length(1) > 1) && !batch_on_y) {
+    if (domain.length(1) > 1) {
         if (! m_cx.empty()) {
             // copy(m_cx->m_cy)
             m_dom_cy = Box(IntVect(0), IntVect(AMREX_D_DECL(m_dom_cx.bigEnd(1),


### PR DESCRIPTION
PR #4671 did not fix all the issues with the 2d mode OpenBC FFT solver in 3D WarpX/ImpactX runs. The scaling was still wrong.
