### PR TITLE
Add SArena: The_Arena wrapper using Gpu::freeAsync

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -930,9 +930,8 @@ async-safe.
 Async Arena
 -----------
 
-CUDA 11.2 has introduced a new feature, stream-ordered CUDA memory
-allocator.  This feature enables AMReX to solve the temporary memory
-allocation and deallocation issue discussed above using a memory pool.
+Using a stream-ordered allocator, the temporary memory
+allocation and deallocation issue discussed above can be solved.
 Instead of using :cpp:`Elixir`, we can write code like below,
 
 .. highlight:: c++
@@ -947,12 +946,10 @@ Instead of using :cpp:`Elixir`, we can write code like below,
       // GPU kernels using the temporary
     }
 
+The freed memory is held in a buffer until the next time the GPU stream is synchronized.
+In case too much memory is in this buffer, the stream is synchronized automatically.
 This is now the recommended way because it's usually more efficient than
-:cpp:`Elixir`.  Note that the code above works for CUDA older than 11.2, HIP
-and SYCL as well, and it's equivalent to using :cpp:`Elixir` in these
-cases.  By default, the release threshold for the memory pool is unlimited.
-One can adjust it with :cpp:`ParmParse` parameter,
-``amrex.the_async_arena_release_threshold``.
+:cpp:`Elixir`. Note that the code above works on all platforms.
 
 .. _sec:gpu:launch:
 

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1077,14 +1077,6 @@ Memory
 
    This controls the release threshold of the communication arena.
 
-.. py:data:: amrex.the_async_arena_release_threshold
-   :type: long
-   :value: LONG_MAX
-
-   This controls the release threshold of the asynchronous arena. Note that
-   this is only relevant for the CUDA (>= 11.2) and HIP backends that
-   support stream-ordered memory allocator.
-
 .. py:data:: amrex.the_arena_defragmentation
    :type: bool
    :value: true

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -2,7 +2,7 @@
 #include <AMReX_Arena.H>
 #include <AMReX_BArena.H>
 #include <AMReX_CArena.H>
-#include <AMReX_PArena.H>
+#include <AMReX_SArena.H>
 
 #include <AMReX.H>
 #include <AMReX_BLProfiler.H>
@@ -47,7 +47,6 @@ namespace {
     Long the_managed_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_pinned_arena_release_threshold = std::numeric_limits<Long>::max();
     Long the_comms_arena_release_threshold = std::numeric_limits<Long>::max();
-    Long the_async_arena_release_threshold = std::numeric_limits<Long>::max();
     bool the_arena_defragmentation = true;
     bool the_device_arena_defragmentation = true;
     bool the_managed_arena_defragmentation = true;
@@ -427,7 +426,6 @@ Arena::Initialize (bool minimal)
     pp.queryAdd("the_managed_arena_release_threshold", the_managed_arena_release_threshold);
     pp.queryAdd( "the_pinned_arena_release_threshold",  the_pinned_arena_release_threshold);
     pp.queryAdd(  "the_comms_arena_release_threshold",   the_comms_arena_release_threshold);
-    pp.queryAdd(  "the_async_arena_release_threshold",   the_async_arena_release_threshold);
     pp.queryAdd(        "the_arena_defragmentation",         the_arena_defragmentation);
     pp.queryAdd( "the_device_arena_defragmentation",  the_device_arena_defragmentation);
     pp.queryAdd("the_managed_arena_defragmentation", the_managed_arena_defragmentation);
@@ -469,7 +467,7 @@ Arena::Initialize (bool minimal)
 #endif
     }
 
-    the_async_arena = new PArena(the_async_arena_release_threshold);
+    the_async_arena = new SArena();
     the_async_arena->registerForProfiling("Async Memory");
 
 #ifdef AMREX_USE_GPU

--- a/Src/Base/AMReX_SArena.H
+++ b/Src/Base/AMReX_SArena.H
@@ -1,0 +1,39 @@
+#ifndef AMREX_SARENA_H_
+#define AMREX_SARENA_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_Arena.H>
+
+
+namespace amrex {
+/**
+* \brief Doc TODO
+*/
+class SArena
+    :
+    public Arena
+{
+public:
+    /**
+    * \brief Allocates a dynamic memory arena of size sz.
+    * Returns a pointer to this memory.
+    * Doc TODO
+    */
+    [[nodiscard]] void* alloc (std::size_t sz) final;
+    /**
+    * \brief Deletes the arena pointed to by pt.
+    * Doc TODO
+    */
+    void free (void* pt) final;
+
+    [[nodiscard]] bool isDeviceAccessible () const final;
+    [[nodiscard]] bool isHostAccessible () const final;
+
+    [[nodiscard]] bool isManaged () const final;
+    [[nodiscard]] bool isDevice () const final;
+    [[nodiscard]] bool isPinned () const final;
+};
+
+}
+
+#endif

--- a/Src/Base/AMReX_SArena.H
+++ b/Src/Base/AMReX_SArena.H
@@ -49,7 +49,7 @@ public:
     [[nodiscard]] bool isPinned () const final;
 
 #ifdef AMREX_USE_GPU
-    //! Is this a CUDA stream ordered memory allocator?
+    //! Is this a GPU stream ordered memory allocator?
     [[nodiscard]] bool isStreamOrderedArena () const final { return true; }
 #endif
 };

--- a/Src/Base/AMReX_SArena.H
+++ b/Src/Base/AMReX_SArena.H
@@ -7,7 +7,19 @@
 
 namespace amrex {
 /**
-* \brief Doc TODO
+* \brief A STREAM-ordered memory arena.
+*
+* This Arena is implemented as a wrapper around amrex::The_Arena()
+* where the free() function calls amrex::Gpu::freeAsync().
+* This allows memory to be used by GPU kernels that were launched before free() was called
+* but may execute afterward, without calling amrex::Gpu::streamSynchronize().
+* These kernels need to use the same GPU stream that is active when free() is called,
+* otherwise explicit synchronization is needed.
+*
+* This is achieved by holding freed memory in a temporary buffer until the next time the
+* GPU stream is synchronized. In case too much memory is held up in this buffer or if The_Arena
+* needs more memory, the stream is automatically synchronized to clear the buffer.
+*
 */
 class SArena
     :
@@ -15,14 +27,17 @@ class SArena
 {
 public:
     /**
-    * \brief Allocates a dynamic memory arena of size sz.
+    * \brief Allocates dynamic memory from the arena of size sz.
     * Returns a pointer to this memory.
-    * Doc TODO
+    * The memory can be used immediately by both the CPU and GPU with any stream.
+    * This function may synchronize all GPU streams to free up memory.
     */
     [[nodiscard]] void* alloc (std::size_t sz) final;
     /**
     * \brief Deletes the arena pointed to by pt.
-    * Doc TODO
+    * After this function is called, the memory can still be used by already launched
+    * GPU kernels on the currently active stream.
+    * This function may synchronize the currently active GPU stream to free up memory.
     */
     void free (void* pt) final;
 
@@ -34,7 +49,7 @@ public:
     [[nodiscard]] bool isPinned () const final;
 
 #ifdef AMREX_USE_GPU
-    //! Is this CUDA stream ordered memory allocator?
+    //! Is this a CUDA stream ordered memory allocator?
     [[nodiscard]] bool isStreamOrderedArena () const final { return true; }
 #endif
 };

--- a/Src/Base/AMReX_SArena.H
+++ b/Src/Base/AMReX_SArena.H
@@ -32,6 +32,11 @@ public:
     [[nodiscard]] bool isManaged () const final;
     [[nodiscard]] bool isDevice () const final;
     [[nodiscard]] bool isPinned () const final;
+
+#ifdef AMREX_USE_GPU
+    //! Is this CUDA stream ordered memory allocator?
+    [[nodiscard]] bool isStreamOrderedArena () const final { return true; }
+#endif
 };
 
 }

--- a/Src/Base/AMReX_SArena.cpp
+++ b/Src/Base/AMReX_SArena.cpp
@@ -2,10 +2,10 @@
 #include <AMReX_GpuDevice.H>
 
 void*
-amrex::SArena::alloc (std::size_t sz_)
+amrex::SArena::alloc (std::size_t sz)
 {
-    void* pt = The_Arena()->alloc(sz_);
-    m_profiler.profile_alloc(pt, sz_);
+    void* pt = The_Arena()->alloc(sz);
+    m_profiler.profile_alloc(pt, sz);
     return pt;
 }
 

--- a/Src/Base/AMReX_SArena.cpp
+++ b/Src/Base/AMReX_SArena.cpp
@@ -1,0 +1,47 @@
+#include <AMReX_SArena.H>
+#include <AMReX_GpuDevice.H>
+
+void*
+amrex::SArena::alloc (std::size_t sz_)
+{
+    void* pt = The_Arena()->alloc(sz_);
+    m_profiler.profile_alloc(pt, sz_);
+    return pt;
+}
+
+void
+amrex::SArena::free (void* pt)
+{
+    m_profiler.profile_free(pt);
+    amrex::Gpu::freeAsync(The_Arena(), pt);
+}
+
+bool
+amrex::SArena::isDeviceAccessible () const
+{
+    return The_Arena()->isDeviceAccessible();
+}
+
+bool
+amrex::SArena::isHostAccessible () const
+{
+    return The_Arena()->isHostAccessible();
+}
+
+bool
+amrex::SArena::isManaged () const
+{
+    return The_Arena()->isManaged();
+}
+
+bool
+amrex::SArena::isDevice () const
+{
+    return The_Arena()->isDevice();
+}
+
+bool
+amrex::SArena::isPinned () const
+{
+    return The_Arena()->isPinned();
+}

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -81,6 +81,8 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_CArena.cpp
        AMReX_PArena.H
        AMReX_PArena.cpp
+       AMReX_SArena.H
+       AMReX_SArena.cpp
        AMReX_DataAllocator.H
        AMReX_BLProfiler.H
        AMReX_BLBackTrace.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -53,8 +53,8 @@ C$(AMREX_BASE)_headers += AMReX_ParallelReduce.H
 C$(AMREX_BASE)_headers += AMReX_ForkJoin.H AMReX_ParallelContext.H
 C$(AMREX_BASE)_sources += AMReX_ForkJoin.cpp AMReX_ParallelContext.cpp
 
-C$(AMREX_BASE)_sources += AMReX_VisMF.cpp AMReX_Arena.cpp AMReX_BArena.cpp AMReX_CArena.cpp AMReX_PArena.cpp
-C$(AMREX_BASE)_headers += AMReX_VisMFBuffer.H AMReX_VisMF.H AMReX_Arena.H AMReX_BArena.H AMReX_CArena.H AMReX_PArena.H
+C$(AMREX_BASE)_sources += AMReX_VisMF.cpp AMReX_Arena.cpp AMReX_BArena.cpp AMReX_CArena.cpp AMReX_PArena.cpp AMReX_SArena.cpp
+C$(AMREX_BASE)_headers += AMReX_VisMFBuffer.H AMReX_VisMF.H AMReX_Arena.H AMReX_BArena.H AMReX_CArena.H AMReX_PArena.H AMReX_SArena.H
 
 C$(AMREX_BASE)_headers += AMReX_DataAllocator.H
 


### PR DESCRIPTION
## Summary

As discussed here https://github.com/AMReX-Codes/amrex/pull/4804#issuecomment-3599493751, this PR adds a new memory arena that is a wrapper for The_Arena but calls  freeAsync in its free function. The new arena, called SArena for stream-ordered arena, replaces the PArena in the implementation of The_Async_Arena.

## Additional background

I have kept the profiling of the SArena for now. However, I'm not sure how useful it is since the CArena is already profiled.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
