### PR TITLE
Improve out of memory error message

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -361,6 +361,7 @@ jobs:
     - uses: actions/checkout@v5
     - name: Dependencies
       run: |
+        .github/workflows/dependencies/ubuntu_free_disk_space.sh
         .github/workflows/dependencies/dependencies_gcc.sh 12
         .github/workflows/dependencies/dependencies_clang-tidy-apt-llvm.sh 17
         .github/workflows/dependencies/dependencies_ccache.sh

--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -225,8 +225,8 @@ protected:
     virtual std::size_t freeUnused_protected () { return 0; }
     void* allocate_system (std::size_t nbytes);
     void deallocate_system (void* p, std::size_t nbytes);
-    void out_of_memory_abort (std::string const& memory_type, amrex::Long nbytes,
-                              std::string const& error_msg);
+    static void out_of_memory_abort (std::string const& memory_type, amrex::Long nbytes,
+                                     std::string const& error_msg);
 
     struct ArenaProfiler {
         //! If this arena is profiled by TinyProfiler

--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -225,7 +225,7 @@ protected:
     virtual std::size_t freeUnused_protected () { return 0; }
     void* allocate_system (std::size_t nbytes);
     void deallocate_system (void* p, std::size_t nbytes);
-    static void out_of_memory_abort (std::string const& memory_type, amrex::Long nbytes,
+    static void out_of_memory_abort (std::string const& memory_type, std::size_t nbytes,
                                      std::string const& error_msg);
 
     struct ArenaProfiler {

--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -194,6 +194,7 @@ public:
 
     static void Initialize (bool minimal);
     static void PrintUsage (bool print_max_usage=false);
+    static void PrintUsageToStream (std::ostream& os, std::string const& space);
     static void PrintUsageToFiles (std::string const& filename, std::string const& message);
     static void Finalize ();
 
@@ -224,6 +225,8 @@ protected:
     virtual std::size_t freeUnused_protected () { return 0; }
     void* allocate_system (std::size_t nbytes);
     void deallocate_system (void* p, std::size_t nbytes);
+    void out_of_memory_abort (std::string const& memory_type, amrex::Long nbytes,
+                              std::string const& error_msg);
 
     struct ArenaProfiler {
         //! If this arena is profiled by TinyProfiler

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -694,7 +694,7 @@ Arena::PrintUsageToFiles (const std::string& filename, const std::string& messag
 }
 
 void
-Arena::out_of_memory_abort (std::string const& memory_type, amrex::Long nbytes,
+Arena::out_of_memory_abort (std::string const& memory_type, std::size_t nbytes,
                             std::string const& error_msg)
 {
     std::ostringstream ss;

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -705,11 +705,13 @@ Arena::out_of_memory_abort (std::string const& memory_type, amrex::Long nbytes,
     ss << "MPI rank: " << ParallelDescriptor::MyProc() << '\n';
     ss << "Error: " << error_msg << '\n';
 
+#ifdef AMREX_TINY_PROFILING
     ss << "\n\nTinyProfiler call stack:\n\n";
     TinyProfiler::PrintCallStack(ss);
 
     ss << "\n\nTinyProfiler memory usage so far:\n\n";
     TinyProfiler::PrintMemoryUsage(&ss, true);
+#endif
 
     ss << "\nAMReX Arena usage so far:\n\n";
     PrintUsageToStream(ss, "");

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -162,11 +162,20 @@ Arena::allocate_system (std::size_t nbytes) // NOLINT(readability-make-member-fu
 #ifdef AMREX_USE_GPU
     if (arena_info.use_cpu_memory)
     {
+#endif
         p = std::malloc(nbytes);
         if (!p) {
             freeUnused_protected();
             p = std::malloc(nbytes);
         }
+        if (!p) {
+            // out_of_memory_abort uses heap allocations,
+            // so we print an error before in case it doesn't work.
+            amrex::ErrorStream() <<
+                "Out of CPU memory: got nullptr from std::malloc, aborting...\n";
+            out_of_memory_abort("CPU memory", nbytes, "std::malloc returned nullptr");
+        }
+
 #ifndef _WIN32
 #if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
@@ -177,24 +186,44 @@ Arena::allocate_system (std::size_t nbytes) // NOLINT(readability-make-member-fu
 #pragma GCC diagnostic pop
 #endif
 #endif
+
+#ifdef AMREX_USE_GPU
     }
     else if (arena_info.device_use_hostalloc)
     {
-#if defined(AMREX_USE_HIP)
-        auto ret = hipHostMalloc(&p, nbytes, hipHostMallocMapped|hipHostMallocNonCoherent);
-        if (ret != hipSuccess) { p = nullptr; }
-#elif defined(AMREX_USE_CUDA)
-        auto ret = cudaHostAlloc(&p, nbytes, cudaHostAllocMapped);
-        if (ret != cudaSuccess) { p = nullptr; }
-#else
-        p = sycl::malloc_host(nbytes, Gpu::Device::syclContext());
-#endif
+        AMREX_HIP_OR_CUDA_OR_SYCL(
+            auto ret = hipHostMalloc(&p, nbytes, hipHostMallocMapped | hipHostMallocNonCoherent);
+            if (ret != hipSuccess) { p = nullptr; },
+            auto ret = cudaHostAlloc(&p, nbytes, cudaHostAllocMapped);
+            if (ret != cudaSuccess) { p = nullptr; },
+            p = sycl::malloc_host(nbytes, Gpu::Device::syclContext())
+        );
+
         if (!p) {
             freeUnused_protected();
             AMREX_HIP_OR_CUDA_OR_SYCL(
-                AMREX_HIP_SAFE_CALL (hipHostMalloc(&p, nbytes, hipHostMallocMapped|hipHostMallocNonCoherent));,
-                AMREX_CUDA_SAFE_CALL(cudaHostAlloc(&p, nbytes, cudaHostAllocMapped));,
-                p = sycl::malloc_host(nbytes, Gpu::Device::syclContext()));
+                ret = hipHostMalloc(&p, nbytes, hipHostMallocMapped | hipHostMallocNonCoherent);
+                if (ret != hipSuccess) { p = nullptr; },
+                ret = cudaHostAlloc(&p, nbytes, cudaHostAllocMapped);
+                if (ret != cudaSuccess) { p = nullptr; },
+                p = sycl::malloc_host(nbytes, Gpu::Device::syclContext())
+            );
+        }
+
+        if (!p) {
+            // out_of_memory_abort uses heap allocations,
+            // so we print an error before in case it doesn't work.
+            amrex::ErrorStream() <<
+                "Out of CPU pinned memory: got nullptr from host malloc, aborting...\n";
+            std::string msg = "";
+            AMREX_HIP_OR_CUDA_OR_SYCL(
+                msg = "hipHostMalloc returned " + std::to_string(ret) +
+                      ": " + hipGetErrorString(ret),
+                msg = "cudaHostAlloc returned " + std::to_string(ret) +
+                      ": " + cudaGetErrorString(ret),
+                msg = "sycl::malloc_host returned nullptr"
+            );
+            out_of_memory_abort("CPU pinned memory", nbytes, msg);
         }
     }
     else
@@ -202,30 +231,48 @@ Arena::allocate_system (std::size_t nbytes) // NOLINT(readability-make-member-fu
         std::size_t free_mem_avail = Gpu::Device::freeMemAvailable();
         if (nbytes >= free_mem_avail) {
             free_mem_avail += freeUnused_protected(); // For CArena, mutex has already acquired
-            if (abort_on_out_of_gpu_memory && nbytes >= free_mem_avail && arena_info.device_use_managed_memory) {
-                amrex::Abort("Out of gpu memory. Free: " + std::to_string(free_mem_avail)
-                             + " Asked: " + std::to_string(nbytes));
+            if (abort_on_out_of_gpu_memory && nbytes >= free_mem_avail &&
+                arena_info.device_use_managed_memory) {
+                out_of_memory_abort("GPU memory", nbytes,
+                                    "Free memory: " + std::to_string(free_mem_avail));
             }
         }
 
         if (arena_info.device_use_managed_memory)
         {
-#if defined(AMREX_USE_HIP)
-            auto ret = hipMallocManaged(&p, nbytes);
-            if (ret != hipSuccess) { p = nullptr; }
-#elif defined(AMREX_USE_CUDA)
-            auto ret = cudaMallocManaged(&p, nbytes);
-            if (ret != cudaSuccess) { p = nullptr; }
-#else
-            p = sycl::malloc_shared(nbytes, Gpu::Device::syclDevice(), Gpu::Device::syclContext());
-#endif
+            AMREX_HIP_OR_CUDA_OR_SYCL(
+                auto ret = hipMallocManaged(&p, nbytes);
+                if (ret != hipSuccess) { p = nullptr; },
+                auto ret = cudaMallocManaged(&p, nbytes);
+                if (ret != cudaSuccess) { p = nullptr; },
+                p = sycl::malloc_shared(nbytes, Gpu::Device::syclDevice(),
+                                        Gpu::Device::syclContext())
+            );
+
             if (!p) {
                 freeUnused_protected();
-                AMREX_HIP_OR_CUDA_OR_SYCL
-                    (AMREX_HIP_SAFE_CALL(hipMallocManaged(&p, nbytes));,
-                     AMREX_CUDA_SAFE_CALL(cudaMallocManaged(&p, nbytes));,
-                     p = sycl::malloc_shared(nbytes, Gpu::Device::syclDevice(), Gpu::Device::syclContext()));
+                AMREX_HIP_OR_CUDA_OR_SYCL(
+                    ret = hipMallocManaged(&p, nbytes);
+                    if (ret != hipSuccess) { p = nullptr; },
+                    ret = cudaMallocManaged(&p, nbytes);
+                    if (ret != cudaSuccess) { p = nullptr; },
+                    p = sycl::malloc_shared(nbytes, Gpu::Device::syclDevice(),
+                                            Gpu::Device::syclContext())
+                );
             }
+
+            if (!p) {
+                std::string msg = "";
+                AMREX_HIP_OR_CUDA_OR_SYCL(
+                    msg = "hipMallocManaged returned " + std::to_string(ret) +
+                          ": " + hipGetErrorString(ret),
+                    msg = "cudaMallocManaged returned " + std::to_string(ret) +
+                          ": " + cudaGetErrorString(ret),
+                    msg = "sycl::malloc_shared returned nullptr"
+                );
+                out_of_memory_abort("GPU managed memory", nbytes, msg);
+            }
+
 #ifdef AMREX_USE_HIP
             // Otherwise atomiAdd won't work because we instruct the compiler to do unsafe atomics
             AMREX_HIP_SAFE_CALL(hipMemAdvise(p, nbytes, hipMemAdviseSetCoarseGrain,
@@ -243,42 +290,42 @@ Arena::allocate_system (std::size_t nbytes) // NOLINT(readability-make-member-fu
         }
         else
         {
-#if defined(AMREX_USE_HIP)
-            auto ret = hipMalloc(&p, nbytes);
-            if (ret != hipSuccess) { p = nullptr; }
-#elif defined(AMREX_USE_CUDA)
-            auto ret = cudaMalloc(&p, nbytes);
-            if (ret != cudaSuccess) { p = nullptr; }
-#else
-            p = sycl::malloc_device(nbytes, Gpu::Device::syclDevice(), Gpu::Device::syclContext());
-#endif
+            AMREX_HIP_OR_CUDA_OR_SYCL(
+                auto ret = hipMalloc(&p, nbytes);
+                if (ret != hipSuccess) { p = nullptr; },
+                auto ret = cudaMalloc(&p, nbytes);
+                if (ret != cudaSuccess) { p = nullptr; },
+                p = sycl::malloc_device(nbytes, Gpu::Device::syclDevice(),
+                                        Gpu::Device::syclContext())
+            );
+
             if (!p) {
                 freeUnused_protected();
-                AMREX_HIP_OR_CUDA_OR_SYCL
-                    (AMREX_HIP_SAFE_CALL ( hipMalloc(&p, nbytes));,
-                     AMREX_CUDA_SAFE_CALL(cudaMalloc(&p, nbytes));,
-                     p = sycl::malloc_device(nbytes, Gpu::Device::syclDevice(), Gpu::Device::syclContext()));
+                AMREX_HIP_OR_CUDA_OR_SYCL(
+                    ret = hipMalloc(&p, nbytes);
+                    if (ret != hipSuccess) { p = nullptr; },
+                    ret = cudaMalloc(&p, nbytes);
+                    if (ret != cudaSuccess) { p = nullptr; },
+                    p = sycl::malloc_device(nbytes, Gpu::Device::syclDevice(),
+                                            Gpu::Device::syclContext())
+                );
+            }
+
+            if (!p) {
+                std::string msg = "";
+                AMREX_HIP_OR_CUDA_OR_SYCL(
+                    msg = "hipMalloc returned " + std::to_string(ret) +
+                          ": " + hipGetErrorString(ret),
+                    msg = "cudaMalloc returned " + std::to_string(ret) +
+                          ": " + cudaGetErrorString(ret),
+                    msg = "sycl::malloc_device returned nullptr"
+                );
+                out_of_memory_abort("GPU device memory", nbytes, msg);
             }
         }
     }
-#else
-    p = std::malloc(nbytes);
-    if (!p) {
-        freeUnused_protected();
-        p = std::malloc(nbytes);
-    }
-#ifndef _WIN32
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
-    if (p && (nbytes > 0) && arena_info.device_use_hostalloc) { mlock(p, nbytes); }
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#endif
-#endif
-    if (p == nullptr) { amrex::Abort("Sorry, malloc failed"); }
+    AMREX_ALWAYS_ASSERT(p != nullptr);
     return p;
 }
 
@@ -288,8 +335,10 @@ Arena::deallocate_system (void* p, std::size_t nbytes) // NOLINT(readability-mak
 #ifdef AMREX_USE_GPU
     if (arena_info.use_cpu_memory)
     {
+#endif
         if (p && arena_info.device_use_hostalloc) { AMREX_MUNLOCK(p, nbytes); }
         std::free(p);
+#ifdef AMREX_USE_GPU
     }
     else if (arena_info.device_use_hostalloc)
     {
@@ -305,9 +354,6 @@ Arena::deallocate_system (void* p, std::size_t nbytes) // NOLINT(readability-mak
              AMREX_CUDA_SAFE_CALL(cudaFree(p));,
              sycl::free(p,Gpu::Device::syclContext()));
     }
-#else
-    if (p && arena_info.device_use_hostalloc) { AMREX_MUNLOCK(p, nbytes); }
-    std::free(p);
 #endif
 }
 
@@ -588,6 +634,50 @@ Arena::PrintUsage (bool print_max_usage)
 }
 
 void
+Arena::PrintUsageToStream (std::ostream& os, std::string const& space)
+{
+#ifdef AMREX_USE_GPU
+    Long megabytes = Gpu::Device::totalGlobalMem() / (1024*1024);
+    os << space << "Total GPU global memory (MB): " << megabytes << "\n";
+
+    megabytes = Gpu::Device::freeMemAvailable() / (1024*1024);
+    os << space << "Free  GPU global memory (MB): " << megabytes << "\n";
+#endif
+
+    if (The_Arena()) {
+        auto* p = dynamic_cast<CArena*>(The_Arena());
+        if (p) {
+            p->PrintUsage(os, "The         Arena", space);
+        }
+    }
+    if (The_Device_Arena() && The_Device_Arena() != The_Arena()) {
+        auto* p = dynamic_cast<CArena*>(The_Device_Arena());
+        if (p) {
+            p->PrintUsage(os, "The  Device Arena", space);
+        }
+    }
+    if (The_Managed_Arena() && The_Managed_Arena() != The_Arena()) {
+        auto* p = dynamic_cast<CArena*>(The_Managed_Arena());
+        if (p) {
+            p->PrintUsage(os, "The Managed Arena", space);
+        }
+    }
+    if (The_Pinned_Arena()) {
+        auto* p = dynamic_cast<CArena*>(The_Pinned_Arena());
+        if (p) {
+            p->PrintUsage(os, "The  Pinned Arena", space);
+        }
+    }
+    if (The_Comms_Arena() && The_Comms_Arena() != The_Device_Arena()
+        && The_Comms_Arena() != The_Pinned_Arena()) {
+        auto* p = dynamic_cast<CArena*>(The_Comms_Arena());
+        if (p) {
+            p->PrintUsage(os, "The   Comms Arena", space);
+        }
+    }
+}
+
+void
 Arena::PrintUsageToFiles (const std::string& filename, const std::string& message)
 {
     std::ofstream ofs(filename+"."+std::to_string(ParallelDescriptor::MyProc()),
@@ -598,47 +688,35 @@ Arena::PrintUsageToFiles (const std::string& filename, const std::string& messag
 
     ofs << message << "\n";
 
-#ifdef AMREX_USE_GPU
-    Long megabytes = Gpu::Device::totalGlobalMem() / (1024*1024);
-    ofs << "    Total GPU global memory (MB): " << megabytes << "\n";
-
-    megabytes = Gpu::Device::freeMemAvailable() / (1024*1024);
-    ofs << "    Free  GPU global memory (MB): " << megabytes << "\n";
-#endif
-
-    if (The_Arena()) {
-        auto* p = dynamic_cast<CArena*>(The_Arena());
-        if (p) {
-            p->PrintUsage(ofs, "The         Arena", "    ");
-        }
-    }
-    if (The_Device_Arena() && The_Device_Arena() != The_Arena()) {
-        auto* p = dynamic_cast<CArena*>(The_Device_Arena());
-        if (p) {
-            p->PrintUsage(ofs, "The  Device Arena", "    ");
-        }
-    }
-    if (The_Managed_Arena() && The_Managed_Arena() != The_Arena()) {
-        auto* p = dynamic_cast<CArena*>(The_Managed_Arena());
-        if (p) {
-            p->PrintUsage(ofs, "The Managed Arena", "    ");
-        }
-    }
-    if (The_Pinned_Arena()) {
-        auto* p = dynamic_cast<CArena*>(The_Pinned_Arena());
-        if (p) {
-            p->PrintUsage(ofs, "The  Pinned Arena", "    ");
-        }
-    }
-    if (The_Comms_Arena() && The_Comms_Arena() != The_Device_Arena()
-        && The_Comms_Arena() != The_Pinned_Arena()) {
-        auto* p = dynamic_cast<CArena*>(The_Comms_Arena());
-        if (p) {
-            p->PrintUsage(ofs, "The   Comms Arena", "    ");
-        }
-    }
+    PrintUsageToStream(ofs, "    ");
 
     ofs << "\n";
+}
+
+void
+Arena::out_of_memory_abort (std::string const& memory_type, amrex::Long nbytes,
+                            std::string const& error_msg)
+{
+    std::ostringstream ss;
+
+    ss << "Arena out of memory!!!\n";
+    ss << "Bytes to allocate: " << nbytes << " (" << nbytes/(1024*1024) << " MiB)\n";
+    ss << "Memory type: " << memory_type << '\n';
+    ss << "MPI rank: " << ParallelDescriptor::MyProc() << '\n';
+    ss << "Error: " << error_msg << '\n';
+
+    ss << "\n\nTinyProfiler call stack:\n\n";
+    TinyProfiler::PrintCallStack(ss);
+
+    ss << "\n\nTinyProfiler memory usage so far:\n\n";
+    TinyProfiler::PrintMemoryUsage(&ss, true);
+
+    ss << "\nAMReX Arena usage so far:\n\n";
+    PrintUsageToStream(ss, "");
+
+    ss << "\n\nOut of memory, see message above";
+
+    amrex::Abort(ss.str());
 }
 
 void

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -36,13 +36,6 @@ CArena::alloc (std::size_t nbytes)
 void*
 CArena::alloc_protected (std::size_t nbytes)
 {
-    MemStat* stat = nullptr;
-#ifdef AMREX_TINY_PROFILING
-    if (m_profiler.m_do_profiling) {
-        stat = TinyProfiler::memory_alloc(nbytes, m_profiler.m_profiling_stats);
-    }
-#endif
-
     bool freeunused_called = false;
     if (static_cast<Long>(m_used+nbytes) >= arena_info.release_threshold) {
         freeUnused_protected();
@@ -95,6 +88,13 @@ CArena::alloc_protected (std::size_t nbytes)
             m_freelist.insert(m_freelist.end(), Node(block, vp, N-nbytes));
         }
 
+        MemStat* stat = nullptr;
+#ifdef AMREX_TINY_PROFILING
+        if (m_profiler.m_do_profiling) {
+            stat = TinyProfiler::memory_alloc(nbytes, m_profiler.m_profiling_stats);
+        }
+#endif
+
         m_busylist.insert(Node(vp, vp, nbytes, stat));
     }
     else
@@ -103,6 +103,14 @@ CArena::alloc_protected (std::size_t nbytes)
         BL_ASSERT(m_busylist.find(*free_it) == m_busylist.end());
 
         vp = (*free_it).block();
+
+        MemStat* stat = nullptr;
+#ifdef AMREX_TINY_PROFILING
+        if (m_profiler.m_do_profiling) {
+            stat = TinyProfiler::memory_alloc(nbytes, m_profiler.m_profiling_stats);
+        }
+#endif
+
         m_busylist.insert(Node(vp, free_it->owner(), nbytes, stat));
 
         if ((*free_it).size() > nbytes)

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -66,6 +66,7 @@ public:
     static void StopRegion (const std::string& regname) noexcept;
 
     static void PrintCallStack (std::ostream& os);
+    static void PrintMemoryUsage (std::ostream* os, bool only_local) noexcept;
 
 private:
     struct Stats
@@ -101,6 +102,7 @@ private:
     {
         Long nalloc = 0;
         Long nfree = 0;
+        Long curmem_max = 0;
         Long avgmem_min = std::numeric_limits<Long>::max();
         Long avgmem_avg = 0;
         Long avgmem_max = 0;
@@ -135,6 +137,7 @@ private:
     static std::deque<std::tuple<double,double,std::string*> > ttstack;
     static std::map<std::string,std::map<std::string, Stats> > statsmap;
     static double t_init;
+    static double t_memory_init;
     static bool device_synchronize_around_region;
     static int n_print_tabs;
     static int verbose;
@@ -148,7 +151,7 @@ private:
                             std::ostream* os);
     static void PrintMemStats (std::map<std::string, MemStat>& memstats,
                                std::string const& memname, double dt_max,
-                               double t_final, std::ostream* os);
+                               double t_final, std::ostream* os, bool only_local);
 };
 
 class TinyProfileRegion

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -49,6 +49,7 @@ std::vector<std::string>          TinyProfiler::regionstack;
 std::deque<std::tuple<double,double,std::string*> > TinyProfiler::ttstack;
 std::map<std::string,std::map<std::string, TinyProfiler::Stats> > TinyProfiler::statsmap;
 double TinyProfiler::t_init = std::numeric_limits<double>::max();
+double TinyProfiler::t_memory_init = std::numeric_limits<double>::max();
 bool TinyProfiler::device_synchronize_around_region = false;
 int TinyProfiler::n_print_tabs = 0;
 int TinyProfiler::verbose = 0;
@@ -349,6 +350,8 @@ TinyProfiler::MemoryInitialize ()
     mem_stack_thread_private.resize(omp_get_max_threads());
 #endif
 
+    t_memory_init = amrex::second();
+
     memprof_finalized = false;
 }
 
@@ -460,11 +463,6 @@ TinyProfiler::MemoryFinalize (bool bFlushing) noexcept
         }
     }
 
-    double t_final = amrex::second();
-    double dt_max = t_final - t_init;
-    int ioproc = ParallelDescriptor::IOProcessorNumber();
-    ParallelReduce::Max(dt_max, ioproc, ParallelDescriptor::Communicator());
-
     std::ofstream ofs;
     std::ostream* os = nullptr;
     if (ParallelDescriptor::IOProcessor()) {
@@ -480,9 +478,7 @@ TinyProfiler::MemoryFinalize (bool bFlushing) noexcept
         }
     }
 
-    for (std::size_t i = 0; i < all_memstats.size(); ++i) {
-        PrintMemStats(*(all_memstats[i]), all_memnames[i], dt_max, t_final, os);
-    }
+    PrintMemoryUsage(os, false);
 
     if (!bFlushing) {
         all_memstats.clear();
@@ -733,10 +729,10 @@ TinyProfiler::PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
 void
 TinyProfiler::PrintMemStats (std::map<std::string, MemStat>& memstats,
                              std::string const& memname, double dt_max,
-                             double t_final, std::ostream* os)
+                             double t_final, std::ostream* os, bool only_local)
 {
     // make sure the set of profiled functions is the same on all processes
-    {
+    if (!only_local) {
         Vector<std::string> localStrings, syncedStrings;
         bool alreadySynced;
 
@@ -757,46 +753,54 @@ TinyProfiler::PrintMemStats (std::map<std::string, MemStat>& memstats,
 
     if (memstats.empty()) { return; }
 
-    const int nprocs = ParallelDescriptor::NProcs();
-    const int ioproc = ParallelDescriptor::IOProcessorNumber();
+    const int nprocs = only_local ? 1 : ParallelDescriptor::NProcs();
+    const int ioproc = only_local ? 0 : ParallelDescriptor::IOProcessorNumber();
+    const bool is_io_proc = only_local ? true : ParallelDescriptor::IOProcessor();
 
     std::vector<MemProcStats> allprocstats;
+
+    bool has_currently_used_memory = false;
 
     // now collect global data onto the ioproc
     for (const auto & it : memstats)
     {
         Long nalloc = it.second.nalloc;
         Long nfree = it.second.nfree;
+        Long curmem = it.second.currentmem;
         // simulate the freeing of remaining memory currentmem for the avgmem metric
         Long avgmem = static_cast<Long>(
-            (it.second.avgmem + static_cast<double>(it.second.currentmem) * t_final) / dt_max);
+            (it.second.avgmem + static_cast<double>(curmem) * t_final) / dt_max);
         Long maxmem = it.second.maxmem;
 
         std::vector<Long> nalloc_vec(nprocs);
         std::vector<Long> nfree_vec(nprocs);
+        std::vector<Long> curmem_vec(nprocs);
         std::vector<Long> avgmem_vec(nprocs);
         std::vector<Long> maxmem_vec(nprocs);
 
-        if (ParallelDescriptor::NProcs() == 1)
+        if (nprocs == 1)
         {
             nalloc_vec[0] = nalloc;
             nfree_vec[0] = nfree;
+            curmem_vec[0] = curmem;
             avgmem_vec[0] = avgmem;
             maxmem_vec[0] = maxmem;
         } else
         {
             ParallelDescriptor::Gather(&nalloc, 1, nalloc_vec.data(), 1, ioproc);
             ParallelDescriptor::Gather(&nfree , 1,  nfree_vec.data(), 1, ioproc);
+            ParallelDescriptor::Gather(&curmem, 1, curmem_vec.data(), 1, ioproc);
             ParallelDescriptor::Gather(&maxmem, 1, maxmem_vec.data(), 1, ioproc);
             ParallelDescriptor::Gather(&avgmem, 1, avgmem_vec.data(), 1, ioproc);
         }
 
-        if (ParallelDescriptor::IOProcessor()) {
+        if (is_io_proc) {
             MemProcStats pst;
             for (int i = 0; i < nprocs; ++i) {
 
                 pst.nalloc += nalloc_vec[i];
                 pst.nfree += nfree_vec[i];
+                pst.curmem_max = std::max(pst.curmem_max, curmem_vec[i]);
                 pst.avgmem_min = std::min(pst.avgmem_min, avgmem_vec[i]);
                 pst.avgmem_avg += avgmem_vec[i];
                 pst.avgmem_max = std::max(pst.avgmem_max, avgmem_vec[i]);
@@ -807,8 +811,15 @@ TinyProfiler::PrintMemStats (std::map<std::string, MemStat>& memstats,
             pst.avgmem_avg /= nprocs;
             pst.maxmem_avg /= nprocs;
             pst.fname = it.first;
+            if (pst.nalloc != pst.nfree || pst.curmem_max > 0) {
+                has_currently_used_memory = true;
+            }
             allprocstats.push_back(std::move(pst));
         }
+    }
+
+    if (!is_io_proc) {
+        return;
     }
 
     std::sort(allprocstats.begin(), allprocstats.end(), MemProcStats::compmem);
@@ -816,11 +827,22 @@ TinyProfiler::PrintMemStats (std::map<std::string, MemStat>& memstats,
     std::vector<std::vector<std::string>> allstatsstr;
 
     if (nprocs == 1) {
-        allstatsstr.push_back({"Name", "Nalloc", "Nfree", "AvgMem", "MaxMem"});
+        if (has_currently_used_memory) {
+            allstatsstr.push_back({"Name", "Nalloc", "Nfree", "AvgMem", "MaxMem", "CurrentMem"});
+        } else {
+            allstatsstr.push_back({"Name", "Nalloc", "AvgMem", "MaxMem"});
+        }
     } else {
-        allstatsstr.push_back({"Name", "Nalloc", "Nfree",
-                               "AvgMem min", "AvgMem avg", "AvgMem max",
-                               "MaxMem min", "MaxMem avg", "MaxMem max"});
+        if (has_currently_used_memory) {
+            allstatsstr.push_back({"Name", "Nalloc", "Nfree",
+                                   "AvgMem min", "AvgMem avg", "AvgMem max",
+                                   "MaxMem min", "MaxMem avg", "MaxMem max",
+                                   "CurrentMem max"});
+        } else {
+            allstatsstr.push_back({"Name", "Nalloc",
+                                   "AvgMem min", "AvgMem avg", "AvgMem max",
+                                   "MaxMem min", "MaxMem avg", "MaxMem max"});
+        }
     }
 
     auto mem_to_string = [] (Long nbytes) {
@@ -847,21 +869,41 @@ TinyProfiler::PrintMemStats (std::map<std::string, MemStat>& memstats,
     for (auto& stat : allprocstats) {
         if (stat.nalloc != 0 || stat.nfree != 0 || stat.maxmem_max != 0) {
             if (nprocs == 1) {
-                allstatsstr.push_back({stat.fname,
-                                    std::to_string(stat.nalloc),
-                                    std::to_string(stat.nfree),
-                                    mem_to_string(stat.avgmem_max),
-                                    mem_to_string(stat.maxmem_max)});
+                if (has_currently_used_memory) {
+                    allstatsstr.push_back({stat.fname,
+                                        std::to_string(stat.nalloc),
+                                        std::to_string(stat.nfree),
+                                        mem_to_string(stat.avgmem_max),
+                                        mem_to_string(stat.maxmem_max),
+                                        mem_to_string(stat.curmem_max)});
+                } else {
+                    allstatsstr.push_back({stat.fname,
+                                        std::to_string(stat.nalloc),
+                                        mem_to_string(stat.avgmem_max),
+                                        mem_to_string(stat.maxmem_max)});
+                }
             } else {
-                allstatsstr.push_back({stat.fname,
-                                    std::to_string(stat.nalloc),
-                                    std::to_string(stat.nfree),
-                                    mem_to_string(stat.avgmem_min),
-                                    mem_to_string(stat.avgmem_avg),
-                                    mem_to_string(stat.avgmem_max),
-                                    mem_to_string(stat.maxmem_min),
-                                    mem_to_string(stat.maxmem_avg),
-                                    mem_to_string(stat.maxmem_max)});
+                if (has_currently_used_memory) {
+                    allstatsstr.push_back({stat.fname,
+                                        std::to_string(stat.nalloc),
+                                        std::to_string(stat.nfree),
+                                        mem_to_string(stat.avgmem_min),
+                                        mem_to_string(stat.avgmem_avg),
+                                        mem_to_string(stat.avgmem_max),
+                                        mem_to_string(stat.maxmem_min),
+                                        mem_to_string(stat.maxmem_avg),
+                                        mem_to_string(stat.maxmem_max),
+                                        mem_to_string(stat.curmem_max)});
+                } else {
+                    allstatsstr.push_back({stat.fname,
+                                        std::to_string(stat.nalloc),
+                                        mem_to_string(stat.avgmem_min),
+                                        mem_to_string(stat.avgmem_avg),
+                                        mem_to_string(stat.avgmem_max),
+                                        mem_to_string(stat.maxmem_min),
+                                        mem_to_string(stat.maxmem_avg),
+                                        mem_to_string(stat.maxmem_max)});
+                }
             }
         }
     }
@@ -953,6 +995,23 @@ TinyProfiler::PrintCallStack (std::ostream& os)
     os << "===== TinyProfilers ======\n";
     for (auto const& x : ttstack) {
         os << *(std::get<2>(x)) << "\n";
+    }
+}
+
+void
+TinyProfiler::PrintMemoryUsage (std::ostream* os, bool only_local) noexcept
+{
+    if (!memprof_enabled) { return; }
+
+    double t_final = amrex::second();
+    double dt_max = t_final - t_memory_init;
+    if (!only_local) {
+        int ioproc = ParallelDescriptor::IOProcessorNumber();
+        ParallelReduce::Max(dt_max, ioproc, ParallelDescriptor::Communicator());
+    }
+
+    for (std::size_t i = 0; i < all_memstats.size(); ++i) {
+        PrintMemStats(*(all_memstats[i]), all_memnames[i], dt_max, t_final, os, only_local);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds extra information to the abort message if an AMReX Arena runs out of memory. This includes the type of memory, number of bytes asked, MPI rank, allocation function name and error code, TinyProfiler call stack, TinyProfiler profiled memory usage, and total usage of all memory arenas. The information is printed for all memory types, as this is easier and might be useful in case multiple arenas share the same memory type. 

For this, a PrintMemoryUsage function is added to TinyProfiler, which can also be called externally. In case some memory is still currently allocated while the usage is printed, the number of frees and the currently used bytes are printed. If not, both metrics are omitted from the output. This also applies to the output when a program finishes normally, where previously the number of frees was always printed.

Example abort message (with syntax highlighting added):

```powershell
00:00:23 Rank 0 started step 4 at time = 79.4766895 with dt = 19.83517343
00:00:23 Rank 1 started step 5 at time = 99.31186293 with dt = 19.80132949
00:00:23 Rank 2 started step 6 at time = 119.1131924 with dt = 19.76826784
00:00:23 Rank 3 started step 7 at time = 138.8814603 with dt = 19.73563175
amrex::Abort::0::Arena out of memory!!!
Bytes to allocate: 1449379584 (1382 MiB)
Memory type: GPU device memory
MPI rank: 0
Error: cudaMalloc returned 2: out of memory


TinyProfiler call stack:

===== TinyProfilers ======
main()
Hipace::Evolve()
Hipace::SolveOneSlice()
MultiBuffer::put_data()


TinyProfiler memory usage so far:

Device Memory Usage:
---------------------------------------------------------------------------------------
Name                                      Nalloc  Nfree    AvgMem    MaxMem  CurrentMem
---------------------------------------------------------------------------------------
MultiBuffer::put_data()                     2285   1535    24 GiB    34 GiB      32 GiB
The_Arena::Initialize()                        1      1  4563 KiB    29 GiB       0   B
PlasmaParticleContainer::InitParticles()      52     39  1596 MiB  1631 MiB    1599 MiB
Fields::AllocData()                            1      0   673 MiB   673 MiB     673 MiB
BeamParticleContainer::resize()             3300   3280   340 MiB   439 MiB     417 MiB
Hipace::ExplicitMGSolveBxBy()                 40      0   234 MiB   235 MiB     235 MiB
FFTPoissonSolverDirichletFast::define()        7      0   159 MiB   160 MiB     160 MiB
ResizeRandomSeed                               1      0    40 MiB    40 MiB      40 MiB
AdaptiveTimeStep::GatherMinUzSlice()        1385   1385  1444   B   864 KiB       0   B
shiftSlippedParticles()                     5094   5094   282   B   478 KiB       0   B
hpmg::MultiGrid::solve1()                   5513   5513    40 KiB   432 KiB       0   B
MultiBuffer::get_data()                      767    767    74   B   108 KiB       0   B
Hipace::InitData()                            12      0   463   B   464   B     464   B
main()                                        13      0   399   B   400   B     400   B
Hipace::Evolve()                               1      0    31   B    32   B      32   B
DepositCurrent_PlasmaParticleContainer()    1387   1387     2   B    16   B       0   B
---------------------------------------------------------------------------------------

Managed Memory Usage:
---------------------------------------------------------
Name                             Nalloc  AvgMem    MaxMem
---------------------------------------------------------
The_Managed_Arena::Initialize()       1  21   B  8192 KiB
---------------------------------------------------------

Pinned Memory Usage:
---------------------------------------------------------------------------------------
Name                                      Nalloc  Nfree    AvgMem    MaxMem  CurrentMem
---------------------------------------------------------------------------------------
The_Pinned_Arena::Initialize()                 1      1  1675   B  8192 KiB       0   B
Hipace::InitData()                            18      5    17 KiB    17 KiB      17 KiB
Hipace::ExplicitMGSolveBxBy()                  1      0  1083   B  1088   B    1088   B
main()                                        37     24   399   B   400   B     400   B
AdaptiveTimeStep::GatherMinUzSlice()        1385   1385     0   B    32   B       0   B
Hipace::Evolve()                               1      0    31   B    32   B      32   B
MultiBuffer::get_data()                      767    767     0   B    16   B       0   B
PlasmaParticleContainer::InitParticles()       2      2     0   B    16   B       0   B
hpmg::MultiGrid::solve1()                   5513   5513     2   B    16   B       0   B
shiftSlippedParticles()                     2304   2304     0   B    16   B       0   B
---------------------------------------------------------------------------------------

Comms Memory Usage:
--------------------------------------------------------
Name                           Nalloc   AvgMem    MaxMem
--------------------------------------------------------
The_Comms_Arena::Initialize()       1  124   B  8192 KiB
--------------------------------------------------------


AMReX Arena usage so far:

Total GPU global memory (MB): 40441
Free  GPU global memory (MB): 431
[The         Arena] space allocated (MB): 38299
[The         Arena] space used      (MB): 36058
[The         Arena]: 90 allocs, 857 busy blocks, 227 free blocks
[The Managed Arena] space allocated (MB): 8
[The Managed Arena] space used      (MB): 0
[The Managed Arena]: 1 allocs, 0 busy blocks, 1 free blocks
[The  Pinned Arena] space allocated (MB): 8
[The  Pinned Arena] space used      (MB): 0
[The  Pinned Arena]: 1 allocs, 28 busy blocks, 1 free blocks
[The   Comms Arena] space allocated (MB): 8
[The   Comms Arena] space used      (MB): 0
[The   Comms Arena]: 1 allocs, 0 busy blocks, 1 free blocks


Out of memory, see message above !!!
SIGABRT
See Backtrace.0 file for details
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
with errorcode 6.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
```

## Additional background

Technically, I think calling TinyProfiler::PrintCallStack from a non-master thread is not thread-safe, but this is hard to fix and should be unlikely to cause problems.

Should more information be added to the abort message? Maybe there is something from the "full" profiler?

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
