### PR TITLE
fix: `SpMatrix::prepare_comm` in case of no communication necessary

### DIFF
--- a/Src/LinearSolvers/AMReX_SpMV.H
+++ b/Src/LinearSolvers/AMReX_SpMV.H
@@ -192,9 +192,6 @@ void SpMV (AlgVector<T>& y, SpMatrix<T> const& A, AlgVector<T> const& x)
 
 #else
 
-    Long const rowsBegin = x.globalBegin();
-    Long const rowsEnd = x.globalEnd();
-
     Long const ny = y.numLocalRows();
 
 #ifdef AMREX_USE_OMP
@@ -203,9 +200,7 @@ void SpMV (AlgVector<T>& y, SpMatrix<T> const& A, AlgVector<T> const& x)
     for (Long i = 0; i < ny; ++i) {
         T r = 0;
         for (Long j = row[i]; j < row[i+1]; ++j) {
-            r += mat[j] * ((col[j] >= rowsBegin && col[j] < rowsEnd)
-                    ? px[col[j] - rowsBegin]
-                    : 0.0);
+            r += mat[j] * px[col[j]];
         }
         py[i] = r;
     }

--- a/Src/LinearSolvers/AMReX_SpMV.H
+++ b/Src/LinearSolvers/AMReX_SpMV.H
@@ -192,14 +192,20 @@ void SpMV (AlgVector<T>& y, SpMatrix<T> const& A, AlgVector<T> const& x)
 
 #else
 
+    Long const rowsBegin = x.globalBegin();
+    Long const rowsEnd = x.globalEnd();
+
     Long const ny = y.numLocalRows();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel for
+#endif
     for (Long i = 0; i < ny; ++i) {
         T r = 0;
-#ifdef AMREX_USE_OMP
-#pragma omp parallel for reduction(+:r)
-#endif
         for (Long j = row[i]; j < row[i+1]; ++j) {
-            r += mat[j] * px[col[j]];
+            r += mat[j] * ((col[j] >= rowsBegin && col[j] < rowsEnd)
+                    ? px[col[j] - rowsBegin]
+                    : 0.0);
         }
         py[i] = r;
     }

--- a/Src/LinearSolvers/AMReX_SpMatrix.H
+++ b/Src/LinearSolvers/AMReX_SpMatrix.H
@@ -542,6 +542,13 @@ void SpMatrix<T,Allocator>::prepare_comm ()
             }
         }
     }
+    else
+    {
+        auto* pcol = m_data.col_index.data();
+        ParallelFor(all_nnz, [=] AMREX_GPU_DEVICE (Long i)
+        { pcol[i] -= row_begin; });
+        m_shifted = true;
+    }
 
     // Need to make plans for MPI
     auto const mpi_tag = ParallelDescriptor::SeqNum();

--- a/Tests/Algebra/SpMV/CMakeLists.txt
+++ b/Tests/Algebra/SpMV/CMakeLists.txt
@@ -1,0 +1,9 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources main.cpp)
+    set(_input_files )
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Algebra/SpMV/GNUmakefile
+++ b/Tests/Algebra/SpMV/GNUmakefile
@@ -1,0 +1,17 @@
+# AMREX_HOME defines the directory in which we will find all the AMReX code.
+AMREX_HOME := ../../..
+
+DEBUG        = FALSE
+USE_MPI      = TRUE
+USE_OMP      = FALSE
+COMP         = gnu
+DIM          = 3
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/LinearSolvers/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Algebra/SpMV/Make.package
+++ b/Tests/Algebra/SpMV/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Algebra/SpMV/main.cpp
+++ b/Tests/Algebra/SpMV/main.cpp
@@ -29,32 +29,31 @@ int main(int argc, char *argv[]) {
     //     s_n + 2.0 * s_{n+1} = (n + 1) + 2 * (n + 2)
     //
     // independent on each processor
-    ParallelFor(nrows - 1, [=] AMREX_GPU_DEVICE(Long lrow) {
+    ParallelFor(nrows, [=] AMREX_GPU_DEVICE(Long lrow) {
       auto row = lrow + ib; // global row index
 
-      rhs[lrow + 1] = static_cast<Real>((lrow + 1.0) + 2.0 * (lrow + 2.0));
-      phi[lrow + 1] = static_cast<Real>(lrow + 2);
+      if (lrow == 0) {
+        rhs[0] = Real(1.0);
+        phi[0] = Real(1.0);
 
-      matRowOffsets[lrow + 1] = static_cast<Long>(2 * (lrow + 1));
-      matCols[2 * (lrow + 1)] = row + 1;
-      matCols[2 * (lrow + 1) + 1] = row;
-      matVals[2 * (lrow + 1)] = static_cast<Real>(2.0);
-      matVals[2 * (lrow + 1) + 1] = static_cast<Real>(1.0);
+        matRowOffsets[0] = 0;
+        matRowOffsets[nrows] = 2*nrows;
+        matCols[0] = ib;
+        matCols[1] = ib + 1;
+        matVals[0] = Real(1.0);
+        matVals[1] = Real(0.0);
+      } else {
+        rhs[lrow] = static_cast<Real>(lrow + 2 * (lrow + 1));
+        phi[lrow] = static_cast<Real>(lrow + 1);
+
+        matRowOffsets[lrow] = static_cast<Long>(2 * lrow);
+        matCols[2*lrow    ] = row;
+        matCols[2*lrow + 1] = row - 1;
+        matVals[2*lrow    ] = static_cast<Real>(2.0);
+        matVals[2*lrow + 1] = static_cast<Real>(1.0);
+      }
     });
 
-    // boundary condition: s_0 = 1.0
-    ParallelFor(1, [=] AMREX_GPU_DEVICE(Long) {
-      // global row index
-
-      rhs[0] = 1.0;
-      phi[0] = 1.0;
-
-      matRowOffsets[0] = 0;
-      matCols[0] = ib;
-      matCols[1] = ib + 1;
-      matVals[0] = 1.0;
-      matVals[1] = 0.0;
-    });
 
     auto eps = (sizeof(Real) == 4) ? Real(1.e-5) : Real(1.e-12);
     amrex::SpMV(xvec, mat, exact);

--- a/Tests/Algebra/SpMV/main.cpp
+++ b/Tests/Algebra/SpMV/main.cpp
@@ -1,0 +1,85 @@
+#include <AMReX_GMRES_MV.H>
+#include <AMReX_SpMV.H>
+
+#include <AMReX.H>
+
+using namespace amrex;
+
+int main(int argc, char *argv[]) {
+  amrex::Initialize(argc, argv);
+  {
+    AlgVector<Real> xvec(100);
+    AlgVector<Real> bvec(xvec.partition());
+    AlgVector<Real> exact(xvec.partition());
+
+    int num_non_zeros = 2;
+    SpMatrix<Real> mat(xvec.partition(), num_non_zeros);
+
+    auto *rhs = bvec.data();
+    auto *phi = exact.data();
+    auto nrows = bvec.numLocalRows();
+    auto ib = bvec.globalBegin();
+
+    auto *matVals = mat.data();
+    auto *matRowOffsets = mat.rowOffset();
+    auto *matCols = mat.columnIndex();
+
+    // simple algebraic system:
+    //
+    //     s_n + 2.0 * s_{n+1} = (n + 1) + 2 * (n + 2)
+    //
+    // independent on each processor
+    ParallelFor(nrows - 1, [=] AMREX_GPU_DEVICE(Long lrow) {
+      auto row = lrow + ib; // global row index
+
+      rhs[lrow + 1] = static_cast<Real>((lrow + 1.0) + 2.0 * (lrow + 2.0));
+      phi[lrow + 1] = static_cast<Real>(lrow + 2);
+
+      matRowOffsets[lrow + 1] = static_cast<Long>(2 * (lrow + 1));
+      matCols[2 * (lrow + 1)] = row + 1;
+      matCols[2 * (lrow + 1) + 1] = row;
+      matVals[2 * (lrow + 1)] = static_cast<Real>(2.0);
+      matVals[2 * (lrow + 1) + 1] = static_cast<Real>(1.0);
+    });
+
+    // boundary condition: s_0 = 1.0
+    ParallelFor(1, [=] AMREX_GPU_DEVICE(Long) {
+      // global row index
+
+      rhs[0] = 1.0;
+      phi[0] = 1.0;
+
+      matRowOffsets[0] = 0;
+      matCols[0] = ib;
+      matCols[1] = ib + 1;
+      matVals[0] = 1.0;
+      matVals[1] = 0.0;
+    });
+
+    auto eps = (sizeof(Real) == 4) ? Real(1.e-5) : Real(1.e-12);
+    amrex::SpMV(xvec, mat, exact);
+
+    // Check the multiplication
+    amrex::Axpy(xvec, Real(-1.0), bvec);
+
+    Real multiplicationError = xvec.norminf();
+
+    xvec.setVal(1.0);
+
+    GMRES_MV<Real> gmres(&mat);
+    gmres.setPrecond(JacobiSmoother<Real>(&mat));
+    gmres.setVerbose(2);
+
+    gmres.solve(xvec, bvec, Real(0.0), eps);
+
+    // Check the solution
+    amrex::Axpy(xvec, Real(-1.0), exact);
+
+    auto solveError = xvec.norminf();
+    amrex::Print() << " Max norm error: multiplication = "
+                   << multiplicationError << ", solve = " << solveError << "\n";
+
+    AMREX_ALWAYS_ASSERT(multiplicationError < eps && solveError < eps);
+  }
+  amrex::Finalize();
+}

--- a/Tests/Algebra/SpMV/main.cpp
+++ b/Tests/Algebra/SpMV/main.cpp
@@ -21,7 +21,6 @@ int main(int argc, char *argv[]) {
     auto ib = bvec.globalBegin();
 
     auto *matVals = mat.data();
-    auto *matRowOffsets = mat.rowOffset();
     auto *matCols = mat.columnIndex();
 
     // simple algebraic system:
@@ -36,8 +35,6 @@ int main(int argc, char *argv[]) {
         rhs[0] = Real(1.0);
         phi[0] = Real(1.0);
 
-        matRowOffsets[0] = 0;
-        matRowOffsets[nrows] = 2*nrows;
         matCols[0] = ib;
         matCols[1] = ib + 1;
         matVals[0] = Real(1.0);
@@ -46,7 +43,6 @@ int main(int argc, char *argv[]) {
         rhs[lrow] = static_cast<Real>(lrow + 2 * (lrow + 1));
         phi[lrow] = static_cast<Real>(lrow + 1);
 
-        matRowOffsets[lrow] = static_cast<Long>(2 * lrow);
         matCols[2*lrow    ] = row;
         matCols[2*lrow + 1] = row - 1;
         matVals[2*lrow    ] = static_cast<Real>(2.0);


### PR DESCRIPTION
## Summary

Currently, when computing matrix vector multiplication on the CPU, the `amrex::SpMV` method can accesses memory of the input vector wherever the matrix has non zero column indices if the matrix is distributed but does not need any communication to do the multiplication. This can lead to errors since accessing out of bounds memory is UB and can effectively lead to completely wrong results.

This contribution proposes first a fix by adding an else clause for the case where there are only local non-zero values in the matrix.

This commit also proposes to put the OpenMP loop one loop higher to avoid excessive thread spawning at this local matrix multiplication.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
