### PR TITLE
`PC::make_alike<Allocator>` Change Default

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1370,14 +1370,14 @@ public:
     /** Create an empty particle container
      *
      * This creates a new AMReX particle container type with same compile-time
-     * and run-time attributes. But, it can change its allocator. This is
-     * helpful when creating temporary particle buffers for filter operations
+     * and run-time attributes. But, it can change its allocator (default: same allocator).
+     * This is helpful when creating temporary particle buffers for filter operations
      * and device-to-host copies.
      *
-     * @tparam Allocator AMReX allocator, e.g., amrex::PinnedArenaAllocator
+     * @tparam Allocator AMReX allocator, e.g., amrex::PinnedArenaAllocator, default: same allocator as the creating PC
      * @return an empty particle container
      * */
-    template <template<class> class NewAllocator=amrex::DefaultAllocator>
+    template <template<class> class NewAllocator=Allocator>
     ContainerLike<NewAllocator>
     make_alike () const
     {


### PR DESCRIPTION
## Summary

Change the template default of `make_alike<>()` to use the same allocator as the creating allocator. This is a breaking change.

In practice, this was so far used to create a pinned allocator, e.g., for I/O operations. It is more sensible to create the same allocator if unspecified as the creating PC and it also makes "modern"/future AMReX, which uses PCs with `PolymorphicArena` allocators, shorter/cleaner in user code.

## Additional background

Introduced a few years ago for BLAST codes. Not sure how widely this is used yet, will ask on Slack, too. I doubt in practice this is used a lot without explicit template arguments.

In pyAMReX, we already implement this only for the same allocator as the creating one (no break).

See the [particle roadmap](https://github.com/AMReX-Codes/pyamrex/issues/460).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
