### PR TITLE
Add information about generating particles for GPU codes to the docs

### DIFF
--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -315,10 +315,10 @@ outside their parent grid).
    vectors, assumes you have compiled AMReX for CPU execution.
    For GPU codes, one can either generate particles on the host and copy them
    to the device, or generate the particles directly on the GPU. For the first
-   approach, please see the sample code `here <https://github.com/AMReX-Codes/amrex/blob/development/Tests/Particles/Redistribute/main.cpp#L81>`_.
+   approach, please see the sample code `here <https://github.com/AMReX-Codes/amrex/blob/development/Tests/Particles/Redistribute/main.cpp#L81>`__.
    For an example of generating a variable number of particles in each cell
    directly on the GPU, please see
-   `this <https://github.com/AMReX-Codes/amrex-tutorials/blob/main/ExampleCodes/Particles/ElectromagneticPIC/Source/EMParticleContainerInit.cpp#L48>`_
+   `this <https://github.com/AMReX-Codes/amrex-tutorials/blob/main/ExampleCodes/Particles/ElectromagneticPIC/Source/EMParticleContainerInit.cpp#L48>`__
    Electromagnetic Particle-in-Cell tutorial
 
 .. _sec:Particles:Runtime:

--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -309,6 +309,17 @@ particles, if the processes generate particles they don't own (for example, if
 the particle positions are perturbed from the cell centers and thus end up
 outside their parent grid).
 
+.. note::
+
+   The above code snippet, which successively calls :cpp:`push_back` on the particle
+   vectors, assumes you have compiled AMReX for CPU execution.
+   For GPU codes, one can either generate particles on the host and copy them
+   to the device, or generate the particles directly on the GPU. For the first
+   approach, please see the sample code `here <https://github.com/AMReX-Codes/amrex/blob/development/Tests/Particles/Redistribute/main.cpp#L81>`_.
+   For an example of generating a variable number of particles in each cell
+   directly on the GPU, please see the Electromagnetic Particle-in-Cell tutorial
+   `here <https://github.com/AMReX-Codes/amrex-tutorials/blob/main/ExampleCodes/Particles/ElectromagneticPIC/Source/EMParticleContainerInit.cpp#L48>`_.
+
 .. _sec:Particles:Runtime:
 
 Adding particle components at runtime

--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -317,8 +317,9 @@ outside their parent grid).
    to the device, or generate the particles directly on the GPU. For the first
    approach, please see the sample code `here <https://github.com/AMReX-Codes/amrex/blob/development/Tests/Particles/Redistribute/main.cpp#L81>`_.
    For an example of generating a variable number of particles in each cell
-   directly on the GPU, please see the Electromagnetic Particle-in-Cell tutorial
-   `here <https://github.com/AMReX-Codes/amrex-tutorials/blob/main/ExampleCodes/Particles/ElectromagneticPIC/Source/EMParticleContainerInit.cpp#L48>`_.
+   directly on the GPU, please see
+   `this <https://github.com/AMReX-Codes/amrex-tutorials/blob/main/ExampleCodes/Particles/ElectromagneticPIC/Source/EMParticleContainerInit.cpp#L48>`_
+   Electromagnetic Particle-in-Cell tutorial
 
 .. _sec:Particles:Runtime:
 


### PR DESCRIPTION
The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
