### PR TITLE
Add reserve methods to ParticleTile, ArrayOfStructs, and StructOfArrays

### DIFF
--- a/Src/Particle/AMReX_ArrayOfStructs.H
+++ b/Src/Particle/AMReX_ArrayOfStructs.H
@@ -93,6 +93,8 @@ public:
 
     void resize (size_t count) { m_data.resize(count); }
 
+    void reserve (size_t capacity) { m_data.reserve(capacity); }
+
     Iterator erase ( ConstIterator first, ConstIterator second) { return m_data.erase(first, second); }
 
     template< class InputIt >

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -973,6 +973,14 @@ struct ParticleTile
         m_soa_tile.resize(count);
     }
 
+    void reserve (std::size_t capacity)
+    {
+        if constexpr (!ParticleType::is_soa_particle) {
+            m_aos_tile.reserve(capacity);
+        }
+        m_soa_tile.reserve(capacity);
+    }
+
     ///
     /// Add one particle to this tile.
     ///

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -282,6 +282,21 @@ struct StructOfArrays {
         for (int i = 0; i < int(m_runtime_idata.size()); ++i) { m_runtime_idata[i].resize(count); }
     }
 
+    void reserve (size_t capacity)
+    {
+        if constexpr (use64BitIdCpu == true) {
+            m_idcpu.reserve(capacity);
+        }
+        if constexpr (NReal > 0) {
+            for (int i = 0; i < NReal; ++i) { m_rdata[i].reserve(capacity); }
+        }
+        if constexpr (NInt > 0) {
+            for (int i = 0; i < NInt;  ++i) { m_idata[i].reserve(capacity); }
+        }
+        for (int i = 0; i < int(m_runtime_rdata.size()); ++i) { m_runtime_rdata[i].reserve(capacity); }
+        for (int i = 0; i < int(m_runtime_idata.size()); ++i) { m_runtime_idata[i].reserve(capacity); }
+    }
+
     [[nodiscard]] uint64_t* idcpuarray () {
         if constexpr (use64BitIdCpu == true) {
             return m_idcpu.dataPtr();


### PR DESCRIPTION
As with `std::vector`, this allows changing the capacity without changing the size of the underlying containers.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
