### PR TITLE
Remove identity Lambdas in amrex::launch

### DIFF
--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -154,7 +154,7 @@ void single_task (gpuStream_t stream, L const& f) noexcept
     auto& q = *(stream.queue);
     try {
         q.submit([&] (sycl::handler& h) {
-            h.single_task([=] () { f(); });
+            h.single_task(f);
         });
     } catch (sycl::exception const& ex) {
         amrex::Abort(std::string("single_task: ")+ex.what()+"!!!!!");
@@ -711,8 +711,7 @@ void ParallelFor (Gpu::KernelInfo const& /*info*/,
 template <typename L>
 void single_task (gpuStream_t stream, L const& f) noexcept
 {
-    AMREX_LAUNCH_KERNEL(Gpu::Device::warp_size, 1, 1, 0, stream,
-                        [=] AMREX_GPU_DEVICE () noexcept {f();});
+    AMREX_LAUNCH_KERNEL(Gpu::Device::warp_size, 1, 1, 0, stream, f);
     AMREX_GPU_ERROR_CHECK();
 }
 
@@ -720,16 +719,14 @@ template <int MT, typename L>
 void launch (int nblocks, std::size_t shared_mem_bytes, gpuStream_t stream,
              L const& f) noexcept
 {
-    AMREX_LAUNCH_KERNEL(MT, nblocks, MT, shared_mem_bytes, stream,
-                        [=] AMREX_GPU_DEVICE () noexcept { f(); });
+    AMREX_LAUNCH_KERNEL(MT, nblocks, MT, shared_mem_bytes, stream, f);
     AMREX_GPU_ERROR_CHECK();
 }
 
 template <int MT, typename L>
 void launch (int nblocks, gpuStream_t stream, L const& f) noexcept
 {
-    AMREX_LAUNCH_KERNEL(MT, nblocks, MT, 0, stream,
-                        [=] AMREX_GPU_DEVICE () noexcept { f(); });
+    AMREX_LAUNCH_KERNEL(MT, nblocks, MT, 0, stream, f);
     AMREX_GPU_ERROR_CHECK();
 }
 
@@ -737,8 +734,7 @@ template<typename L>
 void launch (int nblocks, int nthreads_per_block, std::size_t shared_mem_bytes,
              gpuStream_t stream, L const& f) noexcept
 {
-    AMREX_LAUNCH_KERNEL_NOBOUND(nblocks, nthreads_per_block, shared_mem_bytes,
-                                stream, [=] AMREX_GPU_DEVICE () noexcept { f(); });
+    AMREX_LAUNCH_KERNEL_NOBOUND(nblocks, nthreads_per_block, shared_mem_bytes, stream, f);
     AMREX_GPU_ERROR_CHECK();
 }
 


### PR DESCRIPTION
## Summary

I think these are unnecessary. Removing them shortens the name of the generated kernels a little bit.

Before:
```
void amrex::launch_global<(int)1024, void amrex::launch<(int)1024, void hpmg::<unnamed>::gsrb_shared<
(int)1, (bool)0,(bool)0, (bool)0>(const amrex::BoxND<(int)3> &, const amrex::Array4<double> &,
const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &,
const amrex::Array4<const double> &, double, double)::
[lambda() (instance 1)]>(int, CUstream_st *, const T2 &)::[lambda() (instance 1)]>(T2)
```
After:
```
void amrex::launch_global<(int)1024, void hpmg::<unnamed>::gsrb_shared<
(int)1, (bool)0, (bool)0, (bool)0>(const amrex::BoxND<(int)3> &, const amrex::Array4<double> &,
const amrex::Array4<const double> &, const amrex::Array4<const double> &, const amrex::Array4<double> &,
const amrex::Array4<const double> &, double, double)::
[lambda() (instance 1)]>(T2)
```


## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
