### PR TITLE
Add amrex::Math::rsqrt

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -325,6 +325,26 @@ T comp_ellint_2 (T k)
     return Kcomp*sum_val;
 }
 
+//! Return inverse square root of x
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double rsqrt (double x)
+{
+    double r;
+    AMREX_IF_ON_DEVICE(( r = rsqrt(x); ))
+    AMREX_IF_ON_HOST(( r = 1. / std::sqrt(x); ))
+    return r;
+}
+
+//! Return inverse square root of x
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+float rsqrt (float x)
+{
+    float r;
+    AMREX_IF_ON_DEVICE(( r = rsqrtf(x); ))
+    AMREX_IF_ON_HOST(( r = 1.f / std::sqrt(x); ))
+    return r;
+}
+
 /***************************************************************************************************
  * Copyright (c) 2017 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -341,7 +341,7 @@ float rsqrt (float x)
 {
     float r;
     AMREX_IF_ON_DEVICE(( r = rsqrtf(x); ))
-    AMREX_IF_ON_HOST(( r = 1.f / std::sqrt(x); ))
+    AMREX_IF_ON_HOST(( r = 1.F / std::sqrt(x); ))
     return r;
 }
 

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -330,7 +330,11 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double rsqrt (double x)
 {
     double r;
+#if defined(AMREX_USE_SYCL)
+    AMREX_IF_ON_DEVICE(( r = sycl::rsqrt(x); ))
+#else
     AMREX_IF_ON_DEVICE(( r = ::rsqrt(x); ))
+#endif
     AMREX_IF_ON_HOST(( r = 1. / std::sqrt(x); ))
     return r;
 }
@@ -340,7 +344,11 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 float rsqrt (float x)
 {
     float r;
+#if defined(AMREX_USE_SYCL)
+    AMREX_IF_ON_DEVICE(( r = sycl::rsqrt(x); ))
+#else
     AMREX_IF_ON_DEVICE(( r = ::rsqrtf(x); ))
+#endif
     AMREX_IF_ON_HOST(( r = 1.F / std::sqrt(x); ))
     return r;
 }

--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -330,7 +330,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double rsqrt (double x)
 {
     double r;
-    AMREX_IF_ON_DEVICE(( r = rsqrt(x); ))
+    AMREX_IF_ON_DEVICE(( r = ::rsqrt(x); ))
     AMREX_IF_ON_HOST(( r = 1. / std::sqrt(x); ))
     return r;
 }
@@ -340,7 +340,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 float rsqrt (float x)
 {
     float r;
-    AMREX_IF_ON_DEVICE(( r = rsqrtf(x); ))
+    AMREX_IF_ON_DEVICE(( r = ::rsqrtf(x); ))
     AMREX_IF_ON_HOST(( r = 1.F / std::sqrt(x); ))
     return r;
 }


### PR DESCRIPTION
## Summary

This PR adds a function to compute the inverse square root of a single- or double-precision value. On GPUs this should be faster than doing the inverse and square root separately.

## Additional background

https://godbolt.org/z/sb8P3TMvq

https://docs.nvidia.com/cuda/cuda-c-best-practices-guide/index.html#reciprocal-square-root

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
