### PR TITLE
Fix compile error with Conduit + Particles

### DIFF
--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
@@ -244,7 +244,7 @@ ParticleTileToBlueprint(const ParticleTile<ParticleType,
 //---------------------------------------------------------------------------//
 // Converts a AMReX Particle Container into a Conduit Mesh Blueprint Hierarchy.
 //---------------------------------------------------------------------------//
-template <typename ParticleType, int NArrayReal, int NArrayInt, template<class> class Allocator=DefaultAllocator>
+template <typename ParticleType, int NArrayReal, int NArrayInt, template<class> class Allocator>
 void
 ParticleContainerToBlueprint(const ParticleContainer_impl<ParticleType,
                                                      NArrayReal,


### PR DESCRIPTION
## Summary

Remove redefinition of default argument for 'template class Allocator' that causes compiler error.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
