### PR TITLE
Gitlab CI: Simplify status checker sleep logic

### DIFF
--- a/.github/workflows/trigger-hpsf-gitlab-ci.yml
+++ b/.github/workflows/trigger-hpsf-gitlab-ci.yml
@@ -84,23 +84,8 @@ jobs:
           echo "Waiting on GitLab pipeline $PIPELINE_ID..."
 
           STATUS="running"
-          MAX_WAIT=86400  # 24 hours
-          ELAPSED=0
-
           while [[ "$STATUS" == "running" || "$STATUS" == "pending" ]]; do
-            if [ $ELAPSED -ge $MAX_WAIT ]; then
-              echo "Timeout waiting for pipeline after $MAX_WAIT seconds"
-              echo "final_status=timeout" >> $GITHUB_OUTPUT
-              exit 1
-            fi
-
-            if [ $ELAPSED -lt 7200 ]; then
-              SLEEP_TIME=600   # 10 minutes
-            else
-              SLEEP_TIME=3600  # 1 hour
-            fi
-            sleep $SLEEP_TIME
-            ELAPSED=$((ELAPSED + SLEEP_TIME))
+            sleep 900  # 15 minutes
 
             STATUS=$(curl -s \
               "https://gitlab.spack.io/api/v4/projects/${{ env.GITLAB_PROJECT_ID }}/pipelines/$PIPELINE_ID" \


### PR DESCRIPTION
Simply check every 15 minutes and let it timeout when it reaches the limit set by GitHub (6 hours).
