### PR TITLE
Fix PODVector shrink_to_fit() with nonzero size

### DIFF
--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -685,6 +685,7 @@ namespace amrex
                                             (Allocator const&)(*this));
                         deallocate(m_data, m_capacity);
                     }
+                    m_data = new_data;
                     m_capacity = m_size;
                 }
             }


### PR DESCRIPTION
## Summary

While working on #4735 I noticed that in shrink_to_fit the newly allocated data pointer was not saved in the PODVector.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
