### PR TITLE
Adding the new function setOversetMask() in AMReX_MLCellABecLap.H

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -43,22 +43,22 @@ public:
         return m_overset_mask[amrlev][mglev].get();
     }
 
-    void setOversetMask(int amrlev, const iMultiFab& a_mask){
+    void setOversetMask(int amrlev, const iMultiFab& a_mask)
+    {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if(Gpu::notInLaunchRegion())
 #endif
-	for (MFIter mfi(*m_overset_mask[amrlev][0], TilingIfNotGPU());mfi.isValid();++mfi){
-	Array4<int const> const& amsk = a_mask.const_array(mfi);
-	Array4<int> const& omsk = m_overset_mask[amrlev][0]->array(mfi);
-	Box const& bx = mfi.tilebox();
-	AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx,i,j,k,
-	{
-	omsk(i,j,k) = 1-amsk(i,j,k);
-	});
-	}
-	
-}
-	
+        for (MFIter mfi(*m_overset_mask[amrlev][0], TilingIfNotGPU());mfi.isValid();++mfi)
+        {
+            Array4<int const> const& amsk = a_mask.const_array(mfi);
+            Array4<int> const& omsk = m_overset_mask[amrlev][0]->array(mfi);
+            Box const& bx = mfi.tilebox();
+            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx,i,j,k,
+            {
+                omsk(i,j,k) = 1-amsk(i,j,k);
+            });
+        }
+    }
 
     [[nodiscard]] bool needsUpdate () const override {
         return MLCellLinOpT<MF>::needsUpdate();

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -43,6 +43,23 @@ public:
         return m_overset_mask[amrlev][mglev].get();
     }
 
+    void setOversetMask(int amrlev, const iMultiFab& a_mask){
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if(Gpu::notInLaunchRegion())
+#endif
+	for (MFIter mfi(*m_overset_mask[amrlev][0], TilingIfNotGPU());mfi.isValid();++mfi){
+	Array4<int const> const& amsk = a_mask.const_array(mfi);
+	Array4<int> const& omsk = m_overset_mask[amrlev][0]->array(mfi);
+	Box const& bx = mfi.tilebox();
+	AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx,i,j,k,
+	{
+	omsk(i,j,k) = 1-amsk(i,j,k);
+	});
+	}
+	
+}
+	
+
     [[nodiscard]] bool needsUpdate () const override {
         return MLCellLinOpT<MF>::needsUpdate();
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -48,14 +48,14 @@ public:
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if(Gpu::notInLaunchRegion())
 #endif
-        for (MFIter mfi(*m_overset_mask[amrlev][0], TilingIfNotGPU());mfi.isValid();++mfi)
+        for (MFIter mfi(*m_overset_mask[amrlev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
             Array4<int const> const& amsk = a_mask.const_array(mfi);
             Array4<int> const& omsk = m_overset_mask[amrlev][0]->array(mfi);
             Box const& bx = mfi.tilebox();
             AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx,i,j,k,
             {
-                omsk(i,j,k) = 1-amsk(i,j,k);
+                omsk(i,j,k) = amsk(i,j,k);
             });
         }
     }


### PR DESCRIPTION
## Adding a new function to allow for updating the overset mask of an existing MLCellABecLap linear operator

## Currently, a new constructor call is made in AMR-Wind at each time step to impose the updated overset mask onto the linear operator. This PR aims to eliminate that 

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
