### PR TITLE
ParmParse: Print parsed values as comments in prettyPrint

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -361,6 +361,7 @@ jobs:
     - uses: actions/checkout@v5
     - name: Dependencies
       run: |
+        .github/workflows/dependencies/ubuntu_free_disk_space.sh
         .github/workflows/dependencies/dependencies_gcc.sh 12
         .github/workflows/dependencies/dependencies_clang-tidy-apt-llvm.sh 17
         .github/workflows/dependencies/dependencies_ccache.sh

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1710,7 +1710,7 @@ public:
         // vector<vector<std::string>>.
         std::vector<std::vector<std::string>> m_vals;
         mutable Long                          m_count = 0;
-        std::variant<
+        mutable std::variant<
             std::string*,
             bool*,
             int*,
@@ -1721,6 +1721,8 @@ public:
             float*,
             double*
         > m_typehint = static_cast<std::string*>(nullptr);
+        mutable std::vector<std::variant<bool, int, long, long long, float, double>> m_last_vals;
+        mutable bool m_parsed = false;
     };
     using Table = std::unordered_map<std::string, PP_entry>;
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -690,7 +690,7 @@ void pp_entry_set_last_val (ParmParse::PP_entry const& entry, int ival, T ref, b
 #pragma omp single nowait
 #endif
     {
-        if (ival >= entry.m_last_vals.size()) {
+        if (ival >= int(entry.m_last_vals.size())) {
             entry.m_last_vals.resize(ival+1);
         }
         entry.m_last_vals[ival] = ref;
@@ -2351,7 +2351,6 @@ bool squeryarrWithParser (const ParmParse::Table& table,
 #pragma omp single nowait
 #endif
     {
-        auto const& entry = table.at(name);
         using T_ptr = std::decay_t<T>*;
         entry.m_typehint = static_cast<T_ptr>(nullptr);
     }

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -48,12 +48,28 @@ namespace
 {
 
 std::string pp_to_pretty_string (std::string const& name,
-                                 std::vector<std::string> const& vals)
+                                 std::vector<std::string> const& vals,
+                                 ParmParse::PP_entry const* entry)
 {
     std::stringstream ss;
     ss << name << " =";
     for (auto const& v : vals) {
         ss << " " << v;
+    }
+    if (entry && entry->m_parsed && ! entry->m_last_vals.empty()) {
+        int min_col = 36;
+        int pad = min_col - static_cast<int>(ss.str().size());
+        if (pad > 0) {
+            ss << std::string(pad, ' ');
+        }
+        ss.precision(17);
+        ss << "    #";
+        for (auto const& x : entry->m_last_vals) {
+            std::visit([&] (auto&& arg)
+            {
+                ss << " " << arg;
+            }, x);
+        }
     }
     return ss.str();
 }
@@ -667,6 +683,21 @@ bool pp_parser (const ParmParse::Table& table, const std::string& parser_prefix,
                 const std::string& name, const std::string& val, T& ref,
                 bool use_querywithparser);
 
+template <typename T>
+void pp_entry_set_last_val (ParmParse::PP_entry const& entry, int ival, T ref, bool parsed)
+{
+#ifdef AMREX_USE_OMP
+#pragma omp single nowait
+#endif
+    {
+        if (ival >= entry.m_last_vals.size()) {
+            entry.m_last_vals.resize(ival+1);
+        }
+        entry.m_last_vals[ival] = ref;
+        if (parsed) { entry.m_parsed = true; }
+    }
+}
+
 template <class T>
 bool
 squeryval (const ParmParse::Table& table,
@@ -684,6 +715,17 @@ squeryval (const ParmParse::Table& table,
     {
         return false;
     }
+
+    auto const& entry = table.at(name);
+
+#ifdef AMREX_USE_OMP
+#pragma omp single nowait
+#endif
+    {
+        using T_ptr = std::decay_t<T>*;
+        entry.m_typehint = static_cast<T_ptr>(nullptr);
+    }
+
     //
     // Does it have ival values?
     //
@@ -705,17 +747,21 @@ squeryval (const ParmParse::Table& table,
 
     const std::string& valname = (*def)[ival];
 
-    bool ok = is(valname, ref);
-    if ( !ok )
-    {
-        if constexpr (std::is_same_v<T,bool> ||
-                      std::is_same_v<T,int> ||
-                      std::is_same_v<T,long> ||
-                      std::is_same_v<T,long long> ||
-                      std::is_same_v<T,float> ||
-                      std::is_same_v<T,double>)
-        {
+    constexpr bool is_integral_floating = (std::is_same_v<T,bool> ||
+                                           std::is_same_v<T,int> ||
+                                           std::is_same_v<T,long> ||
+                                           std::is_same_v<T,long long> ||
+                                           std::is_same_v<T,float> ||
+                                           std::is_same_v<T,double>);
+
+    if (is(valname, ref)) {
+        if constexpr (is_integral_floating) {
+            pp_entry_set_last_val(entry, ival, ref, false);
+        }
+    } else {
+        if constexpr (is_integral_floating) {
             if (pp_parser(table, parser_prefix, name, valname, ref, false)) {
+                pp_entry_set_last_val(entry, ival, ref, true);
                 return true;
             }
         } else {
@@ -789,6 +835,17 @@ squeryarr (const ParmParse::Table& table,
     {
         return false;
     }
+
+    auto const& entry = table.at(name);
+
+#ifdef AMREX_USE_OMP
+#pragma omp single nowait
+#endif
+    {
+        using T_ptr = std::decay_t<T>*;
+        entry.m_typehint = static_cast<T_ptr>(nullptr);
+    }
+
     //
     // Does it have sufficient number of values and are they all
     // the same type?
@@ -799,6 +856,13 @@ squeryarr (const ParmParse::Table& table,
     }
 
     if ( num_val == 0 ) { return true; }
+
+    constexpr bool is_integral_floating = (std::is_same_v<T,bool> ||
+                                           std::is_same_v<T,int> ||
+                                           std::is_same_v<T,long> ||
+                                           std::is_same_v<T,long long> ||
+                                           std::is_same_v<T,float> ||
+                                           std::is_same_v<T,double>);
 
     int stop_ix = start_ix + num_val - 1;
     if ( static_cast<int>(ref.size()) <= stop_ix )
@@ -822,16 +886,14 @@ squeryarr (const ParmParse::Table& table,
     for ( int n = start_ix; n <= stop_ix; n++ )
     {
         const std::string& valname = (*def)[n];
-        bool ok = is(valname, ref[n]);
-        if ( !ok )
-        {
-            if constexpr (std::is_same_v<T,int> ||
-                          std::is_same_v<T,long> ||
-                          std::is_same_v<T,long long> ||
-                          std::is_same_v<T,float> ||
-                          std::is_same_v<T,double>)
-            {
+        if (is(valname, ref[n])) {
+            if constexpr (is_integral_floating) {
+                pp_entry_set_last_val(entry, n, ref[n], false);
+            }
+        } else {
+            if constexpr (is_integral_floating) {
                 if (pp_parser(table, parser_prefix, name, valname, ref[n], false)) {
+                    pp_entry_set_last_val(entry, n, ref[n], true);
                     continue;
                 }
             } else {
@@ -1283,7 +1345,7 @@ ParmParse::dumpTable (std::ostream& os, bool prettyPrint)
         auto const& entry = g_table[name];
         if (prettyPrint && entry.m_count > 0) {
             for (auto const& vals : entry.m_vals) {
-                os << pp_to_pretty_string(name, vals) << '\n';
+                os << pp_to_pretty_string(name, vals, nullptr) << '\n';
             }
         }
         else {
@@ -1317,16 +1379,9 @@ void pretty_print_table (std::ostream& os, PPFlag pp_flag)
 
     for (auto const& name : sorted_names) {
         auto const& entry = g_table[name];
-        std::vector<std::string> value_string;
-        std::unordered_map<std::string,int> count;
-        for (auto const& vals : entry.m_vals) {
-            value_string.emplace_back(pp_to_pretty_string(name, vals));
-            ++count[value_string.back()];
-        }
-        for (auto const& s : value_string) {
-            if (--count[s] == 0) {
-                os << s << '\n';
-            }
+        if (! entry.m_vals.empty()) {
+            auto const& val = entry.m_vals.back();
+            os << pp_to_pretty_string(name, val, &entry) << '\n';
         }
     }
 }
@@ -2229,7 +2284,34 @@ bool squeryWithParser (const ParmParse::Table& table,
     for (auto const& v : vals) {
         combined_string.append(v);
     }
-    return pp_parser(table, parser_prefix, name, combined_string, ref, true);
+
+    constexpr bool is_integral_floating = (std::is_same_v<T,bool> ||
+                                           std::is_same_v<T,int> ||
+                                           std::is_same_v<T,long> ||
+                                           std::is_same_v<T,long long> ||
+                                           std::is_same_v<T,float> ||
+                                           std::is_same_v<T,double>);
+
+    auto const& entry = table.at(name);
+
+    if (pp_parser(table, parser_prefix, name, combined_string, ref, true))
+    {
+#ifdef AMREX_USE_OMP
+#pragma omp single nowait
+#endif
+        {
+            using T_ptr = std::decay_t<T>*;
+            entry.m_typehint = static_cast<T_ptr>(nullptr);
+        }
+
+        if constexpr (is_integral_floating) {
+            pp_entry_set_last_val(entry, 0, ref, true);
+        }
+
+        return true;
+    } else {
+        return false;
+    }
 }
 
 template <class T>
@@ -2244,11 +2326,36 @@ bool squeryarrWithParser (const ParmParse::Table& table,
                            ParmParse::FIRST, ParmParse::ALL, ParmParse::LAST);
     if (!exist) { return false; }
 
+    constexpr bool is_integral_floating = (std::is_same_v<T,bool> ||
+                                           std::is_same_v<T,int> ||
+                                           std::is_same_v<T,long> ||
+                                           std::is_same_v<T,long long> ||
+                                           std::is_same_v<T,float> ||
+                                           std::is_same_v<T,double>);
+
+    auto const& entry = table.at(name);
+
     AMREX_ALWAYS_ASSERT(int(vals.size()) == nvals);
     for (int ival = 0; ival < nvals; ++ival) {
         bool r = pp_parser(table, parser_prefix, name, vals[ival], ptr[ival], true);
-        if (!r) { return false; }
+        if (r) {
+            if constexpr (is_integral_floating) {
+                pp_entry_set_last_val(entry, ival, ptr[ival], true);
+            }
+        } else {
+            return false;
+        }
     }
+
+#ifdef AMREX_USE_OMP
+#pragma omp single nowait
+#endif
+    {
+        auto const& entry = table.at(name);
+        using T_ptr = std::decay_t<T>*;
+        entry.m_typehint = static_cast<T_ptr>(nullptr);
+    }
+
     return true;
 }
 }


### PR DESCRIPTION
Below is an example of the difference of the prettyPrint output.
```
< electrons.charge = -q_e            # -1.6021766339999999e-19
< electrons.density = n0             # 9.9999999999999992e+22
---
> electrons.charge = -q_e
> electrons.density = n0
```
