### PR TITLE
Add Build with Explicit Multi-Level Geometry for EB

### DIFF
--- a/Docs/sphinx_documentation/source/EB.rst
+++ b/Docs/sphinx_documentation/source/EB.rst
@@ -141,9 +141,12 @@ Given an implicit function object, say :cpp:`f`, we can make a
 :cpp:`EB2::IndexSpace`
 ----------------------
 
-We build :cpp:`EB2::IndexSpace` with a template function
+We build :cpp:`EB2::IndexSpace` with one of several template functions depending
+on the application needs.
 
-.. highlight: c++
+**Standard Build with Automatic Coarsening**
+
+.. highlight:: c++
 
 ::
 
@@ -151,7 +154,10 @@ We build :cpp:`EB2::IndexSpace` with a template function
     void EB2::Build (const G& gshop, const Geometry& geom,
                      int required_coarsening_level,
                      int max_coarsening_level,
-                     int ngrow = 4);
+                     int ngrow = 4,
+                     bool build_coarse_level_by_coarsening = true,
+                     bool extend_domain_face = ExtendDomainFace(),
+                     int num_coarsen_opt = NumCoarsenOpt());
 
 Here the template parameter is a :cpp:`EB2::GeometryShop`. :cpp:`Geometry` (see
 section :ref:`sec:basics:geom`) describes the rectangular problem domain and the
@@ -173,12 +179,73 @@ ngrow` parameter specifies the number of ghost cells outside the domain on
 required levels. For levels coarser than the required level, no EB data are
 generated for ghost cells outside the domain.
 
-The newly built :cpp:`EB2::IndexSpace` is pushed on to a stack. Static function
+**Build with Explicit Multi-Level Geometry**
+
+For applications requiring explicit control over the geometry at each AMR level:
+
+.. highlight:: c++
+
+::
+
+    template <typename G>
+    void EB2::Build (const G& gshop, const Vector<Geometry>& geom,
+                     int ngrow = 4,
+                     bool extend_domain_face = ExtendDomainFace(),
+                     int num_coarsen_opt = NumCoarsenOpt());
+
+This version takes a :cpp:`Vector<Geometry>` where each element corresponds to
+the geometry of a specific AMR level, ordered from finest (index 0) to coarsest.
+Unlike the standard :cpp:`Build` function, coarse level EB data is generated
+directly from the provided geometries rather than through automatic coarsening.
+This is useful when coarse level domains are not simple coarsenings of the fine
+level, or when you need precise control over the domain and mesh spacing at each
+level.
+
+Example usage:
+
+.. highlight:: c++
+
+::
+
+    EB2::SphereIF sphere(0.5, {0., 0., 0.}, false);
+    auto shop = EB2::makeShop(sphere);
+
+    Vector<Geometry> geom_vec(3);  // 3 AMR levels
+    geom_vec[0] = Geometry(...);   // finest level
+    geom_vec[1] = Geometry(...);   // middle level
+    geom_vec[2] = Geometry(...);   // coarsest level
+
+    EB2::Build(shop, geom_vec);
+
+**Build from STL File**
+
+As mentioned earlier, the EB information can alternatively be initialized from
+an STL file using:
+
+.. highlight:: c++
+
+::
+
+   void EB2::Build (const Geometry& geom,
+                    int required_coarsening_level,
+                    int max_coarsening_level,
+                    int ngrow = 4,
+                    bool build_coarse_level_by_coarsening = true,
+                    bool extend_domain_face = ExtendDomainFace(),
+                    int num_coarsen_opt = NumCoarsenOpt());
+
+This requires setting :cpp:`ParmParse` parameters ``eb2.geom_type = stl`` and
+``eb2.stl_file`` to specify the STL file path.
+
+**Managing IndexSpace Objects**
+
+Regardless of which :cpp:`Build` variant is used, the newly built
+:cpp:`EB2::IndexSpace` is pushed on to a stack. Static function
 :cpp:`EB2::IndexSpace::top()` returns a :cpp:`const &` to the new
 :cpp:`EB2::IndexSpace` object. We usually only need to build one
 :cpp:`EB2::IndexSpace` object. However, if your application needs multiple
 :cpp:`EB2::IndexSpace` objects, you can save the pointers for later use. For
-simplicity, we assume there is only one `EB2::IndexSpace` object for the rest of
+simplicity, we assume there is only one :cpp:`EB2::IndexSpace` object for the rest of
 this chapter.
 
 EBFArrayBoxFactory

--- a/Docs/sphinx_documentation/source/EB.rst
+++ b/Docs/sphinx_documentation/source/EB.rst
@@ -141,7 +141,7 @@ Given an implicit function object, say :cpp:`f`, we can make a
 :cpp:`EB2::IndexSpace`
 ----------------------
 
-We build :cpp:`EB2::IndexSpace` with one of several template functions depending
+We build :cpp:`EB2::IndexSpace` with one of several functions depending
 on the application needs.
 
 **Standard Build with Automatic Coarsening**
@@ -200,22 +200,6 @@ directly from the provided geometries rather than through automatic coarsening.
 This is useful when coarse level domains are not simple coarsenings of the fine
 level, or when you need precise control over the domain and mesh spacing at each
 level.
-
-Example usage:
-
-.. highlight:: c++
-
-::
-
-    EB2::SphereIF sphere(0.5, {0., 0., 0.}, false);
-    auto shop = EB2::makeShop(sphere);
-
-    Vector<Geometry> geom_vec(3);  // 3 AMR levels
-    geom_vec[0] = Geometry(...);   // finest level
-    geom_vec[1] = Geometry(...);   // middle level
-    geom_vec[2] = Geometry(...);   // coarsest level
-
-    EB2::Build(shop, geom_vec);
 
 **Build from STL File**
 

--- a/Docs/sphinx_documentation/source/EB.rst
+++ b/Docs/sphinx_documentation/source/EB.rst
@@ -188,13 +188,14 @@ For applications requiring explicit control over the geometry at each AMR level:
 ::
 
     template <typename G>
-    void EB2::Build (const G& gshop, const Vector<Geometry>& geom,
+    void EB2::Build (const G& gshop, Vector<Geometry> geom,
                      int ngrow = 4,
                      bool extend_domain_face = ExtendDomainFace(),
                      int num_coarsen_opt = NumCoarsenOpt());
 
 This version takes a :cpp:`Vector<Geometry>` where each element corresponds to
-the geometry of a specific AMR level, ordered from finest (index 0) to coarsest.
+the geometry of a specific AMR level. The Vector can be unordered, as it will be
+sorted based on :cpp:`numPts`.
 Unlike the standard :cpp:`Build` function, coarse level EB data is generated
 directly from the provided geometries rather than through automatic coarsening.
 This is useful when coarse level domains are not simple coarsenings of the fine

--- a/Src/EB/AMReX_EB2.H
+++ b/Src/EB/AMReX_EB2.H
@@ -140,12 +140,13 @@ Build (const G& gshop, const Geometry& geom,
 
 template <typename G>
 void
-Build (const G& gshop, const Vector<Geometry>& geom,
+Build (const G& gshop, Vector<Geometry> geom,
        int ngrow = 4,
        bool extend_domain_face = ExtendDomainFace(),
        int num_coarsen_opt = NumCoarsenOpt())
 {
     BL_PROFILE("EB2::Initialize()");
+    std::sort(geom.begin(), geom.end(), [] (Geometry const& a, Geometry const& b) { return a.Domain().numPts() > b.Domain().numPts(); });
     IndexSpace::push(new IndexSpaceImp<G>(gshop, geom,
                                           ngrow,
                                           extend_domain_face,

--- a/Src/EB/AMReX_EB2.H
+++ b/Src/EB/AMReX_EB2.H
@@ -130,7 +130,6 @@ Build (const G& gshop, const Geometry& geom,
        int num_coarsen_opt = NumCoarsenOpt())
 {
     BL_PROFILE("EB2::Initialize()");
-    Print()<<"EB2 H Build line 129"<<std::endl;
     IndexSpace::push(new IndexSpaceImp<G>(gshop, geom,
                                           required_coarsening_level,
                                           max_coarsening_level,
@@ -147,7 +146,6 @@ Build (const G& gshop, const Vector<Geometry>& geom,
        int num_coarsen_opt = NumCoarsenOpt())
 {
     BL_PROFILE("EB2::Initialize()");
-    Print()<<"EB2 H Build line 146"<<std::endl;
     IndexSpace::push(new IndexSpaceImp<G>(gshop, geom,
                                           ngrow,
                                           extend_domain_face,

--- a/Src/EB/AMReX_EB2.H
+++ b/Src/EB/AMReX_EB2.H
@@ -80,6 +80,10 @@ public:
                    int ngrow, bool build_coarse_level_by_coarsening,
                    bool extend_domain_face, int num_coarsen_opt);
 
+    IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
+                   int ngrow,
+                   bool extend_domain_face, int num_coarsen_opt);
+
     IndexSpaceImp (IndexSpaceImp<G> const&) = delete;
     IndexSpaceImp (IndexSpaceImp<G> &&) = delete;
     void operator= (IndexSpaceImp<G> const&) = delete;

--- a/Src/EB/AMReX_EB2.H
+++ b/Src/EB/AMReX_EB2.H
@@ -126,10 +126,26 @@ Build (const G& gshop, const Geometry& geom,
        int num_coarsen_opt = NumCoarsenOpt())
 {
     BL_PROFILE("EB2::Initialize()");
+    Print()<<"EB2 H Build line 129"<<std::endl;
     IndexSpace::push(new IndexSpaceImp<G>(gshop, geom,
                                           required_coarsening_level,
                                           max_coarsening_level,
                                           ngrow, build_coarse_level_by_coarsening,
+                                          extend_domain_face,
+                                          num_coarsen_opt));
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+template <typename G>
+void
+Build (const G& gshop, const Vector<Geometry>& geom,
+       int ngrow = 4,
+       bool extend_domain_face = ExtendDomainFace(),
+       int num_coarsen_opt = NumCoarsenOpt())
+{
+    BL_PROFILE("EB2::Initialize()");
+    Print()<<"EB2 H Build line 146"<<std::endl;
+    IndexSpace::push(new IndexSpaceImp<G>(gshop, geom,
+                                          ngrow,
                                           extend_domain_face,
                                           num_coarsen_opt));
 } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)

--- a/Src/EB/AMReX_EB2.cpp
+++ b/Src/EB/AMReX_EB2.cpp
@@ -85,6 +85,7 @@ Build (const Geometry& geom, int required_coarsening_level,
        int max_coarsening_level, int ngrow, bool build_coarse_level_by_coarsening,
        bool a_extend_domain_face, int a_num_coarsen_opt)
 {
+    Print()<<"EB2 build line 88"<<std::endl;
     ParmParse pp("eb2");
     std::string geom_type;
     pp.get("geom_type", geom_type);

--- a/Src/EB/AMReX_EB2.cpp
+++ b/Src/EB/AMReX_EB2.cpp
@@ -85,7 +85,6 @@ Build (const Geometry& geom, int required_coarsening_level,
        int max_coarsening_level, int ngrow, bool build_coarse_level_by_coarsening,
        bool a_extend_domain_face, int a_num_coarsen_opt)
 {
-    Print()<<"EB2 build line 88"<<std::endl;
     ParmParse pp("eb2");
     std::string geom_type;
     pp.get("geom_type", geom_type);

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -75,6 +75,7 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
 {
   Print()<<"IndexSpaceI line 76"<<std::endl;
 }
+
 template <typename G>
 const Level&
 IndexSpaceImp<G>::getLevel (const Geometry& geom) const

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -74,18 +74,12 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
 {
 
     int nlevels = geom.size();
-    int ngrow_finest = std::max(ngrow,0);
-    // Base ngrow_finest on the levels passed in with the Vector
-    for (int i = 1; i <= nlevels; ++i) {
-        ngrow_finest *= 2;
-    }
+    int ngrow_finest = ngrow;
     m_gslevel.reserve(nlevels);
 
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {
-        int ng = ngrow_finest;
-        if (ilev > 0)
-          ng = m_ngrow.back()/2; // Don't check required levels here
+        int ng = ngrow;
         Geometry cgeom = geom[ilev];
         Box cdomain = cgeom.Domain();
         m_gslevel.emplace_back(this, gshop, cgeom, EB2::max_grid_size, ng, extend_domain_face,

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -12,7 +12,6 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
 {
     // build finest level (i.e., level 0) first
     AMREX_ALWAYS_ASSERT(required_coarsening_level >= 0 && required_coarsening_level <= 30);
-    Print()<<"IndexSpaceImp line 15"<<std::endl;
     max_coarsening_level = std::max(required_coarsening_level,max_coarsening_level);
     max_coarsening_level = std::min(30,max_coarsening_level);
 
@@ -73,7 +72,6 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
       m_extend_domain_face(extend_domain_face),
       m_num_coarsen_opt(num_coarsen_opt)
 {
-    Print()<<"IndexSpaceI line 76 using same ngrow all levels"<<std::endl;
 
     int nlevels = geom.size();
     int ngrow_finest = std::max(ngrow,0);

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -73,7 +73,7 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
       m_num_coarsen_opt(num_coarsen_opt)
 {
 
-    int nlevels = geom.size();
+    auto nlevels = int(geom.size());
     m_gslevel.reserve(nlevels);
 
     for (int ilev = 0; ilev < nlevels; ++ilev)

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -73,7 +73,25 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
       m_extend_domain_face(extend_domain_face),
       m_num_coarsen_opt(num_coarsen_opt)
 {
-  Print()<<"IndexSpaceI line 76"<<std::endl;
+    Print()<<"IndexSpaceI line 76"<<std::endl;
+
+    m_geom.push_back(geom);
+    m_domain.push_back(geom.Domain());
+    m_ngrow.push_back(ngrow_finest);
+    m_gslevel.reserve(max_coarsening_level+1);
+    m_gslevel.emplace_back(this, gshop, geom, EB2::max_grid_size, ngrow_finest, extend_domain_face,
+                           num_coarsen_opt);
+
+    for (int ilev = 1; ilev <= max_coarsening_level; ++ilev)
+    {
+        Box cdomain = amrex::coarsen(m_geom.back().Domain(),2);
+        Geometry cgeom = amrex::coarsen(m_geom.back(),2);
+        m_gslevel.emplace_back(this, gshop, cgeom, EB2::max_grid_size, ng, extend_domain_face,
+                                           num_coarsen_opt-ilev);
+        m_geom.push_back(cgeom);
+        m_domain.push_back(cdomain);
+        m_ngrow.push_back(ng);
+    }
 }
 
 template <typename G>

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -76,12 +76,18 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
     Print()<<"IndexSpaceI line 76 using same ngrow all levels"<<std::endl;
 
     int nlevels = geom.size();
-    int ngrow_finest = ngrow;
+    int ngrow_finest = std::max(ngrow,0);
+    // Base ngrow_finest on the levels passed in with the Vector
+    for (int i = 1; i <= nlevels; ++i) {
+        ngrow_finest *= 2;
+    }
     m_gslevel.reserve(nlevels);
 
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {
-        int ng = ngrow;
+        int ng = ngrow_finest;
+        if (ilev > 0)
+          ng = m_ngrow.back()/2; // Don't check required levels here
         Geometry cgeom = geom[ilev];
         Box cdomain = cgeom.Domain();
         m_gslevel.emplace_back(this, gshop, cgeom, EB2::max_grid_size, ng, extend_domain_face,

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -12,6 +12,7 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
 {
     // build finest level (i.e., level 0) first
     AMREX_ALWAYS_ASSERT(required_coarsening_level >= 0 && required_coarsening_level <= 30);
+    Print()<<"IndexSpaceImp line 15"<<std::endl;
     max_coarsening_level = std::max(required_coarsening_level,max_coarsening_level);
     max_coarsening_level = std::min(30,max_coarsening_level);
 
@@ -63,6 +64,17 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Geometry& geom,
 }
 
 
+template <typename G>
+IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
+                                 int ngrow,
+                                 bool extend_domain_face, int num_coarsen_opt)
+    : m_gshop(gshop),
+      m_build_coarse_level_by_coarsening(false),
+      m_extend_domain_face(extend_domain_face),
+      m_num_coarsen_opt(num_coarsen_opt)
+{
+  Print()<<"IndexSpaceI line 76"<<std::endl;
+}
 template <typename G>
 const Level&
 IndexSpaceImp<G>::getLevel (const Geometry& geom) const

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -73,19 +73,17 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
       m_extend_domain_face(extend_domain_face),
       m_num_coarsen_opt(num_coarsen_opt)
 {
-    Print()<<"IndexSpaceI line 76"<<std::endl;
+    Print()<<"IndexSpaceI line 76 using same ngrow all levels"<<std::endl;
 
-    m_geom.push_back(geom);
-    m_domain.push_back(geom.Domain());
-    m_ngrow.push_back(ngrow_finest);
-    m_gslevel.reserve(max_coarsening_level+1);
-    m_gslevel.emplace_back(this, gshop, geom, EB2::max_grid_size, ngrow_finest, extend_domain_face,
-                           num_coarsen_opt);
+    int nlevels = geom.size();
+    int ngrow_finest = ngrow;
+    m_gslevel.reserve(nlevels);
 
-    for (int ilev = 1; ilev <= max_coarsening_level; ++ilev)
+    for (int ilev = 0; ilev < nlevels; ++ilev)
     {
-        Box cdomain = amrex::coarsen(m_geom.back().Domain(),2);
-        Geometry cgeom = amrex::coarsen(m_geom.back(),2);
+        int ng = ngrow;
+        Geometry cgeom = geom[ilev];
+        Box cdomain = cgeom.Domain();
         m_gslevel.emplace_back(this, gshop, cgeom, EB2::max_grid_size, ng, extend_domain_face,
                                            num_coarsen_opt-ilev);
         m_geom.push_back(cgeom);

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -74,7 +74,6 @@ IndexSpaceImp<G>::IndexSpaceImp (const G& gshop, const Vector<Geometry>& geom,
 {
 
     int nlevels = geom.size();
-    int ngrow_finest = ngrow;
     m_gslevel.reserve(nlevels);
 
     for (int ilev = 0; ilev < nlevels; ++ilev)


### PR DESCRIPTION
## Summary
This PR adds a new `EB2::Build` variant that accepts a `Vector<Geometry>` to explicitly specify the geometry at each AMR level. Unlike the existing Build function that generates coarse levels through automatic coarsening, this version constructs EB data directly from the provided geometries at each level. This is useful for applications that need precise control over domain specification at each AMR level or when coarse levels are not simple coarsenings of the finest level.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [X] include documentation in the code and/or rst files, if appropriate
