### PR TITLE
AMREX_ENUM: Fix enumerator = int

### DIFF
--- a/Src/Base/AMReX_Enum.H
+++ b/Src/Base/AMReX_Enum.H
@@ -34,10 +34,19 @@ namespace detail
                 ++next_value;
             } else if (kv.size() == 2) {
                 auto const& value_string = amrex::trim(kv[1]);
+                // For k = v, find if v exists as a key. If not, v must be an int.
                 auto it = std::find_if(r.begin(), r.end(),
                                        [&] (auto const& x) -> bool
                                            { return x.first == value_string; });
-                auto this_value = it->second;
+                T this_value;
+                if (it != r.end()) {
+                    this_value = it->second;
+                } else { // v is an int
+                    // Note that if value_string is not a valid string for int,
+                    // it will fail at compile time, because the compiler
+                    // will not allow something like `enum FOO : int { x = 3% }`.
+                    this_value =  static_cast<T>(std::stoi(value_string));
+                }
                 r.emplace_back(amrex::trim(kv[0]), this_value);
                 next_value = static_cast<int>(this_value) + 1;
             } else {

--- a/Tests/Enum/main.cpp
+++ b/Tests/Enum/main.cpp
@@ -153,6 +153,9 @@ int main (int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(static_cast<int>(Location::entry) == 1);
         AMREX_ALWAYS_ASSERT(static_cast<int>(Location::exit) == -1);
         AMREX_ALWAYS_ASSERT(static_cast<int>(Location::after_exit) == 0);
+        AMREX_ALWAYS_ASSERT(amrex::toUnderlying(Location::entry) == 1);
+        AMREX_ALWAYS_ASSERT(amrex::toUnderlying(Location::exit) == -1);
+        AMREX_ALWAYS_ASSERT(amrex::toUnderlying(Location::after_exit) == 0);
         AMREX_ALWAYS_ASSERT(amrex::getEnum<Location>("entry") == Location::entry);
         AMREX_ALWAYS_ASSERT(amrex::getEnum<Location>("exit") == Location::exit);
         AMREX_ALWAYS_ASSERT(amrex::getEnum<Location>("after_exit") == Location::after_exit);

--- a/Tests/Enum/main.cpp
+++ b/Tests/Enum/main.cpp
@@ -17,6 +17,8 @@ AMREX_ENUM(MyColor2,
            blue,      // 2
            Default = green); // 1
 
+AMREX_ENUM(Location, entry = 1, exit = -1, after_exit);
+
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc, argv);
@@ -138,6 +140,25 @@ int main (int argc, char* argv[])
         auto my_green = MyColor2::red;
         pp.query_enum_sloppy("color6", my_green, "-.");
         AMREX_ALWAYS_ASSERT(my_green == MyColor2::green);
+    }
+
+
+    {
+        auto const& kv = amrex::getEnumNameValuePairs<Location>();
+        amrex::Print() << "Name : Value\n";
+        for (auto const& item : kv) {
+            amrex::Print() << "  " << item.first << ": "
+                           << static_cast<int>(item.second) << "\n";
+        }
+        AMREX_ALWAYS_ASSERT(static_cast<int>(Location::entry) == 1);
+        AMREX_ALWAYS_ASSERT(static_cast<int>(Location::exit) == -1);
+        AMREX_ALWAYS_ASSERT(static_cast<int>(Location::after_exit) == 0);
+        AMREX_ALWAYS_ASSERT(amrex::getEnum<Location>("entry") == Location::entry);
+        AMREX_ALWAYS_ASSERT(amrex::getEnum<Location>("exit") == Location::exit);
+        AMREX_ALWAYS_ASSERT(amrex::getEnum<Location>("after_exit") == Location::after_exit);
+        AMREX_ALWAYS_ASSERT(amrex::getEnumNameString(Location::entry) == "entry");
+        AMREX_ALWAYS_ASSERT(amrex::getEnumNameString(Location::exit) == "exit");
+        AMREX_ALWAYS_ASSERT(amrex::getEnumNameString(Location::after_exit) == "after_exit");
     }
 
     amrex::Finalize();


### PR DESCRIPTION
Previously, we only considered enumerator = constant-expression, where constant-expression is an enumerator, but not an int.
