### PR TITLE
Convert Array4 to ArrayND

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -377,7 +377,11 @@ jobs:
       # /home/runner/work/amrex/amrex/Src/Base/AMReX_IntVect.H:194:92: error: array subscript -1 is below array bounds of ‘int [3]’ [-Werror=array-bounds]
       # int& operator[] (int i) noexcept { BL_ASSERT(i>=0 && i < AMREX_SPACEDIM); return vect[i]; }
       #
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-array-bounds"}
+      # /home/runner/work/amrex/amrex/Src/Particle/AMReX_Particle_mod_K.H:101:49: error: ‘p’ may be used uninitialized [-Werror=maybe-uninitialized]
+      # /home/runner/work/amrex/amrex/Src/Particle/AMReX_ParticleContainerI.H:2652:26: note: ‘p’ declared here
+      # auto p = ptd[i];
+      #
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wunreachable-code -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs -Wno-array-bounds -Wno-maybe-uninitialized"}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10

--- a/Src/AmrCore/AMReX_MFInterp_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_C.H
@@ -14,7 +14,7 @@ Real mf_compute_slopes_x (int i, int j, int k, Array4<Real const> const& u, int 
     Real dc = Real(0.5) * (u(i+1,j,k,nu) - u(i-1,j,k,nu));
     if (i == domain.smallEnd(0) && (bc.lo(0) == BCType::ext_dir ||
                                     bc.lo(0) == BCType::hoextrap)) {
-        if (i+2 < u.end.x) {
+        if (i+2 < u.end[0]) {
             dc = -Real(16./15.)*u(i-1,j,k,nu) + Real(0.5)*u(i,j,k,nu)
                 + Real(2./3.)*u(i+1,j,k,nu) - Real(0.1)*u(i+2,j,k,nu);
         } else {
@@ -23,7 +23,7 @@ Real mf_compute_slopes_x (int i, int j, int k, Array4<Real const> const& u, int 
     }
     if (i == domain.bigEnd(0) && (bc.hi(0) == BCType::ext_dir ||
                                   bc.hi(0) == BCType::hoextrap)) {
-        if (i-2 >= u.begin.x) {
+        if (i-2 >= u.begin[0]) {
             dc = Real(16./15.)*u(i+1,j,k,nu) - Real(0.5)*u(i,j,k,nu)
                 - Real(2./3.)*u(i-1,j,k,nu) + Real(0.1)*u(i-2,j,k,nu);
         } else {
@@ -40,7 +40,7 @@ Real mf_compute_slopes_y (int i, int j, int k, Array4<Real const> const& u, int 
     Real dc = Real(0.5) * (u(i,j+1,k,nu) - u(i,j-1,k,nu));
     if (j == domain.smallEnd(1) && (bc.lo(1) == BCType::ext_dir ||
                                     bc.lo(1) == BCType::hoextrap)) {
-        if (j+2 < u.end.y) {
+        if (j+2 < u.end[1]) {
             dc = -Real(16./15.)*u(i,j-1,k,nu) + Real(0.5)*u(i,j,k,nu)
                 + Real(2./3.)*u(i,j+1,k,nu) - Real(0.1)*u(i,j+2,k,nu);
         } else {
@@ -49,7 +49,7 @@ Real mf_compute_slopes_y (int i, int j, int k, Array4<Real const> const& u, int 
     }
     if (j == domain.bigEnd(1) && (bc.hi(1) == BCType::ext_dir ||
                                   bc.hi(1) == BCType::hoextrap)) {
-        if (j-2 >= u.begin.y) {
+        if (j-2 >= u.begin[1]) {
             dc = Real(16./15.)*u(i,j+1,k,nu) - Real(0.5)*u(i,j,k,nu)
                 - Real(2./3.)*u(i,j-1,k,nu) + Real(0.1)*u(i,j-2,k,nu);
         } else {
@@ -66,7 +66,7 @@ Real mf_compute_slopes_z (int i, int j, int k, Array4<Real const> const& u, int 
     Real dc = Real(0.5) * (u(i,j,k+1,nu) - u(i,j,k-1,nu));
     if (k == domain.smallEnd(2) && (bc.lo(2) == BCType::ext_dir ||
                                     bc.lo(2) == BCType::hoextrap)) {
-        if (k+2 < u.end.z) {
+        if (k+2 < u.end[2]) {
             dc = -Real(16./15.)*u(i,j,k-1,nu) + Real(0.5)*u(i,j,k,nu)
                 + Real(2./3.)*u(i,j,k+1,nu) - Real(0.1)*u(i,j,k+2,nu);
         } else {
@@ -75,7 +75,7 @@ Real mf_compute_slopes_z (int i, int j, int k, Array4<Real const> const& u, int 
     }
     if (k == domain.bigEnd(2) && (bc.hi(2) == BCType::ext_dir ||
                                   bc.hi(2) == BCType::hoextrap)) {
-        if (k-2 >= u.begin.z) {
+        if (k-2 >= u.begin[2]) {
             dc = Real(16./15.)*u(i,j,k+1,nu) - Real(0.5)*u(i,j,k,nu)
                 - Real(2./3.)*u(i,j,k-1,nu) + Real(0.1)*u(i,j,k-2,nu);
         } else {
@@ -93,13 +93,13 @@ Real mf_cell_quadratic_compute_slopes_xx (int i, int j, int k,
     Real xx = u(i-1,j,k,nu) - 2.0_rt * u(i,j,k,nu) + u(i+1,j,k,nu);
     if (i == domain.smallEnd(0) && (bc.lo(0) == BCType::ext_dir ||
                                     bc.lo(0) == BCType::hoextrap)) {
-        if (i+2 < u.end.x) {
+        if (i+2 < u.end[0]) {
             xx = 0._rt;
         }
     }
     if (i == domain.bigEnd(0) && (bc.hi(0) == BCType::ext_dir ||
                                   bc.hi(0) == BCType::hoextrap)) {
-        if (i-2 >= u.begin.x) {
+        if (i-2 >= u.begin[0]) {
             xx = 0._rt;
         }
     }
@@ -114,13 +114,13 @@ Real mf_cell_quadratic_compute_slopes_yy (int i, int j, int k,
     Real yy = u(i,j-1,k,nu) - 2.0_rt * u(i,j,k,nu) + u(i,j+1,k,nu);
     if (j == domain.smallEnd(1) && (bc.lo(1) == BCType::ext_dir ||
                                     bc.lo(1) == BCType::hoextrap)) {
-        if (j+2 < u.end.y) {
+        if (j+2 < u.end[1]) {
             yy = 0._rt;
         }
     }
     if (j == domain.bigEnd(1) && (bc.hi(1) == BCType::ext_dir ||
                                   bc.hi(1) == BCType::hoextrap)) {
-        if (j-2 >= u.begin.y) {
+        if (j-2 >= u.begin[1]) {
             yy = 0._rt;
         }
     }
@@ -135,13 +135,13 @@ Real mf_cell_quadratic_compute_slopes_zz (int i, int j, int k,
     Real zz = u(i,j,k-1,nu) - 2.0_rt * u(i,j,k,nu) + u(i,j,k+1,nu);
     if (k == domain.smallEnd(2) && (bc.lo(2) == BCType::ext_dir ||
                                     bc.lo(2) == BCType::hoextrap)) {
-        if (k+2 < u.end.z) {
+        if (k+2 < u.end[2]) {
             zz = 0._rt;
         }
     }
     if (k == domain.bigEnd(1) && (bc.hi(2) == BCType::ext_dir ||
                                   bc.hi(2) == BCType::hoextrap)) {
-        if (k-2 >= u.begin.z) {
+        if (k-2 >= u.begin[2]) {
             zz = 0._rt;
         }
     }
@@ -157,25 +157,25 @@ Real mf_cell_quadratic_compute_slopes_xy (int i, int j, int k,
                               - u(i-1,j+1,k,nu) + u(i+1,j+1,k,nu) );
     if (i == domain.smallEnd(0) && (bc.lo(0) == BCType::ext_dir ||
                                     bc.lo(0) == BCType::hoextrap)) {
-        if (i+2 < u.end.x) {
+        if (i+2 < u.end[0]) {
             xy = 0._rt;
         }
     }
     if (i == domain.bigEnd(0) && (bc.hi(0) == BCType::ext_dir ||
                                   bc.hi(0) == BCType::hoextrap)) {
-        if (i-2 >= u.begin.x) {
+        if (i-2 >= u.begin[0]) {
             xy = 0._rt;
         }
     }
     if (j == domain.smallEnd(1) && (bc.lo(1) == BCType::ext_dir ||
                                     bc.lo(1) == BCType::hoextrap)) {
-        if (j+2 < u.end.y) {
+        if (j+2 < u.end[1]) {
             xy = 0._rt;
         }
     }
     if (j == domain.bigEnd(1) && (bc.hi(1) == BCType::ext_dir ||
                                   bc.hi(1) == BCType::hoextrap)) {
-        if (j-2 >= u.begin.y) {
+        if (j-2 >= u.begin[1]) {
             xy = 0._rt;
         }
     }
@@ -191,25 +191,25 @@ Real mf_cell_quadratic_compute_slopes_xz (int i, int j, int k,
                               - u(i-1,j,k+1,nu) + u(i+1,j,k+1,nu) );
     if (i == domain.smallEnd(0) && (bc.lo(0) == BCType::ext_dir ||
                                     bc.lo(0) == BCType::hoextrap)) {
-        if (i+2 < u.end.x) {
+        if (i+2 < u.end[0]) {
             xz = 0._rt;
         }
     }
     if (i == domain.bigEnd(0) && (bc.hi(0) == BCType::ext_dir ||
                                   bc.hi(0) == BCType::hoextrap)) {
-        if (i-2 >= u.begin.x) {
+        if (i-2 >= u.begin[0]) {
             xz = 0._rt;
         }
     }
     if (k == domain.smallEnd(2) && (bc.lo(2) == BCType::ext_dir ||
                                     bc.lo(2) == BCType::hoextrap)) {
-        if (k+2 < u.end.z) {
+        if (k+2 < u.end[2]) {
             xz = 0._rt;
         }
     }
     if (k == domain.bigEnd(1) && (bc.hi(2) == BCType::ext_dir ||
                                   bc.hi(2) == BCType::hoextrap)) {
-        if (k-2 >= u.begin.z) {
+        if (k-2 >= u.begin[2]) {
             xz = 0._rt;
         }
     }
@@ -225,25 +225,25 @@ Real mf_cell_quadratic_compute_slopes_yz (int i, int j, int k,
                               - u(i,j+1,k-1,nu) + u(i,j+1,k+1,nu) );
     if (j == domain.smallEnd(1) && (bc.lo(1) == BCType::ext_dir ||
                                     bc.lo(1) == BCType::hoextrap)) {
-        if (j+2 < u.end.y) {
+        if (j+2 < u.end[1]) {
             yz = 0._rt;
         }
     }
     if (j == domain.bigEnd(1) && (bc.hi(1) == BCType::ext_dir ||
                                   bc.hi(1) == BCType::hoextrap)) {
-        if (j-2 >= u.begin.y) {
+        if (j-2 >= u.begin[1]) {
             yz = 0._rt;
         }
     }
     if (k == domain.smallEnd(2) && (bc.lo(2) == BCType::ext_dir ||
                                     bc.lo(2) == BCType::hoextrap)) {
-        if (k+2 < u.end.z) {
+        if (k+2 < u.end[2]) {
             yz = 0._rt;
         }
     }
     if (k == domain.bigEnd(1) && (bc.hi(2) == BCType::ext_dir ||
                                   bc.hi(2) == BCType::hoextrap)) {
-        if (k-2 >= u.begin.z) {
+        if (k-2 >= u.begin[2]) {
             yz = 0._rt;
         }
     }

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -663,9 +663,6 @@ namespace amrex {
             constexpr_for<1, M>([&](int d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
             });
-            constexpr_for<M, N-1>([&](int d) {
-                offset += (Long(0) - begin[d]) * nstride[d-1];
-            });
             offset += (n - begin[N-1]) * nstride[N-2];
             return offset;
         }

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -5,7 +5,6 @@
 #include <AMReX.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_GpuPrint.H>
-#include <AMReX_ConstexprFor.H>
 
 #include <iostream>
 #include <sstream>
@@ -444,11 +443,11 @@ namespace amrex {
         void index_assert (IntVectND<dim> const& iv) const
         {
             bool out_of_bounds = false;
-            constexpr_for<0, dim>([&] (auto d) {
+            for (int d = 0; d < dim; ++d) {
                 if (iv[d] < begin[d] || iv[d] >= end[d]) {
                     out_of_bounds = true;
                 }
-            });
+            }
             if (out_of_bounds) {
                 AMREX_IF_ON_DEVICE((
                     device_printf_impl(std::make_index_sequence<dim>{}, iv, begin, end);
@@ -457,15 +456,15 @@ namespace amrex {
                 AMREX_IF_ON_HOST((
                     std::stringstream ss;
                     ss << " (";
-                    constexpr_for<0, dim>([&] (auto d) {
+                    for (int d = 0; d < dim; ++d) {
                         ss << iv[d];
                         if (d + 1 < dim) ss << ",";
-                    });
+                    }
                     ss << ") is out of bound (";
-                    constexpr_for<0, dim>([&] (auto d) {
+                    for (int d = 0; d < dim; ++d) {
                         ss << begin[d] << ":" << end[d]-1;
                         if (d + 1 < dim) ss << ",";
-                    });
+                    };
                     ss << ")";
                     amrex::Abort(ss.str());
                 ))

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -1,5 +1,6 @@
 #ifndef AMREX_ARRAY4_H_
 #define AMREX_ARRAY4_H_
+
 #include <AMReX_Config.H>
 
 #include <AMReX.H>
@@ -10,6 +11,9 @@
 #include <sstream>
 
 namespace amrex {
+
+    template<int dim>
+    class BoxND;
 
     template <typename T>
     struct CellData // Data in a single cell
@@ -167,22 +171,9 @@ namespace amrex {
         constexpr ArrayND (ArrayND<std::remove_const_t<T>, N> const& rhs) noexcept
             : p(rhs.p), nstride(rhs.nstride), begin(rhs.begin), end(rhs.end) {}
 
-        AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (T* a_p, IntVectND<N> const& a_begin, IntVectND<N> const& a_end) noexcept
-            : p(a_p), begin(a_begin), end(a_end)
-        {
-            if constexpr (N > 1) {
-                Long current_stride = 1;
-                for (int d = 0; d < N - 1; ++d) {
-                    Long len = a_end[d] - a_begin[d];
-                    current_stride *= len;
-                    nstride[d] = current_stride;
-                }
-            }
-        }
-
         // Dim3 overload for dim=4
         template <int Dim=N, std::enable_if_t<Dim==4,int> = 0>
+        AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
             : p(a_p), begin(a_begin.x, a_begin.y, a_begin.z, 0), end(a_end.x, a_end.y, a_end.z, a_ncomp)
         {
@@ -194,10 +185,91 @@ namespace amrex {
             }
         }
 
+        // Note: BoxND constructors are not constexpr because functions in BoxND are not constexpr
+        template <int Dim>
+        AMREX_GPU_HOST_DEVICE
+        ArrayND (T* a_p, BoxND<Dim> const& box) noexcept
+            : ArrayND(a_p, box.smallEnd(), box.bigEnd() + 1)
+        {}
+
+        template <int Dim>
+        AMREX_GPU_HOST_DEVICE
+        ArrayND (T* a_p, BoxND<Dim> const& box, int ncomp) noexcept
+            : ArrayND(a_p, box.smallEnd(), box.bigEnd() + 1, ncomp)
+        {}
+
+
+        // Standard constructor for full dimension N
+        AMREX_GPU_HOST_DEVICE
+        constexpr ArrayND (T* a_p, IntVectND<N> const& a_smallend, IntVectND<N> const& a_bigend) noexcept
+            : p(a_p), begin(a_smallend), end(a_bigend)
+        {
+            if constexpr (N > 1) {
+                Long current_stride = 1;
+                for (int d = 0; d < N - 1; ++d) {
+                    Long len = a_bigend[d] - a_smallend[d];
+                    current_stride *= len;
+                    nstride[d] = current_stride;
+                }
+            }
+        }
+
+        // Reduced dimension constructor: Pads remaining dims with [0,1)
+        template <int M, std::enable_if_t<(M < N),int> = 0>
+        AMREX_GPU_HOST_DEVICE
+        constexpr ArrayND (T* a_p, IntVectND<M> const& a_smallend, IntVectND<M> const& a_bigend) noexcept
+            : p(a_p), begin(), end()
+        {
+            for (int d = 0; d < M; ++d) {
+                begin[d] = a_smallend[d];
+                end[d] = a_bigend[d];
+            }
+            for (int d = M; d < N; ++d) {
+                begin[d] = 0;
+                end[d] = 1;
+            }
+
+            if constexpr (N > 1) {
+                Long current_stride = 1;
+                for (int d = 0; d < N - 1; ++d) {
+                    Long len = end[d] - begin[d];
+                    current_stride *= len;
+                    nstride[d] = current_stride;
+                }
+            }
+        }
+
+        // Reduced dimension constructor with ncomp: Pads intermediate dims with [0,1), sets last dim to [0,ncomp)
+        template <int M, std::enable_if_t<(M < N) && (N != 1),int> = 0>
+        AMREX_GPU_HOST_DEVICE
+        constexpr ArrayND (T* a_p, IntVectND<M> const& a_smallend, IntVectND<M> const& a_bigend, int ncomp) noexcept
+            : p(a_p), begin(), end()
+        {
+            for (int d = 0; d < M; ++d) {
+                begin[d] = a_smallend[d];
+                end[d] = a_bigend[d];
+            }
+            for (int d = M; d < N-1; ++d) {
+                begin[d] = 0;
+                end[d] = 1;
+            }
+            begin[N-1] = 0;
+            end[N-1] = ncomp;
+
+            if constexpr (N > 1) {
+                Long current_stride = 1;
+                for (int d = 0; d < N - 1; ++d) {
+                    Long len = end[d] - begin[d];
+                    current_stride *= len;
+                    nstride[d] = current_stride;
+                }
+            }
+        }
+
         template <class U,
             std::enable_if_t
                   <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>> && (N == 4),int> = 0>
+                                std::remove_const_t<U>> && (N  >= 2),int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (ArrayND<U, N> const& rhs, int start_comp) noexcept
             : p((T*)(rhs.p + start_comp*rhs.nstride[N-2])),
@@ -212,7 +284,7 @@ namespace amrex {
         template <class U,
             std::enable_if_t
                   <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>> && (N == 4),int> = 0>
+                                std::remove_const_t<U>> && (N >= 2),int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (ArrayND<U, N> const& rhs, int start_comp, int num_comp) noexcept
             : p((T*)(rhs.p + start_comp*rhs.nstride[N-2])),
@@ -225,7 +297,9 @@ namespace amrex {
         }
 
         AMREX_GPU_HOST_DEVICE
-        explicit operator bool() const noexcept { return p != nullptr; }
+        explicit operator bool() const noexcept {
+            return p != nullptr && end.allGT(begin);    // Additional check for properly initialized ArrayND
+        }
 
         // This overload is enabled only when number of indices matches dimension or is one less than dimension
         template <typename... idx, class U=T,
@@ -494,6 +568,24 @@ namespace amrex {
         }
 #endif
     };
+
+    // Deduction guides for ArrayND
+    // 1: Matches ArrayND (T*, BoxND<N>) -> ArrayND<T,N>
+    template <typename T, int Dim>
+    ArrayND (T*, BoxND<Dim> const&) -> ArrayND<T, Dim>;
+
+    // 2: Matches ArrayND (T*, BoxND<N>, ncomp) -> ArrayND<T,N+1>
+    // This supports the "N+1" logic (Spatial + Component)
+    template <typename T, int Dim>
+    ArrayND (T*, BoxND<Dim> const&, int) -> ArrayND<T, Dim+1>;
+
+    // 3: Matches ArrayND (T*, IntVectND<N>, IntVectND<N>) -> ArrayND<T,N>
+    template <typename T, int N>
+    ArrayND (T*, IntVectND<N> const&, IntVectND<N> const&) -> ArrayND<T, N>;
+
+    // 4: Matches ArrayND (T*, IntVectND<N>, IntVectND<N>, int) -> ArrayND<T,N+1>
+    template <typename T, int N>
+    ArrayND (T*, IntVectND<N> const&, IntVectND<N> const&, int) -> ArrayND<T, N+1>;
 
     template<typename T>
     using Array4 = ArrayND<T,4>;

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -71,7 +71,7 @@ namespace amrex {
         template <int N, typename... idx>
         struct ArrayNDIndexCheck_impl {
         private:
-            static constexpr int num_indicies = sizeof...(idx);
+            static constexpr int num_indices = sizeof...(idx);
 
             template <typename... Ts>
             struct AllExceptLastEnum;
@@ -95,8 +95,8 @@ namespace amrex {
                 IsValidIndexType<std::decay_t<idx>>...>::value;
 
         public:
-            static constexpr bool value = ((num_indicies == N) && index_with_enum) ||
-                                          ((num_indicies == N - 1) && index_all_values);
+            static constexpr bool value = ((num_indices == N) && index_with_enum) ||
+                                          ((num_indices == N - 1) && index_all_values);
         };
 
         template <int N, class... idx>
@@ -235,7 +235,7 @@ namespace amrex {
          * \param a_p Pointer to data.
          * \param box The domain covered by this array.
          *
-         * \TODO: Make BoxND functions constexpr to allow this constructor to be constexpr.
+         * TODO: Make BoxND functions constexpr to allow this constructor to be constexpr.
          */
         template <int M>
         AMREX_GPU_HOST_DEVICE
@@ -396,13 +396,14 @@ namespace amrex {
 
         /**
          * \brief Multi-index operator() for accessing elements.
-         * \param i... Indices for each dimension.
+         * \tparam idx Variadic template for indices.
+         * \param i Variadic list of indicies.
          * \return Reference to the element.
          *
          * This operator is only enabled when the number of indices provided matches the dimension N or N-1
          * where in the latter case the last dimension is assumed to be 0. The passed indices must be of
          * integral types that can be converted to int without narrowing. The last index can also be an enum type.
-         * \TODO: Use concepts when we move to C++20. The error message now is not user friendly.
+         * TODO: Use concepts when we move to C++20. The error message now is not user friendly.
          */
         template <typename... idx, class U=T,
             std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<N, idx...>,int> = 0>
@@ -473,7 +474,8 @@ namespace amrex {
 
         /**
          * \brief Multi-index ptr() for accessing pointer to element.
-         * \param i... Indices for each dimension.
+         * \tparam idx Variadic template for indices.
+         * \param i Variadic list of indicies.
          * \return Pointer to the element.
          */
         template <typename... idx, class U=T,

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -181,6 +181,7 @@ namespace amrex {
      * \brief A multidimensional array accessor.
      * \tparam T The type of data (e.g., Real, int).
      * \tparam N The dimension of the array (rank).
+     * \tparam last_dim_component If true, the last dimension is treated as components.
      *
      * ArrayND is a lightweight, non-owning wrapper around a pointer that provides
      * multidimensional indexing into a contiguous memory block. It is trivially
@@ -190,10 +191,11 @@ namespace amrex {
      * It stores the pointer, stride information, and the bounds (begin and end)
      * of the array.
      */
-    template<typename T, int N>
+    template<typename T, int N, bool last_dim_component = true>
     struct ArrayND
     {
         static_assert(N >= 1, "ArrayND must have at least one dimension");
+        static_assert(N > 1 || !last_dim_component, "ArrayND with N=1 cannot have last_dim_component=true");
 
         T* AMREX_RESTRICT p = nullptr;
         std::array<Long, N-1> nstride{};
@@ -562,10 +564,14 @@ namespace amrex {
          * For N!=4 case, the user is expected to keep track if they are using the last dimension
          * as components.
          */
-        template <int M=N, std::enable_if_t<M==4,int> = 0>
+        template <int M=N, std::enable_if_t<M==4 || last_dim_component,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr int nComp () const noexcept {
-            return end[N-1] - begin[N-1];
+            if constexpr (last_dim_component) {
+                return end[N-1];
+            } else {
+                return end[N-1] - begin[N-1];
+            }
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -587,9 +593,16 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (IntVectND<N> const& iv) const noexcept {
             bool inside = true;
-            constexpr_for<0, N>([&](int d) {
-                inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
-            });
+            if constexpr (last_dim_component == false) {
+                constexpr_for<0, N>([&](int d) {
+                    inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
+                });
+            } else {
+                constexpr_for<0, N-1>([&](int d) {
+                    inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
+                });
+                inside = inside && (iv[N-1] >= 0) && (iv[N-1] < end[N-1]);
+            }
             return inside;
         }
 
@@ -633,9 +646,16 @@ namespace amrex {
         constexpr Long get_offset (IntVectND<N> const& iv) const noexcept
         {
             Long offset = iv[0] - begin[0];
-            constexpr_for<1, N>([&](int d) {
-                offset += (iv[d] - begin[d]) * nstride[d-1];
-            });
+            if constexpr (last_dim_component == false) {
+                constexpr_for<1, N>([&](int d) {
+                    offset += (iv[d] - begin[d]) * nstride[d-1];
+                });
+            } else {
+                constexpr_for<1, N-1>([&](int d) {
+                    offset += (iv[d] - begin[d]) * nstride[d-1];
+                });
+                offset += iv[N-1] * nstride[N-2];
+            }
             return offset;
         }
 
@@ -663,7 +683,11 @@ namespace amrex {
             constexpr_for<1, M>([&](int d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
             });
-            offset += (n - begin[N-1]) * nstride[N-2];
+            if constexpr (last_dim_component == false) {
+                offset += (n - begin[N-1]) * nstride[N-2];
+            } else {
+                offset += n * nstride[N-2];
+            }
             return offset;
         }
 
@@ -733,25 +757,25 @@ namespace amrex {
     };
 
     // Deduction guides for ArrayND
-    // 1: Matches ArrayND (T*, BoxND<N>) -> ArrayND<T,N>
+    // 1: Matches ArrayND (T*, BoxND<N>) -> ArrayND<T,N, last_dim_component=false>
     template <typename T, int N>
-    ArrayND (T*, BoxND<N> const&) -> ArrayND<T, N>;
+    ArrayND (T*, BoxND<N> const&) -> ArrayND<T, N, false>;
 
-    // 2: Matches ArrayND (T*, BoxND<N>, ncomp) -> ArrayND<T,N+1>
+    // 2: Matches ArrayND (T*, BoxND<N>, ncomp) -> ArrayND<T,N+1, last_dim_component=true>
     // This supports the "N+1" logic (Spatial + Component)
     template <typename T, int N>
-    ArrayND (T*, BoxND<N> const&, int) -> ArrayND<T, N+1>;
+    ArrayND (T*, BoxND<N> const&, int) -> ArrayND<T, N+1, true>;
 
-    // 3: Matches ArrayND (T*, IntVectND<N>, IntVectND<N>) -> ArrayND<T,N>
+    // 3: Matches ArrayND (T*, IntVectND<N>, IntVectND<N>) -> ArrayND<T,N, last_dim_component=false>
     template <typename T, int N>
-    ArrayND (T*, IntVectND<N> const&, IntVectND<N> const&) -> ArrayND<T, N>;
+    ArrayND (T*, IntVectND<N> const&, IntVectND<N> const&) -> ArrayND<T, N, false>;
 
-    // 4: Matches ArrayND (T*, IntVectND<N>, IntVectND<N>, int) -> ArrayND<T,N+1>
+    // 4: Matches ArrayND (T*, IntVectND<N>, IntVectND<N>, int) -> ArrayND<T,N+1, last_dim_component=true>
     template <typename T, int N>
-    ArrayND (T*, IntVectND<N> const&, IntVectND<N> const&, int) -> ArrayND<T, N+1>;
+    ArrayND (T*, IntVectND<N> const&, IntVectND<N> const&, int) -> ArrayND<T, N+1, true>;
 
     template<typename T>
-    using Array4 = ArrayND<T,4>;
+    using Array4 = ArrayND<T, 4, true>;
 
     template <class Tto, class Tfrom, int N>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -6,6 +6,7 @@
 #include <AMReX.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_GpuPrint.H>
+#include <AMReX_ConstexprFor.H>
 
 #include <iostream>
 #include <sstream>
@@ -172,29 +173,29 @@ namespace amrex {
             : p(rhs.p), nstride(rhs.nstride), begin(rhs.begin), end(rhs.end) {}
 
         // Dim3 overload for dim=4
-        template <int Dim=N, std::enable_if_t<Dim==4,int> = 0>
+        template <int M=N, std::enable_if_t<M==4,int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
             : p(a_p), begin(a_begin.x, a_begin.y, a_begin.z, 0), end(a_end.x, a_end.y, a_end.z, a_ncomp)
         {
             Long current_stride = 1;
-            for (int d = 0; d < N - 1; ++d) {
+            constexpr_for<0, N-1>([&](int d) {
                 Long len = end[d] - begin[d];
                 current_stride *= len;
                 nstride[d] = current_stride;
-            }
+            });
         }
 
         // Note: BoxND constructors are not constexpr because functions in BoxND are not constexpr
-        template <int Dim>
+        template <int M>
         AMREX_GPU_HOST_DEVICE
-        ArrayND (T* a_p, BoxND<Dim> const& box) noexcept
+        ArrayND (T* a_p, BoxND<M> const& box) noexcept
             : ArrayND(a_p, box.smallEnd(), box.bigEnd() + 1)
         {}
 
-        template <int Dim>
+        template <int M>
         AMREX_GPU_HOST_DEVICE
-        ArrayND (T* a_p, BoxND<Dim> const& box, int ncomp) noexcept
+        ArrayND (T* a_p, BoxND<M> const& box, int ncomp) noexcept
             : ArrayND(a_p, box.smallEnd(), box.bigEnd() + 1, ncomp)
         {}
 
@@ -206,11 +207,11 @@ namespace amrex {
         {
             if constexpr (N > 1) {
                 Long current_stride = 1;
-                for (int d = 0; d < N - 1; ++d) {
+                constexpr_for<0, N-1>([&](int d) {
                     Long len = a_bigend[d] - a_smallend[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
-                }
+                });
             }
         }
 
@@ -220,22 +221,22 @@ namespace amrex {
         constexpr ArrayND (T* a_p, IntVectND<M> const& a_smallend, IntVectND<M> const& a_bigend) noexcept
             : p(a_p), begin(), end()
         {
-            for (int d = 0; d < M; ++d) {
+            constexpr_for<0, M>([&](int d) {
                 begin[d] = a_smallend[d];
                 end[d] = a_bigend[d];
-            }
-            for (int d = M; d < N; ++d) {
+            });
+            constexpr_for<M, N>([&](int d) {
                 begin[d] = 0;
                 end[d] = 1;
-            }
+            });
 
             if constexpr (N > 1) {
                 Long current_stride = 1;
-                for (int d = 0; d < N - 1; ++d) {
+                constexpr_for<0, N-1>([&](int d) {
                     Long len = end[d] - begin[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
-                }
+                });
             }
         }
 
@@ -245,24 +246,24 @@ namespace amrex {
         constexpr ArrayND (T* a_p, IntVectND<M> const& a_smallend, IntVectND<M> const& a_bigend, int ncomp) noexcept
             : p(a_p), begin(), end()
         {
-            for (int d = 0; d < M; ++d) {
+            constexpr_for<0, M>([&](int d) {
                 begin[d] = a_smallend[d];
                 end[d] = a_bigend[d];
-            }
-            for (int d = M; d < N-1; ++d) {
+            });
+            constexpr_for<M, N-1>([&](int d) {
                 begin[d] = 0;
                 end[d] = 1;
-            }
+            });
             begin[N-1] = 0;
             end[N-1] = ncomp;
 
             if constexpr (N > 1) {
                 Long current_stride = 1;
-                for (int d = 0; d < N - 1; ++d) {
+                constexpr_for<0, N-1>([&](int d) {
                     Long len = end[d] - begin[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
-                }
+                });
             }
         }
 
@@ -313,18 +314,18 @@ namespace amrex {
             return p[get_offset(IntVectND<nidx>{i...})];
         }
 
-        template <int Dim, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <int M, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (IntVectND<Dim> const& iv) const noexcept {
+        U& operator() (IntVectND<M> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv);
 #endif
             return p[get_offset(iv)];
         }
 
-        template <int Dim, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <int M, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (IntVectND<Dim> const& iv, int n) const noexcept {
+        U& operator() (IntVectND<M> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv, n);
 #endif
@@ -355,31 +356,31 @@ namespace amrex {
             return p + get_offset(IntVectND<nidx>{i...});
         }
 
-        template <int Dim>
+        template <int M>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (IntVectND<Dim> const& iv) const noexcept {
+        T* ptr (IntVectND<M> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv);
 #endif
             return p + get_offset(iv);
         }
 
-        template <int Dim>
+        template <int M>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (IntVectND<Dim> const& iv, int n) const noexcept {
+        T* ptr (IntVectND<M> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv, n);
 #endif
             return p + get_offset(iv, n);
         }
 
-        template <int Dim=N, std::enable_if_t<(Dim == 4),int> = 0>
+        template <int M=N, std::enable_if_t<(M == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (Dim3 const& cell) const noexcept {
             return this->ptr(cell.x,cell.y,cell.z);
         }
 
-        template <int Dim=N, std::enable_if_t<(Dim == 4),int> = 0>
+        template <int M=N, std::enable_if_t<(M == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (Dim3 const& cell, int n) const noexcept {
             return this->ptr(cell.x,cell.y,cell.z,n);
@@ -390,7 +391,7 @@ namespace amrex {
             return this->p;
         }
 
-        template <int Dim=N, std::enable_if_t<Dim==4,int> = 0>
+        template <int M=N, std::enable_if_t<M==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr int nComp () const noexcept {
             return end[3] - begin[3];
@@ -399,9 +400,9 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr std::size_t size () const noexcept {
             std::size_t s = 1;
-            for (int d = 0; d < N; ++d) {
+            constexpr_for<0, N>([&](int d) {
                 s *= (end[d] - begin[d]);
-            }
+            });
             return s;
         }
 
@@ -415,54 +416,54 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (IntVectND<N> const& iv) const noexcept {
             bool inside = true;
-            for (int d = 0; d < N; ++d) {
+            constexpr_for<0, N>([&](int d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
-            }
+            });
             return inside;
         }
 
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1),int> = 0>
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr bool contains (IntVectND<Dim> const& iv) const noexcept {
+        constexpr bool contains (IntVectND<M> const& iv) const noexcept {
             bool inside = true;
-            for (int d = 0; d < Dim; ++d) {
+            constexpr_for<0, M>([&](int d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
-            }
-            for (int d = Dim; d < N-1; ++d) {
+            });
+            constexpr_for<M, N-1>([&](int d) {
                 inside = inside && (0 >= begin[d]) && (0 < end[d]);
-            }
+            });
             // Check last dimension with begin[N-1] which is always true
             // inside = inside && (begin[N-1] >= begin[N-1]) && (begin[N-1] < end[N-1]);
             return inside;
         }
 
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1) && (N != 1),int> = 0>
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && (N != 1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr bool contains (IntVectND<Dim> const& iv, int n) const noexcept {
+        constexpr bool contains (IntVectND<M> const& iv, int n) const noexcept {
             bool inside = true;
-            for (int d = 0; d < Dim; ++d) {
+            constexpr_for<0, M>([&](int d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
-            }
-            for (int d = Dim; d < N-1; ++d) {
+            });
+            constexpr_for<M, N-1>([&](int d) {
                 inside = inside && (0 >= begin[d]) && (0 < end[d]);
-            }
+            });
             // Check last dimension with n
             inside = inside && (n >= begin[N-1]) && (n < end[N-1]);
             return inside;
         }
 
 
-        template <int Dim=N, std::enable_if_t<Dim==4,int> = 0>
+        template <int M=N, std::enable_if_t<M==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (Dim3 const& cell) const noexcept {
-            return this->contains(IntVectND<Dim>{cell.x, cell.y, cell.z, begin[Dim-1]});
+            return this->contains(IntVectND<M>{cell.x, cell.y, cell.z, begin[M-1]});
         }
 
-        template <int Dim=N, std::enable_if_t<Dim==4,int> = 0>
+        template <int M=N, std::enable_if_t<M==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         CellData<T> cellData (int i, int j, int k) const noexcept {
             int ncomp = end[3] - begin[3];
-            return CellData<T>(this->ptr(i,j,k), nstride[Dim-2], ncomp);
+            return CellData<T>(this->ptr(i,j,k), nstride[M-2], ncomp);
         }
 
         // Main get_offset function for N
@@ -470,41 +471,41 @@ namespace amrex {
         constexpr Long get_offset (IntVectND<N> const& iv) const noexcept
         {
             Long offset = iv[0] - begin[0];
-            for (int d = 1; d < N; ++d) {
+            constexpr_for<1, N>([&](int d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
-            }
+            });
             return offset;
         }
 
-        // get_offset overload for 1<= Dim <= N-1
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1),int> = 0>
+        // get_offset overload for 1<= M <= N-1
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr Long get_offset (IntVectND<Dim> const& iv) const noexcept
+        constexpr Long get_offset (IntVectND<M> const& iv) const noexcept
         {
             Long offset = iv[0] - begin[0];
-            for (int d = 1; d < Dim; ++d) {
+            constexpr_for<1, M>([&](int d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
-            }
-            for (int d = Dim; d < N-1; ++d) {
+            });
+            constexpr_for<M, N-1>([&](int d) {
                 offset += (Long(0) - begin[d]) * nstride[d-1];
-            }
-            // offset += (begin[dim-1] - begin[dim-1]) * nstride[dim-2];
+            });
+            // offset += (begin[M-1] - begin[M-1]) * nstride[M-2];
             return offset;
         }
 
-        // get_offset overload for 1<= Dim <= N-1, last index n
+        // get_offset overload for 1<= M <= N-1, last index n
         // Overload not valid for N=1
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1) && (N != 1),int> = 0>
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && (N != 1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr Long get_offset (IntVectND<Dim> const& iv, int n) const noexcept
+        constexpr Long get_offset (IntVectND<M> const& iv, int n) const noexcept
         {
             Long offset = iv[0] - begin[0];
-            for (int d = 1; d < Dim; ++d) {
+            constexpr_for<1, M>([&](int d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
-            }
-            for (int d = Dim; d < N-1; ++d) {
+            });
+            constexpr_for<M, N-1>([&](int d) {
                 offset += (Long(0) - begin[d]) * nstride[d-1];
-            }
+            });
             offset += (n - begin[N-1]) * nstride[N-2];
             return offset;
         }
@@ -546,21 +547,21 @@ namespace amrex {
             }
         }
 
-        // index_assert overload for Dim <= N-1
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1),int> = 0>
+        // index_assert overload for M <= N-1
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
         AMREX_GPU_HOST_DEVICE inline
-        void index_assert (IntVectND<Dim> const& iv) const
+        void index_assert (IntVectND<M> const& iv) const
         {
             IntVectND<N> iv_full = iv.template expand<N>(0);
             iv_full[N-1] = begin[N-1];
             index_assert(iv_full);
         }
 
-        // index_assert overload for Dim <= N-1, last index n
+        // index_assert overload for M <= N-1, last index n
         // Overload not valid for N=1
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1) && (N != 1),int> = 0>
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && (N != 1),int> = 0>
         AMREX_GPU_HOST_DEVICE inline
-        void index_assert (IntVectND<Dim> const& iv, int n) const
+        void index_assert (IntVectND<M> const& iv, int n) const
         {
             IntVectND<N> iv_full = iv.template expand<N>(0);
             iv_full[N-1] = n;
@@ -571,13 +572,13 @@ namespace amrex {
 
     // Deduction guides for ArrayND
     // 1: Matches ArrayND (T*, BoxND<N>) -> ArrayND<T,N>
-    template <typename T, int Dim>
-    ArrayND (T*, BoxND<Dim> const&) -> ArrayND<T, Dim>;
+    template <typename T, int N>
+    ArrayND (T*, BoxND<N> const&) -> ArrayND<T, N>;
 
     // 2: Matches ArrayND (T*, BoxND<N>, ncomp) -> ArrayND<T,N+1>
     // This supports the "N+1" logic (Spatial + Component)
-    template <typename T, int Dim>
-    ArrayND (T*, BoxND<Dim> const&, int) -> ArrayND<T, Dim+1>;
+    template <typename T, int N>
+    ArrayND (T*, BoxND<N> const&, int) -> ArrayND<T, N+1>;
 
     // 3: Matches ArrayND (T*, IntVectND<N>, IntVectND<N>) -> ArrayND<T,N>
     template <typename T, int N>

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -594,11 +594,15 @@ namespace amrex {
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr std::size_t size () const noexcept {
-            std::size_t s = 1;
-            constexpr_for<0, N>([&](int d) {
-                s *= (end[d] - begin[d]);
-            });
-            return s;
+            if (ok()) {
+                std::size_t s = 1;
+                constexpr_for<0, N>([&](int d) {
+                    s *= (end[d] - begin[d]);
+                });
+                return s;
+            } else {
+                return 0;
+            }
         }
 
         template <typename... idx, std::enable_if_t<

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -62,21 +62,39 @@ namespace amrex {
     };
 
     namespace detail {
-        /**
-         * /brief Indices checker for ArrayND
-         *
-         * 1. All indices are int
-         * 2. Number of indices matches dimension or is one less than dimension
-         */
         template <int N, typename... idx>
-        struct ArrayNDIndexCheck_impl {
-            constexpr static bool value =
-                (sizeof...(idx) == N || sizeof...(idx) == N - 1)
-                && (Conjunction<std::is_same<int, std::decay_t<idx>>...>::value);
+        struct ValidIndiciesForArrayNDImpl {
+        private:
+            static constexpr int num_indicies = sizeof...(idx);
+
+            template <typename... Ts>
+            struct AllExceptLastEnum;
+
+            template <typename first, typename... Ts>
+            struct AllExceptLastEnum<first, Ts...> {
+                static constexpr bool value =
+                    IsValidIndexType<std::decay_t<first>>::value
+                    && AllExceptLastEnum<Ts...>::value;
+            };
+
+            template <typename last>
+            struct AllExceptLastEnum<last> {
+                static constexpr bool value = IsValidIndexType<std::decay_t<last>>::value
+                        || (std::is_enum_v<std::decay_t<last>>);
+            };
+
+            static constexpr bool index_with_enum = AllExceptLastEnum<idx...>::value;
+
+            static constexpr bool index_all_values = Conjunction<
+                IsValidIndexType<std::decay_t<idx>>...>::value;
+
+        public:
+            static constexpr bool value = ((num_indicies == N) && index_with_enum) ||
+                                          ((num_indicies == N - 1) && index_all_values);
         };
 
         template <int N, class... idx>
-        inline constexpr bool ArrayNDIndexCheck_impl_v = ArrayNDIndexCheck_impl<N, idx...>::value;
+        inline constexpr bool ArrayNDIndexCheck_impl_v = ValidIndiciesForArrayNDImpl<N, idx...>::value;
 
         template<std::size_t... idx>
         constexpr auto make_oob_message_impl (std::index_sequence<idx...>) {
@@ -139,16 +157,15 @@ namespace amrex {
             );
         }
 
-        template <std::size_t... idx, std::enable_if_t<sizeof...(idx)>=1,int> = 0>
+        template <int N, std::enable_if_t<(N>=1),int> = 0>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void device_printf_impl (std::index_sequence<idx...>,
-                                const IntVectND<sizeof...(idx)>& iv,
-                                const IntVectND<sizeof...(idx)>& begin,
-                                const IntVectND<sizeof...(idx)>& end)
+        void device_printf_impl (const IntVectND<N>& iv,
+                                const IntVectND<N>& begin,
+                                const IntVectND<N>& end)
         {
             device_print_impl2(
-                std::index_sequence<idx...>{},
-                std::make_index_sequence<sizeof...(idx)*2>{},
+                std::make_index_sequence<N>{},
+                std::make_index_sequence<N*2>{},
                 iv, begin, end
             );
         }
@@ -278,8 +295,8 @@ namespace amrex {
               begin(rhs.begin),
               end(rhs.end)
         {
-            begin[3] = 0;
-            end[3] = rhs.end[3] - start_comp;
+            begin[N-1] = 0;
+            end[N-1] = rhs.end[N-1] - start_comp;
         }
 
         template <class U,
@@ -293,8 +310,8 @@ namespace amrex {
               begin(rhs.begin),
               end(rhs.end)
         {
-            begin[3] = 0;
-            end[3] = num_comp;
+            begin[N-1] = 0;
+            end[N-1] = num_comp;
         }
 
         AMREX_GPU_HOST_DEVICE
@@ -391,10 +408,11 @@ namespace amrex {
             return this->p;
         }
 
+        // Overload for nComp only when N=4. Here, last dimension is number of components
         template <int M=N, std::enable_if_t<M==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr int nComp () const noexcept {
-            return end[3] - begin[3];
+            return end[N-1] - begin[N-1];
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -429,11 +447,6 @@ namespace amrex {
             constexpr_for<0, M>([&](int d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
             });
-            constexpr_for<M, N-1>([&](int d) {
-                inside = inside && (0 >= begin[d]) && (0 < end[d]);
-            });
-            // Check last dimension with begin[N-1] which is always true
-            // inside = inside && (begin[N-1] >= begin[N-1]) && (begin[N-1] < end[N-1]);
             return inside;
         }
 
@@ -444,10 +457,6 @@ namespace amrex {
             constexpr_for<0, M>([&](int d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
             });
-            constexpr_for<M, N-1>([&](int d) {
-                inside = inside && (0 >= begin[d]) && (0 < end[d]);
-            });
-            // Check last dimension with n
             inside = inside && (n >= begin[N-1]) && (n < end[N-1]);
             return inside;
         }
@@ -486,9 +495,9 @@ namespace amrex {
             constexpr_for<1, M>([&](int d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
             });
-            constexpr_for<M, N-1>([&](int d) {
-                offset += (Long(0) - begin[d]) * nstride[d-1];
-            });
+            // constexpr_for<M, N-1>([&](int d) {
+            //     offset += (begin[d] - begin[d]) * nstride[d-1];
+            // });
             // offset += (begin[M-1] - begin[M-1]) * nstride[M-2];
             return offset;
         }
@@ -526,7 +535,7 @@ namespace amrex {
             }
             if (out_of_bounds) {
                 AMREX_IF_ON_DEVICE((
-                    device_printf_impl(std::make_index_sequence<N>{}, iv, begin, end);
+                    detail::device_printf_impl(iv, begin, end);
                     amrex::Abort();
                 ))
                 AMREX_IF_ON_HOST((
@@ -553,7 +562,9 @@ namespace amrex {
         void index_assert (IntVectND<M> const& iv) const
         {
             IntVectND<N> iv_full = iv.template expand<N>(0);
-            iv_full[N-1] = begin[N-1];
+            for (int d = M; d < N; ++d) {
+                iv_full[d] = begin[d];
+            }
             index_assert(iv_full);
         }
 
@@ -564,6 +575,9 @@ namespace amrex {
         void index_assert (IntVectND<M> const& iv, int n) const
         {
             IntVectND<N> iv_full = iv.template expand<N>(0);
+            for (int d = M; d < N-1; ++d) {
+                iv_full[d] = begin[d];
+            }
             iv_full[N-1] = n;
             index_assert(iv_full);
         }

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -108,9 +108,9 @@ namespace amrex {
                 IsValidIndexType<std::decay_t<idx>>...>::value;
 
         public:
-            static constexpr bool value = ((num_indices == N) && index_all_values)      // N indicies are integer types
-                                || ((num_indices == N - 1) && index_all_values && last_dim_component) // N-1 indicies are integer types, last is component
-                                || ((num_indices == N) && index_with_maybe_enum && last_dim_component); // N indicies, last dim is component and can be enum
+            static constexpr bool value = ((num_indices == N) && index_all_values)      // N indices are integer types
+                                || ((num_indices == N - 1) && index_all_values && last_dim_component) // N-1 indices are integer types, last is component
+                                || ((num_indices == N) && index_with_maybe_enum && last_dim_component); // N indices, last dim is component and can be enum
         };
 
         template <int N, bool last_dim_component, class... idx>

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -144,7 +144,7 @@ namespace amrex {
         static_assert(dim >= 1, "ArrayND must have at least one dimension");
 
         T* AMREX_RESTRICT p;
-        GpuArray<Long, dim-1> nstride = {0}; // GpuArray safeguards against zero-size array
+        std::array<Long, dim-1> nstride{};
         IntVectND<dim> begin{1};
         IntVectND<dim> end{0}; // end is hi+1
 
@@ -186,7 +186,7 @@ namespace amrex {
         template <class U,
             std::enable_if_t
                   <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>> && dim == 4,int> = 0>
+                                std::remove_const_t<U>> && (dim == 4),int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (ArrayND<U, dim> const& rhs, int start_comp) noexcept
             : p((T*)(rhs.p + start_comp*rhs.nstride[dim-2])),
@@ -244,8 +244,7 @@ namespace amrex {
             return p[get_offset_iv(iv)];
         }
 
-        template <class U=T, int Dim=dim,
-            std::enable_if_t<!std::is_void_v<U> && (Dim==4),int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim==4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVect const& iv) const noexcept {
 #if (AMREX_SPACEDIM == 1)
@@ -257,8 +256,7 @@ namespace amrex {
 #endif
         }
 
-        template <class U=T, int Dim=dim,
-            std::enable_if_t<!std::is_void_v<U> && (Dim==4),int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim==4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVect const& iv, int n) const noexcept {
 #if (AMREX_SPACEDIM == 1)
@@ -271,8 +269,7 @@ namespace amrex {
         }
 
         // Explicit overload for dim=4
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0,
-                    std::enable_if_t<dim==4,int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (int i, int j, int k) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -281,8 +278,7 @@ namespace amrex {
             return p[get_offset(i,j,k,0)];
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0,
-                    std::enable_if_t<dim==4,int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (int i, int j, int k, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -310,23 +306,19 @@ namespace amrex {
             }
         }
 
-        template <class U=T, int Dim=dim, std::enable_if_t<!std::is_void_v<U>,int> = 0,
-                    std::enable_if_t<dim==4,int> = 0>
+        template <typename... idx, class U=T,
+            std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (IntVect const& iv) const noexcept {
-#if (AMREX_SPACEDIM == 1)
-            return this->ptr(iv[0],0,0,0);
-#elif (AMREX_SPACEDIM == 2)
-            return this->ptr(iv[0],iv[1],0,0);
-#elif (AMREX_SPACEDIM == 3)
-            return this->ptr(iv[0],iv[1],iv[2],0);
+        T* ptr (IntVectND<dim> const& iv) const noexcept {
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+            index_assert(iv);
 #endif
+            return p + get_offset_iv(iv);
         }
 
-        template <class U=T, int Dim=dim, std::enable_if_t<!std::is_void_v<U>,int> = 0,
-                    std::enable_if_t<dim==4,int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (IntVect const& iv, int n) const noexcept {
+        T* ptr (IntVect const& iv, int n = 0) const noexcept {
 #if (AMREX_SPACEDIM == 1)
             return this->ptr(iv[0],0,0,n);
 #elif (AMREX_SPACEDIM == 2)
@@ -336,15 +328,13 @@ namespace amrex {
 #endif
         }
 
-        template <class U=T, int Dim=dim,
-            std::enable_if_t<!std::is_void_v<U> && (Dim==4),int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z,0);
         }
 
-        template <class U=T, int Dim=dim,
-            std::enable_if_t<!std::is_void_v<U> && (Dim==4),int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell, int n) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z,n);
@@ -357,12 +347,12 @@ namespace amrex {
 
         template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        int nComp () const noexcept {
+        constexpr int nComp () const noexcept {
             return end[3] - begin[3];
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        std::size_t size () const noexcept {
+        constexpr std::size_t size () const noexcept {
             std::size_t s = 1;
             constexpr_for<0, dim>([&] (auto d) {
                 s *= (end[d] - begin[d]);
@@ -417,7 +407,7 @@ namespace amrex {
 
         template <typename... idx, std::enable_if_t<sizeof...(idx) == dim,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        Long get_offset (idx... indices) const noexcept
+        constexpr Long get_offset (idx... indices) const noexcept
         {
             Long offset = detail::get_impl<0>(indices...) - begin[0];
             constexpr_for<1, dim>([&] (auto i) {
@@ -427,7 +417,7 @@ namespace amrex {
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        Long get_offset_iv (IntVectND<dim> const& iv) const noexcept
+        constexpr Long get_offset_iv (IntVectND<dim> const& iv) const noexcept
         {
             Long offset = iv[0] - begin[0];
             constexpr_for<1, dim>([&] (auto d) {

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -62,8 +62,14 @@ namespace amrex {
     };
 
     namespace detail {
+        /**
+         * \brief Helper struct to check if index types are valid.
+         *
+         * Valid index types are integral types that can be safely converted to int
+         * without narrowing. The last index type can also be an enum.
+         */
         template <int N, typename... idx>
-        struct ValidIndiciesForArrayNDImpl {
+        struct ArrayNDIndexCheck_impl {
         private:
             static constexpr int num_indicies = sizeof...(idx);
 
@@ -94,7 +100,7 @@ namespace amrex {
         };
 
         template <int N, class... idx>
-        inline constexpr bool ArrayNDIndexCheck_impl_v = ValidIndiciesForArrayNDImpl<N, idx...>::value;
+        inline constexpr bool ArrayNDIndexCheck_impl_v = ArrayNDIndexCheck_impl<N, idx...>::value;
 
         template<std::size_t... idx>
         constexpr auto make_oob_message_impl (std::index_sequence<idx...>) {
@@ -171,6 +177,19 @@ namespace amrex {
         }
     }
 
+    /**
+     * \brief A multidimensional array accessor.
+     * \tparam T The type of data (e.g., Real, int).
+     * \tparam N The dimension of the array (rank).
+     *
+     * ArrayND is a lightweight, non-owning wrapper around a pointer that provides
+     * multidimensional indexing into a contiguous memory block. It is trivially
+     * copyable and designed to be passed by value into GPU kernels. Note, ArrayND
+     * follows fortran-style column-major ordering.
+     *
+     * It stores the pointer, stride information, and the bounds (begin and end)
+     * of the array.
+     */
     template<typename T, int N>
     struct ArrayND
     {
@@ -189,7 +208,15 @@ namespace amrex {
         constexpr ArrayND (ArrayND<std::remove_const_t<T>, N> const& rhs) noexcept
             : p(rhs.p), nstride(rhs.nstride), begin(rhs.begin), end(rhs.end) {}
 
-        // Dim3 overload for dim=4
+        /**
+         * \brief Constructor for N=4 using Dim3.
+         * \param a_p Pointer to data.
+         * \param a_begin Start index.
+         * \param a_end End index exclusive.
+         * \param a_ncomp Number of components (4th dimension).
+         *
+         * Typically used for standard (i, j, k, n) access in 3D simulations.
+         */
         template <int M=N, std::enable_if_t<M==4,int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
@@ -203,7 +230,13 @@ namespace amrex {
             });
         }
 
-        // Note: BoxND constructors are not constexpr because functions in BoxND are not constexpr
+        /**
+         * \brief Constructor using a BoxND.
+         * \param a_p Pointer to data.
+         * \param box The domain covered by this array.
+         *
+         * \TODO: Make BoxND functions constexpr to allow this constructor to be constexpr.
+         */
         template <int M>
         AMREX_GPU_HOST_DEVICE
         ArrayND (T* a_p, BoxND<M> const& box) noexcept
@@ -217,7 +250,14 @@ namespace amrex {
         {}
 
 
-        // Standard constructor for full dimension N
+        /**
+         * \brief IntVectND<N> constructor.
+         * \param a_p Pointer to data.
+         * \param a_smallend Start index (inclusive).
+         * \param a_bigend End index (exclusive).
+         *
+         * This constructor specifies begin and end indices using IntVectND<N> for all N dimensions.
+         */
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, IntVectND<N> const& a_smallend, IntVectND<N> const& a_bigend) noexcept
             : p(a_p), begin(a_smallend), end(a_bigend)
@@ -232,7 +272,14 @@ namespace amrex {
             }
         }
 
-        // Reduced dimension constructor: Pads remaining dims with [0,1)
+        /**
+         * \brief IntVectND<M> constructor for M < N.
+         * \param a_p Pointer to data.
+         * \param a_smallend Start index (inclusive).
+         * \param a_bigend End index (exclusive).
+         *
+         * For dimensions not specified are padded with [0,1).
+         */
         template <int M, std::enable_if_t<(M < N),int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, IntVectND<M> const& a_smallend, IntVectND<M> const& a_bigend) noexcept
@@ -257,7 +304,15 @@ namespace amrex {
             }
         }
 
-        // Reduced dimension constructor with ncomp: Pads intermediate dims with [0,1), sets last dim to [0,ncomp)
+        /**
+         * \brief Reduced dimension constructor with component count.
+         * \param a_p Pointer to data.
+         * \param a_smallend Start index (inclusive).
+         * \param a_bigend End index (exclusive).
+         * \param ncomp Number of components (size of last dimension).
+         *
+         * Pads intermediate dimensions with [0,1) and sets the last dimension to [0, ncomp).
+         */
         template <int M, std::enable_if_t<(M < N) && (N != 1),int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, IntVectND<M> const& a_smallend, IntVectND<M> const& a_bigend, int ncomp) noexcept
@@ -284,6 +339,13 @@ namespace amrex {
             }
         }
 
+        /**
+         * \brief Slicing constructor (Component subset).
+         * \param rhs The source ArrayND to slice from.
+         * \param start_comp The starting component index for the slice.
+         *
+         * Creates a new ArrayND that is a slice of the input ArrayND along the last dimension (components).
+         */
         template <class U,
             std::enable_if_t
                   <std::is_same_v<std::remove_const_t<T>,
@@ -299,6 +361,14 @@ namespace amrex {
             end[N-1] = rhs.end[N-1] - start_comp;
         }
 
+        /**
+         * \brief Slicing constructor (Component subset with count).
+         * \param rhs The source ArrayND to slice from.
+         * \param start_comp The starting component index for the slice.
+         * \param num_comp The number of components to include in the slice.
+         *
+         * Creates a new ArrayND that is a slice of the input ArrayND along the last dimension (components).
+         */
         template <class U,
             std::enable_if_t
                   <std::is_same_v<std::remove_const_t<T>,
@@ -314,12 +384,26 @@ namespace amrex {
             end[N-1] = num_comp;
         }
 
+
+        /**
+         * \brief Check if the ArrayND is properly initialized.
+         * \return True if initialized properly.
+         */
         AMREX_GPU_HOST_DEVICE
         explicit operator bool() const noexcept {
             return p != nullptr && end.allGT(begin);    // Additional check for properly initialized ArrayND
         }
 
-        // This overload is enabled only when number of indices matches dimension or is one less than dimension
+        /**
+         * \brief Multi-index operator() for accessing elements.
+         * \param i... Indices for each dimension.
+         * \return Reference to the element.
+         *
+         * This operator is only enabled when the number of indices provided matches the dimension N or N-1
+         * where in the latter case the last dimension is assumed to be 0. The passed indices must be of
+         * integral types that can be converted to int without narrowing. The last index can also be an enum type.
+         * \TODO: Use concepts when we move to C++20. The error message now is not user friendly.
+         */
         template <typename... idx, class U=T,
             std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<N, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -331,6 +415,12 @@ namespace amrex {
             return p[get_offset(IntVectND<nidx>{i...})];
         }
 
+        /**
+         * \brief Access element by IntVectND<M>.
+         * \param iv IntVectND<M> (1 <= M <= N).
+         * \return Reference to the element.
+         * When M < N, the missing indices are set to begin values.
+         */
         template <int M, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVectND<M> const& iv) const noexcept {
@@ -340,6 +430,15 @@ namespace amrex {
             return p[get_offset(iv)];
         }
 
+        /**
+         * \brief Access element by IntVectND<M> and component index.
+         * \param iv IntVectND<M> (1 <= M <= N-1).
+         * \param n Component index (last dimension).
+         * \return Reference to the element.
+         *
+         * The missing indices are set to begin values except the last dimension which is set to n.
+         * This overload is not valid for N=1.
+         */
         template <int M, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVectND<M> const& iv, int n) const noexcept {
@@ -349,19 +448,34 @@ namespace amrex {
             return p[get_offset(iv, n)];
         }
 
+        /**
+         * \brief Access element by Dim3 (only when N=4).
+         * \param cell Dim3
+         * \return Reference to the element.
+         */
         template <class U=T, std::enable_if_t<!std::is_void_v<U> && (N == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z);
         }
 
+        /**
+         * \brief Access element by Dim3 and component index (only when N=4).
+         * \param cell Dim3
+         * \param n Component index (last dimension).
+         * \return Reference to the element.
+         */
         template <class U=T, std::enable_if_t<!std::is_void_v<U> && (N == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell, int n) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z,n);
         }
 
-        // This overload is enabled only when number of indices matches dimension or is one less than dimension
+        /**
+         * \brief Multi-index ptr() for accessing pointer to element.
+         * \param i... Indices for each dimension.
+         * \return Pointer to the element.
+         */
         template <typename... idx, class U=T,
             std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<N, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -373,6 +487,13 @@ namespace amrex {
             return p + get_offset(IntVectND<nidx>{i...});
         }
 
+        /**
+         * \brief Access pointer by IntVectND<M>.
+         * \param iv IntVectND<M> (1 <= M <= N).
+         * \return Pointer to the element.
+         *
+         * When M < N, the missing indices are set to begin values.
+         */
         template <int M>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<M> const& iv) const noexcept {
@@ -382,6 +503,15 @@ namespace amrex {
             return p + get_offset(iv);
         }
 
+        /**
+         * \brief Access pointer by IntVectND<M> and component index.
+         * \param iv IntVectND<M> (1 <= M <= N-1).
+         * \param n Component index (last dimension).
+         * \return Pointer to the element.
+         *
+         * The missing indices are set to begin values except the last dimension which is set to n.
+         * This overload is not valid for N=1.
+         */
         template <int M>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<M> const& iv, int n) const noexcept {
@@ -391,24 +521,45 @@ namespace amrex {
             return p + get_offset(iv, n);
         }
 
+        /**
+         * \brief Access pointer by Dim3 (only when N=4).
+         * \param cell Dim3
+         * \return Pointer to the element.
+         */
         template <int M=N, std::enable_if_t<(M == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (Dim3 const& cell) const noexcept {
             return this->ptr(cell.x,cell.y,cell.z);
         }
 
+        /**
+         * \brief Access pointer by Dim3 and component index (only when N=4).
+         * \param cell Dim3
+         * \param n Component index (last dimension).
+         * \return Pointer to the element.
+         */
         template <int M=N, std::enable_if_t<(M == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (Dim3 const& cell, int n) const noexcept {
             return this->ptr(cell.x,cell.y,cell.z,n);
         }
 
+        /**
+         * \brief Get raw data pointer.
+         * \return Raw data pointer.
+         */
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr T* dataPtr () const noexcept {
             return this->p;
         }
 
-        // Overload for nComp only when N=4. Here, last dimension is number of components
+        /**
+         * \brief Get number of components (only when N=4).
+         * \return Number of components.
+         *
+         * For N!=4 case, the user is expected to keep track if they are using the last dimension
+         * as components.
+         */
         template <int M=N, std::enable_if_t<M==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr int nComp () const noexcept {
@@ -487,6 +638,7 @@ namespace amrex {
         }
 
         // get_offset overload for 1<= M <= N-1
+        // When M < N, the missing indices are set to begin values.
         template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr Long get_offset (IntVectND<M> const& iv) const noexcept
@@ -495,14 +647,11 @@ namespace amrex {
             constexpr_for<1, M>([&](int d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
             });
-            // constexpr_for<M, N-1>([&](int d) {
-            //     offset += (begin[d] - begin[d]) * nstride[d-1];
-            // });
-            // offset += (begin[M-1] - begin[M-1]) * nstride[M-2];
             return offset;
         }
 
         // get_offset overload for 1<= M <= N-1, last index n
+        // Here the missing indices are set to begin values except the last dimension which is set to n.
         // Overload not valid for N=1
         template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && (N != 1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -5,6 +5,7 @@
 #include <AMReX.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_GpuPrint.H>
+#include <AMReX_ConstexprFor.H>
 
 #include <iostream>
 #include <sstream>
@@ -56,182 +57,298 @@ namespace amrex {
         }
     };
 
-    template <typename T>
-    struct Array4
+    namespace detail {
+        // Helper to get N-th argument from a parameter pack
+        template <int idx, typename... Ts>
+        inline constexpr auto get_impl (Ts&&... ts) {                    // NOLINT (cppcoreguidelines-missing-std-forward)
+            return std::get<idx>(std::forward_as_tuple(ts...));
+        }
+
+        /**
+         * /brief Indices checker for ArrayND
+         *
+         * 1. All indices are int
+         * 2. Number of indices matches dimension or is one less than dimension
+         */
+        template <int dim, typename... idx>
+        struct ArrayNDIndexCheck_impl {
+            constexpr static bool value =
+                (sizeof...(idx) == dim || sizeof...(idx) == dim - 1)
+                && (Conjunction<std::is_same<int, std::decay_t<idx>>...>::value);
+        };
+
+        template <int dim, class... idx>
+        inline constexpr bool ArrayNDIndexCheck_impl_v = ArrayNDIndexCheck_impl<dim, idx...>::value;
+
+        template<std::size_t... idx>
+        constexpr auto make_oob_message_impl (std::index_sequence<idx...>&&) {
+            constexpr std::size_t Dim = sizeof...(idx);
+            constexpr char prefix[] = " (";
+            constexpr char middle[] = ") is out of bound (";
+            constexpr char suffix[] = ")\n";
+
+            constexpr std::size_t size =
+                sizeof(prefix) - 1 +
+                (2*Dim + (Dim-1)) +
+                sizeof(middle) - 1 +
+                (5*Dim + (Dim-1)) +
+                sizeof(suffix); // include null terminator
+
+            std::array<char, size> buf{};
+
+            std::size_t pos = 0;
+
+            // prefix
+            for (char c : prefix) {
+                if (c != '\0') {
+                    buf[pos++] = c;
+                }
+            }
+            // %d,%d,...
+            ((buf[pos++] = '%', buf[pos++] = 'd', idx + 1 < Dim ? buf[pos++] = ',' : 0), ...);
+
+            // ") is out of bound ("
+            for (char c : middle) {
+                if (c != '\0') {
+                    buf[pos++] = c;
+                }
+            }
+
+            // %d:%d,%d:%d,...
+            ((buf[pos++] = '%', buf[pos++] = 'd', buf[pos++] = ':', buf[pos++] = '%', buf[pos++] = 'd',
+                idx + 1 < Dim ? buf[pos++] = ',' : 0), ...);
+
+            // suffix
+            for (char c : suffix) {
+                buf[pos++] = c;
+            }
+            return buf;
+        }
+
+        template <std::size_t... idx, std::enable_if_t<sizeof...(idx)>=1,int> = 0>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void device_printf_impl (std::index_sequence<idx...>&& index_seq,
+                                   const IntVectND<sizeof...(idx)>& iv,
+                                   const IntVectND<sizeof...(idx)>& begin,
+                                   const IntVectND<sizeof...(idx)>& end) {
+            constexpr auto msg = make_oob_message_impl(std::move(index_seq));
+            AMREX_DEVICE_PRINTF(msg.data(),
+                iv[idx]...,
+                ((begin[idx]), (end[idx]))...);
+        }
+    }
+
+    template<typename T, int dim>
+    struct ArrayND
     {
+        static_assert(dim >= 1, "ArrayND must have at least one dimension");
+
         T* AMREX_RESTRICT p;
-        Long jstride = 0;
-        Long kstride = 0;
-        Long nstride = 0;
-        Dim3 begin{1,1,1};
-        Dim3 end{0,0,0};  // end is hi + 1
-        int  ncomp=0;
+        GpuArray<Long, dim-1> nstride = {0}; // GpuArray safeguards against zero-size array
+        IntVectND<dim> begin{1};
+        IntVectND<dim> end{0}; // end is hi+1
 
         AMREX_GPU_HOST_DEVICE
-        constexpr Array4 () noexcept : p(nullptr) {}
+        constexpr ArrayND () noexcept : p(nullptr) {}
 
         template <class U=T, std::enable_if_t<std::is_const_v<U>,int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr Array4 (Array4<std::remove_const_t<T>> const& rhs) noexcept
-            : p(rhs.p),
-              jstride(rhs.jstride),
-              kstride(rhs.kstride),
-              nstride(rhs.nstride),
-              begin(rhs.begin),
-              end(rhs.end),
-              ncomp(rhs.ncomp)
-            {}
+        constexpr ArrayND (ArrayND<std::remove_const_t<T>, dim> const& rhs) noexcept
+            : p(rhs.p), nstride(rhs.nstride), begin(rhs.begin), end(rhs.end) {}
 
         AMREX_GPU_HOST_DEVICE
-        constexpr Array4 (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
-            : p(a_p),
-              jstride(a_end.x-a_begin.x),
-              kstride(jstride*(a_end.y-a_begin.y)),
-              nstride(kstride*(a_end.z-a_begin.z)),
-              begin(a_begin),
-              end(a_end),
-              ncomp(a_ncomp)
-            {}
+        constexpr ArrayND (T* a_p, IntVectND<dim> const& a_begin, IntVectND<dim> const& a_end) noexcept
+            : p(a_p), begin(a_begin), end(a_end)
+        {
+            if constexpr (dim > 1) {
+                Long current_stride = 1;
+                constexpr_for<0, dim - 1>([&] (int d) {
+                    Long len = a_end[d] - a_begin[d];
+                    current_stride *= len;
+                    nstride[d] = current_stride;
+                });
+            }
+        }
 
-        template <class U,
-                  std::enable_if_t
-                  <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>>,int> = 0>
-        AMREX_GPU_HOST_DEVICE
-        constexpr Array4 (Array4<U> const& rhs, int start_comp) noexcept
-            : p((T*)(rhs.p+start_comp*rhs.nstride)),
-              jstride(rhs.jstride),
-              kstride(rhs.kstride),
-              nstride(rhs.nstride),
-              begin(rhs.begin),
-              end(rhs.end),
-              ncomp(rhs.ncomp-start_comp)
-        {}
+        // Dim3 overload for dim=4
+        template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
+        constexpr ArrayND (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
+            : p(a_p), begin(a_begin.x, a_begin.y, a_begin.z, 0), end(a_end.x, a_end.y, a_end.z, a_ncomp)
+        {
+            Long current_stride = 1;
+            constexpr_for<0, dim-1>([&] (int d) {
+                Long len = end[d] - begin[d];
+                current_stride *= len;
+                nstride[d] = current_stride;
+            });
+        }
 
         template <class U,
-                  std::enable_if_t
+            std::enable_if_t
                   <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>>,int> = 0>
+                                std::remove_const_t<U>> && dim == 4,int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr Array4 (Array4<U> const& rhs, int start_comp, int num_comps) noexcept
-            : p((T*)(rhs.p+start_comp*rhs.nstride)),
-              jstride(rhs.jstride),
-              kstride(rhs.kstride),
+        constexpr ArrayND (ArrayND<U, dim> const& rhs, int start_comp) noexcept
+            : p((T*)(rhs.p + start_comp*rhs.nstride[dim-2])),
               nstride(rhs.nstride),
               begin(rhs.begin),
-              end(rhs.end),
-              ncomp(num_comps)
-        {}
+              end(rhs.end)
+        {
+            begin[3] = 0;
+            end[3] = rhs.end[3] - start_comp;
+        }
+
+        template <class U,
+            std::enable_if_t
+                  <std::is_same_v<std::remove_const_t<T>,
+                                std::remove_const_t<U>>,int> = 0,
+            std::enable_if_t<dim == 4,int> = 0>
+        AMREX_GPU_HOST_DEVICE
+        constexpr ArrayND (ArrayND<U, dim> const& rhs, int start_comp, int num_comp) noexcept
+            : p((T*)(rhs.p + start_comp*rhs.nstride[dim-2])),
+              nstride(rhs.nstride),
+              begin(rhs.begin),
+              end(rhs.end)
+        {
+            begin[3] = 0;
+            end[3] = num_comp;
+        }
 
         AMREX_GPU_HOST_DEVICE
         explicit operator bool() const noexcept { return p != nullptr; }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <typename... idx, class U=T,
+            std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<dim, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (int i, int j, int k) const noexcept {
+        U& operator() (idx... i) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(i,j,k,0);
+            if constexpr (sizeof...(i) == dim) {
+                index_assert(i...);
+            } else if constexpr (sizeof...(i) == dim - 1) {
+                // When number of indices is one less than dimension, we assume the last index is zero
+                index_assert(i...,0);
+            }
 #endif
-            return p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride];
+            if constexpr (sizeof...(i) == dim) {
+                return p[get_offset(i...)];
+            } else {
+                return p[get_offset(i...,0)];
+            }
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (int i, int j, int k, int n) const noexcept {
+        U& operator() (IntVectND<dim> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(i,j,k,n);
+            index_assert(iv);
 #endif
-            return p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride];
+            return p[get_offset_iv(iv)];
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (int i, int j, int k) const noexcept {
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(i,j,k,0);
-#endif
-            return p + ((i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride);
-        }
-
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (int i, int j, int k, int n) const noexcept {
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(i,j,k,n);
-#endif
-            return p + ((i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride);
-        }
-
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <class U=T, int Dim=dim,
+            std::enable_if_t<!std::is_void_v<U> && (Dim==4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVect const& iv) const noexcept {
 #if (AMREX_SPACEDIM == 1)
-            return this->operator()(iv[0],0,0);
+            return this->operator()(iv[0],0,0,0);
 #elif (AMREX_SPACEDIM == 2)
-            return this->operator()(iv[0],iv[1],0);
-#else
-            return this->operator()(iv[0],iv[1],iv[2]);
+            return this->operator()(iv[0],iv[1],0,0);
+#elif (AMREX_SPACEDIM == 3)
+            return this->operator()(iv[0],iv[1],iv[2],0);
 #endif
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <class U=T, int Dim=dim,
+            std::enable_if_t<!std::is_void_v<U> && (Dim==4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVect const& iv, int n) const noexcept {
 #if (AMREX_SPACEDIM == 1)
             return this->operator()(iv[0],0,0,n);
 #elif (AMREX_SPACEDIM == 2)
             return this->operator()(iv[0],iv[1],0,n);
-#else
+#elif (AMREX_SPACEDIM == 3)
             return this->operator()(iv[0],iv[1],iv[2],n);
 #endif
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        // Explicit overload for dim=4
+        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0,
+                    std::enable_if_t<dim==4,int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        U& operator() (int i, int j, int k) const noexcept {
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+            index_assert(i,j,k,0);
+#endif
+            return p[get_offset(i,j,k,0)];
+        }
+
+        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0,
+                    std::enable_if_t<dim==4,int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        U& operator() (int i, int j, int k, int n) const noexcept {
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+            index_assert(i,j,k,n);
+#endif
+            return p[get_offset(i,j,k,n)];
+        }
+
+        template <typename... idx, class U=T,
+            std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<dim, idx...>,int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T* ptr (idx... i) const noexcept {
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+            if constexpr (sizeof...(i) == dim) {
+                index_assert(i...);
+            } else if constexpr (sizeof...(i) == dim - 1) {
+                // When number of indices is one less than dimension, we assume the last index is zero
+                index_assert(i...,0);
+            }
+#endif
+            if constexpr (sizeof...(i) == dim) {
+                return p + get_offset(i...);
+            } else {
+                return p + get_offset(i...,0);
+            }
+        }
+
+        template <class U=T, int Dim=dim, std::enable_if_t<!std::is_void_v<U>,int> = 0,
+                    std::enable_if_t<dim==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVect const& iv) const noexcept {
 #if (AMREX_SPACEDIM == 1)
-            return this->ptr(iv[0],0,0);
+            return this->ptr(iv[0],0,0,0);
 #elif (AMREX_SPACEDIM == 2)
-            return this->ptr(iv[0],iv[1],0);
-#else
-            return this->ptr(iv[0],iv[1],iv[2]);
+            return this->ptr(iv[0],iv[1],0,0);
+#elif (AMREX_SPACEDIM == 3)
+            return this->ptr(iv[0],iv[1],iv[2],0);
 #endif
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <class U=T, int Dim=dim, std::enable_if_t<!std::is_void_v<U>,int> = 0,
+                    std::enable_if_t<dim==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVect const& iv, int n) const noexcept {
 #if (AMREX_SPACEDIM == 1)
             return this->ptr(iv[0],0,0,n);
 #elif (AMREX_SPACEDIM == 2)
             return this->ptr(iv[0],iv[1],0,n);
-#else
+#elif (AMREX_SPACEDIM == 3)
             return this->ptr(iv[0],iv[1],iv[2],n);
 #endif
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <class U=T, int Dim=dim,
+            std::enable_if_t<!std::is_void_v<U> && (Dim==4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell) const noexcept {
-            return this->operator()(cell.x,cell.y,cell.z);
+            return this->operator()(cell.x,cell.y,cell.z,0);
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <class U=T, int Dim=dim,
+            std::enable_if_t<!std::is_void_v<U> && (Dim==4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell, int n) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z,n);
-        }
-
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (Dim3 const& cell) const noexcept {
-            return this->ptr(cell.x,cell.y,cell.z);
-        }
-
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (Dim3 const& cell, int n) const noexcept {
-            return this->ptr(cell.x,cell.y,cell.z,n);
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -239,29 +356,85 @@ namespace amrex {
             return this->p;
         }
 
+        template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        std::size_t size () const noexcept {
-            return this->nstride * this->ncomp;
+        int nComp () const noexcept {
+            return end[3] - begin[3];
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        int nComp () const noexcept { return ncomp; }
+        std::size_t size () const noexcept {
+            std::size_t s = 1;
+            constexpr_for<0, dim>([&] (auto d) {
+                s *= (end[d] - begin[d]);
+            });
+            return s;
+        }
 
+        template <typename... idx, std::enable_if_t<detail::ArrayNDIndexCheck_impl_v<dim, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        bool contains (int i, int j, int k) const noexcept {
-            return (i>=begin.x && i<end.x && j>=begin.y && j<end.y && k>=begin.z && k<end.z);
+        bool contains (idx... i) const noexcept {
+            if constexpr (sizeof...(i) == dim) {
+                return this->contains(IntVectND<dim>{i...});
+            } else {
+                // When number of indices is one less than dimension, we assume the last index is zero
+                return this->contains(IntVectND<dim>{i...,0});
+            }
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         bool contains (IntVect const& iv) const noexcept {
-            return AMREX_D_TERM(   iv[0]>=begin.x && iv[0]<end.x,
-                                && iv[1]>=begin.y && iv[1]<end.y,
-                                && iv[2]>=begin.z && iv[2]<end.z);
+#if (AMREX_SPACEDIM == 1)
+            return this->contains(IntVectND<dim>{iv[0],0,0,0});
+#elif (AMREX_SPACEDIM == 2)
+            return this->contains(IntVectND<dim>{iv[0],iv[1],0,0});
+#elif (AMREX_SPACEDIM == 3)
+            return this->contains(IntVectND<dim>{iv[0],iv[1],iv[2],0});
+#endif
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        bool contains (IntVectND<dim> const& iv) const noexcept {
+            bool inside = true;
+            constexpr_for<0, dim>([&] (auto d) {
+                inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
+            });
+            return inside;
+        }
+
+        template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         bool contains (Dim3 const& cell) const noexcept {
-            return this->contains(cell.x,cell.y,cell.z);
+            return this->contains(IntVectND<dim>{cell.x, cell.y, cell.z, 0});
+        }
+
+        template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        CellData<T> cellData (int i, int j, int k) const noexcept {
+            int ncomp = end[3] - begin[3];
+            return CellData<T>(this->ptr(i,j,k), nstride[dim-2], ncomp);
+        }
+
+
+        template <typename... idx, std::enable_if_t<sizeof...(idx) == dim,int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        Long get_offset (idx... indices) const noexcept
+        {
+            Long offset = detail::get_impl<0>(indices...) - begin[0];
+            constexpr_for<1, dim>([&] (auto i) {
+                offset += (detail::get_impl<i>(indices...) - begin[i]) * nstride[i - 1];
+            });
+            return offset;
+        }
+
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        Long get_offset_iv (IntVectND<dim> const& iv) const noexcept
+        {
+            Long offset = iv[0] - begin[0];
+            constexpr_for<1, dim>([&] (auto d) {
+                offset += (iv[d] - begin[d]) * nstride[d-1];
+            });
+            return offset;
         }
 
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -270,67 +443,86 @@ namespace amrex {
 #else
         AMREX_GPU_HOST_DEVICE inline
 #endif
-        void index_assert (int i, int j, int k, int n) const
+        void index_assert (IntVectND<dim> const& iv) const
         {
-            if (i<begin.x || i>=end.x || j<begin.y || j>=end.y || k<begin.z || k>=end.z
-                || n < 0 || n >= ncomp) {
+            bool out_of_bounds = false;
+            constexpr_for<0, dim>([&] (auto d) {
+                if (iv[d] < begin[d] || iv[d] >= end[d]) {
+                    out_of_bounds = true;
+                }
+            });
+            if (out_of_bounds) {
                 AMREX_IF_ON_DEVICE((
-                    AMREX_DEVICE_PRINTF(" (%d,%d,%d,%d) is out of bound (%d:%d,%d:%d,%d:%d,0:%d)\n",
-                                        i, j, k, n, begin.x, end.x-1, begin.y, end.y-1,
-                                        begin.z, end.z-1, ncomp-1);
+                    device_printf_impl(std::make_index_sequence<dim>{}, iv, begin, end);
                     amrex::Abort();
                 ))
                 AMREX_IF_ON_HOST((
                     std::stringstream ss;
-                    ss << " (" << i << "," << j << "," << k << "," <<  n
-                    << ") is out of bound ("
-                    << begin.x << ":" << end.x-1 << ","
-                    << begin.y << ":" << end.y-1 << ","
-                    << begin.z << ":" << end.z-1 << ","
-                    << "0:" << ncomp-1 << ")";
+                    ss << " (";
+                    constexpr_for<0, dim>([&] (auto d) {
+                        ss << iv[d];
+                        if (d + 1 < dim) ss << ",";
+                    });
+                    ss << ") is out of bound (";
+                    constexpr_for<0, dim>([&] (auto d) {
+                        ss << begin[d] << ":" << end[d]-1;
+                        if (d + 1 < dim) ss << ",";
+                    });
+                    ss << ")";
                     amrex::Abort(ss.str());
                 ))
             }
         }
 #endif
 
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        CellData<T> cellData (int i, int j, int k) const noexcept {
-            return CellData<T>{this->ptr(i,j,k), nstride, ncomp};
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+        template<typename... idx, std::enable_if_t<sizeof...(idx) == dim,int> = 0>
+#if defined(AMREX_USE_HIP)
+        AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
+#else
+        AMREX_GPU_HOST_DEVICE inline
+#endif
+        void index_assert (idx... indices) const
+        {
+            this->index_assert(IntVectND<dim>{indices...});
         }
+#endif
     };
+
+    template<typename T>
+    using Array4 = ArrayND<T,4>;
 
     template <class Tto, class Tfrom>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
     Array4<Tto> ToArray4 (Array4<Tfrom> const& a_in) noexcept
     {
-        return Array4<Tto>((Tto*)(a_in.p), a_in.begin, a_in.end, a_in.ncomp);
+        return Array4<Tto>((Tto*)(a_in.p), a_in.begin, a_in.end);
     }
 
     template <class T>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Dim3 lbound (Array4<T> const& a) noexcept
     {
-        return a.begin;
+        return Dim3{a.begin[0],a.begin[1],a.begin[2]};
     }
 
     template <class T>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Dim3 ubound (Array4<T> const& a) noexcept
     {
-        return Dim3{a.end.x-1,a.end.y-1,a.end.z-1};
+        return Dim3{a.end[0]-1,a.end[1]-1,a.end[2]-1};
     }
 
     template <class T>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Dim3 length (Array4<T> const& a) noexcept
     {
-        return Dim3{a.end.x-a.begin.x,a.end.y-a.begin.y,a.end.z-a.begin.z};
+        return Dim3{a.end[0]-a.begin[0],a.end[1]-a.begin[1],a.end[2]-a.begin[2]};
     }
 
     template <typename T>
     std::ostream& operator<< (std::ostream& os, const Array4<T>& a) {
-        os << "((" << lbound(a) << ',' << ubound(a) << ")," << a.ncomp << ')';
+        os << "((" << lbound(a) << ',' << ubound(a) << ")," << a.nComp() << ')';
         return os;
     }
 

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -228,37 +228,14 @@ namespace amrex {
             : p(rhs.p), nstride(rhs.nstride), begin(rhs.begin), end(rhs.end) {}
 
         /**
-         * \brief Constructor for N=4 using Dim3.
-         * \param a_p Pointer to data.
-         * \param a_begin Start index.
-         * \param a_end End index exclusive.
-         * \param a_ncomp Number of components (4th dimension).
-         *
-         * Typically used for standard (i, j, k, n) access in 3D simulations.
-         */
-        template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
-        AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
-            : p(a_p), begin(a_begin.x, a_begin.y, a_begin.z, 0), end(a_end.x, a_end.y, a_end.z, a_ncomp)
-        {
-            Long current_stride = 1;
-            constexpr_for<0, N-1>([&](int d) {
-                Long len = end[d] - begin[d];
-                current_stride *= len;
-                nstride[d] = current_stride;
-            });
-        }
-
-        /**
          * \brief Constructor using a BoxND.
          * \param a_p Pointer to data.
          * \param box The domain covered by this array.
          *
          * TODO: Make BoxND functions constexpr to allow this constructor to be constexpr.
          */
-        template <int M>
         AMREX_GPU_HOST_DEVICE
-        ArrayND (T* a_p, BoxND<M> const& box) noexcept
+        ArrayND (T* a_p, BoxND<N> const& box) noexcept
             : ArrayND(a_p, box.smallEnd(), box.bigEnd() + 1)
         {}
 
@@ -270,7 +247,7 @@ namespace amrex {
          *
          * TODO: Make BoxND functions constexpr to allow this constructor to be constexpr.
          */
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && last_dim_component,int> = 0>
+        template <int M, std::enable_if_t<(M+1==N) && last_dim_component, int> = 0>
         AMREX_GPU_HOST_DEVICE
         ArrayND (T* a_p, BoxND<M> const& box, int ncomp) noexcept
             : ArrayND(a_p, box.smallEnd(), box.bigEnd() + 1, ncomp)
@@ -300,35 +277,25 @@ namespace amrex {
         }
 
         /**
-         * \brief IntVectND<M> constructor for M <= N-1.
+         * \brief Constructor for N=4 using Dim3.
          * \param a_p Pointer to data.
-         * \param a_begin Start index (inclusive).
-         * \param a_end End index (exclusive).
+         * \param a_begin Start index.
+         * \param a_end End index exclusive.
+         * \param a_ncomp Number of components (4th dimension).
          *
-         * For dimensions not specified are padded with [0,1).
+         * Typically used for standard (i, j, k, n) access in 3D simulations.
          */
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
+        template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (T* a_p, IntVectND<M> const& a_begin, IntVectND<M> const& a_end) noexcept
-            : p(a_p), begin(), end()
+        constexpr ArrayND (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
+            : p(a_p), begin(a_begin.x, a_begin.y, a_begin.z, 0), end(a_end.x, a_end.y, a_end.z, a_ncomp)
         {
-            constexpr_for<0, M>([&](int d) {
-                begin[d] = a_begin[d];
-                end[d] = a_end[d];
+            Long current_stride = 1;
+            constexpr_for<0, N-1>([&](int d) {
+                Long len = end[d] - begin[d];
+                current_stride *= len;
+                nstride[d] = current_stride;
             });
-            constexpr_for<M, N>([&](int d) {
-                begin[d] = 0;
-                end[d] = 1;
-            });
-
-            if constexpr (N > 1) {
-                Long current_stride = 1;
-                constexpr_for<0, N-1>([&](int d) {
-                    Long len = end[d] - begin[d];
-                    current_stride *= len;
-                    nstride[d] = current_stride;
-                });
-            }
         }
 
         /**
@@ -340,20 +307,20 @@ namespace amrex {
          *
          * Pads intermediate dimensions with [0,1) and sets the last dimension to [0, ncomp).
          */
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && (N != 1) && last_dim_component,int> = 0>
+        template <int M, std::enable_if_t<((M+1 == N) || (N == 4 && M == AMREX_SPACEDIM))
+            && last_dim_component, int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, IntVectND<M> const& a_begin, IntVectND<M> const& a_end, int ncomp) noexcept
-            : p(a_p), begin(), end()
+            : p(a_p)
         {
             constexpr_for<0, M>([&](int d) {
                 begin[d] = a_begin[d];
                 end[d] = a_end[d];
             });
-            constexpr_for<M, N-1>([&](int d) {
+            constexpr_for<M, N>([&](int d) {
                 begin[d] = 0;
                 end[d] = 1;
             });
-            begin[N-1] = 0;
             end[N-1] = ncomp;
 
             if constexpr (N > 1) {
@@ -452,26 +419,19 @@ namespace amrex {
         }
 
         /**
-         * \brief Access element by IntVectND<N>.
-         * \param iv IntVectND<N>
+         * \brief Access element by IntVectND.
+         * \tparam M The dimension of the index vector.
+         * \param iv The index vector.
          * \return Reference to the element.
+         *
+         * This function handles access via:
+         * 1. Full dimension vector (M == N).
+         * 2. Spatial dimension vector (M == N-1 or (M == AMREX_SPACEDIM) && N == 4)
+         *    (only enabled if last_dim_component is true).
          */
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (IntVectND<N> const& iv) const noexcept {
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(iv);
-#endif
-            return p[get_offset(iv)];
-        }
-
-        /**
-         * \brief Access element by IntVectND<M>.
-         * \param iv IntVectND<M> (1 <= M <= N-1).
-         * \return Reference to the element.
-         * When 1 <= M <= N-1, the missing indices are set to begin values.
-         */
-        template <int M, class U=T, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
+        template <int M, class U=T, std::enable_if_t<
+            !std::is_void_v<U> &&
+            ((M == N) || (last_dim_component && ((M + 1 == N) || (N == 4 && M == AMREX_SPACEDIM)))), int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVectND<M> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -481,16 +441,18 @@ namespace amrex {
         }
 
         /**
-         * \brief Access element by IntVectND<M> and component index.
-         * \param iv IntVectND<M> (1 <= M <= N-1).
+         * \brief Access element by spatial IntVectND and component index.
+         * \tparam M The dimension of the spatial index vector (typically N-1 or AMREX_SPACEDIM).
+         * \param iv The spatial index vector.
          * \param n Component index (last dimension).
          * \return Reference to the element.
          *
-         * The missing indices are set to begin values except the last dimension which is set to n.
-         * This overload is not valid for N=1 and last_dim_component=false
+         * This overload is enabled only when last_dim_component is true and M represents
+         * the spatial dimensions (either N-1 or AMREX_SPACEDIM).
          */
-        template <int M, class U=T, std::enable_if_t<last_dim_component &&
-            (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
+        template <int M, class U=T, std::enable_if_t<
+            !std::is_void_v<U> && last_dim_component
+            && ((M + 1 == N) || (N == 4 && M == AMREX_SPACEDIM)),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVectND<M> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -500,24 +462,13 @@ namespace amrex {
         }
 
         /**
-         * \brief Access element by Dim3 (only when N=4).
+         * \brief Access element by Dim3.
          * \param cell Dim3
          * \return Reference to the element.
+         * Only enabled when N=4 and last_dim_component == true or N=3 and last_dim_component == false.
          */
         template <class U=T, std::enable_if_t<!std::is_void_v<U>
-            && last_dim_component && (N == 4),int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (Dim3 const& cell) const noexcept {
-            return this->operator()(cell.x,cell.y,cell.z);
-        }
-
-        /**
-         * \brief Access element by Dim3 (only when N=3 and last_dim_component == false).
-         * \param cell Dim3
-         * \return Reference to the element.
-         */
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>
-            && !last_dim_component && (N == 3),int> = 0>
+            && ((N == 4 && last_dim_component) || (N == 3 && !last_dim_component)),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z);
@@ -554,26 +505,18 @@ namespace amrex {
         }
 
         /**
-         * \brief Access pointer by IntVectND<N>.
-         * \param iv IntVectND<N>
-         * \return Pointer to the element.
-         */
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (IntVectND<N> const& iv) const noexcept {
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(iv);
-#endif
-            return p + get_offset(iv);
-        }
-
-        /**
-         * \brief Access pointer by IntVectND<M>.
-         * \param iv IntVectND<M> (1 <= M <= N-1).
+         * \brief Access pointer by IntVectND.
+         * \tparam M The dimension of the index vector.
+         * \param iv The index vector.
          * \return Pointer to the element.
          *
-         * The missing indices are set to begin values.
+         * This function handles access via:
+         * 1. Full dimension vector (M == N).
+         * 2. Spatial dimension vector (M == N-1 or M == AMREX_SPACEDIM)
+         *    (only enabled if last_dim_component is true).
          */
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
+        template <int M, std::enable_if_t<(M == N)
+            || (last_dim_component && ((M + 1 == N) || (N == 4 && M == AMREX_SPACEDIM))), int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<M> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -583,16 +526,17 @@ namespace amrex {
         }
 
         /**
-         * \brief Access pointer by IntVectND<M> and component index.
-         * \param iv IntVectND<M> (1 <= M <= N-1).
+         * \brief Access pointer by spatial IntVectND and component index.
+         * \tparam M The dimension of the spatial index vector (typically N-1 or AMREX_SPACEDIM).
+         * \param iv The spatial index vector.
          * \param n Component index (last dimension).
          * \return Pointer to the element.
          *
-         * The missing indices are set to begin values except the last dimension which is set to n.
-         * This overload is not valid for N=1 and last_dim_component=false
+         * This overload is enabled only when last_dim_component is true and M represents
+         * the spatial dimensions (either N-1 or AMREX_SPACEDIM).
          */
-        template <int M, std::enable_if_t<last_dim_component &&
-            (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
+        template <int M, std::enable_if_t<last_dim_component
+            && ((M + 1 == N) || (N == 4 && M == AMREX_SPACEDIM)), int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<M> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -602,22 +546,13 @@ namespace amrex {
         }
 
         /**
-         * \brief Access pointer by Dim3 (only when N=4 and last_dim_component == true).
+         * \brief Access pointer by Dim3.
          * \param cell Dim3
          * \return Pointer to the element.
+         * Only enabled when N=4 and last_dim_component == true or N=3 and last_dim_component == false.
          */
-        template <int M=N, std::enable_if_t<(M == 4) && last_dim_component,int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (Dim3 const& cell) const noexcept {
-            return this->ptr(cell.x,cell.y,cell.z);
-        }
-
-        /**
-         * \brief Access pointer by Dim3 (only when N=3 and last_dim_component == false).
-         * \param cell Dim3
-         * \return Pointer to the element.
-         */
-        template <int M=N, std::enable_if_t<(M == 3) && !last_dim_component,int> = 0>
+        template <int M=N, std::enable_if_t<(M == 4 && last_dim_component)
+            || (M == 3 && !last_dim_component),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (Dim3 const& cell) const noexcept {
             return this->ptr(cell.x,cell.y,cell.z);
@@ -648,7 +583,6 @@ namespace amrex {
          * \brief Get number of components
          * \return Number of components.
          */
-        template <int M=N, std::enable_if_t<(1 <= M) && (M <= N),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr int nComp () const noexcept {
             if constexpr (last_dim_component) {
@@ -675,94 +609,69 @@ namespace amrex {
             return this->contains(IntVectND<nidx>{i...});
         }
 
+        template <int M, std::enable_if_t<(M == N)
+            || (last_dim_component && (M + 1 == N || (N == 4 && M == AMREX_SPACEDIM))), int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr bool contains (IntVectND<N> const& iv) const noexcept {
+        constexpr bool contains (IntVectND<M> const& iv) const noexcept {
             bool inside = true;
-            if constexpr (last_dim_component == false) {
-                constexpr_for<0, N>([&](int d) {
-                    inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
-                });
-            } else {
-                constexpr_for<0, N-1>([&](int d) {
-                    inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
-                });
+            constexpr int idx = (last_dim_component && M == N) ? N - 1 : M;
+            constexpr_for<0, idx>([&](int d) {
+                inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
+            });
+            if constexpr (last_dim_component && M == N) {
                 inside = inside && (iv[N-1] >= 0) && (iv[N-1] < end[N-1]);
             }
             return inside;
         }
 
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr bool contains (IntVectND<M> const& iv) const noexcept {
-            bool inside = true;
-            constexpr_for<0, M>([&](int d) {
-                inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
-            });
-            return inside;
-        }
-
-        template <int M, std::enable_if_t<last_dim_component &&
-            (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
+        template <int M, std::enable_if_t<last_dim_component
+            && ((M + 1 == N) || (N == 4 && M == AMREX_SPACEDIM)), int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (IntVectND<M> const& iv, int n) const noexcept {
             bool inside = true;
             constexpr_for<0, M>([&](int d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
             });
-            inside = inside && (n >= begin[N-1]) && (n < end[N-1]);
+            inside = inside && (n >= 0) && (n < end[N-1]);
             return inside;
         }
-
 
         template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (Dim3 const& cell) const noexcept {
-            return this->contains(IntVectND<M>{cell.x, cell.y, cell.z, begin[M-1]});
+            return this->contains(IntVectND{cell.x, cell.y, cell.z});
         }
 
         template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         CellData<T> cellData (int i, int j, int k) const noexcept {
-            int ncomp = end[3] - begin[3];
+            int ncomp = end[M-1];
             return CellData<T>(this->ptr(i,j,k), nstride[M-2], ncomp);
         }
 
-        // Main get_offset function for N
+        template <int M, std::enable_if_t<(M == N)
+            || (last_dim_component && (M + 1 == N || M == AMREX_SPACEDIM)), int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr Long get_offset (IntVectND<N> const& iv) const noexcept
+        constexpr Long get_offset (IntVectND<M> const& iv) const noexcept
         {
             Long offset = iv[0] - begin[0];
-            if constexpr (last_dim_component == false) {
-                constexpr_for<1, N>([&](int d) {
-                    offset += (iv[d] - begin[d]) * nstride[d-1];
-                });
-            } else {
-                constexpr_for<1, N-1>([&](int d) {
-                    offset += (iv[d] - begin[d]) * nstride[d-1];
-                });
+            // If M == N and we have a component at the end, we only loop up to N-1 for spatial.
+            // Otherwise, we loop up to M.
+            constexpr int idx = (last_dim_component && M == N) ? N - 1 : M;
+            constexpr_for<1, idx>([&](int d) {
+                offset += (iv[d] - begin[d]) * nstride[d-1];
+            });
+
+            // Handle the component offset if the input is the full N dimensions
+            // and the last dimension is a component.
+            if constexpr (last_dim_component && M == N) {
                 offset += iv[N-1] * nstride[N-2];
             }
             return offset;
         }
 
-        // get_offset overload for 1<= M <= N-1
-        // When M <= N-1, the missing indices are set to begin values.
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr Long get_offset (IntVectND<M> const& iv) const noexcept
-        {
-            Long offset = iv[0] - begin[0];
-            constexpr_for<1, M>([&](int d) {
-                offset += (iv[d] - begin[d]) * nstride[d-1];
-            });
-            return offset;
-        }
-
-        // get_offset overload for 1<= M <= N-1, last index n
-        // Here the missing indices are set to begin values except the last dimension which is set to n.
-        // Overload not valid if last_dim_component == false and N=1
-        template <int M, std::enable_if_t<last_dim_component &&
-            (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
+        template <int M, std::enable_if_t<last_dim_component
+            && ((M + 1 == N) || (N == 4 && M == AMREX_SPACEDIM)), int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr Long get_offset (IntVectND<M> const& iv, int n) const noexcept
         {
@@ -811,8 +720,10 @@ namespace amrex {
             }
         }
 
-        // index_assert overload for M <= N-1
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
+        // index_assert overload for M == N-1 last index assumed 0
+        // Only valid when last_dim_component == true
+        template <int M, std::enable_if_t<((M+1 == N) || (M == AMREX_SPACEDIM))
+            && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE inline
         void index_assert (IntVectND<M> const& iv) const
         {
@@ -823,10 +734,10 @@ namespace amrex {
             index_assert(iv_full);
         }
 
-        // index_assert overload for M <= N-1, last index n
-        // Overload not valid if last_dim_component == false and N=1
-        template <int M, std::enable_if_t<
-            last_dim_component && (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
+        // index_assert overload for M == N-1 and last index n
+        // Only valid when last_dim_component == true
+        template <int M, std::enable_if_t<((M+1 == N) || (M == AMREX_SPACEDIM))
+            && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE inline
         void index_assert (IntVectND<M> const& iv, int n) const
         {
@@ -857,6 +768,10 @@ namespace amrex {
     // 4: Matches ArrayND (T*, IntVectND<N>, IntVectND<N>, int) -> ArrayND<T,N+1, last_dim_component=true>
     template <typename T, int N>
     ArrayND (T*, IntVectND<N> const&, IntVectND<N> const&, int) -> ArrayND<T, N+1, true>;
+
+    // 5: Matches ArrayND (T*, Dim3, Dim3) -> ArrayND<T,4, last_dim_component=true>
+    template <typename T>
+    ArrayND (T*, Dim3 const&, Dim3 const&, int) -> ArrayND<T, 4, true>;
 
     template<typename T>
     using Array4 = ArrayND<T, 4, true>;

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -62,13 +62,24 @@ namespace amrex {
     };
 
     namespace detail {
+
+        /**
+         * \brief Helper struct to check if a type is a valid index type.
+         *
+         * Valid index types are integral types that can be safely converted to int without narrowing.
+         */
+        template <typename T>
+        struct IsValidIndexType {
+            static constexpr bool value = std::is_integral_v<T> && IsNonNarrowingConversion_v<T, int>;
+        };
+
         /**
          * \brief Helper struct to check if index types are valid.
          *
          * Valid index types are integral types that can be safely converted to int
          * without narrowing. The last index type can also be an enum.
          */
-        template <int N, typename... idx>
+        template <int N, bool last_dim_component, typename... idx>
         struct ArrayNDIndexCheck_impl {
         private:
             static constexpr int num_indices = sizeof...(idx);
@@ -83,24 +94,27 @@ namespace amrex {
                     && AllExceptLastEnum<Ts...>::value;
             };
 
+            // Check if the last index type is an enum or valid index type.
+            // An enum is only allowed if last_dim_component is true.
             template <typename last>
             struct AllExceptLastEnum<last> {
                 static constexpr bool value = IsValidIndexType<std::decay_t<last>>::value
                         || (std::is_enum_v<std::decay_t<last>>);
             };
 
-            static constexpr bool index_with_enum = AllExceptLastEnum<idx...>::value;
+            static constexpr bool index_with_maybe_enum = AllExceptLastEnum<idx...>::value;
 
             static constexpr bool index_all_values = Conjunction<
                 IsValidIndexType<std::decay_t<idx>>...>::value;
 
         public:
-            static constexpr bool value = ((num_indices == N) && index_with_enum) ||
-                                          ((num_indices == N - 1) && index_all_values);
+            static constexpr bool value = ((num_indices == N) && index_all_values)      // N indicies are integer types
+                                || ((num_indices == N - 1) && index_all_values && last_dim_component) // N-1 indicies are integer types, last is component
+                                || ((num_indices == N) && index_with_maybe_enum && last_dim_component); // N indicies, last dim is component and can be enum
         };
 
-        template <int N, class... idx>
-        inline constexpr bool ArrayNDIndexCheck_impl_v = ArrayNDIndexCheck_impl<N, idx...>::value;
+        template <int N, bool last_dim_component, class... idx>
+        inline constexpr bool ArrayNDIndexCheck_impl_v = ArrayNDIndexCheck_impl<N, last_dim_component, idx...>::value;
 
         template<std::size_t... idx>
         constexpr auto make_oob_message_impl (std::index_sequence<idx...>) {
@@ -191,11 +205,14 @@ namespace amrex {
      * It stores the pointer, stride information, and the bounds (begin and end)
      * of the array.
      */
-    template<typename T, int N, bool last_dim_component = true>
+    template<typename T, int N, bool last_dim_component = false>
     struct ArrayND
     {
         static_assert(N >= 1, "ArrayND must have at least one dimension");
         static_assert(N > 1 || !last_dim_component, "ArrayND with N=1 cannot have last_dim_component=true");
+
+        // Last dimension info for compile-time operations
+        using LastDimComponent = std::integral_constant<bool, last_dim_component>;
 
         T* AMREX_RESTRICT p = nullptr;
         std::array<Long, N-1> nstride{};
@@ -207,7 +224,7 @@ namespace amrex {
 
         template <class U=T, std::enable_if_t<std::is_const_v<U>,int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (ArrayND<std::remove_const_t<T>, N> const& rhs) noexcept
+        constexpr ArrayND (ArrayND<std::remove_const_t<T>, N, last_dim_component> const& rhs) noexcept
             : p(rhs.p), nstride(rhs.nstride), begin(rhs.begin), end(rhs.end) {}
 
         /**
@@ -219,7 +236,7 @@ namespace amrex {
          *
          * Typically used for standard (i, j, k, n) access in 3D simulations.
          */
-        template <int M=N, std::enable_if_t<M==4,int> = 0>
+        template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
             : p(a_p), begin(a_begin.x, a_begin.y, a_begin.z, 0), end(a_end.x, a_end.y, a_end.z, a_ncomp)
@@ -245,7 +262,15 @@ namespace amrex {
             : ArrayND(a_p, box.smallEnd(), box.bigEnd() + 1)
         {}
 
-        template <int M>
+        /**
+         * \brief Constructor using a BoxND.
+         * \param a_p Pointer to data.
+         * \param box BoxND<M> with M <= N-1 defining the spatial dimensions.
+         * \param ncomp Number of components (size of last dimension).
+         *
+         * TODO: Make BoxND functions constexpr to allow this constructor to be constexpr.
+         */
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE
         ArrayND (T* a_p, BoxND<M> const& box, int ncomp) noexcept
             : ArrayND(a_p, box.smallEnd(), box.bigEnd() + 1, ncomp)
@@ -275,14 +300,14 @@ namespace amrex {
         }
 
         /**
-         * \brief IntVectND<M> constructor for M < N.
+         * \brief IntVectND<M> constructor for M <= N-1.
          * \param a_p Pointer to data.
          * \param a_begin Start index (inclusive).
          * \param a_end End index (exclusive).
          *
          * For dimensions not specified are padded with [0,1).
          */
-        template <int M, std::enable_if_t<(M < N),int> = 0>
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, IntVectND<M> const& a_begin, IntVectND<M> const& a_end) noexcept
             : p(a_p), begin(), end()
@@ -315,7 +340,7 @@ namespace amrex {
          *
          * Pads intermediate dimensions with [0,1) and sets the last dimension to [0, ncomp).
          */
-        template <int M, std::enable_if_t<(M < N) && (N != 1),int> = 0>
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && (N != 1) && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (T* a_p, IntVectND<M> const& a_begin, IntVectND<M> const& a_end, int ncomp) noexcept
             : p(a_p), begin(), end()
@@ -350,10 +375,10 @@ namespace amrex {
          */
         template <class U,
             std::enable_if_t
-                  <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>> && (N  >= 2),int> = 0>
+                  <std::is_same_v<std::remove_const_t<T>, std::remove_const_t<U>>
+                    && (N >= 2) && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (ArrayND<U, N> const& rhs, int start_comp) noexcept
+        constexpr ArrayND (ArrayND<U, N, last_dim_component> const& rhs, int start_comp) noexcept
             : p((T*)(rhs.p + start_comp*rhs.nstride[N-2])),
               nstride(rhs.nstride),
               begin(rhs.begin),
@@ -373,10 +398,10 @@ namespace amrex {
          */
         template <class U,
             std::enable_if_t
-                  <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>> && (N >= 2),int> = 0>
+                  <std::is_same_v<std::remove_const_t<T>, std::remove_const_t<U>>
+                    && (N >= 2) && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (ArrayND<U, N> const& rhs, int start_comp, int num_comp) noexcept
+        constexpr ArrayND (ArrayND<U, N, last_dim_component> const& rhs, int start_comp, int num_comp) noexcept
             : p((T*)(rhs.p + start_comp*rhs.nstride[N-2])),
               nstride(rhs.nstride),
               begin(rhs.begin),
@@ -386,15 +411,20 @@ namespace amrex {
             end[N-1] = num_comp;
         }
 
-
         /**
-         * \brief Check if the ArrayND is properly initialized.
-         * \return True if initialized properly.
+         * \brief Check if the ArrayND pointer is valid.
+         * \return true if pointer is valid, false otherwise.
          */
         AMREX_GPU_HOST_DEVICE
-        explicit operator bool() const noexcept {
-            return p != nullptr && end.allGT(begin);
-        }
+        constexpr explicit operator bool() const noexcept { return p != nullptr; }
+
+        /**
+         * \brief Check if the ArrayND pointer is valid and bounds are valid.
+         *
+         * \return true if pointer and bounds are valid, false otherwise.
+         */
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE
+        bool ok () const noexcept { return p != nullptr && end.allGT(begin); }
 
         /**
          * \brief Multi-index operator() for accessing elements.
@@ -402,13 +432,16 @@ namespace amrex {
          * \param i Variadic list of indices.
          * \return Reference to the element.
          *
-         * This operator is only enabled when the number of indices provided matches the dimension N or N-1
-         * where in the latter case the last dimension is assumed to be 0. The passed indices must be of
-         * integral types that can be converted to int without narrowing. The last index can also be an enum type.
-         * TODO: Use concepts when we move to C++20. The error message now is not user friendly.
+         * This operator is only enabled when the number of indices provided matches the dimension N or
+         * N-1 if last_dim_component is true, where in the latter case the last dimension is assumed to be 0.
+         * The passed indices must be of integral types that can be converted to int
+         * without narrowing. The last index can also be an enum type.
+         *
+         * TODO: Use concepts when we move to C++20.
          */
         template <typename... idx, class U=T,
-            std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<N, idx...>,int> = 0>
+            std::enable_if_t<!std::is_void_v<U>
+                && detail::ArrayNDIndexCheck_impl_v<N, last_dim_component, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (idx... i) const noexcept {
             constexpr auto nidx = sizeof...(i);
@@ -419,12 +452,26 @@ namespace amrex {
         }
 
         /**
-         * \brief Access element by IntVectND<M>.
-         * \param iv IntVectND<M> (1 <= M <= N).
+         * \brief Access element by IntVectND<N>.
+         * \param iv IntVectND<N>
          * \return Reference to the element.
-         * When M < N, the missing indices are set to begin values.
          */
-        template <int M, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        U& operator() (IntVectND<N> const& iv) const noexcept {
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+            index_assert(iv);
+#endif
+            return p[get_offset(iv)];
+        }
+
+        /**
+         * \brief Access element by IntVectND<M>.
+         * \param iv IntVectND<M> (1 <= M <= N-1).
+         * \return Reference to the element.
+         * When 1 <= M <= N-1, the missing indices are set to begin values.
+         */
+        template <int M, class U=T, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVectND<M> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -440,9 +487,10 @@ namespace amrex {
          * \return Reference to the element.
          *
          * The missing indices are set to begin values except the last dimension which is set to n.
-         * This overload is not valid for N=1.
+         * This overload is not valid for N=1 and last_dim_component=false
          */
-        template <int M, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <int M, class U=T, std::enable_if_t<last_dim_component &&
+            (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVectND<M> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -456,7 +504,20 @@ namespace amrex {
          * \param cell Dim3
          * \return Reference to the element.
          */
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (N == 4),int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U>
+            && last_dim_component && (N == 4),int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        U& operator() (Dim3 const& cell) const noexcept {
+            return this->operator()(cell.x,cell.y,cell.z);
+        }
+
+        /**
+         * \brief Access element by Dim3 (only when N=3 and last_dim_component == false).
+         * \param cell Dim3
+         * \return Reference to the element.
+         */
+        template <class U=T, std::enable_if_t<!std::is_void_v<U>
+            && !last_dim_component && (N == 3),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z);
@@ -468,7 +529,8 @@ namespace amrex {
          * \param n Component index (last dimension).
          * \return Reference to the element.
          */
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (N == 4),int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U>
+            && last_dim_component && (N == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell, int n) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z,n);
@@ -480,8 +542,8 @@ namespace amrex {
          * \param i Variadic list of indices.
          * \return Pointer to the element.
          */
-        template <typename... idx, class U=T,
-            std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<N, idx...>,int> = 0>
+        template <typename... idx, class U=T, std::enable_if_t<!std::is_void_v<U>
+            && detail::ArrayNDIndexCheck_impl_v<N, last_dim_component, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (idx... i) const noexcept {
             constexpr auto nidx = sizeof...(i);
@@ -492,13 +554,26 @@ namespace amrex {
         }
 
         /**
+         * \brief Access pointer by IntVectND<N>.
+         * \param iv IntVectND<N>
+         * \return Pointer to the element.
+         */
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T* ptr (IntVectND<N> const& iv) const noexcept {
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+            index_assert(iv);
+#endif
+            return p + get_offset(iv);
+        }
+
+        /**
          * \brief Access pointer by IntVectND<M>.
-         * \param iv IntVectND<M> (1 <= M <= N).
+         * \param iv IntVectND<M> (1 <= M <= N-1).
          * \return Pointer to the element.
          *
-         * When M < N, the missing indices are set to begin values.
+         * The missing indices are set to begin values.
          */
-        template <int M>
+        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<M> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -514,9 +589,10 @@ namespace amrex {
          * \return Pointer to the element.
          *
          * The missing indices are set to begin values except the last dimension which is set to n.
-         * This overload is not valid for N=1.
+         * This overload is not valid for N=1 and last_dim_component=false
          */
-        template <int M>
+        template <int M, std::enable_if_t<last_dim_component &&
+            (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<M> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -526,23 +602,34 @@ namespace amrex {
         }
 
         /**
-         * \brief Access pointer by Dim3 (only when N=4).
+         * \brief Access pointer by Dim3 (only when N=4 and last_dim_component == true).
          * \param cell Dim3
          * \return Pointer to the element.
          */
-        template <int M=N, std::enable_if_t<(M == 4),int> = 0>
+        template <int M=N, std::enable_if_t<(M == 4) && last_dim_component,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (Dim3 const& cell) const noexcept {
             return this->ptr(cell.x,cell.y,cell.z);
         }
 
         /**
-         * \brief Access pointer by Dim3 and component index (only when N=4).
+         * \brief Access pointer by Dim3 (only when N=3 and last_dim_component == false).
+         * \param cell Dim3
+         * \return Pointer to the element.
+         */
+        template <int M=N, std::enable_if_t<(M == 3) && !last_dim_component,int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T* ptr (Dim3 const& cell) const noexcept {
+            return this->ptr(cell.x,cell.y,cell.z);
+        }
+
+        /**
+         * \brief Access pointer by Dim3 and component index (only when N=4 and last_dim_component == true).
          * \param cell Dim3
          * \param n Component index (last dimension).
          * \return Pointer to the element.
          */
-        template <int M=N, std::enable_if_t<(M == 4),int> = 0>
+        template <int M=N, std::enable_if_t<(M == 4) && last_dim_component,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (Dim3 const& cell, int n) const noexcept {
             return this->ptr(cell.x,cell.y,cell.z,n);
@@ -558,19 +645,16 @@ namespace amrex {
         }
 
         /**
-         * \brief Get number of components (only when N=4).
+         * \brief Get number of components
          * \return Number of components.
-         *
-         * For N!=4 case, the user is expected to keep track if they are using the last dimension
-         * as components.
          */
-        template <int M=N, std::enable_if_t<M==4 || last_dim_component,int> = 0>
+        template <int M=N, std::enable_if_t<(1 <= M) && (M <= N),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr int nComp () const noexcept {
             if constexpr (last_dim_component) {
                 return end[N-1];
             } else {
-                return end[N-1] - begin[N-1];
+                return 1;
             }
         }
 
@@ -583,7 +667,8 @@ namespace amrex {
             return s;
         }
 
-        template <typename... idx, std::enable_if_t<detail::ArrayNDIndexCheck_impl_v<N, idx...>,int> = 0>
+        template <typename... idx, std::enable_if_t<
+            detail::ArrayNDIndexCheck_impl_v<N, last_dim_component, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (idx... i) const noexcept {
             constexpr auto nidx = sizeof...(i);
@@ -616,7 +701,8 @@ namespace amrex {
             return inside;
         }
 
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && (N != 1),int> = 0>
+        template <int M, std::enable_if_t<last_dim_component &&
+            (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (IntVectND<M> const& iv, int n) const noexcept {
             bool inside = true;
@@ -628,13 +714,13 @@ namespace amrex {
         }
 
 
-        template <int M=N, std::enable_if_t<M==4,int> = 0>
+        template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (Dim3 const& cell) const noexcept {
             return this->contains(IntVectND<M>{cell.x, cell.y, cell.z, begin[M-1]});
         }
 
-        template <int M=N, std::enable_if_t<M==4,int> = 0>
+        template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         CellData<T> cellData (int i, int j, int k) const noexcept {
             int ncomp = end[3] - begin[3];
@@ -660,7 +746,7 @@ namespace amrex {
         }
 
         // get_offset overload for 1<= M <= N-1
-        // When M < N, the missing indices are set to begin values.
+        // When M <= N-1, the missing indices are set to begin values.
         template <int M, std::enable_if_t<(1 <= M) && (M <= N-1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr Long get_offset (IntVectND<M> const& iv) const noexcept
@@ -674,8 +760,9 @@ namespace amrex {
 
         // get_offset overload for 1<= M <= N-1, last index n
         // Here the missing indices are set to begin values except the last dimension which is set to n.
-        // Overload not valid for N=1
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && (N != 1),int> = 0>
+        // Overload not valid if last_dim_component == false and N=1
+        template <int M, std::enable_if_t<last_dim_component &&
+            (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr Long get_offset (IntVectND<M> const& iv, int n) const noexcept
         {
@@ -683,11 +770,7 @@ namespace amrex {
             constexpr_for<1, M>([&](int d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
             });
-            if constexpr (last_dim_component == false) {
-                offset += (n - begin[N-1]) * nstride[N-2];
-            } else {
-                offset += n * nstride[N-2];
-            }
+            offset += n * nstride[N-2];
             return offset;
         }
 
@@ -741,8 +824,9 @@ namespace amrex {
         }
 
         // index_assert overload for M <= N-1, last index n
-        // Overload not valid for N=1
-        template <int M, std::enable_if_t<(1 <= M) && (M <= N-1) && (N != 1),int> = 0>
+        // Overload not valid if last_dim_component == false and N=1
+        template <int M, std::enable_if_t<
+            last_dim_component && (1 <= M) && (M <= N-1) && (N != 1),int> = 0>
         AMREX_GPU_HOST_DEVICE inline
         void index_assert (IntVectND<M> const& iv, int n) const
         {

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -63,28 +63,28 @@ namespace amrex {
          * 1. All indices are int
          * 2. Number of indices matches dimension or is one less than dimension
          */
-        template <int dim, typename... idx>
+        template <int N, typename... idx>
         struct ArrayNDIndexCheck_impl {
             constexpr static bool value =
-                (sizeof...(idx) == dim || sizeof...(idx) == dim - 1)
+                (sizeof...(idx) == N || sizeof...(idx) == N - 1)
                 && (Conjunction<std::is_same<int, std::decay_t<idx>>...>::value);
         };
 
-        template <int dim, class... idx>
-        inline constexpr bool ArrayNDIndexCheck_impl_v = ArrayNDIndexCheck_impl<dim, idx...>::value;
+        template <int N, class... idx>
+        inline constexpr bool ArrayNDIndexCheck_impl_v = ArrayNDIndexCheck_impl<N, idx...>::value;
 
         template<std::size_t... idx>
         constexpr auto make_oob_message_impl (std::index_sequence<idx...>) {
-            constexpr std::size_t Dim = sizeof...(idx);
+            constexpr std::size_t N = sizeof...(idx);
             constexpr char prefix[] = " (";
             constexpr char middle[] = ") is out of bound (";
             constexpr char suffix[] = ")\n";
 
             constexpr std::size_t size =
                 sizeof(prefix) - 1 +
-                (2*Dim + (Dim-1)) +
+                (2*N + (N-1)) +
                 sizeof(middle) - 1 +
-                (5*Dim + (Dim-1)) +
+                (5*N + (N-1)) +
                 sizeof(suffix); // include null terminator
 
             std::array<char, size> buf{};
@@ -98,7 +98,7 @@ namespace amrex {
                 }
             }
             // %d,%d,...
-            ((buf[pos++] = '%', buf[pos++] = 'd', idx + 1 < Dim ? buf[pos++] = ',' : 0), ...);
+            ((buf[pos++] = '%', buf[pos++] = 'd', idx + 1 < N ? buf[pos++] = ',' : 0), ...);
 
             // ") is out of bound ("
             for (char c : middle) {
@@ -109,7 +109,7 @@ namespace amrex {
 
             // %d:%d,%d:%d,...
             ((buf[pos++] = '%', buf[pos++] = 'd', buf[pos++] = ':', buf[pos++] = '%', buf[pos++] = 'd',
-                idx + 1 < Dim ? buf[pos++] = ',' : 0), ...);
+                idx + 1 < N ? buf[pos++] = ',' : 0), ...);
 
             // suffix
             for (char c : suffix) {
@@ -149,31 +149,31 @@ namespace amrex {
         }
     }
 
-    template<typename T, int dim>
+    template<typename T, int N>
     struct ArrayND
     {
-        static_assert(dim >= 1, "ArrayND must have at least one dimension");
+        static_assert(N >= 1, "ArrayND must have at least one dimension");
 
-        T* AMREX_RESTRICT p;
-        std::array<Long, dim-1> nstride{};
-        IntVectND<dim> begin{1};
-        IntVectND<dim> end{0}; // end is hi+1
+        T* AMREX_RESTRICT p = nullptr;
+        std::array<Long, N-1> nstride{};
+        IntVectND<N> begin{1};
+        IntVectND<N> end{0}; // end is hi+1
 
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND () noexcept : p(nullptr) {}
 
         template <class U=T, std::enable_if_t<std::is_const_v<U>,int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (ArrayND<std::remove_const_t<T>, dim> const& rhs) noexcept
+        constexpr ArrayND (ArrayND<std::remove_const_t<T>, N> const& rhs) noexcept
             : p(rhs.p), nstride(rhs.nstride), begin(rhs.begin), end(rhs.end) {}
 
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (T* a_p, IntVectND<dim> const& a_begin, IntVectND<dim> const& a_end) noexcept
+        constexpr ArrayND (T* a_p, IntVectND<N> const& a_begin, IntVectND<N> const& a_end) noexcept
             : p(a_p), begin(a_begin), end(a_end)
         {
-            if constexpr (dim > 1) {
+            if constexpr (N > 1) {
                 Long current_stride = 1;
-                for (int d = 0; d < dim - 1; ++d) {
+                for (int d = 0; d < N - 1; ++d) {
                     Long len = a_end[d] - a_begin[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
@@ -182,12 +182,12 @@ namespace amrex {
         }
 
         // Dim3 overload for dim=4
-        template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
+        template <int Dim=N, std::enable_if_t<Dim==4,int> = 0>
         constexpr ArrayND (T* a_p, Dim3 const& a_begin, Dim3 const& a_end, int a_ncomp) noexcept
             : p(a_p), begin(a_begin.x, a_begin.y, a_begin.z, 0), end(a_end.x, a_end.y, a_end.z, a_ncomp)
         {
             Long current_stride = 1;
-            for (int d = 0; d < dim - 1; ++d) {
+            for (int d = 0; d < N - 1; ++d) {
                 Long len = end[d] - begin[d];
                 current_stride *= len;
                 nstride[d] = current_stride;
@@ -197,10 +197,10 @@ namespace amrex {
         template <class U,
             std::enable_if_t
                   <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>> && (dim == 4),int> = 0>
+                                std::remove_const_t<U>> && (N == 4),int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (ArrayND<U, dim> const& rhs, int start_comp) noexcept
-            : p((T*)(rhs.p + start_comp*rhs.nstride[dim-2])),
+        constexpr ArrayND (ArrayND<U, N> const& rhs, int start_comp) noexcept
+            : p((T*)(rhs.p + start_comp*rhs.nstride[N-2])),
               nstride(rhs.nstride),
               begin(rhs.begin),
               end(rhs.end)
@@ -212,10 +212,10 @@ namespace amrex {
         template <class U,
             std::enable_if_t
                   <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>> && (dim == 4),int> = 0>
+                                std::remove_const_t<U>> && (N == 4),int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (ArrayND<U, dim> const& rhs, int start_comp, int num_comp) noexcept
-            : p((T*)(rhs.p + start_comp*rhs.nstride[dim-2])),
+        constexpr ArrayND (ArrayND<U, N> const& rhs, int start_comp, int num_comp) noexcept
+            : p((T*)(rhs.p + start_comp*rhs.nstride[N-2])),
               nstride(rhs.nstride),
               begin(rhs.begin),
               end(rhs.end)
@@ -229,7 +229,7 @@ namespace amrex {
 
         // This overload is enabled only when number of indices matches dimension or is one less than dimension
         template <typename... idx, class U=T,
-            std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<dim, idx...>,int> = 0>
+            std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<N, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (idx... i) const noexcept {
             constexpr auto nidx = sizeof...(i);
@@ -257,13 +257,13 @@ namespace amrex {
             return p[get_offset(iv, n)];
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (N == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z);
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (N == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell, int n) const noexcept {
             return this->operator()(cell.x,cell.y,cell.z,n);
@@ -271,7 +271,7 @@ namespace amrex {
 
         // This overload is enabled only when number of indices matches dimension or is one less than dimension
         template <typename... idx, class U=T,
-            std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<dim, idx...>,int> = 0>
+            std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<N, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (idx... i) const noexcept {
             constexpr auto nidx = sizeof...(i);
@@ -299,13 +299,13 @@ namespace amrex {
             return p + get_offset(iv, n);
         }
 
-        template <int Dim=dim, std::enable_if_t<(Dim == 4),int> = 0>
+        template <int Dim=N, std::enable_if_t<(Dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (Dim3 const& cell) const noexcept {
             return this->ptr(cell.x,cell.y,cell.z);
         }
 
-        template <int Dim=dim, std::enable_if_t<(Dim == 4),int> = 0>
+        template <int Dim=N, std::enable_if_t<(Dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (Dim3 const& cell, int n) const noexcept {
             return this->ptr(cell.x,cell.y,cell.z,n);
@@ -316,7 +316,7 @@ namespace amrex {
             return this->p;
         }
 
-        template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
+        template <int Dim=N, std::enable_if_t<Dim==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr int nComp () const noexcept {
             return end[3] - begin[3];
@@ -325,13 +325,13 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr std::size_t size () const noexcept {
             std::size_t s = 1;
-            for (int d = 0; d < dim; ++d) {
+            for (int d = 0; d < N; ++d) {
                 s *= (end[d] - begin[d]);
             }
             return s;
         }
 
-        template <typename... idx, std::enable_if_t<detail::ArrayNDIndexCheck_impl_v<dim, idx...>,int> = 0>
+        template <typename... idx, std::enable_if_t<detail::ArrayNDIndexCheck_impl_v<N, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (idx... i) const noexcept {
             constexpr auto nidx = sizeof...(i);
@@ -339,71 +339,71 @@ namespace amrex {
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr bool contains (IntVectND<dim> const& iv) const noexcept {
+        constexpr bool contains (IntVectND<N> const& iv) const noexcept {
             bool inside = true;
-            for (int d = 0; d < dim; ++d) {
+            for (int d = 0; d < N; ++d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
             }
             return inside;
         }
 
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1),int> = 0>
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (IntVectND<Dim> const& iv) const noexcept {
             bool inside = true;
             for (int d = 0; d < Dim; ++d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
             }
-            for (int d = Dim; d < dim-1; ++d) {
+            for (int d = Dim; d < N-1; ++d) {
                 inside = inside && (0 >= begin[d]) && (0 < end[d]);
             }
-            // Check last dimension with begin[dim-1] which is always true
-            // inside = inside && (begin[dim-1] >= begin[dim-1]) && (begin[dim-1] < end[dim-1]);
+            // Check last dimension with begin[N-1] which is always true
+            // inside = inside && (begin[N-1] >= begin[N-1]) && (begin[N-1] < end[N-1]);
             return inside;
         }
 
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1) && (dim != 1),int> = 0>
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1) && (N != 1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (IntVectND<Dim> const& iv, int n) const noexcept {
             bool inside = true;
             for (int d = 0; d < Dim; ++d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
             }
-            for (int d = Dim; d < dim-1; ++d) {
+            for (int d = Dim; d < N-1; ++d) {
                 inside = inside && (0 >= begin[d]) && (0 < end[d]);
             }
             // Check last dimension with n
-            inside = inside && (n >= begin[dim-1]) && (n < end[dim-1]);
+            inside = inside && (n >= begin[N-1]) && (n < end[N-1]);
             return inside;
         }
 
 
-        template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
+        template <int Dim=N, std::enable_if_t<Dim==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (Dim3 const& cell) const noexcept {
             return this->contains(IntVectND<Dim>{cell.x, cell.y, cell.z, begin[Dim-1]});
         }
 
-        template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
+        template <int Dim=N, std::enable_if_t<Dim==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         CellData<T> cellData (int i, int j, int k) const noexcept {
             int ncomp = end[3] - begin[3];
             return CellData<T>(this->ptr(i,j,k), nstride[Dim-2], ncomp);
         }
 
-        // Main get_offset function for dim
+        // Main get_offset function for N
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr Long get_offset (IntVectND<dim> const& iv) const noexcept
+        constexpr Long get_offset (IntVectND<N> const& iv) const noexcept
         {
             Long offset = iv[0] - begin[0];
-            for (int d = 1; d < dim; ++d) {
+            for (int d = 1; d < N; ++d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
             }
             return offset;
         }
 
-        // Overload for Dim < dim
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1),int> = 0>
+        // get_offset overload for 1<= Dim <= N-1
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr Long get_offset (IntVectND<Dim> const& iv) const noexcept
         {
@@ -411,15 +411,16 @@ namespace amrex {
             for (int d = 1; d < Dim; ++d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
             }
-            for (int d = Dim; d < dim-1; ++d) {
+            for (int d = Dim; d < N-1; ++d) {
                 offset += (Long(0) - begin[d]) * nstride[d-1];
             }
             // offset += (begin[dim-1] - begin[dim-1]) * nstride[dim-2];
             return offset;
         }
 
-        // Overload for Dim < dim with last index n. Dim must be at least 2
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1) && (dim != 1),int> = 0>
+        // get_offset overload for 1<= Dim <= N-1, last index n
+        // Overload not valid for N=1
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1) && (N != 1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr Long get_offset (IntVectND<Dim> const& iv, int n) const noexcept
         {
@@ -427,10 +428,10 @@ namespace amrex {
             for (int d = 1; d < Dim; ++d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
             }
-            for (int d = Dim; d < dim-1; ++d) {
+            for (int d = Dim; d < N-1; ++d) {
                 offset += (Long(0) - begin[d]) * nstride[d-1];
             }
-            offset += (n - begin[dim-1]) * nstride[dim-2];
+            offset += (n - begin[N-1]) * nstride[N-2];
             return offset;
         }
 
@@ -440,30 +441,30 @@ namespace amrex {
 #else
         AMREX_GPU_HOST_DEVICE inline
 #endif
-        void index_assert (IntVectND<dim> const& iv) const
+        void index_assert (IntVectND<N> const& iv) const
         {
             bool out_of_bounds = false;
-            for (int d = 0; d < dim; ++d) {
+            for (int d = 0; d < N; ++d) {
                 if (iv[d] < begin[d] || iv[d] >= end[d]) {
                     out_of_bounds = true;
                 }
             }
             if (out_of_bounds) {
                 AMREX_IF_ON_DEVICE((
-                    device_printf_impl(std::make_index_sequence<dim>{}, iv, begin, end);
+                    device_printf_impl(std::make_index_sequence<N>{}, iv, begin, end);
                     amrex::Abort();
                 ))
                 AMREX_IF_ON_HOST((
                     std::stringstream ss;
                     ss << " (";
-                    for (int d = 0; d < dim; ++d) {
+                    for (int d = 0; d < N; ++d) {
                         ss << iv[d];
-                        if (d + 1 < dim) ss << ",";
+                        if (d + 1 < N) ss << ",";
                     }
                     ss << ") is out of bound (";
-                    for (int d = 0; d < dim; ++d) {
+                    for (int d = 0; d < N; ++d) {
                         ss << begin[d] << ":" << end[d]-1;
-                        if (d + 1 < dim) ss << ",";
+                        if (d + 1 < N) ss << ",";
                     };
                     ss << ")";
                     amrex::Abort(ss.str());
@@ -471,24 +472,24 @@ namespace amrex {
             }
         }
 
-        // index_assert overload for Dim <= dim-1
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1),int> = 0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        // index_assert overload for Dim <= N-1
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1),int> = 0>
+        AMREX_GPU_HOST_DEVICE inline
         void index_assert (IntVectND<Dim> const& iv) const
         {
-            IntVectND<dim> iv_full = iv.template expand<dim>(0);
-            iv_full[dim-1] = begin[dim-1];
+            IntVectND<N> iv_full = iv.template expand<N>(0);
+            iv_full[N-1] = begin[N-1];
             index_assert(iv_full);
         }
 
-        // index_assert overload for Dim <= dim-1, last index n
-        // Overload not valid for dim=1
-        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1) && (dim != 1),int> = 0>
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        // index_assert overload for Dim <= N-1, last index n
+        // Overload not valid for N=1
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= N-1) && (N != 1),int> = 0>
+        AMREX_GPU_HOST_DEVICE inline
         void index_assert (IntVectND<Dim> const& iv, int n) const
         {
-            IntVectND<dim> iv_full = iv.template expand<dim>(0);
-            iv_full[dim-1] = n;
+            IntVectND<N> iv_full = iv.template expand<N>(0);
+            iv_full[N-1] = n;
             index_assert(iv_full);
         }
 #endif
@@ -497,11 +498,11 @@ namespace amrex {
     template<typename T>
     using Array4 = ArrayND<T,4>;
 
-    template <class Tto, class Tfrom>
+    template <class Tto, class Tfrom, int N>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
-    Array4<Tto> ToArray4 (Array4<Tfrom> const& a_in) noexcept
+    ArrayND<Tto,N> ToArray4 (ArrayND<Tfrom,N> const& a_in) noexcept
     {
-        return Array4<Tto>((Tto*)(a_in.p), a_in.begin, a_in.end);
+        return ArrayND<Tto,N>((Tto*)(a_in.p), a_in.begin, a_in.end);
     }
 
     template <class T>
@@ -511,11 +512,29 @@ namespace amrex {
         return Dim3{a.begin[0],a.begin[1],a.begin[2]};
     }
 
+    template <class T, int N, std::enable_if_t<(N != 4), int> = 0>
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    IntVectND<N> lbound (ArrayND<T,N> const& a) noexcept
+    {
+        return a.begin;
+    }
+
     template <class T>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Dim3 ubound (Array4<T> const& a) noexcept
     {
         return Dim3{a.end[0]-1,a.end[1]-1,a.end[2]-1};
+    }
+
+    template <class T, int N, std::enable_if_t<(N != 4), int> = 0>
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    IntVectND<N> ubound (ArrayND<T,N> const& a) noexcept
+    {
+        IntVectND<N> hi;
+        for (int d = 0; d < N; ++d) {
+            hi[d] = a.end[d] - 1;
+        }
+        return hi;
     }
 
     template <class T>
@@ -525,9 +544,20 @@ namespace amrex {
         return Dim3{a.end[0]-a.begin[0],a.end[1]-a.begin[1],a.end[2]-a.begin[2]};
     }
 
-    template <typename T>
-    std::ostream& operator<< (std::ostream& os, const Array4<T>& a) {
-        os << "((" << lbound(a) << ',' << ubound(a) << ")," << a.nComp() << ')';
+    template <class T, int N, std::enable_if_t<(N != 4), int> = 0>
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    IntVectND<N> length (ArrayND<T,N> const& a) noexcept
+    {
+        IntVectND<N> len;
+        for (int d = 0; d < N; ++d) {
+            len[d] = a.end[d] - a.begin[d];
+        }
+        return len;
+    }
+
+    template <typename T, int N>
+    std::ostream& operator<< (std::ostream& os, const ArrayND<T,N>& a) {
+        os << "((" << lbound(a) << ',' << ubound(a) << "))";
         return os;
     }
 

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -81,7 +81,7 @@ namespace amrex {
         inline constexpr bool ArrayNDIndexCheck_impl_v = ArrayNDIndexCheck_impl<dim, idx...>::value;
 
         template<std::size_t... idx>
-        constexpr auto make_oob_message_impl (std::index_sequence<idx...>&&) {
+        constexpr auto make_oob_message_impl (std::index_sequence<idx...>) {
             constexpr std::size_t Dim = sizeof...(idx);
             constexpr char prefix[] = " (";
             constexpr char middle[] = ") is out of bound (";
@@ -201,8 +201,7 @@ namespace amrex {
         template <class U,
             std::enable_if_t
                   <std::is_same_v<std::remove_const_t<T>,
-                                std::remove_const_t<U>>,int> = 0,
-            std::enable_if_t<dim == 4,int> = 0>
+                                std::remove_const_t<U>> && (dim == 4),int> = 0>
         AMREX_GPU_HOST_DEVICE
         constexpr ArrayND (ArrayND<U, dim> const& rhs, int start_comp, int num_comp) noexcept
             : p((T*)(rhs.p + start_comp*rhs.nstride[dim-2])),

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -258,6 +258,17 @@ namespace amrex {
             return p[get_offset(iv, n)];
         }
 
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        U& operator() (Dim3 const& cell) const noexcept {
+            return this->operator()(cell.x,cell.y,cell.z);
+        }
+
+        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        U& operator() (Dim3 const& cell, int n) const noexcept {
+            return this->operator()(cell.x,cell.y,cell.z,n);
+        }
 
         // This overload is enabled only when number of indices matches dimension or is one less than dimension
         template <typename... idx, class U=T,
@@ -271,7 +282,7 @@ namespace amrex {
             return p + get_offset(IntVectND<nidx>{i...});
         }
 
-        template <int Dim, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <int Dim>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<Dim> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -280,7 +291,7 @@ namespace amrex {
             return p + get_offset(iv);
         }
 
-        template <int Dim, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <int Dim>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<Dim> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
@@ -289,16 +300,16 @@ namespace amrex {
             return p + get_offset(iv, n);
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
+        template <int Dim=dim, std::enable_if_t<(Dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (Dim3 const& cell) const noexcept {
-            return this->operator()(cell.x,cell.y,cell.z);
+        T* ptr (Dim3 const& cell) const noexcept {
+            return this->ptr(cell.x,cell.y,cell.z);
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
+        template <int Dim=dim, std::enable_if_t<(Dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (Dim3 const& cell, int n) const noexcept {
-            return this->operator()(cell.x,cell.y,cell.z,n);
+        T* ptr (Dim3 const& cell, int n) const noexcept {
+            return this->ptr(cell.x,cell.y,cell.z,n);
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -397,7 +397,7 @@ namespace amrex {
         /**
          * \brief Multi-index operator() for accessing elements.
          * \tparam idx Variadic template for indices.
-         * \param i Variadic list of indicies.
+         * \param i Variadic list of indices.
          * \return Reference to the element.
          *
          * This operator is only enabled when the number of indices provided matches the dimension N or N-1
@@ -475,7 +475,7 @@ namespace amrex {
         /**
          * \brief Multi-index ptr() for accessing pointer to element.
          * \tparam idx Variadic template for indices.
-         * \param i Variadic list of indicies.
+         * \param i Variadic list of indices.
          * \return Pointer to the element.
          */
         template <typename... idx, class U=T,

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -837,9 +837,9 @@ namespace amrex {
         return len;
     }
 
-    template <typename T, int N>
-    std::ostream& operator<< (std::ostream& os, const ArrayND<T,N>& a) {
-        os << "((" << lbound(a) << ',' << ubound(a) << "))";
+    template <typename T, int N, bool C>
+    std::ostream& operator<< (std::ostream& os, const ArrayND<T,N,C>& a) {
+        os << "(" << a.begin << ',' << a.end-1 << ")";
         return os;
     }
 

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -618,13 +618,9 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (IntVectND<M> const& iv) const noexcept {
             bool inside = true;
-            constexpr int idx = (last_dim_component && M == N) ? N - 1 : M;
-            constexpr_for<0, idx>([&](int d) {
+            constexpr_for<0, M>([&](int d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
             });
-            if constexpr (last_dim_component && M == N) {
-                inside = inside && (iv[N-1] >= 0) && (iv[N-1] < end[N-1]);
-            }
             return inside;
         }
 
@@ -780,25 +776,11 @@ namespace amrex {
     template<typename T>
     using Array4 = ArrayND<T, 4, true>;
 
-    template <class Tto, class Tfrom, int N>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE
-    ArrayND<Tto,N> ToArray4 (ArrayND<Tfrom,N> const& a_in) noexcept
-    {
-        return ArrayND<Tto,N>((Tto*)(a_in.p), a_in.begin, a_in.end);
-    }
-
     template <class T>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Dim3 lbound (Array4<T> const& a) noexcept
     {
         return Dim3{a.begin[0],a.begin[1],a.begin[2]};
-    }
-
-    template <class T, int N, std::enable_if_t<(N != 4), int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    IntVectND<N> lbound (ArrayND<T,N> const& a) noexcept
-    {
-        return a.begin;
     }
 
     template <class T>
@@ -808,33 +790,11 @@ namespace amrex {
         return Dim3{a.end[0]-1,a.end[1]-1,a.end[2]-1};
     }
 
-    template <class T, int N, std::enable_if_t<(N != 4), int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    IntVectND<N> ubound (ArrayND<T,N> const& a) noexcept
-    {
-        IntVectND<N> hi;
-        for (int d = 0; d < N; ++d) {
-            hi[d] = a.end[d] - 1;
-        }
-        return hi;
-    }
-
     template <class T>
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Dim3 length (Array4<T> const& a) noexcept
     {
         return Dim3{a.end[0]-a.begin[0],a.end[1]-a.begin[1],a.end[2]-a.begin[2]};
-    }
-
-    template <class T, int N, std::enable_if_t<(N != 4), int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    IntVectND<N> length (ArrayND<T,N> const& a) noexcept
-    {
-        IntVectND<N> len;
-        for (int d = 0; d < N; ++d) {
-            len[d] = a.end[d] - a.begin[d];
-        }
-        return len;
     }
 
     template <typename T, int N, bool C>

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -391,7 +391,7 @@ namespace amrex {
          * \return true if pointer and bounds are valid, false otherwise.
          */
         [[nodiscard]] AMREX_GPU_HOST_DEVICE
-        bool ok () const noexcept { return p != nullptr && end.allGT(begin); }
+        constexpr bool ok () const noexcept { return p != nullptr && end.allGT(begin); }
 
         /**
          * \brief Multi-index operator() for accessing elements.

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -253,19 +253,19 @@ namespace amrex {
         /**
          * \brief IntVectND<N> constructor.
          * \param a_p Pointer to data.
-         * \param a_smallend Start index (inclusive).
-         * \param a_bigend End index (exclusive).
+         * \param a_begin Start index (inclusive).
+         * \param a_end End index (exclusive).
          *
          * This constructor specifies begin and end indices using IntVectND<N> for all N dimensions.
          */
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (T* a_p, IntVectND<N> const& a_smallend, IntVectND<N> const& a_bigend) noexcept
-            : p(a_p), begin(a_smallend), end(a_bigend)
+        constexpr ArrayND (T* a_p, IntVectND<N> const& a_begin, IntVectND<N> const& a_end) noexcept
+            : p(a_p), begin(a_begin), end(a_end)
         {
             if constexpr (N > 1) {
                 Long current_stride = 1;
                 constexpr_for<0, N-1>([&](int d) {
-                    Long len = a_bigend[d] - a_smallend[d];
+                    Long len = a_end[d] - a_begin[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
                 });
@@ -275,19 +275,19 @@ namespace amrex {
         /**
          * \brief IntVectND<M> constructor for M < N.
          * \param a_p Pointer to data.
-         * \param a_smallend Start index (inclusive).
-         * \param a_bigend End index (exclusive).
+         * \param a_begin Start index (inclusive).
+         * \param a_end End index (exclusive).
          *
          * For dimensions not specified are padded with [0,1).
          */
         template <int M, std::enable_if_t<(M < N),int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (T* a_p, IntVectND<M> const& a_smallend, IntVectND<M> const& a_bigend) noexcept
+        constexpr ArrayND (T* a_p, IntVectND<M> const& a_begin, IntVectND<M> const& a_end) noexcept
             : p(a_p), begin(), end()
         {
             constexpr_for<0, M>([&](int d) {
-                begin[d] = a_smallend[d];
-                end[d] = a_bigend[d];
+                begin[d] = a_begin[d];
+                end[d] = a_end[d];
             });
             constexpr_for<M, N>([&](int d) {
                 begin[d] = 0;
@@ -307,20 +307,20 @@ namespace amrex {
         /**
          * \brief Reduced dimension constructor with component count.
          * \param a_p Pointer to data.
-         * \param a_smallend Start index (inclusive).
-         * \param a_bigend End index (exclusive).
+         * \param a_begin Start index (inclusive).
+         * \param a_end End index (exclusive).
          * \param ncomp Number of components (size of last dimension).
          *
          * Pads intermediate dimensions with [0,1) and sets the last dimension to [0, ncomp).
          */
         template <int M, std::enable_if_t<(M < N) && (N != 1),int> = 0>
         AMREX_GPU_HOST_DEVICE
-        constexpr ArrayND (T* a_p, IntVectND<M> const& a_smallend, IntVectND<M> const& a_bigend, int ncomp) noexcept
+        constexpr ArrayND (T* a_p, IntVectND<M> const& a_begin, IntVectND<M> const& a_end, int ncomp) noexcept
             : p(a_p), begin(), end()
         {
             constexpr_for<0, M>([&](int d) {
-                begin[d] = a_smallend[d];
-                end[d] = a_bigend[d];
+                begin[d] = a_begin[d];
+                end[d] = a_end[d];
             });
             constexpr_for<M, N-1>([&](int d) {
                 begin[d] = 0;
@@ -391,7 +391,7 @@ namespace amrex {
          */
         AMREX_GPU_HOST_DEVICE
         explicit operator bool() const noexcept {
-            return p != nullptr && end.allGT(begin);    // Additional check for properly initialized ArrayND
+            return p != nullptr && end.allGT(begin);
         }
 
         /**

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -58,12 +58,6 @@ namespace amrex {
     };
 
     namespace detail {
-        // Helper to get N-th argument from a parameter pack
-        template <int idx, typename... Ts>
-        inline constexpr auto get_impl (Ts&&... ts) {                    // NOLINT (cppcoreguidelines-missing-std-forward)
-            return std::get<idx>(std::forward_as_tuple(ts...));
-        }
-
         /**
          * /brief Indices checker for ArrayND
          *
@@ -125,16 +119,34 @@ namespace amrex {
             return buf;
         }
 
-        template <std::size_t... idx, std::enable_if_t<sizeof...(idx)>=1,int> = 0>
+        template <std::size_t... idx, std::size_t... idx2x>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void device_printf_impl (std::index_sequence<idx...>&& index_seq,
-                                   const IntVectND<sizeof...(idx)>& iv,
-                                   const IntVectND<sizeof...(idx)>& begin,
-                                   const IntVectND<sizeof...(idx)>& end) {
-            constexpr auto msg = make_oob_message_impl(std::move(index_seq));
+        void device_print_impl2 (std::index_sequence<idx...>,
+                                std::index_sequence<idx2x...>,
+                                IntVectND<sizeof...(idx)> const& iv,
+                                IntVectND<sizeof...(idx)> const& begin,
+                                IntVectND<sizeof...(idx)> const& end)
+        {
+            constexpr auto msg = make_oob_message_impl(std::index_sequence<idx...>{});
+
             AMREX_DEVICE_PRINTF(msg.data(),
                 iv[idx]...,
-                ((begin[idx]), (end[idx]))...);
+                ((idx2x % 2 == 0) ? begin[idx2x / 2] : end[idx2x / 2])...
+            );
+        }
+
+        template <std::size_t... idx, std::enable_if_t<sizeof...(idx)>=1,int> = 0>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void device_printf_impl (std::index_sequence<idx...>,
+                                const IntVectND<sizeof...(idx)>& iv,
+                                const IntVectND<sizeof...(idx)>& begin,
+                                const IntVectND<sizeof...(idx)>& end)
+        {
+            device_print_impl2(
+                std::index_sequence<idx...>{},
+                std::make_index_sequence<sizeof...(idx)*2>{},
+                iv, begin, end
+            );
         }
     }
 
@@ -162,11 +174,11 @@ namespace amrex {
         {
             if constexpr (dim > 1) {
                 Long current_stride = 1;
-                constexpr_for<0, dim - 1>([&] (int d) {
+                for (int d = 0; d < dim - 1; ++d) {
                     Long len = a_end[d] - a_begin[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
-                });
+                }
             }
         }
 
@@ -176,11 +188,11 @@ namespace amrex {
             : p(a_p), begin(a_begin.x, a_begin.y, a_begin.z, 0), end(a_end.x, a_end.y, a_end.z, a_ncomp)
         {
             Long current_stride = 1;
-            constexpr_for<0, dim-1>([&] (int d) {
+            for (int d = 0; d < dim - 1; ++d) {
                 Long len = end[d] - begin[d];
                 current_stride *= len;
                 nstride[d] = current_stride;
-            });
+            }
         }
 
         template <class U,
@@ -216,122 +228,71 @@ namespace amrex {
         AMREX_GPU_HOST_DEVICE
         explicit operator bool() const noexcept { return p != nullptr; }
 
+        // This overload is enabled only when number of indices matches dimension or is one less than dimension
         template <typename... idx, class U=T,
             std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<dim, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (idx... i) const noexcept {
+            constexpr auto nidx = sizeof...(i);
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            if constexpr (sizeof...(i) == dim) {
-                index_assert(i...);
-            } else if constexpr (sizeof...(i) == dim - 1) {
-                // When number of indices is one less than dimension, we assume the last index is zero
-                index_assert(i...,0);
-            }
+            index_assert(IntVectND<nidx>{i...});
 #endif
-            if constexpr (sizeof...(i) == dim) {
-                return p[get_offset(i...)];
-            } else {
-                return p[get_offset(i...,0)];
-            }
+            return p[get_offset(IntVectND<nidx>{i...})];
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <int Dim, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (IntVectND<dim> const& iv) const noexcept {
+        U& operator() (IntVectND<Dim> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv);
 #endif
-            return p[get_offset_iv(iv)];
+            return p[get_offset(iv)];
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim==4),int> = 0>
+        template <int Dim, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (IntVect const& iv) const noexcept {
-#if (AMREX_SPACEDIM == 1)
-            return this->operator()(iv[0],0,0,0);
-#elif (AMREX_SPACEDIM == 2)
-            return this->operator()(iv[0],iv[1],0,0);
-#elif (AMREX_SPACEDIM == 3)
-            return this->operator()(iv[0],iv[1],iv[2],0);
-#endif
-        }
-
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim==4),int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (IntVect const& iv, int n) const noexcept {
-#if (AMREX_SPACEDIM == 1)
-            return this->operator()(iv[0],0,0,n);
-#elif (AMREX_SPACEDIM == 2)
-            return this->operator()(iv[0],iv[1],0,n);
-#elif (AMREX_SPACEDIM == 3)
-            return this->operator()(iv[0],iv[1],iv[2],n);
-#endif
-        }
-
-        // Explicit overload for dim=4
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (int i, int j, int k) const noexcept {
+        U& operator() (IntVectND<Dim> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(i,j,k,0);
+            index_assert(iv, n);
 #endif
-            return p[get_offset(i,j,k,0)];
+            return p[get_offset(iv, n)];
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        U& operator() (int i, int j, int k, int n) const noexcept {
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(i,j,k,n);
-#endif
-            return p[get_offset(i,j,k,n)];
-        }
 
+        // This overload is enabled only when number of indices matches dimension or is one less than dimension
         template <typename... idx, class U=T,
             std::enable_if_t<!std::is_void_v<U> && detail::ArrayNDIndexCheck_impl_v<dim, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (idx... i) const noexcept {
+            constexpr auto nidx = sizeof...(i);
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            if constexpr (sizeof...(i) == dim) {
-                index_assert(i...);
-            } else if constexpr (sizeof...(i) == dim - 1) {
-                // When number of indices is one less than dimension, we assume the last index is zero
-                index_assert(i...,0);
-            }
+            index_assert(IntVectND<nidx>{i...});
 #endif
-            if constexpr (sizeof...(i) == dim) {
-                return p + get_offset(i...);
-            } else {
-                return p + get_offset(i...,0);
-            }
+            return p + get_offset(IntVectND<nidx>{i...});
         }
 
-        template <typename... idx, class U=T,
-            std::enable_if_t<!std::is_void_v<U>,int> = 0>
+        template <int Dim, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (IntVectND<dim> const& iv) const noexcept {
+        T* ptr (IntVectND<Dim> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv);
 #endif
-            return p + get_offset_iv(iv);
+            return p + get_offset(iv);
         }
 
-        template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
+        template <int Dim, class U=T, std::enable_if_t<!std::is_void_v<U>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* ptr (IntVect const& iv, int n = 0) const noexcept {
-#if (AMREX_SPACEDIM == 1)
-            return this->ptr(iv[0],0,0,n);
-#elif (AMREX_SPACEDIM == 2)
-            return this->ptr(iv[0],iv[1],0,n);
-#elif (AMREX_SPACEDIM == 3)
-            return this->ptr(iv[0],iv[1],iv[2],n);
+        T* ptr (IntVectND<Dim> const& iv, int n) const noexcept {
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+            index_assert(iv, n);
 #endif
+            return p + get_offset(iv, n);
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (Dim3 const& cell) const noexcept {
-            return this->operator()(cell.x,cell.y,cell.z,0);
+            return this->operator()(cell.x,cell.y,cell.z);
         }
 
         template <class U=T, std::enable_if_t<!std::is_void_v<U> && (dim == 4),int> = 0>
@@ -341,7 +302,7 @@ namespace amrex {
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        T* dataPtr () const noexcept {
+        constexpr T* dataPtr () const noexcept {
             return this->p;
         }
 
@@ -354,75 +315,112 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr std::size_t size () const noexcept {
             std::size_t s = 1;
-            constexpr_for<0, dim>([&] (auto d) {
+            for (int d = 0; d < dim; ++d) {
                 s *= (end[d] - begin[d]);
-            });
+            }
             return s;
         }
 
         template <typename... idx, std::enable_if_t<detail::ArrayNDIndexCheck_impl_v<dim, idx...>,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        bool contains (idx... i) const noexcept {
-            if constexpr (sizeof...(i) == dim) {
-                return this->contains(IntVectND<dim>{i...});
-            } else {
-                // When number of indices is one less than dimension, we assume the last index is zero
-                return this->contains(IntVectND<dim>{i...,0});
-            }
+        constexpr bool contains (idx... i) const noexcept {
+            constexpr auto nidx = sizeof...(i);
+            return this->contains(IntVectND<nidx>{i...});
         }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        bool contains (IntVect const& iv) const noexcept {
-#if (AMREX_SPACEDIM == 1)
-            return this->contains(IntVectND<dim>{iv[0],0,0,0});
-#elif (AMREX_SPACEDIM == 2)
-            return this->contains(IntVectND<dim>{iv[0],iv[1],0,0});
-#elif (AMREX_SPACEDIM == 3)
-            return this->contains(IntVectND<dim>{iv[0],iv[1],iv[2],0});
-#endif
-        }
-
-        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        bool contains (IntVectND<dim> const& iv) const noexcept {
+        constexpr bool contains (IntVectND<dim> const& iv) const noexcept {
             bool inside = true;
-            constexpr_for<0, dim>([&] (auto d) {
+            for (int d = 0; d < dim; ++d) {
                 inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
-            });
+            }
             return inside;
         }
 
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1),int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        constexpr bool contains (IntVectND<Dim> const& iv) const noexcept {
+            bool inside = true;
+            for (int d = 0; d < Dim; ++d) {
+                inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
+            }
+            for (int d = Dim; d < dim-1; ++d) {
+                inside = inside && (0 >= begin[d]) && (0 < end[d]);
+            }
+            // Check last dimension with begin[dim-1] which is always true
+            // inside = inside && (begin[dim-1] >= begin[dim-1]) && (begin[dim-1] < end[dim-1]);
+            return inside;
+        }
+
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1) && (dim != 1),int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        constexpr bool contains (IntVectND<Dim> const& iv, int n) const noexcept {
+            bool inside = true;
+            for (int d = 0; d < Dim; ++d) {
+                inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
+            }
+            for (int d = Dim; d < dim-1; ++d) {
+                inside = inside && (0 >= begin[d]) && (0 < end[d]);
+            }
+            // Check last dimension with n
+            inside = inside && (n >= begin[dim-1]) && (n < end[dim-1]);
+            return inside;
+        }
+
+
         template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        bool contains (Dim3 const& cell) const noexcept {
-            return this->contains(IntVectND<dim>{cell.x, cell.y, cell.z, 0});
+        constexpr bool contains (Dim3 const& cell) const noexcept {
+            return this->contains(IntVectND<Dim>{cell.x, cell.y, cell.z, begin[Dim-1]});
         }
 
         template <int Dim=dim, std::enable_if_t<Dim==4,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         CellData<T> cellData (int i, int j, int k) const noexcept {
             int ncomp = end[3] - begin[3];
-            return CellData<T>(this->ptr(i,j,k), nstride[dim-2], ncomp);
+            return CellData<T>(this->ptr(i,j,k), nstride[Dim-2], ncomp);
         }
 
-
-        template <typename... idx, std::enable_if_t<sizeof...(idx) == dim,int> = 0>
+        // Main get_offset function for dim
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr Long get_offset (idx... indices) const noexcept
+        constexpr Long get_offset (IntVectND<dim> const& iv) const noexcept
         {
-            Long offset = detail::get_impl<0>(indices...) - begin[0];
-            constexpr_for<1, dim>([&] (auto i) {
-                offset += (detail::get_impl<i>(indices...) - begin[i]) * nstride[i - 1];
-            });
+            Long offset = iv[0] - begin[0];
+            for (int d = 1; d < dim; ++d) {
+                offset += (iv[d] - begin[d]) * nstride[d-1];
+            }
             return offset;
         }
 
+        // Overload for Dim < dim
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1),int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr Long get_offset_iv (IntVectND<dim> const& iv) const noexcept
+        constexpr Long get_offset (IntVectND<Dim> const& iv) const noexcept
         {
             Long offset = iv[0] - begin[0];
-            constexpr_for<1, dim>([&] (auto d) {
+            for (int d = 1; d < Dim; ++d) {
                 offset += (iv[d] - begin[d]) * nstride[d-1];
-            });
+            }
+            for (int d = Dim; d < dim-1; ++d) {
+                offset += (Long(0) - begin[d]) * nstride[d-1];
+            }
+            // offset += (begin[dim-1] - begin[dim-1]) * nstride[dim-2];
+            return offset;
+        }
+
+        // Overload for Dim < dim with last index n. Dim must be at least 2
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1) && (dim != 1),int> = 0>
+        [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        constexpr Long get_offset (IntVectND<Dim> const& iv, int n) const noexcept
+        {
+            Long offset = iv[0] - begin[0];
+            for (int d = 1; d < Dim; ++d) {
+                offset += (iv[d] - begin[d]) * nstride[d-1];
+            }
+            for (int d = Dim; d < dim-1; ++d) {
+                offset += (Long(0) - begin[d]) * nstride[d-1];
+            }
+            offset += (n - begin[dim-1]) * nstride[dim-2];
             return offset;
         }
 
@@ -462,18 +460,26 @@ namespace amrex {
                 ))
             }
         }
-#endif
 
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-        template<typename... idx, std::enable_if_t<sizeof...(idx) == dim,int> = 0>
-#if defined(AMREX_USE_HIP)
-        AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
-#else
-        AMREX_GPU_HOST_DEVICE inline
-#endif
-        void index_assert (idx... indices) const
+        // index_assert overload for Dim <= dim-1
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1),int> = 0>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void index_assert (IntVectND<Dim> const& iv) const
         {
-            this->index_assert(IntVectND<dim>{indices...});
+            IntVectND<dim> iv_full = iv.template expand<dim>(0);
+            iv_full[dim-1] = begin[dim-1];
+            index_assert(iv_full);
+        }
+
+        // index_assert overload for Dim <= dim-1, last index n
+        // Overload not valid for dim=1
+        template <int Dim, std::enable_if_t<(1 <= Dim) && (Dim <= dim-1) && (dim != 1),int> = 0>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void index_assert (IntVectND<Dim> const& iv, int n) const
+        {
+            IntVectND<dim> iv_full = iv.template expand<dim>(0);
+            iv_full[dim-1] = n;
+            index_assert(iv_full);
         }
 #endif
     };

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1536,33 +1536,33 @@ BaseFab<T>::BaseFab (const Box& bx, int ncomp, T const* p)
 template<class T>
 BaseFab<T>::BaseFab (Array4<T> const& a) noexcept
     : dptr(a.p),
-      domain(IntVect(AMREX_D_DECL(a.begin.x,a.begin.y,a.begin.z)),
-             IntVect(AMREX_D_DECL(a.end.x-1,a.end.y-1,a.end.z-1))),
-      nvar(a.ncomp), truesize(a.ncomp*a.nstride)
+      domain(IntVect(AMREX_D_DECL(a.begin[0],a.begin[1],a.begin[2])),
+             IntVect(AMREX_D_DECL(a.end[0]-1,a.end[1]-1,a.end[2]-1))),
+      nvar(a.nComp()), truesize(a.size())
 {}
 
 template<class T>
 BaseFab<T>::BaseFab (Array4<T> const& a, IndexType t) noexcept
     : dptr(a.p),
-      domain(IntVect(AMREX_D_DECL(a.begin.x,a.begin.y,a.begin.z)),
-             IntVect(AMREX_D_DECL(a.end.x-1,a.end.y-1,a.end.z-1)), t),
-      nvar(a.ncomp), truesize(a.ncomp*a.nstride)
+      domain(IntVect(AMREX_D_DECL(a.begin[0],a.begin[1],a.begin[2])),
+             IntVect(AMREX_D_DECL(a.end[0]-1,a.end[1]-1,a.end[2]-1)), t),
+      nvar(a.nComp()), truesize(a.size())
 {}
 
 template<class T>
 BaseFab<T>::BaseFab (Array4<T const> const& a) noexcept
     : dptr(const_cast<T*>(a.p)),
-      domain(IntVect(AMREX_D_DECL(a.begin.x,a.begin.y,a.begin.z)),
-             IntVect(AMREX_D_DECL(a.end.x-1,a.end.y-1,a.end.z-1))),
-      nvar(a.ncomp), truesize(a.ncomp*a.nstride)
+      domain(IntVect(AMREX_D_DECL(a.begin[0],a.begin[1],a.begin[2])),
+             IntVect(AMREX_D_DECL(a.end[0]-1,a.end[1]-1,a.end[2]-1))),
+      nvar(a.nComp()), truesize(a.size())
 {}
 
 template<class T>
 BaseFab<T>::BaseFab (Array4<T const> const& a, IndexType t) noexcept
     : dptr(const_cast<T*>(a.p)),
-      domain(IntVect(AMREX_D_DECL(a.begin.x,a.begin.y,a.begin.z)),
-             IntVect(AMREX_D_DECL(a.end.x-1,a.end.y-1,a.end.z-1)), t),
-      nvar(a.ncomp), truesize(a.ncomp*a.nstride)
+      domain(IntVect(AMREX_D_DECL(a.begin[0],a.begin[1],a.begin[2])),
+             IntVect(AMREX_D_DECL(a.end[0]-1,a.end[1]-1,a.end[2]-1)), t),
+      nvar(a.nComp()), truesize(a.size())
 {}
 
 template <class T>

--- a/Src/Base/AMReX_BaseFwd.H
+++ b/Src/Base/AMReX_BaseFwd.H
@@ -13,7 +13,7 @@ class FabArrayBase;
 class FArrayBox;
 class IArrayBox;
 template <class T> class BaseFab;
-template <typename T> struct Array4;
+template <typename T, int N> struct ArrayND;
 
 template <class T, unsigned int N> struct GpuArray;
 

--- a/Src/Base/AMReX_BaseFwd.H
+++ b/Src/Base/AMReX_BaseFwd.H
@@ -14,6 +14,8 @@ class FArrayBox;
 class IArrayBox;
 template <class T> class BaseFab;
 template <typename T, int N> struct ArrayND;
+template <typename T>
+using Array4 = ArrayND<T,4>;
 
 template <class T, unsigned int N> struct GpuArray;
 

--- a/Src/Base/AMReX_BaseFwd.H
+++ b/Src/Base/AMReX_BaseFwd.H
@@ -13,9 +13,10 @@ class FabArrayBase;
 class FArrayBox;
 class IArrayBox;
 template <class T> class BaseFab;
-template <typename T, int N> struct ArrayND;
+template <typename T, int N, bool last_dim_component>
+struct ArrayND;
 template <typename T>
-using Array4 = ArrayND<T,4>;
+using Array4 = ArrayND<T,4, true>;
 
 template <class T, unsigned int N> struct GpuArray;
 

--- a/Src/Base/AMReX_Box.H
+++ b/Src/Base/AMReX_Box.H
@@ -97,8 +97,8 @@ public:
     template <typename T, int Tdim=dim, std::enable_if_t<( 1<=Tdim && Tdim<=3 ), int> = 0>
     AMREX_GPU_HOST_DEVICE
     explicit BoxND (Array4<T> const& a) noexcept
-        : smallend(a.begin),
-          bigend(IntVectND<dim>(a.end) - 1)
+        : smallend(IntVectShrink<dim>(a.begin)),
+          bigend(IntVectShrink<dim>(a.end) - 1)
         {}
 
     // dtor, copy-ctor, copy-op=, move-ctor, and move-op= are compiler generated.

--- a/Src/Base/AMReX_CudaGraph.H
+++ b/Src/Base/AMReX_CudaGraph.H
@@ -34,22 +34,8 @@ template <typename T, typename U>
 CopyMemory
 makeCopyMemory (Array4<T> const& src, Array4<U> const& dst, int scomp, int ncomp)
 {
-#if __cplusplus < 201402L
-    CopyMemory mem;
-    mem.src = (void*)(src.p);
-    mem.dst = (void*)(dst.p);
-    mem.src_begin = src.begin;
-    mem.src_end = src.end;
-    mem.dst_begin = dst.begin;
-    mem.dst_end = dst.end;
-    mem.scomp = scomp;
-    mem.ncomp = ncomp;
-    return mem;
-
-#else
-
-    return CopyMemory{ (void*)(src.p), (void*)(dst.p), src.begin, src.end, dst.begin, dst.end, scomp, ncomp };
-#endif
+    return CopyMemory{ (void*)(src.p), (void*)(dst.p), IntVectShrink<3>(src.begin).dim3(), IntVectShrink<3>(src.end).dim3(),
+        IntVectShrink<3>(dst.begin).dim3(), IntVectShrink<3>(dst.end).dim3(), scomp, ncomp };
 }
 
 // ======================================================================================

--- a/Src/Base/AMReX_FilCC_1D_C.H
+++ b/Src/Base/AMReX_FilCC_1D_C.H
@@ -22,8 +22,8 @@ struct FilccCell
         const auto& domain_hi = domain_box.hiVect();
         const int ilo = domain_lo[0];
         const int ihi = domain_hi[0];
-        const int is = amrex::max(q.begin.x,ilo);
-        const int ie = amrex::min(q.end.x-1,ihi);
+        const int is = amrex::max(q.begin[0],ilo);
+        const int ie = amrex::min(q.end[0]-1,ihi);
 
         for (int n = dcomp; n < numcomp+dcomp; ++n)
         {

--- a/Src/Base/AMReX_FilCC_2D_C.H
+++ b/Src/Base/AMReX_FilCC_2D_C.H
@@ -25,10 +25,10 @@ struct FilccCell
         const int jlo = domain_lo[1];
         const int ihi = domain_hi[0];
         const int jhi = domain_hi[1];
-        const int is = amrex::max(q.begin.x,ilo);
-        const int js = amrex::max(q.begin.y,jlo);
-        const int ie = amrex::min(q.end.x-1,ihi);
-        const int je = amrex::min(q.end.y-1,jhi);
+        const int is = amrex::max(q.begin[0],ilo);
+        const int js = amrex::max(q.begin[1],jlo);
+        const int ie = amrex::min(q.end[0]-1,ihi);
+        const int je = amrex::min(q.end[1]-1,jhi);
 
         for (int n = dcomp; n < numcomp+dcomp; ++n)
         {

--- a/Src/Base/AMReX_FilCC_3D_C.H
+++ b/Src/Base/AMReX_FilCC_3D_C.H
@@ -48,7 +48,7 @@ struct FilccCell
                         q(i,j,k,n) = q(ilo,j,k,n);
                     }
                     // i == ilo-1
-                    else if (ilo+2 <= amrex::min(q.end.x-1,ihi))
+                    else if (ilo+2 <= amrex::min(q.end[0]-1,ihi))
                     {
                         q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i+1,j,k,n) - Real(10.)*q(i+2,j,k,n) + Real(3.)*q(i+3,j,k,n));
                     }
@@ -91,7 +91,7 @@ struct FilccCell
                         q(i,j,k,n) = q(ihi,j,k,n);
                     }
                     // i == ihi+1
-                    else if (ihi-2 >= amrex::max(q.begin.x,ilo))
+                    else if (ihi-2 >= amrex::max(q.begin[0],ilo))
                     {
                         q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i-1,j,k,n) - Real(10.)*q(i-2,j,k,n) + Real(3.)*q(i-3,j,k,n));
                     }
@@ -135,7 +135,7 @@ struct FilccCell
                         q(i,j,k,n) = q(i,jlo,k,n);
                     }
                     // j == jlo-1
-                    else if (jlo+2 <= amrex::min(q.end.y-1,jhi))
+                    else if (jlo+2 <= amrex::min(q.end[1]-1,jhi))
                     {
                         q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j+1,k,n) - Real(10.)*q(i,j+2,k,n) + Real(3.)*q(i,j+3,k,n));
                     }
@@ -178,7 +178,7 @@ struct FilccCell
                         q(i,j,k,n) = q(i,jhi,k,n);
                     }
                     // j == jhi+1
-                    else if (jhi-2 >= amrex::max(q.begin.y,jlo))
+                    else if (jhi-2 >= amrex::max(q.begin[1],jlo))
                     {
                         q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j-1,k,n) - Real(10.)*q(i,j-2,k,n) + Real(3.)*q(i,j-3,k,n));
                     }
@@ -222,7 +222,7 @@ struct FilccCell
                         q(i,j,k,n) = q(i,j,klo,n);
                     }
                     // k == klo-1
-                    else if (klo+2 <= amrex::min(q.end.z-1,khi))
+                    else if (klo+2 <= amrex::min(q.end[2]-1,khi))
                     {
                         q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j,k+1,n) - Real(10.)*q(i,j,k+2,n) + Real(3.)*q(i,j,k+3,n));
                     }
@@ -265,7 +265,7 @@ struct FilccCell
                         q(i,j,k,n) = q(i,j,khi,n);
                     }
                     // k == khi+1
-                    else if (khi-2 >= amrex::max(q.begin.z,klo))
+                    else if (khi-2 >= amrex::max(q.begin[2],klo))
                     {
                         q(i,j,k,n) = Real(0.125)*(Real(15.)*q(i,j,k-1,n) - Real(10.)*q(i,j,k-2,n) + Real(3.)*q(i,j,k-3,n));
                     }

--- a/Src/Base/AMReX_MultiFabUtil_1D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_1D_C.H
@@ -287,7 +287,7 @@ void amrex_compute_divergence (Box const& bx, Array4<Real> const& divu,
     const auto hi = ubound(bx);
     const Real dxi = dxinv[0];
 
-    for     (int n = 0; n < divu.ncomp; ++n) {
+    for     (int n = 0; n < divu.nComp(); ++n) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             divu(i,0,0,n) = dxi * (u(i+1,0,0,n)-u(i,0,0,n));

--- a/Src/Base/AMReX_MultiFabUtil_2D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_2D_C.H
@@ -359,7 +359,7 @@ void amrex_compute_divergence (Box const& bx, Array4<Real> const& divu,
     const Real dxi = dxinv[0];
     const Real dyi = dxinv[1];
 
-    for     (int n = 0; n < divu.ncomp; ++n) {
+    for     (int n = 0; n < divu.nComp(); ++n) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
@@ -405,7 +405,7 @@ void amrex_compute_convective_difference (Box const& bx, Array4<amrex::Real> con
     const Real dxi = dxinv[0];
     const Real dyi = dxinv[1];
 
-    for         (int n = 0; n <  diff.ncomp; ++n) {
+    for         (int n = 0; n <  diff.nComp(); ++n) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
@@ -430,7 +430,7 @@ void amrex_compute_divergence_rz (Box const& bx, Array4<Real> const& divu,
     const auto lo = lbound(bx);
     const auto hi = ubound(bx);
 
-    for     (int n = 0; n < divu.ncomp; ++n) {
+    for     (int n = 0; n < divu.nComp(); ++n) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {

--- a/Src/Base/AMReX_MultiFabUtil_3D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_3D_C.H
@@ -466,7 +466,7 @@ void amrex_compute_divergence (Box const& bx, Array4<Real> const& divu,
     const Real dyi = dxinv[1];
     const Real dzi = dxinv[2];
 
-    for             (int n = 0; n <  divu.ncomp; ++n) {
+    for             (int n = 0; n <  divu.nComp(); ++n) {
         for         (int k = lo.z; k <= hi.z; ++k) {
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
@@ -523,7 +523,7 @@ void amrex_compute_convective_difference (Box const& bx, Array4<Real> const& dif
     const Real dyi = dxinv[1];
     const Real dzi = dxinv[2];
 
-    for             (int n = 0; n <  diff.ncomp; ++n) {
+    for             (int n = 0; n <  diff.nComp(); ++n) {
         for         (int k = lo.z; k <= hi.z; ++k) {
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -269,6 +269,30 @@ namespace amrex
     template <typename T, typename... Args>
     inline constexpr bool IsConvertible_v = IsConvertible<T, Args...>::value;
 
+    namespace detail {
+        template <typename T, typename U, typename Enable = void>
+        struct IsNarrowingConversionImp : std::true_type {};
+
+        template <typename T, typename U>
+        struct IsNarrowingConversionImp<T, U, std::void_t<decltype(U{std::declval<T>()})>> : std::false_type {};
+    }
+
+    template <typename From, typename To>
+    struct IsNarrowingConversion : detail::IsNarrowingConversionImp<From, To> {};
+
+    template <typename From, typename To>
+    inline constexpr bool IsNarrowingConversion_v = IsNarrowingConversion<From, To>::value;
+
+    template <typename From, typename To>
+    inline constexpr bool IsNonNarrowingConversion_v = !IsNarrowingConversion<From, To>::value;
+
+    //! \brief Test if type T is a valid index type. Valid index type is integral and can be safely
+    //!         converted to int without narrowing.
+    template <typename T>
+    struct IsValidIndexType {
+        static constexpr bool value = std::is_integral_v<T> && IsNonNarrowingConversion_v<T, int>;
+    };
+
     // Move this down, because doxygen can not parse anything below IsStoreAtomic
     template <class T, class Enable = void>
     struct IsStoreAtomic : std::false_type {};

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -286,13 +286,6 @@ namespace amrex
     template <typename From, typename To>
     inline constexpr bool IsNonNarrowingConversion_v = !IsNarrowingConversion<From, To>::value;
 
-    //! \brief Test if type T is a valid index type. Valid index type is integral and can be safely
-    //!         converted to int without narrowing.
-    template <typename T>
-    struct IsValidIndexType {
-        static constexpr bool value = std::is_integral_v<T> && IsNonNarrowingConversion_v<T, int>;
-    };
-
     // Move this down, because doxygen can not parse anything below IsStoreAtomic
     template <class T, class Enable = void>
     struct IsStoreAtomic : std::false_type {};

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -718,11 +718,11 @@ protected:
     [[nodiscard]] Array4<T> compactify (Array4<T> const& a) const noexcept
     {
         if (info.hidden_direction == 0) {
-            return Array4<T>(a.dataPtr(), {a.begin.y,a.begin.z,0}, {a.end.y,a.end.z,1}, a.nComp());
+            return Array4<T>(a.dataPtr(), {a.begin[1],a.begin[2],0}, {a.end[1],a.end[2],1}, a.nComp());
         } else if (info.hidden_direction == 1) {
-            return Array4<T>(a.dataPtr(), {a.begin.x,a.begin.z,0}, {a.end.x,a.end.z,1}, a.nComp());
+            return Array4<T>(a.dataPtr(), {a.begin[0],a.begin[2],0}, {a.end[0],a.end[2],1}, a.nComp());
         } else if (info.hidden_direction == 2) {
-            return Array4<T>(a.dataPtr(), {a.begin.x,a.begin.y,0}, {a.end.x,a.end.y,1}, a.nComp());
+            return Array4<T>(a.dataPtr(), {a.begin[0],a.begin[1],0}, {a.end[0],a.end[1],1}, a.nComp());
         } else {
             return a;
         }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -976,9 +976,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             if(imf_arr(i,j,k,0)!=0)
             {
                 const auto idx = last_offset + offsets_ptr[
-                    ((i-imf_arr.begin.x)
-                    +(j-imf_arr.begin.y)*imf_arr.jstride
-                    +(k-imf_arr.begin.z)*imf_arr.kstride)
+                    ((i-imf_arr.begin[0])
+                    +(j-imf_arr.begin[1])*imf_arr.nstride[1]
+                    +(k-imf_arr.begin[2])*imf_arr.nstride[2])
                 ];
 
                 dst.cpu(idx) = 0;

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -976,9 +976,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             if(imf_arr(i,j,k,0)!=0)
             {
                 const auto idx = last_offset + offsets_ptr[
-                    ((i-imf_arr.begin[0])
-                    +(j-imf_arr.begin[1])*imf_arr.nstride[1]
-                    +(k-imf_arr.begin[2])*imf_arr.nstride[2])
+                    imf_arr.get_offset(IntVectND<3>{i,j,k})
                 ];
 
                 dst.cpu(idx) = 0;

--- a/Src/Particle/AMReX_Particle_mod_K.H
+++ b/Src/Particle/AMReX_Particle_mod_K.H
@@ -138,7 +138,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     int hi_x = static_cast<int>(amrex::Math::floor(hx));
 
     for (int i = lo_x; i <= hi_x; ++i) {
-        if (i < rho.begin.x || i >= rho.end.x) { continue; }
+        if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
         amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
         amrex::Real weight = wx*factor;
         amrex::Gpu::Atomic::AddNoRet(&rho(i, 0, 0, 0), static_cast<Real>(weight*p.rdata(0)));
@@ -147,7 +147,7 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     for (int comp = 1; comp < nc; ++comp)
     {
         for (int i = lo_x; i <= hi_x; ++i) {
-            if (i < rho.begin.x || i >= rho.end.x) { continue; }
+            if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
             amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
             amrex::Real weight = wx*factor;
             amrex::Gpu::Atomic::AddNoRet(&rho(i, 0, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
@@ -170,10 +170,10 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     int hi_y = static_cast<int>(amrex::Math::floor(hy));
 
     for (int j = lo_y; j <= hi_y; ++j) {
-        if (j < rho.begin.y || j >= rho.end.y) { continue; }
+        if (j < rho.begin[1] || j >= rho.end[1]) { continue; }
         amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
         for (int i = lo_x; i <= hi_x; ++i) {
-            if (i < rho.begin.x || i >= rho.end.x) { continue; }
+            if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
             amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
             amrex::Real weight = wx*wy*factor;
             amrex::Gpu::Atomic::AddNoRet(&rho(i, j, 0, 0), static_cast<Real>(weight*p.rdata(0)));
@@ -182,10 +182,10 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 
     for (int comp = 1; comp < nc; ++comp) {
         for (int j = lo_y; j <= hi_y; ++j) {
-            if (j < rho.begin.y || j >= rho.end.y) { continue; }
+            if (j < rho.begin[1] || j >= rho.end[1]) { continue; }
             amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
             for (int i = lo_x; i <= hi_x; ++i) {
-                if (i < rho.begin.x || i >= rho.end.x) { continue; }
+                if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
                 amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
                 amrex::Real weight = wx*wy*factor;
                 amrex::Gpu::Atomic::AddNoRet(&rho(i, j, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
@@ -213,13 +213,13 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     int hi_z = static_cast<int>(amrex::Math::floor(hz));
 
     for (int k = lo_z; k <= hi_z; ++k) {
-        if (k < rho.begin.z || k >= rho.end.z) { continue; }
+        if (k < rho.begin[2] || k >= rho.end[2]) { continue; }
         amrex::Real wz = amrex::min(hz - static_cast<Real>(k), amrex::Real(1.0)) - amrex::max(lz - static_cast<Real>(k), amrex::Real(0.0));
         for (int j = lo_y; j <= hi_y; ++j) {
-            if (j < rho.begin.y || j >= rho.end.y) { continue; }
+            if (j < rho.begin[1] || j >= rho.end[1]) { continue; }
             amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
             for (int i = lo_x; i <= hi_x; ++i) {
-                if (i < rho.begin.x || i >= rho.end.x) { continue; }
+                if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
                 amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
                 amrex::Real weight = wx*wy*wz*factor;
                 amrex::Gpu::Atomic::AddNoRet(&rho(i, j, k, 0), static_cast<Real>(weight*p.rdata(0)));
@@ -229,13 +229,13 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 
     for (int comp = 1; comp < nc; ++comp) {
         for (int k = lo_z; k <= hi_z; ++k) {
-            if (k < rho.begin.z || k >= rho.end.z) { continue; }
+            if (k < rho.begin[2] || k >= rho.end[2]) { continue; }
             amrex::Real wz = amrex::min(hz - static_cast<Real>(k), amrex::Real(1.0)) - amrex::max(lz - static_cast<Real>(k), amrex::Real(0.0));
             for (int j = lo_y; j <= hi_y; ++j) {
-                if (j < rho.begin.y || j >= rho.end.y) { continue; }
+                if (j < rho.begin[1] || j >= rho.end[1]) { continue; }
                 amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
                 for (int i = lo_x; i <= hi_x; ++i) {
-                    if (i < rho.begin.x || i >= rho.end.x) { continue; }
+                    if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
                     amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
                     amrex::Real weight = wx*wy*wz*factor;
                     amrex::Gpu::Atomic::AddNoRet(&rho(i, j, k, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));


### PR DESCRIPTION
## Summary

This PR introduces a preliminary implementation that generalizes Array4 to an N-dimensional case, extending AMReX support for arbitrary dimensionality as outlined in #3955.

The new `ArrayND` implementation has the same size as `Array4` (64 bytes) and is intended to exhibit identical behaviour. However, this change modifies the types of `begin` and `end` and removes `ncomp`, which may break downstream code. In particular, `pyamrex` will likely need to be updated to accommodate these type changes. All internal AMReX source code that uses `begin`, `end`, or `ncomp` has been updated.

One open question concerns the behaviour of `ArrayND<dim>::operator()(idx...)` when the number of indices provided is `dim-1`. In `Array4`, this case sets the last dimension `ncomp` to zero. Should this behaviour be extended to all `dim` cases in `ArrayND` ? 

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
