### PR TITLE
Remove uses of Box range version of amrex::launch

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1166,54 +1166,6 @@ number of threads per block by :cpp:`ParallelFor<MY_BLOCK_SIZE>(...)`, where
 ``MY_BLOCK_SIZE`` is a multiple of the warp size (e.g., 128).  This allows
 the users to do performance tuning for individual kernels.
 
-Launching general kernels
--------------------------
-
-To launch more general work on the GPU, AMReX provides a standard launch function:
-:cpp:`amrex::launch`.  Instead of creating nested loops, this function
-prepares the device launch based on a :cpp:`Box`, launches with an appropriate sized
-GPU kernel and constructs a thread :cpp:`Box` that defines the work for each thread.
-On the CPU, the thread :cpp:`Box` is set equal to the total launch :cpp:`Box`, so
-tiling works as expected.  On the GPU, the thread :cpp:`Box` usually
-contains a single cell to allow all GPU threads to be utilized effectively.
-
-An example of a generic function launch is shown here:
-
-.. highlight:: c++
-
-::
-
-    for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-        const Box& bx = mfi.tilebox();
-        Array4<Real> const& arr = mf.array(mfi);
-
-        amrex::launch(bx,
-        [=] AMREX_GPU_DEVICE (Box const& tbx)
-        {
-            pluseone_array4(tbx, arr);
-            FArrayBox fab(arr, tbx.ixType());
-            plusone_fab(tbx, fab); // this version takes FArrayBox
-        });
-
-        /* MACRO VARIATION
-        /
-        /   AMREX_LAUNCH_DEVICE_LAMBDA ( bx, tbx,
-        /   {
-        /       plusone_array4(tbx, arr);
-        /       plusone_fab(tbx, FArrayBox(arr,tbx.ixType()));
-        /   });
-        */
-    }
-
-It also shows how to make a :cpp:`FArrayBox` from :cpp:`Array4` when
-needed.  Note that :cpp:`FarrayBox`\ es cannot be passed to GPU
-kernels directly.  :cpp:`TilingIfNotGPU()` returns ``false`` in the
-GPU case to turn off tiling and maximize the amount of work given to
-the GPU in each launch, which substantially improves performance.
-When tiling is off, :cpp:`tilebox()` returns the :cpp:`validbox()` of
-the :cpp:`FArrayBox` for that iteration.
-
 Offloading work using OpenACC or OpenMP pragmas
 -----------------------------------------------
 
@@ -1335,8 +1287,8 @@ not work as intended.  For example,
         Box bx;
         int m;                           // integer created on the host.
         void f () {
-            amrex::launch(bx,
-            [=] AMREX_GPU_DEVICE (Box const& tbx)
+            amrex::ParallelFor(bx,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 printf("m = %d\n", m);   // Failed attempt to use m on the GPU.
             });
@@ -1358,8 +1310,8 @@ lambda to capture. For example:
         int m;
         void f () {
             int local_m = m;                  // Local temporary copy of m.
-            amrex::launch(bx,
-            [=] AMREX_GPU_DEVICE (Box const& tbx)
+            amrex::ParallelFor(bx,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 printf("m = %d\n", local_m);  // Lambda captures local_m by value.
             });

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1166,6 +1166,54 @@ number of threads per block by :cpp:`ParallelFor<MY_BLOCK_SIZE>(...)`, where
 ``MY_BLOCK_SIZE`` is a multiple of the warp size (e.g., 128).  This allows
 the users to do performance tuning for individual kernels.
 
+Launching general kernels
+-------------------------
+
+To launch more general work on the GPU, AMReX provides a standard launch function:
+:cpp:`amrex::launch`.  Instead of creating nested loops, this function
+prepares the device launch based on a :cpp:`Box`, launches with an appropriate sized
+GPU kernel and constructs a thread :cpp:`Box` that defines the work for each thread.
+On the CPU, the thread :cpp:`Box` is set equal to the total launch :cpp:`Box`, so
+tiling works as expected.  On the GPU, the thread :cpp:`Box` usually
+contains a single cell to allow all GPU threads to be utilized effectively.
+
+An example of a generic function launch is shown here:
+
+.. highlight:: c++
+
+::
+
+    for (MFIter mfi(mf,TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+        Array4<Real> const& arr = mf.array(mfi);
+
+        amrex::launch(bx,
+        [=] AMREX_GPU_DEVICE (Box const& tbx)
+        {
+            pluseone_array4(tbx, arr);
+            FArrayBox fab(arr, tbx.ixType());
+            plusone_fab(tbx, fab); // this version takes FArrayBox
+        });
+
+        /* MACRO VARIATION
+        /
+        /   AMREX_LAUNCH_DEVICE_LAMBDA ( bx, tbx,
+        /   {
+        /       plusone_array4(tbx, arr);
+        /       plusone_fab(tbx, FArrayBox(arr,tbx.ixType()));
+        /   });
+        */
+    }
+
+It also shows how to make a :cpp:`FArrayBox` from :cpp:`Array4` when
+needed.  Note that :cpp:`FarrayBox`\ es cannot be passed to GPU
+kernels directly.  :cpp:`TilingIfNotGPU()` returns ``false`` in the
+GPU case to turn off tiling and maximize the amount of work given to
+the GPU in each launch, which substantially improves performance.
+When tiling is off, :cpp:`tilebox()` returns the :cpp:`validbox()` of
+the :cpp:`FArrayBox` for that iteration.
+
 Offloading work using OpenACC or OpenMP pragmas
 -----------------------------------------------
 

--- a/Src/Amr/AMReX_StateData.cpp
+++ b/Src/Amr/AMReX_StateData.cpp
@@ -951,49 +951,22 @@ StateDataPhysBCFunct::operator() (MultiFab& mf, int dest_comp, int num_comp, Int
                                 Elixir elitmp = tmp.elixir();
                                 Array4<Real> const& tmpa = tmp.array();
                                 const int ishift = -geom->period(dir);
-                                amrex::launch(lo_slab,
-                                [=] AMREX_GPU_DEVICE (Box const& tbx) noexcept
-                                {
-                                    const Box db = amrex::shift(tbx, dir, ishift);
-                                    const auto dlo = amrex::lbound(db);
-                                    const auto tlo = amrex::lbound(tbx);
-                                    const auto len = amrex::length(db);
-                                    for (int n = 0; n < num_comp; ++n) {
-                                        for         (int k = 0; k < len.z; ++k) {
-                                            for     (int j = 0; j < len.y; ++j) {
-                                                AMREX_PRAGMA_SIMD
-                                                for (int i = 0; i < len.x; ++i) {
-                                                    tmpa(i+tlo.x,j+tlo.y,k+tlo.z,n)
-                                                        = desta(i+dlo.x,j+dlo.y,k+dlo.z,n+dest_comp);
-                                                }
-                                            }
-                                        }
-                                    }
-                                });
+                                const IntVect shift_iv = ishift * IntVect::TheDimensionVector(dir);
+                                amrex::ParallelFor(lo_slab, num_comp,
+                                    [=] AMREX_GPU_DEVICE (const IntVect& iv, int n) noexcept
+                                    {
+                                        tmpa(iv, n) = desta(iv + shift_iv, n + dest_comp);
+                                    });
                                 if (has_bndryfunc_fab) {
                                     statedata->FillBoundary(lo_slab, tmp, time, *geom, 0, src_comp, num_comp);
                                 } else {
                                     statedata->FillBoundary(tmp, time, dx, prob_domain, 0, src_comp, num_comp);
                                 }
-                                amrex::launch(lo_slab,
-                                [=] AMREX_GPU_DEVICE (Box const& tbx) noexcept
-                                {
-                                    const Box db = amrex::shift(tbx, dir, ishift);
-                                    const auto dlo = amrex::lbound(db);
-                                    const auto tlo = amrex::lbound(tbx);
-                                    const auto len = amrex::length(db);
-                                    for (int n = 0; n < num_comp; ++n) {
-                                        for         (int k = 0; k < len.z; ++k) {
-                                            for     (int j = 0; j < len.y; ++j) {
-                                                AMREX_PRAGMA_SIMD
-                                                for (int i = 0; i < len.x; ++i) {
-                                                    desta(i+dlo.x,j+dlo.y,k+dlo.z,n+dest_comp)
-                                                        = tmpa(i+tlo.x,j+tlo.y,k+tlo.z,n);
-                                                }
-                                            }
-                                        }
-                                    }
-                                });
+                                amrex::ParallelFor(lo_slab, num_comp,
+                                    [=] AMREX_GPU_DEVICE (const IntVect& iv, int n) noexcept
+                                    {
+                                        desta(iv + shift_iv, n + dest_comp) = tmpa(iv, n);
+                                    });
                             }
                             else
 #endif
@@ -1019,49 +992,22 @@ StateDataPhysBCFunct::operator() (MultiFab& mf, int dest_comp, int num_comp, Int
                                 Elixir elitmp = tmp.elixir();
                                 Array4<Real> const& tmpa = tmp.array();
                                 const int ishift = geom->period(dir);
-                                amrex::launch(hi_slab,
-                                [=] AMREX_GPU_DEVICE (Box const& tbx) noexcept
-                                {
-                                    const Box db = amrex::shift(tbx, dir, ishift);
-                                    const auto dlo = amrex::lbound(db);
-                                    const auto tlo = amrex::lbound(tbx);
-                                    const auto len = amrex::length(db);
-                                    for (int n = 0; n < num_comp; ++n) {
-                                        for         (int k = 0; k < len.z; ++k) {
-                                            for     (int j = 0; j < len.y; ++j) {
-                                                AMREX_PRAGMA_SIMD
-                                                for (int i = 0; i < len.x; ++i) {
-                                                    tmpa(i+tlo.x,j+tlo.y,k+tlo.z,n)
-                                                        = desta(i+dlo.x,j+dlo.y,k+dlo.z,n+dest_comp);
-                                                }
-                                            }
-                                        }
-                                    }
-                                });
+                                const IntVect shift_iv = ishift * IntVect::TheDimensionVector(dir);
+                                amrex::ParallelFor(hi_slab, num_comp,
+                                    [=] AMREX_GPU_DEVICE (const IntVect& iv, int n) noexcept
+                                    {
+                                        tmpa(iv, n) = desta(iv + shift_iv, n + dest_comp);
+                                    });
                                 if (has_bndryfunc_fab) {
                                     statedata->FillBoundary(hi_slab, tmp, time, *geom, 0, src_comp, num_comp);
                                 } else {
                                     statedata->FillBoundary(tmp, time, dx, prob_domain, 0, src_comp, num_comp);
                                 }
-                                amrex::launch(hi_slab,
-                                [=] AMREX_GPU_DEVICE (Box const& tbx) noexcept
-                                {
-                                    const Box db = amrex::shift(tbx, dir, ishift);
-                                    const auto dlo = amrex::lbound(db);
-                                    const auto tlo = amrex::lbound(tbx);
-                                    const auto len = amrex::length(db);
-                                    for (int n = 0; n < num_comp; ++n) {
-                                        for         (int k = 0; k < len.z; ++k) {
-                                            for     (int j = 0; j < len.y; ++j) {
-                                                AMREX_PRAGMA_SIMD
-                                                for (int i = 0; i < len.x; ++i) {
-                                                    desta(i+dlo.x,j+dlo.y,k+dlo.z,n+dest_comp)
-                                                        = tmpa(i+tlo.x,j+tlo.y,k+tlo.z,n);
-                                                }
-                                            }
-                                        }
-                                    }
-                                });
+                                amrex::ParallelFor(hi_slab, num_comp,
+                                    [=] AMREX_GPU_DEVICE (const IntVect& iv, int n) noexcept
+                                    {
+                                        desta(iv + shift_iv, n + dest_comp) = tmpa(iv, n);
+                                    });
                             }
                             else
 #endif

--- a/Tests/Amr/Advection_AmrCore/Exec/Prob.H
+++ b/Tests/Amr/Advection_AmrCore/Exec/Prob.H
@@ -8,25 +8,16 @@
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 void
-initdata(amrex::Box const& bx, amrex::Array4<amrex::Real> const& phi,
+initdata(int i, int j, int k, amrex::Array4<amrex::Real> const& phi,
          amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_lo,
          amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx)
 {
     using namespace amrex;
 
-    const auto lo = lbound(bx);
-    const auto hi = ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            Real y = prob_lo[1] + (0.5+j) * dx[1];
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real x = prob_lo[0] + (0.5+i) * dx[0];
-                Real r2 = (std::pow(x-0.5, 2) + std::pow((y-0.75),2)) / 0.01;
-                phi(i,j,k) = 1.0 + std::exp(-r2);
-            }
-        }
-    }
+    Real y = prob_lo[1] + (0.5+j) * dx[1];
+    Real x = prob_lo[0] + (0.5+i) * dx[0];
+    Real r2 = (std::pow(x-0.5, 2) + std::pow((y-0.75),2)) / 0.01;
+    phi(i,j,k) = 1.0 + std::exp(-r2);
 }
 
 #endif

--- a/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAllLevels.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAllLevels.cpp
@@ -78,16 +78,16 @@ AmrCoreAdv::AdvancePhiAllLevels (Real time, Real dt_lev, int /*iteration*/)
                 Array4<Real const> phix_c = phix;
                 itmp += 1;
 
-                amrex::launch(amrex::grow(gbx,Direction::x,1),
-                [=] AMREX_GPU_DEVICE (const Box& tbx)
+                amrex::ParallelFor(amrex::grow(gbx,Direction::x,1),
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    slopex2(tbx, slope2, statein);
+                    slopex2(i, j, k, slope2, statein);
                 });
 
-                amrex::launch(gbx,
-                [=] AMREX_GPU_DEVICE (const Box& tbx)
+                amrex::ParallelFor(gbx,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    slopex4(tbx, slope4, statein, slope2_c);
+                    slopex4(i, j, k, slope4, statein, slope2_c);
                 });
 
                 Box b = gbx;
@@ -102,16 +102,16 @@ AmrCoreAdv::AdvancePhiAllLevels (Real time, Real dt_lev, int /*iteration*/)
                 Array4<Real const> phiy_c = phiy;
                 itmp += 1; // NOLINT(clang-analyzer-deadcode.DeadStores)
 
-                amrex::launch(amrex::grow(gbx,Direction::y,1),
-                [=] AMREX_GPU_DEVICE (const Box& tbx)
+                amrex::ParallelFor(amrex::grow(gbx,Direction::y,1),
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    slopey2(tbx, slope2, statein);
+                    slopey2(i, j, k, slope2, statein);
                 });
 
-                amrex::launch(gbx,
-                [=] AMREX_GPU_DEVICE (const Box& tbx)
+                amrex::ParallelFor(gbx,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    slopey4(tbx, slope4, statein, slope2_c);
+                    slopey4(i, j, k, slope4, statein, slope2_c);
                 });
 
                 b = gbx;
@@ -127,16 +127,16 @@ AmrCoreAdv::AdvancePhiAllLevels (Real time, Real dt_lev, int /*iteration*/)
                 Array4<Real const> phiz_c = phiz;
                 itmp += 1;
 
-                amrex::launch(amrex::grow(gbx,Direction::z,1),
-                [=] AMREX_GPU_DEVICE (const Box& tbx)
+                amrex::ParallelFor(amrex::grow(gbx,Direction::z,1),
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    slopez2(tbx, slope2, statein);
+                    slopez2(i, j, k, slope2, statein);
                 });
 
-                amrex::launch(gbx,
-                [=] AMREX_GPU_DEVICE (const Box& tbx)
+                amrex::ParallelFor(gbx,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    slopez4(tbx, slope4, statein, slope2_c);
+                    slopez4(i, j, k, slope4, statein, slope2_c);
                 });
 
                 b = gbx;

--- a/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAtLevel.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AdvancePhiAtLevel.cpp
@@ -80,16 +80,16 @@ AmrCoreAdv::AdvancePhiAtLevel (int lev, Real time, Real dt_lev, int /*iteration*
             Array4<Real> phix = tmpfab.array(itmp++);
             Array4<Real const> phix_c = phix;
 
-            amrex::launch(amrex::grow(gbx,Direction::x,1),
-            [=] AMREX_GPU_DEVICE (const Box& tbx)
+            amrex::ParallelFor(amrex::grow(gbx,Direction::x,1),
+            [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                slopex2(tbx, slope2, statein);
+                slopex2(i, j, k, slope2, statein);
             });
 
-            amrex::launch(gbx,
-            [=] AMREX_GPU_DEVICE (const Box& tbx)
+            amrex::ParallelFor(gbx,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                slopex4(tbx, slope4, statein, slope2_c);
+                slopex4(i, j, k, slope4, statein, slope2_c);
             });
 
             Box b = gbx;
@@ -103,16 +103,16 @@ AmrCoreAdv::AdvancePhiAtLevel (int lev, Real time, Real dt_lev, int /*iteration*
             Array4<Real> phiy = tmpfab.array(itmp++);
             Array4<Real const> phiy_c = phiy;
 
-            amrex::launch(amrex::grow(gbx,Direction::y,1),
-            [=] AMREX_GPU_DEVICE (const Box& tbx)
+            amrex::ParallelFor(amrex::grow(gbx,Direction::y,1),
+            [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                slopey2(tbx, slope2, statein);
+                slopey2(i, j, k, slope2, statein);
             });
 
-            amrex::launch(gbx,
-            [=] AMREX_GPU_DEVICE (const Box& tbx)
+            amrex::ParallelFor(gbx,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                slopey4(tbx, slope4, statein, slope2_c);
+                slopey4(i, j, k, slope4, statein, slope2_c);
             });
 
             b = gbx;
@@ -127,16 +127,16 @@ AmrCoreAdv::AdvancePhiAtLevel (int lev, Real time, Real dt_lev, int /*iteration*
             Array4<Real> phiz = tmpfab.array(itmp++);
             Array4<Real const> phiz_c = phiz;
 
-            amrex::launch(amrex::grow(gbx,Direction::z,1),
-            [=] AMREX_GPU_DEVICE (const Box& tbx)
+            amrex::ParallelFor(amrex::grow(gbx,Direction::z,1),
+            [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                slopez2(tbx, slope2, statein);
+                slopez2(i, j, k, slope2, statein);
             });
 
-            amrex::launch(gbx,
-            [=] AMREX_GPU_DEVICE (const Box& tbx)
+            amrex::ParallelFor(gbx,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                slopez4(tbx, slope4, statein, slope2_c);
+                slopez4(i, j, k, slope4, statein, slope2_c);
             });
 
             b = gbx;

--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -346,10 +346,10 @@ void AmrCoreAdv::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba
         Array4<Real> fab = state[mfi].array();
         const Box& box = mfi.tilebox();
 
-        amrex::launch(box,
-        [=] AMREX_GPU_DEVICE (Box const& tbx)
+        amrex::ParallelFor(box,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            initdata(tbx, fab, problo, dx);
+            initdata(i, j, k, fab, problo, dx);
         });
     }
 }

--- a/Tests/Amr/Advection_AmrCore/Source/DefineVelocity.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/DefineVelocity.cpp
@@ -51,10 +51,10 @@ AmrCoreAdv::DefineVelocityAtLevel (int lev, Real time)
             Array4<Real> psi = psifab.array();
             GeometryData geomdata = geom[lev].data();
 
-            amrex::launch(psibox,
-            [=] AMREX_GPU_DEVICE (const Box& tbx)
+            amrex::ParallelFor(psibox,
+            [=] AMREX_GPU_DEVICE (int i, int j, int)
             {
-                get_face_velocity_psi(tbx, time, psi, geomdata);
+                get_face_velocity_psi(i, j, time, psi, geomdata);
             });
 
             amrex::ParallelFor

--- a/Tests/Amr/Advection_AmrCore/Source/Src_K/slope_K.H
+++ b/Tests/Amr/Advection_AmrCore/Source/Src_K/slope_K.H
@@ -7,174 +7,119 @@
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopex2(amrex::Box const& bx,
+void slopex2(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q)
 {
     using namespace amrex;
-
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i-1,j,k);
-                Real drgt = q(i+1,j,k) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i-1,j,k);
+    Real drgt = q(i+1,j,k) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
 }
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopex4(amrex::Box const& bx,
+void slopex4(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq4,
              amrex::Array4<amrex::Real const> const& q,
              amrex::Array4<amrex::Real const> const& dq)
 {
     using namespace amrex;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i-1,j,k);
-                Real drgt = q(i+1,j,k) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i+1,j,k) + dq(i-1,j,k));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i-1,j,k);
+    Real drgt = q(i+1,j,k) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i+1,j,k) + dq(i-1,j,k));
+    dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
 }
 
 // ***********************************************************
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopey2(amrex::Box const& bx,
+void slopey2(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q)
 {
     using namespace amrex;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i,j-1,k);
-                Real drgt = q(i,j+1,k) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i,j-1,k);
+    Real drgt = q(i,j+1,k) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
 }
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopey4(amrex::Box const& bx,
+void slopey4(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq4,
              amrex::Array4<amrex::Real const> const& q,
              amrex::Array4<amrex::Real const> const& dq)
 {
     using namespace amrex;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i,j-1,k);
-                Real drgt = q(i,j+1,k) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j+1,k) + dq(i,j-1,k));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i,j-1,k);
+    Real drgt = q(i,j+1,k) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j+1,k) + dq(i,j-1,k));
+    dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
 }
 
 // ***********************************************************
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopez2(amrex::Box const& bx,
+void slopez2(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q)
 {
     using namespace amrex;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i,j,k-1);
-                Real drgt = q(i,j,k+1) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i,j,k-1);
+    Real drgt = q(i,j,k+1) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
 }
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopez4(amrex::Box const& bx,
+void slopez4(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq4,
              amrex::Array4<amrex::Real const> const& q,
              amrex::Array4<amrex::Real const> const& dq)
 {
     using namespace amrex;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i,j,k-1);
-                Real drgt = q(i,j,k+1) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j,k+1) + dq(i,j,k-1));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i,j,k-1);
+    Real drgt = q(i,j,k+1) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j,k+1) + dq(i,j,k-1));
+    dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
 }
 
 #endif

--- a/Tests/Amr/Advection_AmrCore/Source/face_velocity.H
+++ b/Tests/Amr/Advection_AmrCore/Source/face_velocity.H
@@ -7,7 +7,7 @@
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void get_face_velocity_psi(amrex::Box const& bx,
+void get_face_velocity_psi(int i, int j,
                            const amrex::Real time,
                            amrex::Array4<amrex::Real> const& psi,
                            amrex::GeometryData const& geomdata)
@@ -15,21 +15,13 @@ void get_face_velocity_psi(amrex::Box const& bx,
     using namespace amrex;
     constexpr Real PI = 3.1415926535897932384626;
 
-    const auto lo  = lbound(bx);
-    const auto hi  = ubound(bx);
-
     const Real* AMREX_RESTRICT prob_lo = geomdata.ProbLo();
     const Real* AMREX_RESTRICT dx      = geomdata.CellSize();
 
-    for     (int j = lo.y; j <= hi.y; ++j) {
-        Real y = dx[1]*(0.5+j) + prob_lo[1];
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            Real x = dx[0]*(0.5+i) + prob_lo[0];
-            psi(i,j,0) = std::pow(std::sin(PI*x), 2) * std::pow(std::sin(PI*y), 2)
-                       * std::cos(PI*time/2.0) * 1.0/PI;
-        }
-    }
+    Real y = dx[1]*(0.5+j) + prob_lo[1];
+    Real x = dx[0]*(0.5+i) + prob_lo[0];
+    psi(i,j,0) = std::pow(std::sin(PI*x), 2) * std::pow(std::sin(PI*y), 2)
+                * std::cos(PI*time/2.0) * 1.0/PI;
 }
 
 AMREX_GPU_DEVICE

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_2d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_2d_K.H
@@ -6,7 +6,7 @@
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void get_face_velocity_psi(amrex::Box const& bx,
+void get_face_velocity_psi(int i, int j,
                            amrex::Real time,
                            amrex::Array4<amrex::Real> const& psi,
                            amrex::Real dx,
@@ -17,22 +17,11 @@ void get_face_velocity_psi(amrex::Box const& bx,
     using namespace amrex;
     constexpr Real PI = 3.141592653589793238462643383279502884197;
 
-    // Extract box bounds
-    const auto plo = lbound(bx);
-    const auto phi = ubound(bx);
-
     // Compute streamfunction psi
-    for     (int j = plo.y; j <= phi.y; ++j)
-    {
-        Real y = ( (Real)j + 0.5 )*dy + prob_lo_y;
-        AMREX_PRAGMA_SIMD
-        for (int i = plo.x; i <= phi.x; ++i)
-        {
-            Real x = ( (Real)i + 0.5 )*dx + prob_lo_x;
-            psi(i,j,0) = std::pow(std::sin(PI*x), 2) * std::pow(std::sin(PI*y), 2)
-                       * std::cos(PI*time/2.0) * 1.0/PI;
-        }
-    }
+    Real y = ( (Real)j + 0.5 )*dy + prob_lo_y;
+    Real x = ( (Real)i + 0.5 )*dx + prob_lo_x;
+    psi(i,j,0) = std::pow(std::sin(PI*x), 2) * std::pow(std::sin(PI*y), 2)
+                * std::cos(PI*time/2.0) * 1.0/PI;
 }
 
 AMREX_GPU_DEVICE
@@ -89,10 +78,10 @@ void get_face_velocity(amrex::Real time,
     Array4<Real> psi = psifab.array();
 
     // Compute streamfunction psi (can run on GPU)
-    amrex::launch(psibox,
-    [=] AMREX_GPU_DEVICE (const Box& tbx)
+    amrex::ParallelFor(psibox,
+    [=] AMREX_GPU_DEVICE (int i, int j, int)
     {
-        get_face_velocity_psi(tbx, time, psi,
+        get_face_velocity_psi(i, j, time, psi,
                               dx[0], dx[1],
                               prob_lo[0], prob_lo[1]);
     });

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_3d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_3d_K.H
@@ -6,7 +6,7 @@
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void get_face_velocity_psi(amrex::Box const& bx,
+void get_face_velocity_psi(int i, int j,
                            amrex::Real time,
                            amrex::Array4<amrex::Real> const& psi,
                            amrex::Real dx,
@@ -19,22 +19,11 @@ void get_face_velocity_psi(amrex::Box const& bx,
     using namespace amrex;
     constexpr Real PI = 3.141592653589793238462643383279502884197;
 
-    // Extract box bounds
-    const auto plo = lbound(bx);
-    const auto phi = ubound(bx);
-
     // Compute streamfunction psi
-    for     (int j = plo.y; j <= phi.y; ++j)
-    {
-        Real y = ( (Real)j + 0.5 )*dy + prob_lo_y;
-        AMREX_PRAGMA_SIMD
-        for (int i = plo.x; i <= phi.x; ++i)
-        {
-            Real x = ( (Real)i + 0.5 )*dx + prob_lo_x;
-            psi(i,j,0) = std::pow(std::sin(PI*x), 2) * std::pow(std::sin(PI*y), 2)
-                       * std::cos(PI*time/2.0) * 1.0/PI;
-        }
-    }
+    Real y = ( (Real)j + 0.5 )*dy + prob_lo_y;
+    Real x = ( (Real)i + 0.5 )*dx + prob_lo_x;
+    psi(i,j,0) = std::pow(std::sin(PI*x), 2) * std::pow(std::sin(PI*y), 2)
+                * std::cos(PI*time/2.0) * 1.0/PI;
 }
 
 AMREX_GPU_DEVICE
@@ -100,10 +89,10 @@ void get_face_velocity(amrex::Real time,
     Array4<Real> psi = psifab.array();
 
     // Compute streamfunction psi (can run on GPU)
-    amrex::launch(psibox,
-    [=] AMREX_GPU_DEVICE (const Box& tbx)
+    amrex::ParallelFor(psibox,
+    [=] AMREX_GPU_DEVICE (int i, int j, int)
     {
-        get_face_velocity_psi(tbx, time, psi,
+        get_face_velocity_psi(i, j, time, psi,
                               dx[0], dx[1], dx[2],
                               prob_lo[0], prob_lo[1], prob_lo[2]);
     });

--- a/Tests/Amr/Advection_AmrLevel/Source/Adv.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/Adv.cpp
@@ -83,17 +83,17 @@ AmrLevelAdv::advect (amrex::Real /*time*/,
     Array4<Real const> phix_c = phix;
 
     // Fromm slope
-    amrex::launch(amrex::grow(gbx,Direction::x,1),
-    [=] AMREX_GPU_DEVICE (const Box& tbx)
+    amrex::ParallelFor(amrex::grow(gbx,Direction::x,1),
+    [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {
-        slopex2(tbx, slope2, phi_in);
+        slopex2(i, j, k, slope2, phi_in);
     });
 
     // Limited fourth order slope
-    amrex::launch(gbx,
-    [=] AMREX_GPU_DEVICE (const Box& tbx)
+    amrex::ParallelFor(gbx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {
-        slopex4(tbx, slope4, phi_in, slope2_c);
+        slopex4(i, j, k, slope4, phi_in, slope2_c);
     });
 
     // Longitudinal flux
@@ -109,17 +109,17 @@ AmrLevelAdv::advect (amrex::Real /*time*/,
     Array4<Real const> phiy_c = phiy;
 
     // Fromm slope
-    amrex::launch(amrex::grow(gbx,Direction::y,1),
-    [=] AMREX_GPU_DEVICE (const Box& tbx)
+    amrex::ParallelFor(amrex::grow(gbx,Direction::y,1),
+    [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {
-        slopey2(tbx, slope2, phi_in);
+        slopey2(i, j, k, slope2, phi_in);
     });
 
     // Limited fourth order slope
-    amrex::launch(gbx,
-    [=] AMREX_GPU_DEVICE (const Box& tbx)
+    amrex::ParallelFor(gbx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {
-        slopey4(tbx, slope4, phi_in, slope2_c);
+        slopey4(i, j, k, slope4, phi_in, slope2_c);
     });
 
     // Longitudinal flux
@@ -136,17 +136,17 @@ AmrLevelAdv::advect (amrex::Real /*time*/,
     Array4<Real const> phiz_c = phiz;
 
     // Fromm slope
-    amrex::launch(amrex::grow(gbx,Direction::z,1),
-    [=] AMREX_GPU_DEVICE (const Box& tbx)
+    amrex::ParallelFor(amrex::grow(gbx,Direction::z,1),
+    [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {
-        slopez2(tbx, slope2, phi_in);
+        slopez2(i, j, k, slope2, phi_in);
     });
 
     // Limited fourth order slope
-    amrex::launch(gbx,
-    [=] AMREX_GPU_DEVICE (const Box& tbx)
+    amrex::ParallelFor(gbx,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {
-        slopez4(tbx, slope4, phi_in, slope2_c);
+        slopez4(i, j, k, slope4, phi_in, slope2_c);
     });
 
     // Longitudinal flux

--- a/Tests/Amr/Advection_AmrLevel/Source/Src_K/slope_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Source/Src_K/slope_K.H
@@ -8,116 +8,80 @@
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopex2(amrex::Box const& bx,
+void slopex2(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q)
 {
     using amrex::Real;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i-1,j,k);
-                Real drgt = q(i+1,j,k) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i-1,j,k);
+    Real drgt = q(i+1,j,k) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
 }
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopex4(amrex::Box const& bx,
+void slopex4(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq4,
              amrex::Array4<amrex::Real const> const& q,
              amrex::Array4<amrex::Real const> const& dq)
 {
     using amrex::Real;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i-1,j,k);
-                Real drgt = q(i+1,j,k) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i+1,j,k) + dq(i-1,j,k));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i-1,j,k);
+    Real drgt = q(i+1,j,k) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i+1,j,k) + dq(i-1,j,k));
+    dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
 }
 
 // ***********************************************************
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopey2(amrex::Box const& bx,
+void slopey2(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q)
 {
     using amrex::Real;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i,j-1,k);
-                Real drgt = q(i,j+1,k) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i,j-1,k);
+    Real drgt = q(i,j+1,k) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
 }
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopey4(amrex::Box const& bx,
+void slopey4(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq4,
              amrex::Array4<amrex::Real const> const& q,
              amrex::Array4<amrex::Real const> const& dq)
 {
     using amrex::Real;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i,j-1,k);
-                Real drgt = q(i,j+1,k) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j+1,k) + dq(i,j-1,k));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i,j-1,k);
+    Real drgt = q(i,j+1,k) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j+1,k) + dq(i,j-1,k));
+    dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
 }
 
 #if (AMREX_SPACEDIM > 2)
@@ -125,58 +89,40 @@ void slopey4(amrex::Box const& bx,
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopez2(amrex::Box const& bx,
+void slopez2(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq,
              amrex::Array4<amrex::Real const> const& q)
 {
     using amrex::Real;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i,j,k-1);
-                Real drgt = q(i,j,k+1) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i,j,k-1);
+    Real drgt = q(i,j,k+1) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    dq(i,j,k) = dsgn*amrex::min(dlim, std::abs(dcen));
 }
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
-void slopez4(amrex::Box const& bx,
+void slopez4(int i, int j, int k,
              amrex::Array4<amrex::Real> const& dq4,
              amrex::Array4<amrex::Real const> const& q,
              amrex::Array4<amrex::Real const> const& dq)
 {
     using amrex::Real;
 
-    const auto lo = amrex::lbound(bx);
-    const auto hi = amrex::ubound(bx);
-
-    for         (int k = lo.z; k <= hi.z; ++k) {
-        for     (int j = lo.y; j <= hi.y; ++j) {
-            for (int i = lo.x; i <= hi.x; ++i) {
-                Real dlft = q(i,j,k) - q(i,j,k-1);
-                Real drgt = q(i,j,k+1) - q(i,j,k);
-                Real dcen = Real(0.5)*(dlft+drgt);
-                Real dsgn = std::copysign(Real(1.0), dcen);
-                Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
-                                           std::abs(dlft) : std::abs(drgt));
-                Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
-                Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j,k+1) + dq(i,j,k-1));
-                dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
-            }
-        }
-    }
+    Real dlft = q(i,j,k) - q(i,j,k-1);
+    Real drgt = q(i,j,k+1) - q(i,j,k);
+    Real dcen = Real(0.5)*(dlft+drgt);
+    Real dsgn = std::copysign(Real(1.0), dcen);
+    Real dslop = Real(2.0) * ((std::abs(dlft) < std::abs(drgt)) ?
+                                std::abs(dlft) : std::abs(drgt));
+    Real dlim = (dlft*drgt >= Real(0.0)) ? dslop : Real(0.0);
+    Real dq1 = Real(4.0/3.0)*dcen - Real(1.0/6.0)*(dq(i,j,k+1) + dq(i,j,k-1));
+    dq4(i,j,k) = dsgn*amrex::min(dlim, std::abs(dq1));
 }
 #endif
 


### PR DESCRIPTION
## Summary

There are two very different types of functions called `amrex::launch`. One gives raw access to a GPU block to be used with shared memory. The other type iterates over threads more like ParallelFor but gives a Box to the functor, not an IntVect. For GPU the box will only have one element, for CPU this is the same box that was passed into launch. This was used to quickly port amrex CPU code to GPU. However, I find this quite confusing.

This PR replaces the uses of the second type of launch inside amrex with ParallelFor and removes the section in the documentation that covered it. This avoids having to write the 4D loop inside every kernel.

TODO (in a future PR?): replace ...LAMBDA_RANGE macros used in LinearSolvers.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
