### PR TITLE
Fix comparison with zero warning

### DIFF
--- a/Src/Particle/AMReX_WriteBinaryParticleData.H
+++ b/Src/Particle/AMReX_WriteBinaryParticleData.H
@@ -260,10 +260,12 @@ rPackParticleData (const PTD& ptd, int idx, typename PTD::RealType * rdata_ptr,
 
     constexpr int real_start_offset = PTD::ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
 
-    for (int j = real_start_offset; j < PTD::NAR; ++j) {
-        if (write_real_comp[PTD::ParticleType::NReal + j - real_start_offset]) {
-            rdata_ptr[rout_index] = ptd.rdata(j)[idx];
-            rout_index++;
+    if constexpr (PTD::NAR > 0) {
+        for (int j = real_start_offset; j < PTD::NAR; ++j) {
+            if (write_real_comp[PTD::ParticleType::NReal + j - real_start_offset]) {
+                rdata_ptr[rout_index] = ptd.rdata(j)[idx];
+                rout_index++;
+            }
         }
     }
 
@@ -296,10 +298,12 @@ iPackParticleData (const PTD& ptd, int idx, typename PTD::IntType * idata_ptr,
         }
     }
 
-    for (int j = 0; j < PTD::NAI; ++j) {
-        if (write_int_comp[PTD::ParticleType::NInt + j]) {
-            idata_ptr[iout_index] = ptd.idata(j)[idx];
-            iout_index++;
+    if constexpr (PTD::NAI > 0) {
+        for (int j = 0; j < PTD::NAI; ++j) {
+            if (write_int_comp[PTD::ParticleType::NInt + j]) {
+                idata_ptr[iout_index] = ptd.idata(j)[idx];
+                iout_index++;
+            }
         }
     }
 


### PR DESCRIPTION
This removes warnings like:

```
AMReX_Array.H(158): warning #186-D: pointless comparison of unsigned integer with zero
```

that can arise in cases where `NAR` or `NAI` is zero. 

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
