### PR TITLE
Update GNUMake for Catalyst 2.0

### DIFF
--- a/Tools/GNUMake/packages/Make.catalyst
+++ b/Tools/GNUMake/packages/Make.catalyst
@@ -1,14 +1,14 @@
 #########################################################
-# Catalyst (https://gitlab.kitware.com/paraview/catalyst) Support 
+# Catalyst (https://gitlab.kitware.com/paraview/catalyst) Support
 #########################################################
 
 CPPFLAGS += -DAMREX_USE_CATALYST
 
 ifdef CATALYST_DIR
-  INCLUDE_LOCATIONS += $(CATALYST_DIR)/include
-  VPATH_LOCATIONS   += $(CATALYST_DIR)/include
-  LIBRARY_LOCATIONS += $(CATALYST_DIR)/lib
-  LIBRARIES += -Wl,-rpath,$(CATALYST_DIR)/lib
+  INCLUDE_LOCATIONS += $(CATALYST_DIR)/include/catalyst-2.0
+  VPATH_LOCATIONS   += $(CATALYST_DIR)/include/catalyst-2.0
+  LIBRARY_LOCATIONS += $(CATALYST_DIR)/lib64
+  LIBRARIES += -Wl,-rpath,$(CATALYST_DIR)/lib64
 
   LIBRARIES += -lcatalyst
 


### PR DESCRIPTION
## Summary

Update the GNUMake include and library locations for Catalyst 2.0 [released in March 2024](https://www.kitware.com/catalyst-2-0-0-release/).

https://catalyst-in-situ.readthedocs.io/en/latest/for_simulation_developers.html#using-make-or-similar

No changes are needed for CMake

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
