### PR TITLE
ReduceOps.eval with BoxND

### DIFF
--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -31,7 +31,7 @@ namespace detail {
     auto call_f_scalar_handler (F const& f, N i)
         noexcept -> decltype(f(0))
     {
-        f(i);
+        return f(i);
     }
 
     template <typename F, typename N>
@@ -39,7 +39,7 @@ namespace detail {
     auto call_f_scalar_handler (F const& f, N i)
         noexcept -> decltype(f(0,Gpu::Handler{}))
     {
-        f(i, Gpu::Handler{});
+        return f(i, Gpu::Handler{});
     }
 
     // call_f_intvect_inner
@@ -49,7 +49,7 @@ namespace detail {
     auto call_f_intvect_inner (std::index_sequence<Ns...>, F const& f, IntVectND<1> iv, Args...args)
         noexcept -> decltype(f(0, 0, 0, args...))
     {
-        f(iv[0], 0, 0, args...);
+        return f(iv[0], 0, 0, args...);
     }
 
     template <typename F, std::size_t...Ns, class...Args>
@@ -57,7 +57,7 @@ namespace detail {
     auto call_f_intvect_inner (std::index_sequence<Ns...>, F const& f, IntVectND<2> iv, Args...args)
         noexcept -> decltype(f(0, 0, 0, args...))
     {
-        f(iv[0], iv[1], 0, args...);
+        return f(iv[0], iv[1], 0, args...);
     }
 
     template <typename F, int dim, std::size_t...Ns, class...Args>
@@ -65,7 +65,7 @@ namespace detail {
     auto call_f_intvect_inner (std::index_sequence<Ns...>, F const& f, IntVectND<dim> iv, Args...args)
         noexcept -> decltype(f(iv, args...))
     {
-        f(iv, args...);
+        return f(iv, args...);
     }
 
     template <typename F, int dim, std::size_t...Ns, class...Args>
@@ -73,7 +73,7 @@ namespace detail {
     auto call_f_intvect_inner (std::index_sequence<Ns...>, F const& f, IntVectND<dim> iv, Args...args)
         noexcept -> decltype(f(iv[Ns]..., args...))
     {
-        f(iv[Ns]..., args...);
+        return f(iv[Ns]..., args...);
     }
 
     // call_f_intvect_engine
@@ -83,7 +83,7 @@ namespace detail {
     auto call_f_intvect_engine (F const& f, IntVectND<dim> iv, RandomEngine engine)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, engine))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, engine);
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, engine);
     }
 
     // call_f_intvect_handler
@@ -93,7 +93,7 @@ namespace detail {
     auto call_f_intvect_handler (F const& f, IntVectND<dim> iv)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv);
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv);
     }
 
     template <typename F, int dim>
@@ -101,7 +101,7 @@ namespace detail {
     auto call_f_intvect_handler (F const& f, IntVectND<dim> iv)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, Gpu::Handler{}))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, Gpu::Handler{});
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, Gpu::Handler{});
     }
 
     // call_f_intvect_ncomp_engine
@@ -111,7 +111,7 @@ namespace detail {
     auto call_f_intvect_ncomp_engine (F const& f, IntVectND<dim> iv, T n, RandomEngine engine)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n, engine))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n, engine);
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n, engine);
     }
 
     // call_f_intvect_ncomp_handler
@@ -121,7 +121,7 @@ namespace detail {
     auto call_f_intvect_ncomp_handler (F const& f, IntVectND<dim> iv, T n)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n);
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n);
     }
 
     template <typename F, typename T, int dim>
@@ -129,7 +129,7 @@ namespace detail {
     auto call_f_intvect_ncomp_handler (F const& f, IntVectND<dim> iv, T n)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n, Gpu::Handler{}))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n, Gpu::Handler{});
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n, Gpu::Handler{});
     }
 
 }

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -13,7 +13,7 @@ namespace detail {
     auto call_f_scalar_handler (F const& f, N i, Gpu::Handler const&)
         noexcept -> decltype(f(0))
     {
-        f(i);
+        return f(i);
     }
 
     template <typename F, typename N>
@@ -21,7 +21,7 @@ namespace detail {
     auto call_f_scalar_handler (F const& f, N i, Gpu::Handler const& handler)
         noexcept -> decltype(f(0,Gpu::Handler{}))
     {
-        f(i, handler);
+        return f(i, handler);
     }
 
     // call_f_intvect_inner
@@ -31,7 +31,7 @@ namespace detail {
     auto call_f_intvect_inner (std::index_sequence<Ns...>, F const& f, IntVectND<1> iv, Args...args)
         noexcept -> decltype(f(0, 0, 0, args...))
     {
-        f(iv[0], 0, 0, args...);
+        return f(iv[0], 0, 0, args...);
     }
 
     template <typename F, std::size_t...Ns, class...Args>
@@ -39,7 +39,7 @@ namespace detail {
     auto call_f_intvect_inner (std::index_sequence<Ns...>, F const& f, IntVectND<2> iv, Args...args)
         noexcept -> decltype(f(0, 0, 0, args...))
     {
-        f(iv[0], iv[1], 0, args...);
+        return f(iv[0], iv[1], 0, args...);
     }
 
     template <typename F, int dim, std::size_t...Ns, class...Args>
@@ -47,7 +47,7 @@ namespace detail {
     auto call_f_intvect_inner (std::index_sequence<Ns...>, F const& f, IntVectND<dim> iv, Args...args)
         noexcept -> decltype(f(iv, args...))
     {
-        f(iv, args...);
+        return f(iv, args...);
     }
 
     template <typename F, int dim, std::size_t...Ns, class...Args>
@@ -55,7 +55,7 @@ namespace detail {
     auto call_f_intvect_inner (std::index_sequence<Ns...>, F const& f, IntVectND<dim> iv, Args...args)
         noexcept -> decltype(f(iv[Ns]..., args...))
     {
-        f(iv[Ns]..., args...);
+        return f(iv[Ns]..., args...);
     }
 
     // call_f_intvect
@@ -65,7 +65,7 @@ namespace detail {
     auto call_f_intvect (F const& f, IntVectND<dim> iv)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv);
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv);
     }
 
     // call_f_intvect_engine
@@ -75,7 +75,7 @@ namespace detail {
     auto call_f_intvect_engine (F const& f, IntVectND<dim> iv, RandomEngine engine)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, engine))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, engine);
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, engine);
     }
 
     // call_f_intvect_handler
@@ -85,7 +85,7 @@ namespace detail {
     auto call_f_intvect_handler (F const& f, IntVectND<dim> iv, Gpu::Handler const&)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv);
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv);
     }
 
     template <typename F, int dim>
@@ -93,7 +93,7 @@ namespace detail {
     auto call_f_intvect_handler (F const& f, IntVectND<dim> iv, Gpu::Handler const& handler)
         noexcept -> decltype(call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, Gpu::Handler{}))
     {
-        call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, handler);
+        return call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, handler);
     }
 
     // call_f_intvect_ncomp

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -1281,11 +1281,10 @@ bool AnyOf (N n, T const* v, P&& pred)
 template <typename P, int dim>
 bool AnyOf (BoxND<dim> const& box, P const& pred)
 {
-    auto box_it = box.iterator();
-    return std::any_of(box_it.begin(), box_it.end(),
-        [&] (auto iv) {
-            return Reduce::detail::call_f_intvect(pred, iv);
-        });
+    for (auto iv : box.iterator()) { // NOLINT(readability-use-anyofallof)
+        if (Reduce::detail::call_f_intvect(pred, iv)) { return true; }
+    }
+    return false;
 }
 
 }

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -316,24 +316,36 @@ private:
 };
 
 namespace Reduce::detail {
-    template <typename F>
+
+    // call_f_intvect_box
+
+    template <typename F, int dim>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    auto call_f (F const& f, int i, int j, int k, IndexType)
-        noexcept -> decltype(f(0,0,0))
+    auto call_f_intvect_box (F const& f, IntVectND<dim> iv, IndexTypeND<dim>) noexcept ->
+        decltype(amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv))
     {
-        return f(i,j,k);
+        return amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv);
     }
 
-    template <typename F>
+    template <typename F, int dim>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
-    auto call_f (F const& f, int i, int j, int k, IndexType t)
-        noexcept -> decltype(f(Box()))
+    auto call_f_intvect_box (F const& f, IntVectND<dim> iv, IndexTypeND<dim> t) noexcept ->
+        decltype(f(BoxND<dim>(iv, iv, t)))
     {
-        AMREX_D_PICK(amrex::ignore_unused(j,k),amrex::ignore_unused(k),(void)0);
-        return f(Box(IntVect(AMREX_D_DECL(i,j,k)),
-                     IntVect(AMREX_D_DECL(i,j,k)),
-                     t));
+        return f(BoxND<dim>(iv, iv, t));
     }
+
+    // call_f_intvect_n
+
+    template <typename F, typename T, int dim>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    auto call_f_intvect_n (F const& f, IntVectND<dim> iv, T n) noexcept ->
+        decltype(amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n))
+    {
+        return amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n);
+    }
+
+    // mf_call_f
 
     struct iterate_box {};
     struct iterate_box_comp {};
@@ -482,23 +494,19 @@ public:
         }
     }
 
-    template <typename D, typename F>
-    void eval (Box const& box, D & reduce_data, F const& f)
+    template <typename D, typename F, int dim>
+    void eval (BoxND<dim> const& box, D & reduce_data, F const& f)
     {
         using ReduceTuple = typename D::Type;
         auto const& stream = Gpu::gpuStream();
         auto dp = reduce_data.devicePtr(stream);
         int& nblocks = reduce_data.nBlocks(stream);
-        int ncells = box.numPts();
-        const auto lo  = amrex::lbound(box);
-        const auto len = amrex::length(box);
-        const auto lenxy = len.x*len.y;
-        const auto lenx = len.x;
-        IndexType ixtype = box.ixType();
+        const BoxIndexerND<dim> indexer(box);
+        IndexTypeND<dim> ixtype = box.ixType();
         constexpr int nitems_per_thread = 4;
-        int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
+        Long nblocks_ec = (box.numPts() + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
             / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
-        nblocks_ec = std::min(nblocks_ec, reduce_data.maxBlocks());
+        nblocks_ec = std::min<Long>(nblocks_ec, reduce_data.maxBlocks());
         reduce_data.updateMaxStreamIndex(stream);
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
@@ -520,15 +528,13 @@ public:
             if (threadIdx.x == 0 && static_cast<int>(blockIdx.x) >= nblocks) {
                 dst = r;
             }
-            for (int icell = AMREX_GPU_MAX_THREADS*blockIdx.x+threadIdx.x, stride = AMREX_GPU_MAX_THREADS*gridDim.x;
-                 icell < ncells; icell += stride) {
-                int k =  icell /   lenxy;
-                int j = (icell - k*lenxy) /   lenx;
-                int i = (icell - k*lenxy) - j*lenx;
-                i += lo.x;
-                j += lo.y;
-                k += lo.z;
-                auto pr = Reduce::detail::call_f(f,i,j,k,ixtype);
+            for (std::uint64_t icell = std::uint64_t(AMREX_GPU_MAX_THREADS)*blockIdx.x+threadIdx.x,
+                 stride = std::uint64_t(AMREX_GPU_MAX_THREADS)*gridDim.x;
+                 icell < indexer.numPts();
+                 icell += stride)
+            {
+                auto iv = indexer.intVect(icell);
+                auto pr = Reduce::detail::call_f_intvect_box(f, iv, ixtype);
                 Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
             }
 #ifdef AMREX_USE_SYCL
@@ -537,26 +543,22 @@ public:
             Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
 #endif
         });
-        nblocks = std::max(nblocks, nblocks_ec);
+        nblocks = std::max(nblocks, static_cast<int>(nblocks_ec));
     }
 
-    template <typename N, typename D, typename F,
+    template <typename N, typename D, typename F, int dim,
               typename M=std::enable_if_t<std::is_integral_v<N>> >
-    void eval (Box const& box, N ncomp, D & reduce_data, F const& f)
+    void eval (BoxND<dim> const& box, N ncomp, D & reduce_data, F const& f)
     {
         using ReduceTuple = typename D::Type;
         auto const& stream = Gpu::gpuStream();
         auto dp = reduce_data.devicePtr(stream);
         int& nblocks = reduce_data.nBlocks(stream);
-        int ncells = box.numPts();
-        const auto lo  = amrex::lbound(box);
-        const auto len = amrex::length(box);
-        const auto lenxy = len.x*len.y;
-        const auto lenx = len.x;
+        const BoxIndexerND<dim> indexer(box);
         constexpr int nitems_per_thread = 4;
-        int nblocks_ec = (ncells + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
+        Long nblocks_ec = (box.numPts() + nitems_per_thread*AMREX_GPU_MAX_THREADS-1)
             / (nitems_per_thread*AMREX_GPU_MAX_THREADS);
-        nblocks_ec = std::min(nblocks_ec, reduce_data.maxBlocks());
+        nblocks_ec = std::min<Long>(nblocks_ec, reduce_data.maxBlocks());
         reduce_data.updateMaxStreamIndex(stream);
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
@@ -578,16 +580,14 @@ public:
             if (threadIdx.x == 0 && static_cast<int>(blockIdx.x) >= nblocks) {
                 dst = r;
             }
-            for (int icell = AMREX_GPU_MAX_THREADS*blockIdx.x+threadIdx.x, stride = AMREX_GPU_MAX_THREADS*gridDim.x;
-                 icell < ncells; icell += stride) {
-                int k =  icell /   lenxy;
-                int j = (icell - k*lenxy) /   lenx;
-                int i = (icell - k*lenxy) - j*lenx;
-                i += lo.x;
-                j += lo.y;
-                k += lo.z;
+            for (std::uint64_t icell = std::uint64_t(AMREX_GPU_MAX_THREADS)*blockIdx.x+threadIdx.x,
+                 stride = std::uint64_t(AMREX_GPU_MAX_THREADS)*gridDim.x;
+                 icell < indexer.numPts();
+                 icell += stride)
+            {
+                auto iv = indexer.intVect(icell);
                 for (N n = 0; n < ncomp; ++n) {
-                    auto pr = f(i,j,k,n);
+                    auto pr = Reduce::detail::call_f_intvect_n(f, iv, n);
                     Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
                 }
             }
@@ -597,7 +597,7 @@ public:
             Reduce::detail::for_each_parallel<0, ReduceTuple, Ps...>(dst, r);
 #endif
         });
-        nblocks = std::max(nblocks, nblocks_ec);
+        nblocks = std::max(nblocks, static_cast<int>(nblocks_ec));
     }
 
     template <typename N, typename D, typename F,
@@ -634,8 +634,11 @@ public:
             if (threadIdx.x == 0 && static_cast<int>(blockIdx.x) >= nblocks) {
                 dst = r;
             }
-            for (N i = AMREX_GPU_MAX_THREADS*blockIdx.x+threadIdx.x, stride = AMREX_GPU_MAX_THREADS*gridDim.x;
-                 i < n; i += stride) {
+            for (N i = N(AMREX_GPU_MAX_THREADS)*blockIdx.x+threadIdx.x,
+                 stride = N(AMREX_GPU_MAX_THREADS)*gridDim.x;
+                 i < n;
+                 i += stride)
+            {
                 auto pr = f(i);
                 Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r,pr);
             }
@@ -895,18 +898,14 @@ bool AnyOf (N n, T const* v, P const& pred)
     return ds.dataValue();
 }
 
-template <typename P>
-bool AnyOf (Box const& box, P const& pred)
+template <typename P, int dim>
+bool AnyOf (BoxND<dim> const& box, P const& pred)
 {
     Gpu::LaunchSafeGuard lsg(true);
     Gpu::DeviceScalar<int> ds(0);
     int* dp = ds.dataPtr();
-    int ncells = box.numPts();
-    const auto lo  = amrex::lbound(box);
-    const auto len = amrex::length(box);
-    const auto lenxy = len.x*len.y;
-    const auto lenx = len.x;
-    auto ec = Gpu::ExecutionConfig(ncells);
+    const BoxIndexerND<dim> indexer(box);
+    auto ec = Gpu::ExecutionConfig(box.numPts());
     ec.numBlocks.x = std::min(ec.numBlocks.x, Gpu::Device::maxBlocksPerLaunch());
 
 #ifdef AMREX_USE_SYCL
@@ -921,15 +920,13 @@ bool AnyOf (Box const& box, P const& pred)
         if (!(*has_any))
         {
             int r = false;
-            for (int icell = AMREX_GPU_MAX_THREADS*gh.blockIdx()+gh.threadIdx(), stride = AMREX_GPU_MAX_THREADS*gh.gridDim();
-                 icell < ncells && !r; icell += stride) {
-                int k =  icell /   lenxy;
-                int j = (icell - k*lenxy) /   lenx;
-                int i = (icell - k*lenxy) - j*lenx;
-                i += lo.x;
-                j += lo.y;
-                k += lo.z;
-                r = pred(i,j,k) ? 1 : 0;
+            for (std::uint64_t icell = std::uint64_t(AMREX_GPU_MAX_THREADS)*gh.blockIdx()+gh.threadIdx(),
+                 stride = std::uint64_t(AMREX_GPU_MAX_THREADS)*gh.gridDim();
+                 icell < indexer.numPts() && !r;
+                 icell += stride)
+            {
+                auto iv = indexer.intVect(icell);
+                r = amrex::detail::call_f_intvect(pred, iv) ? 1 : 0;
             }
             r = Gpu::blockReduce<Gpu::Device::warp_size>
                 (r, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::Plus<int> >(), 0, gh);
@@ -947,15 +944,13 @@ bool AnyOf (Box const& box, P const& pred)
         if (!has_any)
         {
             int r = false;
-            for (int icell = AMREX_GPU_MAX_THREADS*blockIdx.x+threadIdx.x, stride = AMREX_GPU_MAX_THREADS*gridDim.x;
-                 icell < ncells && !r; icell += stride) {
-                int k =  icell /   lenxy;
-                int j = (icell - k*lenxy) /   lenx;
-                int i = (icell - k*lenxy) - j*lenx;
-                i += lo.x;
-                j += lo.y;
-                k += lo.z;
-                r = pred(i,j,k) ? 1 : 0;
+            for (std::uint64_t icell = std::uint64_t(AMREX_GPU_MAX_THREADS)*blockIdx.x+threadIdx.x,
+                 stride = std::uint64_t(AMREX_GPU_MAX_THREADS)*gridDim.x;
+                 icell < indexer.numPts() && !r;
+                 icell += stride)
+            {
+                auto iv = indexer.intVect(icell);
+                r = amrex::detail::call_f_intvect(pred, iv) ? 1 : 0;
             }
             r = Gpu::blockReduce<Gpu::Device::warp_size>
                 (r, Gpu::warpReduce<Gpu::Device::warp_size,int,amrex::Plus<int> >(), 0);
@@ -1018,31 +1013,55 @@ private:
     std::function<Type()> m_fn_value;
 };
 
+namespace Reduce::detail {
+
+    // call_f_intvect
+
+    template <typename F, int dim>
+    AMREX_FORCE_INLINE
+    auto call_f_intvect (F const& f, IntVectND<dim> iv) noexcept ->
+        decltype(amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv))
+    {
+        return amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv);
+    }
+
+    // call_f_intvect_n
+
+    template <typename F, typename T, int dim>
+    AMREX_FORCE_INLINE
+    auto call_f_intvect_n (F const& f, IntVectND<dim> iv, T n) noexcept ->
+        decltype(amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n))
+    {
+        return amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv, n);
+    }
+}
+
 template <typename... Ps>
 class ReduceOps
 {
 private:
 
-    template <typename D, typename F>
+    // call_f_box
+
+    template <typename D, typename F, int dim>
     AMREX_FORCE_INLINE
-    static auto call_f (Box const& box, typename D::Type & r, F const& f)
-        noexcept -> std::enable_if_t<std::is_same_v<std::decay_t<decltype(f(0,0,0))>,
-                                                  typename D::Type>>
+    static auto call_f_box (BoxND<dim> const& box, typename D::Type & r, F const& f)
+        noexcept -> std::enable_if_t<std::is_same_v<std::decay_t<decltype(
+            Reduce::detail::call_f_intvect(f, IntVectND<dim>(0))
+        )>, typename D::Type>>
     {
         using ReduceTuple = typename D::Type;
-        const auto lo = amrex::lbound(box);
-        const auto hi = amrex::ubound(box);
-        for (int k = lo.z; k <= hi.z; ++k) {
-        for (int j = lo.y; j <= hi.y; ++j) {
-        for (int i = lo.x; i <= hi.x; ++i) {
-            Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, f(i,j,k));
-        }}}
+        For(box,
+            [&] (IntVectND<dim> iv) {
+                auto pr = Reduce::detail::call_f_intvect(f, iv);
+                Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(r, pr);
+            });
     }
 
-    template <typename D, typename F>
+    template <typename D, typename F, int dim>
     AMREX_FORCE_INLINE
-    static auto call_f (Box const& box, typename D::Type & r, F const& f)
-        noexcept -> std::enable_if_t<std::is_same_v<std::decay_t<decltype(f(Box()))>,
+    static auto call_f_box (BoxND<dim> const& box, typename D::Type & r, F const& f)
+        noexcept -> std::enable_if_t<std::is_same_v<std::decay_t<decltype(f(box))>,
                                                   typename D::Type>>
     {
         using ReduceTuple = typename D::Type;
@@ -1106,32 +1125,29 @@ public:
         }
     }
 
-    template <typename D, typename F>
-    void eval (Box const& box, D & reduce_data, F&& f)
+    template <typename D, typename F, int dim>
+    void eval (BoxND<dim> const& box, D & reduce_data, F&& f)
     {
         using ReduceTuple = typename D::Type;
         ReduceTuple rr;
         Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(rr);
-        call_f<D>(box, rr, std::forward<F>(f));
+        call_f_box<D>(box, rr, std::forward<F>(f));
         Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(
              reduce_data.reference(OpenMP::get_thread_num()), rr);
     }
 
-    template <typename N, typename D, typename F,
+    template <typename N, typename D, typename F, int dim,
               typename M=std::enable_if_t<std::is_integral_v<N>> >
-    void eval (Box const& box, N ncomp, D & reduce_data, F const& f)
+    void eval (BoxND<dim> const& box, N ncomp, D & reduce_data, F const& f)
     {
         using ReduceTuple = typename D::Type;
         ReduceTuple rr;
         Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(rr);
-        const auto lo = amrex::lbound(box);
-        const auto hi = amrex::ubound(box);
-        for (N n = 0; n < ncomp; ++n) {
-        for (int k = lo.z; k <= hi.z; ++k) {
-        for (int j = lo.y; j <= hi.y; ++j) {
-        for (int i = lo.x; i <= hi.x; ++i) {
-            Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(rr, f(i,j,k,n));
-        }}}}
+        For(box, ncomp,
+            [&] (IntVectND<dim> iv, int n) {
+                auto pr = Reduce::detail::call_f_intvect_n(f, iv, n);
+                Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(rr, pr);
+            });
         Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(
              reduce_data.reference(OpenMP::get_thread_num()), rr);
     }
@@ -1262,16 +1278,12 @@ bool AnyOf (N n, T const* v, P&& pred)
     return std::any_of(v, v+n, std::forward<P>(pred));
 }
 
-template <typename P>
-bool AnyOf (Box const& box, P const& pred)
+template <typename P, int dim>
+bool AnyOf (BoxND<dim> const& box, P const& pred)
 {
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-    for (int k = lo.z; k <= hi.z; ++k) {
-    for (int j = lo.y; j <= hi.y; ++j) {
-    for (int i = lo.x; i <= hi.x; ++i) {
-        if (pred(i,j,k)) { return true; }
-    }}}
+    for (auto iv : box.iterator()) {
+        if (Reduce::detail::call_f_intvect(pred, iv)) { return true; }
+    }
     return false;
 }
 

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -1281,10 +1281,11 @@ bool AnyOf (N n, T const* v, P&& pred)
 template <typename P, int dim>
 bool AnyOf (BoxND<dim> const& box, P const& pred)
 {
-    for (auto iv : box.iterator()) {
-        if (Reduce::detail::call_f_intvect(pred, iv)) { return true; }
-    }
-    return false;
+    auto box_it = box.iterator();
+    return std::any_of(box_it.begin(), box_it.end(),
+        [&] (auto iv) {
+            return Reduce::detail::call_f_intvect(pred, iv);
+        });
 }
 
 }

--- a/Src/EB/AMReX_EB2_Level.cpp
+++ b/Src/EB/AMReX_EB2_Level.cpp
@@ -336,9 +336,11 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
             AMREX_D_TERM(auto const& cfcx = m_facecent[0].array(mfi);,
                          auto const& cfcy = m_facecent[1].array(mfi);,
                          auto const& cfcz = m_facecent[2].array(mfi););
-            AMREX_D_TERM(auto const& cecx = m_edgecent[0].array(mfi);,
-                         auto const& cecy = m_edgecent[1].array(mfi);,
-                         auto const& cecz = m_edgecent[2].array(mfi););
+            // We use MultiArray4 instead of Array4 here
+            // to be below the 2 kB kernel parameter limit for SYCL
+            AMREX_D_TERM(auto const& cecx = m_edgecent[0].arrays();,
+                         auto const& cecy = m_edgecent[1].arrays();,
+                         auto const& cecz = m_edgecent[2].arrays(););
             auto const& cflag = m_cellflag.array(mfi);
 
             auto const& fvol = f_volfrac.const_array(mfi);
@@ -352,11 +354,12 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
             AMREX_D_TERM(auto const& ffcx = f_facecent[0].const_array(mfi);,
                          auto const& ffcy = f_facecent[1].const_array(mfi);,
                          auto const& ffcz = f_facecent[2].const_array(mfi););
-            AMREX_D_TERM(auto const& fecx = f_edgecent[0].const_array(mfi);,
-                         auto const& fecy = f_edgecent[1].const_array(mfi);,
-                         auto const& fecz = f_edgecent[2].const_array(mfi););
+            AMREX_D_TERM(auto const& fecx = f_edgecent[0].const_arrays();,
+                         auto const& fecy = f_edgecent[1].const_arrays();,
+                         auto const& fecz = f_edgecent[2].const_arrays(););
             auto const& fflag = f_cellflag.const_array(mfi);
 
+            const int lidx = mfi.LocalIndex();
             Box const& bx = mfi.validbox();
             Box const& gbx = amrex::grow(bx,2);
             Box const& ndgbx = amrex::surroundingNodes(gbx);
@@ -369,11 +372,11 @@ Level::coarsenFromFine (Level& fineLevel, bool fill_boundary)
                                              cvol,ccent,cba,cbc,cbn,
                                              AMREX_D_DECL(capx,capy,capz),
                                              AMREX_D_DECL(cfcx,cfcy,cfcz),
-                                             AMREX_D_DECL(cecx,cecy,cecz),
+                                             AMREX_D_DECL(cecx[lidx],cecy[lidx],cecz[lidx]),
                                              cflag,fvol,fcent,fba,fbc,fbn,
                                              AMREX_D_DECL(fapx,fapy,fapz),
                                              AMREX_D_DECL(ffcx,ffcy,ffcz),
-                                             AMREX_D_DECL(fecx,fecy,fecz),
+                                             AMREX_D_DECL(fecx[lidx],fecy[lidx],fecz[lidx]),
                                              fflag);
                 return {ierr};
             });


### PR DESCRIPTION
## Summary

This PR enables the use of `ReduceOps.eval()` with a BoxND of any dimension. This is achieved using BoxIndexerND, just like ParallelForRNG, which also provides support for 64-bit indexing to support very large boxes.


There was issue where the extra size added by BoxIndexerND pushes an EB kernel over the parameter size limit for SYCL. 
This was fixed by using MultiArray4 for some of the arrays instead.

```
error: Total size of kernel arguments exceeds limit! Total arguments size: 2064, limit: 2048
in kernel: 'typeinfo name for void amrex::launch<256, void amrex::ReduceOps<amrex::ReduceOpMax>::eval<amrex::ReduceData<int>, amrex::EB2::Level::coarsenFromFine(amrex::EB2::Level&, bool)::'lambda4'(int, int, int), 3>(amrex::BoxND<3> const&, amrex::ReduceData<int>&, amrex::EB2::Level::coarsenFromFine(amrex::EB2::Level&, bool)::'lambda4'(int, int, int) const&)::'lambda'(amrex::Gpu::Handler const&)>(int, unsigned long, amrex::gpuStream_t, amrex::EB2::Level::coarsenFromFine(amrex::EB2::Level&, bool)::'lambda4'(int, int, int) const&)::'lambda'(sycl::_V1::handler&)::operator()(sycl::_V1::handler&) const::'lambda'(sycl::_V1::nd_item<1>)'
error: backend compiler failed build.
```

https://github.com/AMReX-Codes/amrex/blob/1fe7883af64291e5c67d0d4ce65eb2e758dab412/Src/EB/AMReX_EB2_Level.cpp#L364-L379




## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
