### PR TITLE
[Docs] Use scrollbar when table is too wide.

### DIFF
--- a/Docs/sphinx_documentation/source/_static/theme_overrides.css
+++ b/Docs/sphinx_documentation/source/_static/theme_overrides.css
@@ -6,5 +6,4 @@
 .wy-table-responsive {
     margin-bottom: 24px;
     max-width: 100%;
-    overflow: visible;
 }


### PR DESCRIPTION
This makes the CMake options table look nicer in the sphinx docs.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
