### PR TITLE
Allow C++20 HIP builds

### DIFF
--- a/Tools/CMake/AMReXParallelBackends.cmake
+++ b/Tools/CMake/AMReXParallelBackends.cmake
@@ -366,10 +366,8 @@ if (AMReX_HIP)
        # 
        target_compile_options(amrex_${D}d PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-munsafe-fp-atomics>)
 
-       # ROCm 5.5: forgets to enforce C++17 (default seems lower)
-       # https://github.com/AMReX-Codes/amrex/issues/3337
-       #
-       target_compile_options(amrex_${D}d PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>)
+       # Ensure ROCm builds enable at least C++17 without overriding higher standards
+       target_compile_features(amrex_${D}d PUBLIC cxx_std_17)
    endforeach()
 
    # Equivalently, relocatable-device-code (RDC) flags are needed for `extern`


### PR DESCRIPTION
## Summary
This removes the hard-coded C++17 compiler flag when HIP is turned on, so codes are able to use C++20 with HIP.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
