### PR TITLE
Added define method to FabArray that makes alias of other FabArray

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -440,6 +440,8 @@ public:
                  const FabFactory<FAB>&     factory = DefaultFabFactory<FAB>());
 #endif
 
+    void define (const FabArray<FAB>& rhs, MakeType maketype, int scomp, int ncomp);
+
     const FabFactory<FAB>& Factory () const noexcept { return *m_factory; }
 
     // Provides access to the Arena this FabArray was build with.
@@ -2177,6 +2179,28 @@ FabArray<FAB>::define (const BoxArray&            bxs,
 #ifdef BL_USE_TEAM
         ParallelDescriptor::MyTeam().MemoryBarrier();
 #endif
+    }
+}
+
+template <class FAB>
+void
+FabArray<FAB>::define (const FabArray<FAB>& rhs, MakeType maketype, int scomp, int ncomp)
+{
+    std::unique_ptr<FabFactory<FAB> > factory(rhs.Factory().clone());
+    m_factory = std::move(factory);
+    define(rhs.boxArray(), rhs.DistributionMap(), ncomp, rhs.nGrowVect(),
+           MFInfo().SetAlloc(false), *m_factory);
+
+    if (maketype == amrex::make_alias)
+    {
+        for (int i = 0, n = indexArray.size(); i < n; ++i) {
+            auto const& rhsfab = *(rhs.m_fabs_v[i]);
+            m_fabs_v.push_back(m_factory->create_alias(rhsfab, scomp, ncomp));
+        }
+    }
+    else
+    {
+        amrex::Abort("FabArray: unknown MakeType");
     }
 }
 

--- a/Src/Base/AMReX_MultiFab.H
+++ b/Src/Base/AMReX_MultiFab.H
@@ -136,6 +136,8 @@ public:
                  const FabFactory<FArrayBox>& factory = FArrayBoxFactory());
 #endif
 
+    void define (const MultiFab& rhs, MakeType maketype, int scomp, int ncomp);
+
     MultiFab& operator= (Real r);
 
     /**

--- a/Src/Base/AMReX_MultiFab.cpp
+++ b/Src/Base/AMReX_MultiFab.cpp
@@ -540,6 +540,12 @@ MultiFab::define (const BoxArray&            bxs,
 }
 
 void
+MultiFab::define (const MultiFab& rhs, MakeType maketype, int scomp, int ncomp)
+{
+    this->FabArray<FArrayBox>::define(rhs,maketype,scomp,ncomp);
+}
+
+void
 MultiFab::initVal ()
 {
 #ifdef AMREX_USE_OMP

--- a/Src/Base/AMReX_iMultiFab.H
+++ b/Src/Base/AMReX_iMultiFab.H
@@ -578,6 +578,8 @@ public:
                  const FabFactory<IArrayBox>& factory = DefaultFabFactory<IArrayBox>());
 #endif
 
+    void define (const iMultiFab& rhs, MakeType maketype, int scomp, int ncomp);
+
     static void Initialize ();
     static void Finalize ();
 };

--- a/Src/Base/AMReX_iMultiFab.cpp
+++ b/Src/Base/AMReX_iMultiFab.cpp
@@ -282,6 +282,12 @@ iMultiFab::define (const BoxArray&            bxs,
     this->FabArray<IArrayBox>::define(bxs,dm,nvar,ngrow,info, factory);
 }
 
+void
+iMultiFab::define (const iMultiFab& rhs, MakeType maketype, int scomp, int ncomp)
+{
+    this->FabArray<IArrayBox>::define(rhs,maketype,scomp,ncomp);
+}
+
 int
 iMultiFab::min (int comp, int nghost, bool local) const
 {


### PR DESCRIPTION
## Summary
Created a new define method for FabArray (and its subclasses iMultiFab and MultiFab), which can be used to make an alias of an existing FabArray. This functionality was already available through a constructor, but only with this change has it become possible to define a FabArray as an alias after it has already been declared.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
