### PR TITLE
Workaround for MSVC

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -55,7 +55,7 @@ public:
                      const AMF* robinbc_b = nullptr,
                      const AMF* robinbc_f = nullptr)
     {
-        this->MLLinOpT<MF>::setLevelBC<AMF>(amrlev, levelbcdata, robinbc_a, robinbc_b, robinbc_f);
+        this->MLLinOpT<MF>::template setLevelBC<AMF>(amrlev, levelbcdata, robinbc_a, robinbc_b, robinbc_f);
     }
 
     bool needsUpdate () const override {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -55,7 +55,7 @@ public:
                      const AMF* robinbc_b = nullptr,
                      const AMF* robinbc_f = nullptr)
     {
-        this->MLLinOpT<AMF>::setLevelBC(amrlev, levelbcdata, robinbc_a, robinbc_b, robinbc_f);
+        this->MLLinOpT<MF>::setLevelBC<AMF>(amrlev, levelbcdata, robinbc_a, robinbc_b, robinbc_f);
     }
 
     bool needsUpdate () const override {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -21,8 +21,8 @@ class MLCellLinOpT  // NOLINT(cppcoreguidelines-virtual-class-destructor)
 {
 public:
 
-    using FAB = typename MF::fab_type;
-    using RT  = typename MF::value_type;
+    using FAB = typename FabDataType<MF>::fab_type;
+    using RT  = typename FabDataType<MF>::value_type;
 
     using BCType = LinOpBCType;
     using BCMode    = typename MLLinOpT<MF>::BCMode;
@@ -48,7 +48,15 @@ public:
                              const MF* robinbc_b = nullptr,
                              const MF* robinbc_f = nullptr) final;
 
-    using MLLinOpT<MF>::setLevelBC;
+    template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF> &&
+                                             IsMultiFabLike_v<AMF>, int> = 0>
+    void setLevelBC (int amrlev, const AMF* levelbcdata,
+                     const AMF* robinbc_a = nullptr,
+                     const AMF* robinbc_b = nullptr,
+                     const AMF* robinbc_f = nullptr)
+    {
+        MLLinOpT<AMF>::setLevelBC(amrlev, levelbcdata, robinbc_a, robinbc_b, robinbc_f);
+    }
 
     bool needsUpdate () const override {
         return MLLinOpT<MF>::needsUpdate();

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -55,7 +55,7 @@ public:
                      const AMF* robinbc_b = nullptr,
                      const AMF* robinbc_f = nullptr)
     {
-        MLLinOpT<AMF>::setLevelBC(amrlev, levelbcdata, robinbc_a, robinbc_b, robinbc_f);
+        this->MLLinOpT<AMF>::setLevelBC(amrlev, levelbcdata, robinbc_a, robinbc_b, robinbc_f);
     }
 
     bool needsUpdate () const override {

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -235,7 +235,8 @@ public:
                              const MF* /*robinbc_b*/ = nullptr,
                              const MF* /*robinbc_f*/ = nullptr) = 0;
 
-    template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF>,int> = 0>
+    template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF> &&
+                                             IsMultiFabLike_v<AMF>, int> = 0>
     void setLevelBC (int amrlev, const AMF* levelbcdata,
                      const AMF* robinbc_a = nullptr,
                      const AMF* robinbc_b = nullptr,
@@ -1607,7 +1608,8 @@ MLLinOpT<MF>::isMFIterSafe (int amrlev, int mglev1, int mglev2) const
 }
 
 template <typename MF>
-template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF>,int>>
+template <typename AMF, std::enable_if_t<!std::is_same_v<MF,AMF> &&
+                                         IsMultiFabLike_v<AMF>, int> >
 void
 MLLinOpT<MF>::setLevelBC (int amrlev, const AMF* levelbcdata,
                           const AMF* robinbc_a, const AMF* robinbc_b,


### PR DESCRIPTION
This is needed for MSVC, because it does not seem to handle `using MLLinOpT<MF>::setLevelBC` correctly.

Additional background: https://github.com/BLAST-WarpX/warpx/issues/6406
