### PR TITLE
ParticleContainerToBlueprint: Allocator

### DIFF
--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint.H
@@ -96,10 +96,11 @@ namespace amrex
     //  coordset and fields used to represent the passed particle container.
     //  This allows you to use unique names to wrap multiple particle containers
     //  into a single blueprint tree.
-    template <typename ParticleType, int NArrayReal, int NArrayInt>
+    template <typename ParticleType, int NArrayReal, int NArrayInt, template<class> class Allocator=DefaultAllocator>
     void ParticleContainerToBlueprint (const ParticleContainer_impl<ParticleType,
                                                                NArrayReal,
-                                                               NArrayInt> &pc,
+                                                               NArrayInt,
+                                                               Allocator> &pc,
                                        const Vector<std::string> &real_comp_names,
                                        const Vector<std::string> &int_comp_names,
                                        conduit::Node &bp_mesh,

--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
@@ -244,11 +244,12 @@ ParticleTileToBlueprint(const ParticleTile<ParticleType,
 //---------------------------------------------------------------------------//
 // Converts a AMReX Particle Container into a Conduit Mesh Blueprint Hierarchy.
 //---------------------------------------------------------------------------//
-template <typename ParticleType, int NArrayReal, int NArrayInt>
+template <typename ParticleType, int NArrayReal, int NArrayInt, template<class> class Allocator=DefaultAllocator>
 void
 ParticleContainerToBlueprint(const ParticleContainer_impl<ParticleType,
                                                      NArrayReal,
-                                                     NArrayInt> &pc,
+                                                     NArrayInt,
+                                                     Allocator> &pc,
                              const Vector<std::string> &real_comp_names,
                              const Vector<std::string> &int_comp_names,
                              conduit::Node &res,


### PR DESCRIPTION
## Summary

Add the `Allocator` template, so we can use this with polymorphic PCs (and generally any PC that does not use the default allocator).

## Additional background

https://github.com/BLAST-WarpX/warpx/pull/6374

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
