### PR TITLE
clear freeAsync buffer before allocating new memory

### DIFF
--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -59,18 +59,15 @@ CArena::alloc_protected (std::size_t nbytes)
         // We need to unlock the mutex for this so that free() can be called.
         // This may invalidate free_it.
         carena_mutex.unlock();
-        const bool freed_something = Gpu::clearFreeAsyncBuffer();
+        Gpu::clearFreeAsyncBuffer();
         carena_mutex.lock();
 
-        if (freed_something) {
-            free_it = m_freelist.begin();
-            for ( ; free_it != m_freelist.end(); ++free_it) {
-                if ((*free_it).size() >= nbytes) {
-                    break;
-                }
+        // Always check freelist again as it might have changed when the mutex was unlocked.
+        free_it = m_freelist.begin();
+        for ( ; free_it != m_freelist.end(); ++free_it) {
+            if ((*free_it).size() >= nbytes) {
+                break;
             }
-        } else {
-            free_it = m_freelist.end();
         }
     }
 #endif

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -60,6 +60,28 @@ CArena::alloc_protected (std::size_t nbytes)
         }
     }
 
+#ifdef AMREX_USE_GPU
+    if (free_it == m_freelist.end()) {
+        // Clear Gpu::freeAsync buffer and try again.
+        // We need to unlock the mutex for this so that free() can be called.
+        // This may invalidate free_it.
+        carena_mutex.unlock();
+        const bool freed_something = Gpu::clearFreeAsyncBuffer();
+        carena_mutex.lock();
+
+        if (freed_something) {
+            free_it = m_freelist.begin();
+            for ( ; free_it != m_freelist.end(); ++free_it) {
+                if ((*free_it).size() >= nbytes) {
+                    break;
+                }
+            }
+        } else {
+            free_it = m_freelist.end();
+        }
+    }
+#endif
+
     void* vp = nullptr;
 
     if (free_it == m_freelist.end())

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -62,6 +62,7 @@ public:
     [[nodiscard]] gpuStream_t& get ();
     void sync ();
     void free_async (Arena* arena, void* mem);
+    std::size_t wait_list_size ();
 };
 #endif
 
@@ -124,6 +125,8 @@ public:
     static void streamSynchronizeAll () noexcept;
 
     static void freeAsync (Arena* arena, void* mem) noexcept;
+
+    static bool clearFreeAsyncBuffer () noexcept;
 
 #if defined(__CUDACC__)
     /**  Generic graph selection. These should be called by users.  */
@@ -281,6 +284,15 @@ inline void
 freeAsync (Arena* arena, void* mem) noexcept
 {
     Device::freeAsync(arena, mem);
+}
+
+/** Clear the temporary buffer used by freeAsync. This is done by synchronizing the stream in
+ * case there is memory in the buffer. Returns true if some memory could be freed.
+ */
+inline bool
+clearFreeAsyncBuffer () noexcept
+{
+    return Device::clearFreeAsyncBuffer();
 }
 
 #ifdef AMREX_USE_GPU

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -200,6 +200,13 @@ StreamManager::free_async (Arena* arena, void* mem) {
     }
 }
 
+std::size_t
+StreamManager::wait_list_size () {
+    // lock mutex before accessing member variables
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_free_wait_list.size();
+}
+
 #endif
 
 void
@@ -771,6 +778,23 @@ Device::freeAsync (Arena* arena, void* mem) noexcept
     gpu_stream_pool[gpu_stream_index[OpenMP::get_thread_num()]].free_async(arena, mem);
 #else
     arena->free(mem);
+#endif
+}
+
+bool
+Device::clearFreeAsyncBuffer () noexcept
+{
+#ifdef AMREX_USE_GPU
+    bool freed_memory = false;
+    for (auto& s : gpu_stream_pool) {
+        if (s.wait_list_size() > 0) {
+            s.sync();
+            freed_memory = true;
+        }
+    }
+    return freed_memory;
+#else
+    return false;
 #endif
 }
 


### PR DESCRIPTION
## Summary

Clear the buffer used by freeAsync every time the CArena needs to make a new memory allocation.

## Additional background

So far I don't have a test where this would be triggered.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
