### PR TITLE
CI: Zenodo Validator

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,3 +29,12 @@ jobs:
         run: |
           sudo apt-get install -y --no-install-recommends doxygen
           .github/workflows/style/doxygen.sh
+
+  zenodo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate Zenodo Metadata
+        uses: vsoch/zenodo-validator@main
+        with:
+          path: '.zenodo.json'

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -96,5 +96,6 @@
         "adaptive mesh refinement",
         "finite difference",
         "finite volume"
-    ]
+    ],
+    "access_right": "open"
 }


### PR DESCRIPTION
## Summary

Zenodo files are brittle, and invalid entries only appear after a release, when one cannot fix them anymore for the release in question.
This adds a validator.

## Additional background

https://github.com/vsoch/zenodo-validator
https://github.com/zenodo/zenodo-rdm/issues/1205#issuecomment-3716786501

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
