### PR TITLE
PODVector: Add multiple growth strategies

### DIFF
--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -4,6 +4,7 @@
 
 #include <AMReX.H>
 #include <AMReX_Arena.H>
+#include <AMReX_Enum.H>
 #include <AMReX_GpuLaunch.H>
 #include <AMReX_GpuAllocators.H>
 #include <AMReX_GpuDevice.H>
@@ -243,6 +244,8 @@ namespace amrex
         }
     }
 
+    AMREX_ENUM(GrowthStrategy, Default, Exact, Geometric, Poisson);
+
     namespace VectorGrowthStrategy
     {
         extern AMREX_EXPORT Real growth_factor;
@@ -255,6 +258,10 @@ namespace amrex
         }
 
         void Initialize ();
+
+        std::size_t GetNewCapacity (std::size_t old_size, std::size_t old_capacity,
+                                    std::size_t new_size, GrowthStrategy strategy,
+                                    std::size_t sizeof_T);
     }
 
     template <class T, class Allocator = std::allocator<T> >
@@ -294,46 +301,57 @@ namespace amrex
             : Allocator(a_allocator)
         {}
 
-        explicit PODVector (size_type a_size)
-            : m_size(a_size), m_capacity(a_size)
+        explicit PODVector (size_type a_size,
+                            GrowthStrategy growth_strategy = GrowthStrategy::Default)
+            : m_size(a_size),
+              m_capacity(VectorGrowthStrategy::GetNewCapacity(
+                0, 0, a_size, growth_strategy, sizeof(T)))
         {
-            if (a_size != 0) {
-                m_data = allocate(m_size);
+            if (m_capacity != 0) {
+                m_data = allocate(m_capacity);
                 detail::maybe_init_snan(m_data, m_size, (Allocator const&)(*this));
             }
         }
 
         PODVector (size_type a_size, const value_type& a_value,
-                   const allocator_type& a_allocator = Allocator())
-            : Allocator(a_allocator), m_size(a_size), m_capacity(a_size)
+                   const allocator_type& a_allocator = Allocator(),
+                   GrowthStrategy growth_strategy = GrowthStrategy::Default)
+            : Allocator(a_allocator),
+              m_size(a_size),
+              m_capacity(VectorGrowthStrategy::GetNewCapacity(
+                0, 0, a_size, growth_strategy, sizeof(T)))
         {
-            if (a_size != 0) {
-                m_data = allocate(m_size);
+            if (m_capacity != 0) {
+                m_data = allocate(m_capacity);
                 detail::uninitializedFillNImpl(m_data, a_size, a_value,
                                                (Allocator const&)(*this));
             }
         }
 
         PODVector (std::initializer_list<T> a_initializer_list,
-                   const allocator_type& a_allocator = Allocator())
+                   const allocator_type& a_allocator = Allocator(),
+                   GrowthStrategy growth_strategy = GrowthStrategy::Default)
             : Allocator(a_allocator),
               m_size    (a_initializer_list.size()),
-              m_capacity(a_initializer_list.size())
+              m_capacity(VectorGrowthStrategy::GetNewCapacity(
+                0, 0, a_initializer_list.size(), growth_strategy, sizeof(T)))
         {
-            if (a_initializer_list.size() != 0) {
-                m_data = allocate(m_size);
+            if (m_capacity != 0) {
+                m_data = allocate(m_capacity);
                 detail::initFromListImpl(m_data, a_initializer_list,
                                          (Allocator const&)(*this));
             }
         }
 
-        PODVector (const PODVector<T, Allocator>& a_vector)
+        PODVector (const PODVector<T, Allocator>& a_vector,
+                   GrowthStrategy growth_strategy = GrowthStrategy::Default)
             : Allocator(a_vector),
               m_size    (a_vector.size()),
-              m_capacity(a_vector.size())
+              m_capacity(VectorGrowthStrategy::GetNewCapacity(
+                0, 0, a_vector.size(), growth_strategy, sizeof(T)))
         {
-            if (a_vector.size() != 0) {
-                m_data = allocate(m_size);
+            if (m_capacity != 0) {
+                m_data = allocate(m_capacity);
                 detail::memCopyImpl(m_data, a_vector.m_data, a_vector.nBytes(),
                                     (Allocator const&)(*this),
                                     (Allocator const&)a_vector);
@@ -569,14 +587,14 @@ namespace amrex
 
         [[nodiscard]] allocator_type get_allocator () const noexcept { return *this; }
 
-        void push_back (const T& a_value)
+        void push_back (const T& a_value,
+                        GrowthStrategy growth_strategy = GrowthStrategy::Geometric)
         {
-            if (m_size == m_capacity) {
-                auto new_capacity = GetNewCapacityForPush();
-                AllocateBufferForPush(new_capacity);
-            }
-            detail::uninitializedFillNImpl(m_data+m_size, 1, a_value,
-                                           (Allocator const&)(*this));
+            auto new_capacity = VectorGrowthStrategy::GetNewCapacity(
+                m_size, m_capacity, m_size + 1, growth_strategy, sizeof(T));
+            ReallocNewCapacity(new_capacity);
+            detail::uninitializedFillNImpl(m_data + m_size, 1, a_value,
+                                          (Allocator const&)(*this));
             ++m_size;
         }
 
@@ -638,20 +656,28 @@ namespace amrex
 
         [[nodiscard]] const_reverse_iterator crend () const noexcept { return const_reverse_iterator(begin()); }
 
-        void resize (size_type a_new_size)
+        void resize (size_type a_new_size,
+                     GrowthStrategy growth_strategy = GrowthStrategy::Default)
         {
             auto old_size = m_size;
-            resize_without_init_snan(a_new_size);
+            auto new_capacity = VectorGrowthStrategy::GetNewCapacity(
+                old_size, m_capacity, a_new_size, growth_strategy, sizeof(T));
+            ReallocNewCapacity(new_capacity);
+            m_size = a_new_size;
             if (old_size < a_new_size) {
                 detail::maybe_init_snan(m_data + old_size,
                                         m_size - old_size, (Allocator const&)(*this));
             }
         }
 
-        void resize (size_type a_new_size, const T& a_val)
+        void resize (size_type a_new_size, const T& a_val,
+                     GrowthStrategy growth_strategy = GrowthStrategy::Default)
         {
-            size_type old_size = m_size;
-            resize_without_init_snan(a_new_size);
+            auto old_size = m_size;
+            auto new_capacity = VectorGrowthStrategy::GetNewCapacity(
+                old_size, m_capacity, a_new_size, growth_strategy, sizeof(T));
+            ReallocNewCapacity(new_capacity);
+            m_size = a_new_size;
             if (old_size < a_new_size)
             {
                 detail::uninitializedFillNImpl(m_data + old_size,
@@ -660,34 +686,19 @@ namespace amrex
             }
         }
 
-        void reserve (size_type a_capacity)
+        void reserve (size_type a_capacity,
+                      GrowthStrategy growth_strategy = GrowthStrategy::Default)
         {
             if (m_capacity < a_capacity) {
-                auto fp = detail::allocate_in_place(m_data, a_capacity, a_capacity,
-                                                    (Allocator&)(*this));
-                UpdateDataPtr(fp);
+                auto new_capacity = VectorGrowthStrategy::GetNewCapacity(
+                    m_size, m_capacity, a_capacity, growth_strategy, sizeof(T));
+                ReallocNewCapacity(new_capacity);
             }
         }
 
         void shrink_to_fit ()
         {
-            if (m_data != nullptr) {
-                if (m_size == 0) {
-                    deallocate(m_data, m_capacity);
-                    m_data = nullptr;
-                    m_capacity = 0;
-                } else if (m_size < m_capacity) {
-                    auto* new_data = detail::shrink_in_place(m_data, m_size,
-                                                             (Allocator&)(*this));
-                    if (new_data != m_data) {
-                        detail::memCopyImpl(new_data, m_data, nBytes(),
-                                            (Allocator const&)(*this),
-                                            (Allocator const&)(*this));
-                        deallocate(m_data, m_capacity);
-                    }
-                    m_capacity = m_size;
-                }
-            }
+            ReallocNewCapacity(m_size);
         }
 
         void swap (PODVector<T, Allocator>& a_vector) noexcept
@@ -705,53 +716,14 @@ namespace amrex
             return m_size*sizeof(T);
         }
 
-        // this is where we would change the growth strategy for push_back
-        [[nodiscard]] size_type GetNewCapacityForPush () const noexcept
-        {
-            if (m_capacity == 0) {
-                return std::max(64/sizeof(T), size_type(1));
-            } else {
-                Real const gf = VectorGrowthStrategy::GetGrowthFactor();
-                if (amrex::almostEqual(gf, Real(1.5))) {
-                    return (m_capacity*3+1)/2;
-                } else {
-                    return size_type(gf*Real(m_capacity+1));
-                }
-            }
-        }
-
-        void UpdateDataPtr (FatPtr<T> const& fp)
-        {
-            auto* new_data = fp.ptr();
-            auto new_capacity = fp.size();
-            if (m_data != nullptr && m_data != new_data) {
-                if (m_size > 0) {
-                    detail::memCopyImpl(new_data, m_data, nBytes(),
-                                        (Allocator const&)(*this),
-                                        (Allocator const&)(*this));
-                }
-                deallocate(m_data, capacity());
-            }
-            m_data = new_data;
-            m_capacity = new_capacity;
-        }
-
-        // This is where we play games with the allocator. This function
-        // updates m_data and m_capacity, but not m_size.
-        void AllocateBufferForPush (size_type target_capacity)
-        {
-            auto fp = detail::allocate_in_place(m_data, m_size+1, target_capacity,
-                                                (Allocator&)(*this));
-            UpdateDataPtr(fp);
-        }
-
         // This is where we play games with the allocator and the growth
         // strategy for insert. This function updates m_data, m_size and
         // m_capacity.
         void AllocateBufferForInsert (size_type a_index, size_type a_count)
         {
             size_type new_size = m_size + a_count;
-            size_type new_capacity = std::max(new_size, GetNewCapacityForPush());
+            size_type new_capacity = VectorGrowthStrategy::GetNewCapacity(
+                m_size, m_capacity, new_size, GrowthStrategy::Geometric, sizeof(T));
             auto fp = detail::allocate_in_place(m_data, new_size, new_capacity,
                                                 (Allocator&)(*this));
             auto* new_data = fp.ptr();
@@ -787,12 +759,42 @@ namespace amrex
             m_capacity = new_capacity;
         }
 
-        void resize_without_init_snan (size_type a_new_size)
+        // This function updates m_data and m_capacity
+        void ReallocNewCapacity (size_type new_capacity)
         {
-            if (m_capacity < a_new_size) {
-                reserve(a_new_size);
+            if (new_capacity > m_capacity) {
+                auto fp = detail::allocate_in_place(m_data, new_capacity, new_capacity,
+                                                   (Allocator&)(*this));
+                auto* new_data = fp.ptr();
+                auto fp_new_capacity = fp.size();
+                if (m_data != nullptr && m_data != new_data) {
+                    if (m_size > 0) {
+                        detail::memCopyImpl(new_data, m_data, nBytes(),
+                                            (Allocator const&)(*this),
+                                            (Allocator const&)(*this));
+                    }
+                    deallocate(m_data, capacity());
+                }
+                m_data = new_data;
+                m_capacity = fp_new_capacity;
+            } else if (new_capacity < m_capacity) {
+                auto* new_data = detail::shrink_in_place(m_data, new_capacity,
+                                                        (Allocator&)(*this));
+                if (new_data != m_data) {
+                    if (m_size > 0) {
+                        detail::memCopyImpl(new_data, m_data, nBytes(),
+                                            (Allocator const&)(*this),
+                                            (Allocator const&)(*this));
+                    }
+                    deallocate(m_data, m_capacity);
+                }
+                m_data = new_data;
+                m_capacity = new_capacity;
+            } else if (new_capacity == 0 && m_capacity != 0) {
+                deallocate(m_data, m_capacity);
+                m_data = nullptr;
+                m_capacity = 0;
             }
-            m_size = a_new_size;
         }
     };
 }

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -259,9 +259,18 @@ namespace amrex
 
         void Initialize ();
 
-        std::size_t GetNewCapacity (std::size_t old_size, std::size_t old_capacity,
-                                    std::size_t new_size, GrowthStrategy strategy,
-                                    std::size_t sizeof_T);
+        std::size_t GetNewCapacityImp (std::size_t old_size, std::size_t old_capacity,
+                                       std::size_t new_size, GrowthStrategy strategy,
+                                       std::size_t sizeof_T);
+
+        inline std::size_t GetNewCapacity (std::size_t old_size, std::size_t old_capacity,
+                                           std::size_t new_size, GrowthStrategy strategy,
+                                           std::size_t sizeof_T) {
+            std::size_t new_capacity =
+                GetNewCapacityImp(old_size, old_capacity, new_size, strategy, sizeof_T);
+            AMREX_ALWAYS_ASSERT(new_capacity >= new_size);
+            return new_capacity;
+        }
     }
 
     template <class T, class Allocator = std::allocator<T> >

--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -777,6 +777,10 @@ namespace amrex
                 }
                 m_data = new_data;
                 m_capacity = fp_new_capacity;
+            } else if (new_capacity == 0 && m_capacity != 0) {
+                deallocate(m_data, m_capacity);
+                m_data = nullptr;
+                m_capacity = 0;
             } else if (new_capacity < m_capacity) {
                 auto* new_data = detail::shrink_in_place(m_data, new_capacity,
                                                         (Allocator&)(*this));
@@ -790,11 +794,8 @@ namespace amrex
                 }
                 m_data = new_data;
                 m_capacity = new_capacity;
-            } else if (new_capacity == 0 && m_capacity != 0) {
-                deallocate(m_data, m_capacity);
-                m_data = nullptr;
-                m_capacity = 0;
             }
+            AMREX_ALWAYS_ASSERT((m_capacity == 0) == (m_data == nullptr));
         }
     };
 }

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -70,6 +70,7 @@ namespace amrex::VectorGrowthStrategy
                 } else {
                     new_capacity = old_capacity;
                 }
+                break;
             case GrowthStrategy::Geometric:
                 if (new_size > old_capacity) {
                     const std::size_t min_capacity = std::max(64/sizeof_T, new_size);
@@ -82,12 +83,14 @@ namespace amrex::VectorGrowthStrategy
                 } else {
                     new_capacity = old_capacity;
                 }
+                break;
             case GrowthStrategy::Poisson:
                 if (new_size > old_capacity) {
                     new_capacity = new_size + static_cast<std::size_t>(3 * std::sqrt(new_size));
                 } else {
                     new_capacity = old_capacity;
                 }
+                break;
         }
 
         AMREX_ALWAYS_ASSERT(new_capacity >= new_size);

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -49,51 +49,44 @@ namespace amrex::VectorGrowthStrategy
         detail::ValidateUserInput();
     }
 
-    std::size_t GetNewCapacity ([[maybe_unused]] std::size_t old_size, std::size_t old_capacity,
-                                std::size_t new_size, amrex::GrowthStrategy strategy,
-                                std::size_t sizeof_T) {
-
-        std::size_t new_capacity = 0;
+    std::size_t GetNewCapacityImp ([[maybe_unused]] std::size_t old_size, std::size_t old_capacity,
+                                   std::size_t new_size, amrex::GrowthStrategy strategy,
+                                   std::size_t sizeof_T) {
 
         if (override_strategy != amrex::GrowthStrategy::Default) {
-            return GetNewCapacity(old_size, old_capacity, new_size, override_strategy, sizeof_T);
+            return GetNewCapacityImp(old_size, old_capacity, new_size, override_strategy, sizeof_T);
         }
 
         switch (strategy) {
             case GrowthStrategy::Default:
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(default_strategy != GrowthStrategy::Default,
                     "Must set default growth strategy to something other than Default");
-                return GetNewCapacity(old_size, old_capacity, new_size, default_strategy, sizeof_T);
+                return GetNewCapacityImp(old_size, old_capacity, new_size,
+                                         default_strategy, sizeof_T);
             case GrowthStrategy::Exact:
                 if (new_size > old_capacity) {
-                    new_capacity = new_size;
+                    return new_size;
                 } else {
-                    new_capacity = old_capacity;
+                    return old_capacity;
                 }
-                break;
             case GrowthStrategy::Geometric:
                 if (new_size > old_capacity) {
                     const std::size_t min_capacity = std::max(64/sizeof_T, new_size);
                     Real const gf = GetGrowthFactor();
                     if (amrex::almostEqual(gf, Real(1.5))) {
-                        new_capacity = std::max((old_capacity*3+1)/2, min_capacity);
+                        return std::max((old_capacity*3+1)/2, min_capacity);
                     } else {
-                        new_capacity = std::max(std::size_t(gf*Real(old_capacity+1)), min_capacity);
+                        return std::max(std::size_t(gf*Real(old_capacity+1)), min_capacity);
                     }
                 } else {
-                    new_capacity = old_capacity;
+                    return old_capacity;
                 }
-                break;
             case GrowthStrategy::Poisson:
                 if (new_size > old_capacity) {
-                    new_capacity = new_size + static_cast<std::size_t>(3 * std::sqrt(new_size));
+                    return new_size + static_cast<std::size_t>(3 * std::sqrt(new_size));
                 } else {
-                    new_capacity = old_capacity;
+                    return old_capacity;
                 }
-                break;
         }
-
-        AMREX_ALWAYS_ASSERT(new_capacity >= new_size);
-        return new_capacity;
     }
 }

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -88,5 +88,7 @@ namespace amrex::VectorGrowthStrategy
                     return old_capacity;
                 }
         }
+
+        return new_size;
     }
 }

--- a/Src/Base/AMReX_PODVector.cpp
+++ b/Src/Base/AMReX_PODVector.cpp
@@ -2,9 +2,13 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>
 
+#include <cmath>
+
 namespace amrex::VectorGrowthStrategy
 {
     Real growth_factor = 1.5_rt;
+    amrex::GrowthStrategy default_strategy = amrex::GrowthStrategy::Exact;
+    amrex::GrowthStrategy override_strategy = amrex::GrowthStrategy::Default;
 
     // clamp user input to reasonable values
     constexpr Real min_factor = 1.001_rt;
@@ -34,6 +38,8 @@ namespace amrex::VectorGrowthStrategy
     void Initialize () {
         ParmParse pp("amrex");
         pp.queryAdd("vector_growth_factor", growth_factor);
+        pp.query_enum_case_insensitive("vector_growth_strategy", default_strategy);
+        pp.query_enum_case_insensitive("vector_growth_strategy_override", override_strategy);
 
         detail::ValidateUserInput();
     }
@@ -41,5 +47,50 @@ namespace amrex::VectorGrowthStrategy
     void SetGrowthFactor (Real a_factor) {
         growth_factor = a_factor;
         detail::ValidateUserInput();
+    }
+
+    std::size_t GetNewCapacity ([[maybe_unused]] std::size_t old_size, std::size_t old_capacity,
+                                std::size_t new_size, amrex::GrowthStrategy strategy,
+                                std::size_t sizeof_T) {
+
+        std::size_t new_capacity = 0;
+
+        if (override_strategy != amrex::GrowthStrategy::Default) {
+            return GetNewCapacity(old_size, old_capacity, new_size, override_strategy, sizeof_T);
+        }
+
+        switch (strategy) {
+            case GrowthStrategy::Default:
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(default_strategy != GrowthStrategy::Default,
+                    "Must set default growth strategy to something other than Default");
+                return GetNewCapacity(old_size, old_capacity, new_size, default_strategy, sizeof_T);
+            case GrowthStrategy::Exact:
+                if (new_size > old_capacity) {
+                    new_capacity = new_size;
+                } else {
+                    new_capacity = old_capacity;
+                }
+            case GrowthStrategy::Geometric:
+                if (new_size > old_capacity) {
+                    const std::size_t min_capacity = std::max(64/sizeof_T, new_size);
+                    Real const gf = GetGrowthFactor();
+                    if (amrex::almostEqual(gf, Real(1.5))) {
+                        new_capacity = std::max((old_capacity*3+1)/2, min_capacity);
+                    } else {
+                        new_capacity = std::max(std::size_t(gf*Real(old_capacity+1)), min_capacity);
+                    }
+                } else {
+                    new_capacity = old_capacity;
+                }
+            case GrowthStrategy::Poisson:
+                if (new_size > old_capacity) {
+                    new_capacity = new_size + static_cast<std::size_t>(3 * std::sqrt(new_size));
+                } else {
+                    new_capacity = old_capacity;
+                }
+        }
+
+        AMREX_ALWAYS_ASSERT(new_capacity >= new_size);
+        return new_capacity;
     }
 }

--- a/Src/Particle/AMReX_ArrayOfStructs.H
+++ b/Src/Particle/AMReX_ArrayOfStructs.H
@@ -91,9 +91,13 @@ public:
         m_data.swap(other.m_data);
     }
 
-    void resize (size_t count) { m_data.resize(count); }
+    void resize (size_t count, GrowthStrategy growth_strategy = GrowthStrategy::Default) {
+        m_data.resize(count, growth_strategy);
+    }
 
-    void reserve (size_t capacity) { m_data.reserve(capacity); }
+    void reserve (size_t capacity, GrowthStrategy growth_strategy = GrowthStrategy::Default) {
+        m_data.reserve(capacity, growth_strategy);
+    }
 
     Iterator erase ( ConstIterator first, ConstIterator second) { return m_data.erase(first, second); }
 

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -49,7 +49,7 @@ struct RedistributeUnpackPolicy
         }
 
         for (auto& kv : tile_sizes) {
-            kv.first->resize(kv.second);
+            kv.first->resize(kv.second, GrowthStrategy::Poisson);
         }
     }
 };

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -965,20 +965,20 @@ struct ParticleTile
         }
     }
 
-    void resize (std::size_t count)
+    void resize (std::size_t count, GrowthStrategy growth_strategy = GrowthStrategy::Default)
     {
         if constexpr (!ParticleType::is_soa_particle) {
-            m_aos_tile.resize(count);
+            m_aos_tile.resize(count, growth_strategy);
         }
-        m_soa_tile.resize(count);
+        m_soa_tile.resize(count, growth_strategy);
     }
 
-    void reserve (std::size_t capacity)
+    void reserve (std::size_t capacity, GrowthStrategy growth_strategy = GrowthStrategy::Default)
     {
         if constexpr (!ParticleType::is_soa_particle) {
-            m_aos_tile.reserve(capacity);
+            m_aos_tile.reserve(capacity, growth_strategy);
         }
-        m_soa_tile.reserve(capacity);
+        m_soa_tile.reserve(capacity, growth_strategy);
     }
 
     ///
@@ -997,7 +997,7 @@ struct ParticleTile
         auto np = numParticles();
 
         if constexpr (!ParticleType::is_soa_particle) {
-            m_aos_tile.resize(np+1);
+            m_aos_tile.resize(np+1, GrowthStrategy::Geometric);
             for (int i = 0; i < AMREX_SPACEDIM; ++i) {
                 m_aos_tile[np].pos(i) = sp.pos(i);
             }
@@ -1011,7 +1011,7 @@ struct ParticleTile
             }
         }
 
-        m_soa_tile.resize(np+1);
+        m_soa_tile.resize(np+1, GrowthStrategy::Geometric);
         if constexpr (ParticleType::is_soa_particle) {
             m_soa_tile.GetIdCPUData()[np] = sp.m_idcpu;
         }

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -267,34 +267,42 @@ struct StructOfArrays {
 
     [[nodiscard]] int getNumNeighbors () const { return m_num_neighbor_particles; }
 
-    void resize (size_t count)
+    void resize (size_t count, GrowthStrategy growth_strategy = GrowthStrategy::Default)
     {
         if constexpr (use64BitIdCpu == true) {
-            m_idcpu.resize(count);
+            m_idcpu.resize(count, growth_strategy);
         }
         if constexpr (NReal > 0) {
-            for (int i = 0; i < NReal; ++i) { m_rdata[i].resize(count); }
+            for (int i = 0; i < NReal; ++i) { m_rdata[i].resize(count, growth_strategy); }
         }
         if constexpr (NInt > 0) {
-            for (int i = 0; i < NInt;  ++i) { m_idata[i].resize(count); }
+            for (int i = 0; i < NInt;  ++i) { m_idata[i].resize(count, growth_strategy); }
         }
-        for (int i = 0; i < int(m_runtime_rdata.size()); ++i) { m_runtime_rdata[i].resize(count); }
-        for (int i = 0; i < int(m_runtime_idata.size()); ++i) { m_runtime_idata[i].resize(count); }
+        for (int i = 0; i < int(m_runtime_rdata.size()); ++i) {
+            m_runtime_rdata[i].resize(count, growth_strategy);
+        }
+        for (int i = 0; i < int(m_runtime_idata.size()); ++i) {
+            m_runtime_idata[i].resize(count, growth_strategy);
+        }
     }
 
-    void reserve (size_t capacity)
+    void reserve (size_t capacity, GrowthStrategy growth_strategy = GrowthStrategy::Default)
     {
         if constexpr (use64BitIdCpu == true) {
-            m_idcpu.reserve(capacity);
+            m_idcpu.reserve(capacity, growth_strategy);
         }
         if constexpr (NReal > 0) {
-            for (int i = 0; i < NReal; ++i) { m_rdata[i].reserve(capacity); }
+            for (int i = 0; i < NReal; ++i) { m_rdata[i].reserve(capacity, growth_strategy); }
         }
         if constexpr (NInt > 0) {
-            for (int i = 0; i < NInt;  ++i) { m_idata[i].reserve(capacity); }
+            for (int i = 0; i < NInt;  ++i) { m_idata[i].reserve(capacity, growth_strategy); }
         }
-        for (int i = 0; i < int(m_runtime_rdata.size()); ++i) { m_runtime_rdata[i].reserve(capacity); }
-        for (int i = 0; i < int(m_runtime_idata.size()); ++i) { m_runtime_idata[i].reserve(capacity); }
+        for (int i = 0; i < int(m_runtime_rdata.size()); ++i) {
+            m_runtime_rdata[i].reserve(capacity, growth_strategy);
+        }
+        for (int i = 0; i < int(m_runtime_idata.size()); ++i) {
+            m_runtime_idata[i].reserve(capacity, growth_strategy);
+        }
     }
 
     [[nodiscard]] uint64_t* idcpuarray () {


### PR DESCRIPTION
## Summary

This PR adds an optional GrowthStrategy argument to some PODVector functions to switch the allocation strategy.

It is not yet clear to me which functions should be affected by the runtime controls and if the runtime controls should have priority over explicitly set strategies.

Discussion in #4715

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
