### PR TITLE
Updates for oneAPI 2025.03

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -29,7 +29,10 @@ jobs:
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
+      # Since oneAPI 2025.3
+      # /tmp/icpx-ce94418843/global_vars-header-65acf6.h:42:49: error: zero size arrays are an extension [-Werror,-Wzero-length-array]
+      #    42 | static constexpr unsigned kernel_args_sizes[] = {};
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-zero-length-array"}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
@@ -78,7 +81,10 @@ jobs:
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
+      # Since oneAPI 2025.3
+      # /tmp/icpx-ce94418843/global_vars-header-65acf6.h:42:49: error: zero size arrays are an extension [-Werror,-Wzero-length-array]
+      #    42 | static constexpr unsigned kernel_args_sizes[] = {};
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor -Wno-zero-length-array"}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10

--- a/Src/LinearSolvers/AMReX_SpMV.H
+++ b/Src/LinearSolvers/AMReX_SpMV.H
@@ -11,6 +11,7 @@
 #elif defined(AMREX_USE_HIP)
 #  include <rocsparse/rocsparse.h>
 #elif defined(AMREX_USE_SYCL)
+#  include <mkl_version.h>
 #  include <oneapi/mkl/spblas.hpp>
 #endif
 
@@ -170,8 +171,14 @@ void SpMV (AlgVector<T>& y, SpMatrix<T> const& A, AlgVector<T> const& x)
 
     amrex::ignore_unused(nnz);
     mkl::sparse::matrix_handle_t handle{};
-    mkl::sparse::set_csr_data(Gpu::Device::streamQueue(), handle, nrows, ncols, mkl::index_base::zero,
-                              (Long*)row, (Long*)col, (T*)mat);
+
+#if defined(INTEL_MKL_VERSION) && (INTEL_MKL_VERSION < 20250300)
+    mkl::sparse::set_csr_data(Gpu::Device::streamQueue(), handle, nrows, ncols,
+                              mkl::index_base::zero, (Long*)row, (Long*)col, (T*)mat);
+#else
+    mkl::sparse::set_csr_data(Gpu::Device::streamQueue(), handle, nrows, ncols, nnz,
+                              mkl::index_base::zero, (Long*)row, (Long*)col, (T*)mat);
+#endif
     mkl::sparse::gemv(Gpu::Device::streamQueue(), mkl::transpose::nontrans,
                       T(1), handle, px, T(0), py);
 

--- a/Tools/CMake/AMReXSYCL.cmake
+++ b/Tools/CMake/AMReXSYCL.cmake
@@ -53,7 +53,13 @@ endif()
 #
 target_link_options( SYCL
    INTERFACE
-   $<${_cxx_sycl}:-qmkl=sequential -fsycl -fsycl-device-lib=libc,libm-fp32,libm-fp64> )
+   $<${_cxx_sycl}:-qmkl=sequential -fsycl> )
+
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 2025.3)
+    target_link_options( SYCL
+        INTERFACE
+        $<${_cxx_sycl}:-fsycl-device-lib=libc,libm-fp32,libm-fp64> )
+endif()
 
 
 # TODO: use $<LINK_LANG_AND_ID:> genex for CMake >=3.17

--- a/Tools/GNUMake/comps/dpcpp.mak
+++ b/Tools/GNUMake/comps/dpcpp.mak
@@ -9,6 +9,9 @@ F90 = ifx
 amrex_oneapi_version = $(shell $(CXX) --version | head -1)
 $(info oneAPI version: $(amrex_oneapi_version))
 
+amrex_oneapi_version_major = $(shell $(CXX) --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d. -f1)
+amrex_oneapi_version_minor = $(shell $(CXX) --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d. -f2)
+
 CXXFLAGS =
 CFLAGS   =
 FFLAGS   =
@@ -131,7 +134,24 @@ ifneq ($(BL_NO_FORT),TRUE)
   endif
 endif
 
-LDFLAGS += -qmkl=sequential -fsycl-device-lib=libc,libm-fp32,libm-fp64
+LDFLAGS += -qmkl=sequential
+
+amrex_oneapi_major_lt_2025 = $(shell expr $(amrex_oneapi_version_major) \< 2025)
+amrex_oneapi_minor_le_2    = $(shell expr $(amrex_oneapi_version_minor) \<= 2)
+
+ifeq ($(amrex_oneapi_major_lt_2025),1)
+  amrex_add_sycl_device_lib = 1
+endif
+
+ifeq ($(amrex_oneapi_version_major),2025)
+ifeq ($(amrex_oneapi_minor_le_2),1)
+  amrex_add_sycl_device_lib = 1
+endif
+endif
+
+ifeq ($(amrex_add_sycl_device_lib),1)
+  LDFLAGS += -fsycl-device-lib=libc,libm-fp32,libm-fp64
+endif
 
 ifdef SYCL_PARALLEL_LINK_JOBS
 LDFLAGS += -fsycl-max-parallel-link-jobs=$(SYCL_PARALLEL_LINK_JOBS)


### PR DESCRIPTION
Starting from oneAPI 2025.3, the fsycl-device-lib flag has been deprecated.

Add `-Wno-zero-length-array` to quiet a compiler warning. Note that the variable in question is generated by the compiler itself.
```
/tmp/icpx-ce94418843/global_vars-header-65acf6.h:42:49: error: zero size arrays are an extension [-Werror,-Wzero-length-array]
   42 | static constexpr unsigned kernel_args_sizes[] = {};
```

Fix deprecated `mkl::sparse::set_csr_data`.