### PR TITLE
Improve documentation of OverrideSync

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -2947,6 +2947,18 @@ owners overriding non-owners.
     auto mask = amrex::OwnerMask(mf, geom.periodicity());
     mf.OverrideSync(*mask, geom.periodicity());
 
+This version of :cpp:`OverrideSync` offers the flexibility of providing a custom mask.
+However, when a custom mask is not needed, we can synchronize the data also with
+
+.. highlight:: c++
+
+::
+
+    MultiFab mf(...); // non-cell-centered
+    mf.OverrideSync(geom.periodicity());
+
+This version of :cpp:`OverrideSync` has better performance than the previous one.
+
 To compute the dot product of two nodal :cpp:`MultiFab`\ s, we can use a
 mask to avoid double counting.
 

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1196,6 +1196,14 @@ public:
      * same box, those near the lower corner have higher precedence than
      * those near the upper corner.
      *
+     * Example: Suppose there is a valid point that is shared by 4 boxes.
+     * Some operation assigns values a, b, c, and d to the 4 points in the 4 boxes.
+     * We then call SumBoundary to add the 4 values and store the result in the 4 boxes.
+     * The value in box 0 might be the result of a+b+c+d, the value in box 1 might be
+     * the result of b+a+c+d, etc. The resulting data are out of sync across boxes.
+     * OverrideSync synchronizes the data by overriding all values with one value
+     * (e.g., the value from box 0).
+     *
      * \param period periodic length if it's non-zero
      */
     void OverrideSync (const Periodicity& period = Periodicity::NonPeriodic());

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -708,10 +708,7 @@ public:
     /**
      * \brief Synchronize nodal data.  The synchronization will override
      * valid regions by the intersecting valid regions with a higher
-     * precedence.  The smaller the global box index is, the higher
-     * precedence the box has.  With periodic boundaries, for cells in the
-     * same box, those near the lower corner have higher precedence than
-     * those near the upper corner.
+     * precedence, according to the owner mask provided as input.
      *
      * Example: Suppose there is a valid point that is shared by 4 boxes.
      * Some operation assigns values a, b, c, and d to the 4 points in the 4 boxes.

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -705,7 +705,25 @@ public:
     void AverageSync (const Periodicity& period = Periodicity::NonPeriodic());
     //! Sync up nodal data with weights
     void WeightedSync (const MultiFab& wgt, const Periodicity& period = Periodicity::NonPeriodic());
-    //! Sync up nodal data with owners overriding non-owners
+    /**
+     * \brief Synchronize nodal data.  The synchronization will override
+     * valid regions by the intersecting valid regions with a higher
+     * precedence.  The smaller the global box index is, the higher
+     * precedence the box has.  With periodic boundaries, for cells in the
+     * same box, those near the lower corner have higher precedence than
+     * those near the upper corner.
+     *
+     * Example: Suppose there is a valid point that is shared by 4 boxes.
+     * Some operation assigns values a, b, c, and d to the 4 points in the 4 boxes.
+     * We then call SumBoundary to add the 4 values and store the result in the 4 boxes.
+     * The value in box 0 might be the result of a+b+c+d, the value in box 1 might be
+     * the result of b+a+c+d, etc. The resulting data are out of sync across boxes.
+     * OverrideSync synchronizes the data by overriding all values with one value
+     * (e.g., the value from box 0).
+     *
+     * \param msk    owner mask
+     * \param period periodic length if it's non-zero
+     */
     void OverrideSync (const iMultiFab& msk, const Periodicity& period = Periodicity::NonPeriodic());
 
     using FabArray<FArrayBox>::OverrideSync;


### PR DESCRIPTION
## Summary

This improves the documentation of `OverrideSync`, based on an exchange between @WeiqunZhang, @aeriforme, and myself in https://github.com/BLAST-WarpX/warpx/pull/6438:
- Add @WeiqunZhang's example in https://github.com/BLAST-WarpX/warpx/pull/6438#discussion_r2604801219 to the docstring of `FabArray::OverrideSync` in Src/Base/AMReX_FabArray.H.
- Copy docstring of `FabArray::OverrideSync` over to docstring of `MultiFab::OverrideSync` in Src/Base/AMReX_MultiFab.H for consistency.
- Add @WeiqunZhang's comment in https://github.com/BLAST-WarpX/warpx/pull/6438#discussion_r2615123791 to the documentation in Docs/sphinx_documentation/source/Basics.rst, highlighting the difference between the two ways of synchronizing the data with owners overriding non-owners.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
