### PR TITLE
Restart w/ out-of-bounds Particles

### DIFF
--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -1050,10 +1050,10 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             host_particles[lev][ind];
 
             for (int j = 0; j < AMREX_SPACEDIM; j++) {
-                host_real_attribs[pld.m_lev][ind][j].push_back(ptemp.pos(j));
+                host_real_attribs[lev][ind][j].push_back(ptemp.pos(j));
             }
 
-            host_idcpu[pld.m_lev][ind].push_back(ptemp.m_idcpu);
+            host_idcpu[lev][ind].push_back(ptemp.m_idcpu);
 
             // read all other SoA
             // add the real...


### PR DESCRIPTION
## Summary

Seen on Frontier at 6000 nodes (of course): if the particle locator decides that a particle is out-of-bounds, it used an inconsistent level for the particle in restart.

Now, it uses the currently loaded level consistently, with an invalid-marked tile.

## Additional background

First seen by @titoiride

Co-authored-by: @atmyers 
Co-authored-by: @RemiLehe 
Co-authored-by: @titoiride

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
