### PR TITLE
MFIter: Device sync optimization

### DIFF
--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -20,8 +20,10 @@ struct MFItInfo
 {
     bool do_tiling{false};
     bool dynamic{false};
-    bool device_sync;
-    int  num_streams;
+    bool device_sync = true;
+    bool device_sync_pre = true;
+    bool device_sync_post = true;
+    int  num_streams = 1;
     IntVect tilesize;
     MFItInfo () noexcept
         :  device_sync(!Gpu::inNoSyncRegion()), num_streams(Gpu::numGpuStreams()),
@@ -29,6 +31,10 @@ struct MFItInfo
     MFItInfo& EnableTiling (const IntVect& ts = FabArrayBase::mfiter_tile_size) noexcept {
         do_tiling = true;
         tilesize = ts;
+        return *this;
+    }
+    MFItInfo& SetTiling (bool f) noexcept {
+        do_tiling = f;
         return *this;
     }
     MFItInfo& SetDynamic (bool f) noexcept {
@@ -41,6 +47,22 @@ struct MFItInfo
     }
     MFItInfo& SetDeviceSync (bool f) noexcept {
         device_sync = f;
+        return *this;
+    }
+    MFItInfo& DisableDeviceSyncPre () noexcept {
+        device_sync_pre = false;
+        return *this;
+    }
+    MFItInfo& SetDeviceSyncPre (bool f) noexcept {
+        device_sync_pre = f;
+        return *this;
+    }
+    MFItInfo& DisableDeviceSyncPost () noexcept {
+        device_sync_post = false;
+        return *this;
+    }
+    MFItInfo& SetDeviceSyncPost (bool f) noexcept {
+        device_sync_post = f;
         return *this;
     }
     MFItInfo& SetNumStreams (int n) noexcept {
@@ -206,6 +228,8 @@ protected:
         bool flag = true;
     };
     DeviceSync device_sync;
+    DeviceSync device_sync_pre{true};
+    DeviceSync device_sync_post{true};
 
     const Vector<int>* index_map;
     const Vector<int>* local_index_map;

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -167,6 +167,8 @@ MFIter::MFIter (const BoxArray& ba, const DistributionMapping& dm, const MFItInf
     streams(std::max(1,std::min(Gpu::numGpuStreams(),info.num_streams))),
     dynamic(info.dynamic && (OpenMP::get_num_threads() > 1)),
     device_sync(info.device_sync),
+    device_sync_pre(info.device_sync_pre),
+    device_sync_post(info.device_sync_post),
     index_map(nullptr),
     local_index_map(nullptr),
     tile_array(nullptr),
@@ -199,6 +201,8 @@ MFIter::MFIter (const FabArrayBase& fabarray_, const MFItInfo& info)
     streams(std::max(1,std::min(Gpu::numGpuStreams(),info.num_streams))),
     dynamic(info.dynamic && (OpenMP::get_num_threads() > 1)),
     device_sync(info.device_sync),
+    device_sync_pre(info.device_sync_pre),
+    device_sync_post(info.device_sync_post),
     index_map(nullptr),
     local_index_map(nullptr),
     tile_array(nullptr),
@@ -239,7 +243,7 @@ MFIter::Finalize ()
 #endif
 
 #ifdef AMREX_USE_GPU
-    if (device_sync) {
+    if (device_sync && device_sync_post) {
         const int nstreams = std::min(endIndex, streams);
         for (int i = 0; i < nstreams; ++i) {
             Gpu::Device::setStreamIndex(i);
@@ -281,16 +285,6 @@ MFIter::Initialize ()
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(depth == 1 || MFIter::allow_multiple_mfiters,
             "Nested or multiple active MFIters is not supported by default.  This can be changed by calling MFIter::allowMultipleMFIters(true)");
     }
-
-#if defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP)
-    if (Gpu::inLaunchRegion() && device_sync && (streams > 1)
-        && (OpenMP::get_num_threads() > 1))
-    { // If there are multiple gpu streams and multiple omp threads, we need
-      // to sync here. Otherwise, the sync will be delayed.
-#pragma omp single
-        Gpu::streamSynchronize();
-    }
-#endif
 
     if (flags & AllBoxes)  // a very special case
     {
@@ -375,6 +369,15 @@ MFIter::Initialize ()
         currentIndex = beginIndex;
 
 #ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion() && device_sync && device_sync_pre &&
+            streams > 1 && ((index_map->size() > 1) || this->numLocalTiles() > 1)) {
+            // No need to call streamSynchronize when there is only single
+            // stream or only one box/tile.
+#ifdef AMREX_USE_OMP
+#pragma omp single
+#endif
+            Gpu::streamSynchronize();
+        }
         Gpu::Device::setStreamIndex(currentIndex%streams);
 #endif
 
@@ -535,19 +538,7 @@ MFIter::operator++ () noexcept
 
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion()) {
-            if (device_sync && (streams > 1) && (OpenMP::get_num_threads() == 1)
-                && (currentIndex == 1) && isValid())
-            {
-                // Because omp num threads is 1, gpu stream sync has not
-                // been called in Initialize. We need to sync stream 0
-                // before launching kernels on stream 1, because the user
-                // might have launched kernels (such as memcpyAsync) on
-                // stream 0 before this MFIter and the kernels on stream 1
-                // might depend on it.
-                Gpu::streamSynchronize();
-            }
             Gpu::Device::setStreamIndex(currentIndex%streams);
-            AMREX_GPU_ERROR_CHECK();
 #ifdef AMREX_DEBUG
 //            Gpu::synchronize();
 #endif


### PR DESCRIPTION
For safety reasons, we have a sync before starting jobs on non-default streams (i.e., streams with index > 0) in MFIter. But the previous approach of delaying the sync until necessary is actually slower than performing a sync on stream 0 (i.e., the default stream in amrex, not to be confused with CUDA's legacy default stream) at the beginning. This is because stream sync is relatively cheap when there are no active jobs in that stream. For example, the sequence of sync, kernel, kernel, and sync is faster than the sequence of kernel, sync, kernel, and sync, where there are no previous active jobs.

I have done some testing on perlmutter and frontier, the new way is about 5-10% faster for the following code.
```
BoxArray ba(Box(IntVect(0), IntVect(255)));
ba.maxSize(128);
MultiFab mf(ba, DistributionMapping{ba}, 1, 0);
mf.setVal(1);
auto t0 = amrex::second;
for (int i = 0; i < 10; ++i)
{
    mf.setVal(t0);
}
auto t1 = amrex::second();
```
