### PR TITLE
Move MF ParallelFor out of namespace experimental

### DIFF
--- a/Docs/Doxygen/groups.dox
+++ b/Docs/Doxygen/groups.dox
@@ -160,7 +160,7 @@
  * on CPUs and GPUs without exposing backend-specific programming models.
  *
  * Key functions and classes include:
- * - amrex::ParallelFor
+ * - \ref amrex::ParallelFor
  * - \ref amrex::ParallelForOMP
  * - \ref amrex::ParallelForRNG
  */

--- a/Docs/Doxygen/main.dox
+++ b/Docs/Doxygen/main.dox
@@ -100,7 +100,7 @@
 
   - \ref amrex_execution
     This topic covers performance-portable execution and kernel launch
-    interfaces including various amrex::ParallelFor functions.
+    interfaces including various \ref amrex::ParallelFor functions.
 
   - \ref amrex_collectives
     This topic covers performance-portable reductions and scans, including

--- a/Src/Base/AMReX_MFParallelFor.H
+++ b/Src/Base/AMReX_MFParallelFor.H
@@ -23,8 +23,6 @@ struct DynamicTiling {
     explicit DynamicTiling (bool f) noexcept : dynamic(f) {}
 };
 
-namespace experimental {
-
 /**
  * \brief ParallelFor for MultiFab/FabArray.
  *
@@ -44,7 +42,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, F&& f)
 {
-    detail::ParallelFor(mf, IntVect(0), FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, IntVect(0), FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -68,9 +66,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, IntVect(0), 1, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit<MT>(mf, IntVect(0), 1, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, IntVect(0), FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, IntVect(0), FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -94,7 +92,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, F&& f)
 {
-    detail::ParallelFor(mf, ng, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -119,9 +117,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, 1, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit<MT>(mf, ng, 1, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -146,7 +144,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
 {
-    detail::ParallelFor(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -172,9 +170,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, int ncomp, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit<MT>(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ncomp, FabArrayBase::mfiter_tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -199,7 +197,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, TileSize const& ts, F&& f)
 {
-    detail::ParallelFor(mf, IntVect(0), ts.tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, IntVect(0), ts.tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -225,9 +223,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, TileSize const& ts, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, IntVect(0), 1, ts.tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit<MT>(mf, IntVect(0), 1, ts.tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, IntVect(0), ts.tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, IntVect(0), ts.tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -253,7 +251,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, F&& f)
 {
-    detail::ParallelFor(mf, ng, ts.tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ts.tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -280,9 +278,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, 1, ts.tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit<MT>(mf, ng, 1, ts.tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, ts.tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ts.tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -309,7 +307,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&& f)
 {
-    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ncomp, ts.tile_size, false, std::forward<F>(f));
 }
 
 /**
@@ -337,9 +335,9 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, ncomp, ts.tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit<MT>(mf, ng, ncomp, ts.tile_size, false, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, false, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ncomp, ts.tile_size, false, std::forward<F>(f));
 #endif
 }
 
@@ -366,7 +364,7 @@ template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts, DynamicTiling dt, F&& f)
 {
-    detail::ParallelFor(mf, ng, ts.tile_size, dt.dynamic, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ts.tile_size, dt.dynamic, std::forward<F>(f));
 }
 
 /**
@@ -394,7 +392,7 @@ std::enable_if_t<IsFabArray<MF>::value>
 ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts,
              DynamicTiling dt, F&& f)
 {
-    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, dt.dynamic, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ncomp, ts.tile_size, dt.dynamic, std::forward<F>(f));
 }
 
 /**
@@ -423,9 +421,9 @@ ParallelFor (MF const& mf, IntVect const& ng, TileSize const& ts,
              DynamicTiling dt, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, 1, ts.tile_size, dt.dynamic, std::forward<F>(f));
+    detail::ParallelFor_doit<MT>(mf, ng, 1, ts.tile_size, dt.dynamic, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, ts.tile_size, dt.dynamic, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ts.tile_size, dt.dynamic, std::forward<F>(f));
 #endif
 }
 
@@ -456,15 +454,11 @@ ParallelFor (MF const& mf, IntVect const& ng, int ncomp, TileSize const& ts,
              DynamicTiling dt, F&& f)
 {
 #ifdef AMREX_USE_GPU
-    detail::ParallelFor<MT>(mf, ng, ncomp, ts.tile_size, dt.dynamic, std::forward<F>(f));
+    detail::ParallelFor_doit<MT>(mf, ng, ncomp, ts.tile_size, dt.dynamic, std::forward<F>(f));
 #else
-    detail::ParallelFor(mf, ng, ncomp, ts.tile_size, dt.dynamic, std::forward<F>(f));
+    detail::ParallelFor_doit(mf, ng, ncomp, ts.tile_size, dt.dynamic, std::forward<F>(f));
 #endif
 }
-
-}
-
-using experimental::ParallelFor;
 
 }
 

--- a/Src/Base/AMReX_MFParallelForC.H
+++ b/Src/Base/AMReX_MFParallelForC.H
@@ -6,11 +6,12 @@
 
 #include <AMReX_MFIter.H>
 
-namespace amrex::experimental::detail {
+/// \cond DOXYGEN_IGNORE
+namespace amrex::detail {
 
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, IntVect const& ts, bool dynamic, F const& f)
+ParallelFor_doit (MF const& mf, IntVect const& nghost, IntVect const& ts, bool dynamic, F const& f)
 {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
@@ -33,7 +34,7 @@ ParallelFor (MF const& mf, IntVect const& nghost, IntVect const& ts, bool dynami
 
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, bool dynamic, F const& f)
+ParallelFor_doit (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, bool dynamic, F const& f)
 {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
@@ -57,6 +58,7 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, 
 }
 
 }
+/// \endcond
 
 #endif
 #endif

--- a/Src/Base/AMReX_MFParallelForG.H
+++ b/Src/Base/AMReX_MFParallelForG.H
@@ -8,8 +8,8 @@
 #include <cmath>
 #include <limits>
 
-namespace amrex {
-namespace detail {
+/// \cond DOXYGEN_IGNORE
+namespace amrex::detail {
 
 inline
 void build_par_for_boxes (char*& hp, BoxIndexer*& pboxes, Vector<Box> const& boxes)
@@ -34,9 +34,6 @@ void destroy_par_for_boxes (char* hp, char* dp)
     The_Pinned_Arena()->free(hp);
     The_Arena()->free(dp);
 }
-}
-
-namespace experimental::detail {
 
 namespace parfor_mf_detail {
     template <typename F>
@@ -60,7 +57,7 @@ namespace parfor_mf_detail {
 
 template <int MT, typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, bool, F const& f)
+ParallelFor_doit (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, bool, F const& f)
 {
     const auto& index_array = mf.IndexArray();
     const int nboxes = index_array.size();
@@ -111,31 +108,30 @@ ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const&, boo
 
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, bool dynamic, F&& f)
+ParallelFor_doit (MF const& mf, IntVect const& nghost, int ncomp, IntVect const& ts, bool dynamic, F&& f)
 {
 #ifdef AMREX_USE_CUDA
     constexpr int MT = 128;
 #else
     constexpr int MT = AMREX_GPU_MAX_THREADS;
 #endif
-    ParallelFor<MT>(mf, nghost, ncomp, ts, dynamic, std::forward<F>(f));
+    ParallelFor_doit<MT>(mf, nghost, ncomp, ts, dynamic, std::forward<F>(f));
 }
 
 template <typename MF, typename F>
 std::enable_if_t<IsFabArray<MF>::value>
-ParallelFor (MF const& mf, IntVect const& nghost, IntVect const& ts, bool dynamic, F&& f)
+ParallelFor_doit (MF const& mf, IntVect const& nghost, IntVect const& ts, bool dynamic, F&& f)
 {
 #ifdef AMREX_USE_CUDA
     constexpr int MT = 128;
 #else
     constexpr int MT = AMREX_GPU_MAX_THREADS;
 #endif
-    ParallelFor<MT>(mf, nghost, 1, ts, dynamic, std::forward<F>(f));
+    ParallelFor_doit<MT>(mf, nghost, 1, ts, dynamic, std::forward<F>(f));
 }
 
 }
-
-}
+/// \endcond
 
 #endif
 #endif


### PR DESCRIPTION
The feature is mature enough. Also rename some detail::ParallelFor to detail::ParallelFor_doit. This helps resolve the Doxygen unresolved symbol issue because it had troubles with so many overloaded versions.
