### PR TITLE
Add Amr::derive overloads for all levels

### DIFF
--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -222,6 +222,16 @@ public:
                                       Real           time,
                                       int            lev,
                                       int            ngrow);
+    //! Compute derived data on all levels and store in the dcompth component of
+    //! each Multifab in mf
+    void derive (const std::string&       name,
+                 Real                     time,
+                 const Vector<MultiFab*>& mf,
+                 int                      dcomp);
+    //! Compute derived data on all levels and return as a vector of MultiFab pointers
+    Vector<std::unique_ptr<MultiFab>> derive (const std::string& name,
+                                              amrex::Real        time,
+                                              int                ngrow);
     //! Name of the restart chkpoint file.
     const std::string& theRestartFile () const noexcept { return restart_chkfile; }
     //! Name of the restart plotfile.

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -205,6 +205,46 @@ Amr::derive (const std::string& name,
     return amr_level[lev]->derive(name,time,ngrow);
 }
 
+Vector<std::unique_ptr<MultiFab>>
+Amr::derive(const std::string& name,
+            amrex::Real        time,
+            int                ngrow)
+{
+    BL_PROFILE("Amr::derive()");
+    Vector<std::unique_ptr<MultiFab>> out;
+    out.reserve(finest_level + 1);
+
+    for (int i = 0; i <= finest_level; ++i)
+    {
+        auto mf = amr_level[i]->derive(name,time,ngrow);
+        out.push_back(std::move(mf));
+    }
+
+    return out;
+}
+
+void
+Amr::derive (const std::string&       name,
+             Real                     time,
+             const Vector<MultiFab*>& mf,
+             int                      dcomp)
+{
+    BL_PROFILE("Amr::derive()");
+    AMREX_ASSERT(mf.size() == static_cast<amrex::Long>(finest_level + 1));
+
+    for (int i = 0; i <= finest_level; ++i)
+    {
+        AMREX_ASSERT(mf[i] != nullptr);
+        AMREX_ASSERT(mf[i]->ok());
+        AMREX_ASSERT(mf[i]->nComp() > dcomp);
+    }
+
+    for (int i = 0; i <= finestLevel(); ++i)
+    {
+        amr_level[i]->derive(name,time,*(mf[i]),dcomp);
+    }
+}
+
 Amr::Amr (LevelBld* a_levelbld)
     :
     levelbld(a_levelbld)


### PR DESCRIPTION
## Summary

This allows the user to create a vector of `MultiFab`s (one per level) with the derived quantity computed on each level. The overloads match those in `AmrLevel`.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
