### PR TITLE
Updated `ArrayND` offset calculation 

### DIFF
--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -6,7 +6,6 @@
 #include <AMReX.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_GpuPrint.H>
-#include <AMReX_ConstexprFor.H>
 
 #include <iostream>
 #include <sstream>
@@ -268,11 +267,11 @@ namespace amrex {
         {
             if constexpr (N > 1) {
                 Long current_stride = 1;
-                constexpr_for<0, N-1>([&](int d) {
+                for (int d = 0; d < N-1; ++d) {
                     Long len = a_end.vect[d] - a_begin.vect[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
-                });
+                }
             }
         }
 
@@ -291,11 +290,11 @@ namespace amrex {
             : p(a_p), begin(a_begin.x, a_begin.y, a_begin.z, 0), end(a_end.x, a_end.y, a_end.z, a_ncomp)
         {
             Long current_stride = 1;
-            constexpr_for<0, N-1>([&](int d) {
+            for (int d = 0; d < N-1; ++d) {
                 Long len = end.vect[d] - begin.vect[d];
                 current_stride *= len;
                 nstride[d] = current_stride;
-            });
+            }
         }
 
         /**
@@ -313,23 +312,24 @@ namespace amrex {
         constexpr ArrayND (T* a_p, IntVectND<M> const& a_begin, IntVectND<M> const& a_end, int ncomp) noexcept
             : p(a_p)
         {
-            constexpr_for<0, M>([&](int d) {
+            for (int d = 0; d < M; ++d) {
                 begin.vect[d] = a_begin.vect[d];
                 end.vect[d] = a_end.vect[d];
-            });
-            constexpr_for<M, N>([&](int d) {
+            }
+            for (int d = M; d < N-1; ++d) {
                 begin.vect[d] = 0;
                 end.vect[d] = 1;
-            });
+            }
+            begin.vect[N-1] = 0;
             end.vect[N-1] = ncomp;
 
             if constexpr (N > 1) {
                 Long current_stride = 1;
-                constexpr_for<0, N-1>([&](int d) {
+                for (int d = 0; d < N-1; ++d) {
                     Long len = end.vect[d] - begin.vect[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
-                });
+                }
             }
         }
 
@@ -598,9 +598,9 @@ namespace amrex {
         constexpr std::size_t size () const noexcept {
             if (ok()) {
                 std::size_t s = 1;
-                constexpr_for<0, N>([&](int d) {
+                for (int d = 0; d < N; ++d) {
                     s *= (end.vect[d] - begin.vect[d]);
-                });
+                }
                 return s;
             } else {
                 return 0;
@@ -620,9 +620,9 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (IntVectND<M> const& iv) const noexcept {
             bool inside = true;
-            constexpr_for<0, M>([&](int d) {
+            for (int d = 0; d < M; ++d) {
                 inside = inside && (iv.vect[d] >= begin.vect[d]) && (iv.vect[d] < end.vect[d]);
-            });
+            }
             return inside;
         }
 
@@ -631,9 +631,9 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (IntVectND<M> const& iv, int n) const noexcept {
             bool inside = true;
-            constexpr_for<0, M>([&](int d) {
+            for (int d = 0; d < M; ++d) {
                 inside = inside && (iv.vect[d] >= begin.vect[d]) && (iv.vect[d] < end.vect[d]);
-            });
+            }
             inside = inside && (n >= 0) && (n < end.vect[N-1]);
             return inside;
         }
@@ -641,7 +641,7 @@ namespace amrex {
         template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr bool contains (Dim3 const& cell) const noexcept {
-            return this->contains(IntVectND{cell.x, cell.y, cell.z});
+            return this->contains(cell.x, cell.y, cell.z);
         }
 
         template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
@@ -661,7 +661,6 @@ namespace amrex {
             Long offset = iv[0] - begin.vect[0];
             // If M == N and we have a component at the end, we only loop up to N-1 for spatial.
             // Otherwise, we loop up to M.
-            AMREX_UNROLL_LOOP(10)
             for (int d = 1; d < idx; ++d) {
                 offset += (iv[d] - begin.vect[d]) * nstride[d-1];
             }
@@ -674,7 +673,6 @@ namespace amrex {
             return offset;
 #else
             Long idx_term = iv[0];
-            AMREX_UNROLL_LOOP(10)
             for (int d = 1; d < idx; ++d) {
                 idx_term += static_cast<Long>(iv[d]) * nstride[d-1];
             }
@@ -684,7 +682,6 @@ namespace amrex {
             // Compute the origin term separately.
             // This allows the compiler to calculate this once per nested loop.
             Long origin_term = begin.vect[0];
-            AMREX_UNROLL_LOOP(10)
             for (int d = 1; d < idx; ++d) {
                 origin_term += static_cast<Long>(begin.vect[d]) * nstride[d-1];
             }
@@ -699,7 +696,6 @@ namespace amrex {
         {
 #if defined(AMREX_USE_GPU)
             Long offset = iv[0] - begin.vect[0];
-            AMREX_UNROLL_LOOP(10)
             for (int d = 1; d < M; ++d) {
                 offset += (iv[d] - begin.vect[d]) * nstride[d-1];
             }
@@ -707,7 +703,6 @@ namespace amrex {
             return offset;
 #else
             Long idx_term = iv[0];
-            AMREX_UNROLL_LOOP(10)
             for (int d = 1; d < M; ++d) {
                 idx_term += static_cast<Long>(iv[d]) * nstride[d-1];
             }
@@ -715,7 +710,6 @@ namespace amrex {
             // Compute the origin term separately.
             // This allows the compiler to calculate this once per nested loop.
             Long origin_term = begin.vect[0];
-            AMREX_UNROLL_LOOP(10)
             for (int d = 1; d < M; ++d) {
                 origin_term += static_cast<Long>(begin.vect[d]) * nstride[d-1];
             }

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -269,7 +269,7 @@ namespace amrex {
             if constexpr (N > 1) {
                 Long current_stride = 1;
                 constexpr_for<0, N-1>([&](int d) {
-                    Long len = a_end[d] - a_begin[d];
+                    Long len = a_end.vect[d] - a_begin.vect[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
                 });
@@ -292,7 +292,7 @@ namespace amrex {
         {
             Long current_stride = 1;
             constexpr_for<0, N-1>([&](int d) {
-                Long len = end[d] - begin[d];
+                Long len = end.vect[d] - begin.vect[d];
                 current_stride *= len;
                 nstride[d] = current_stride;
             });
@@ -314,19 +314,19 @@ namespace amrex {
             : p(a_p)
         {
             constexpr_for<0, M>([&](int d) {
-                begin[d] = a_begin[d];
-                end[d] = a_end[d];
+                begin.vect[d] = a_begin.vect[d];
+                end.vect[d] = a_end.vect[d];
             });
             constexpr_for<M, N>([&](int d) {
-                begin[d] = 0;
-                end[d] = 1;
+                begin.vect[d] = 0;
+                end.vect[d] = 1;
             });
-            end[N-1] = ncomp;
+            end.vect[N-1] = ncomp;
 
             if constexpr (N > 1) {
                 Long current_stride = 1;
                 constexpr_for<0, N-1>([&](int d) {
-                    Long len = end[d] - begin[d];
+                    Long len = end.vect[d] - begin.vect[d];
                     current_stride *= len;
                     nstride[d] = current_stride;
                 });
@@ -351,8 +351,8 @@ namespace amrex {
               begin(rhs.begin),
               end(rhs.end)
         {
-            begin[N-1] = 0;
-            end[N-1] = rhs.end[N-1] - start_comp;
+            begin.vect[N-1] = 0;
+            end.vect[N-1] = rhs.end.vect[N-1] - start_comp;
         }
 
         /**
@@ -374,8 +374,8 @@ namespace amrex {
               begin(rhs.begin),
               end(rhs.end)
         {
-            begin[N-1] = 0;
-            end[N-1] = num_comp;
+            begin.vect[N-1] = 0;
+            end.vect[N-1] = num_comp;
         }
 
         /**
@@ -415,7 +415,8 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(IntVectND<nidx>{i...});
 #endif
-            return p[get_offset(IntVectND<nidx>{i...})];
+            const int iv[nidx] = { static_cast<int>(i)... };
+            return p[get_offset(iv)];
         }
 
         /**
@@ -437,7 +438,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv);
 #endif
-            return p[get_offset(iv)];
+            return p[get_offset(iv.vect)];
         }
 
         /**
@@ -458,7 +459,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv, n);
 #endif
-            return p[get_offset(iv, n)];
+            return p[get_offset(iv.vect, n)];
         }
 
         /**
@@ -501,7 +502,8 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(IntVectND<nidx>{i...});
 #endif
-            return p + get_offset(IntVectND<nidx>{i...});
+            const int iv[nidx] = { static_cast<int>(i)... };
+            return p + get_offset(iv);
         }
 
         /**
@@ -522,7 +524,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv);
 #endif
-            return p + get_offset(iv);
+            return p + get_offset(iv.vect);
         }
 
         /**
@@ -542,7 +544,7 @@ namespace amrex {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
             index_assert(iv, n);
 #endif
-            return p + get_offset(iv, n);
+            return p + get_offset(iv.vect, n);
         }
 
         /**
@@ -586,7 +588,7 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr int nComp () const noexcept {
             if constexpr (last_dim_component) {
-                return end[N-1];
+                return end.vect[N-1];
             } else {
                 return 1;
             }
@@ -597,7 +599,7 @@ namespace amrex {
             if (ok()) {
                 std::size_t s = 1;
                 constexpr_for<0, N>([&](int d) {
-                    s *= (end[d] - begin[d]);
+                    s *= (end.vect[d] - begin.vect[d]);
                 });
                 return s;
             } else {
@@ -619,7 +621,7 @@ namespace amrex {
         constexpr bool contains (IntVectND<M> const& iv) const noexcept {
             bool inside = true;
             constexpr_for<0, M>([&](int d) {
-                inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
+                inside = inside && (iv.vect[d] >= begin.vect[d]) && (iv.vect[d] < end.vect[d]);
             });
             return inside;
         }
@@ -630,9 +632,9 @@ namespace amrex {
         constexpr bool contains (IntVectND<M> const& iv, int n) const noexcept {
             bool inside = true;
             constexpr_for<0, M>([&](int d) {
-                inside = inside && (iv[d] >= begin[d]) && (iv[d] < end[d]);
+                inside = inside && (iv.vect[d] >= begin.vect[d]) && (iv.vect[d] < end.vect[d]);
             });
-            inside = inside && (n >= 0) && (n < end[N-1]);
+            inside = inside && (n >= 0) && (n < end.vect[N-1]);
             return inside;
         }
 
@@ -645,44 +647,47 @@ namespace amrex {
         template <int M=N, std::enable_if_t<M==4 && last_dim_component,int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         CellData<T> cellData (int i, int j, int k) const noexcept {
-            int ncomp = end[M-1];
+            int ncomp = end.vect[M-1];
             return CellData<T>(this->ptr(i,j,k), nstride[M-2], ncomp);
         }
 
         template <int M, std::enable_if_t<(M == N)
             || (last_dim_component && (M + 1 == N || M == AMREX_SPACEDIM)), int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr Long get_offset (IntVectND<M> const& iv) const noexcept
+        constexpr Long get_offset (const int (&iv)[M]) const noexcept
         {
             constexpr int idx = (last_dim_component && M == N) ? N - 1 : M;
 #if defined(AMREX_USE_GPU)
-            Long offset = iv.vect[0] - begin.vect[0];
+            Long offset = iv[0] - begin.vect[0];
             // If M == N and we have a component at the end, we only loop up to N-1 for spatial.
             // Otherwise, we loop up to M.
-            constexpr_for<1, idx>([&](int d) {
-                offset += (iv.vect[d] - begin.vect[d]) * nstride[d-1];
-            });
+            AMREX_UNROLL_LOOP(10)
+            for (int d = 1; d < idx; ++d) {
+                offset += (iv[d] - begin.vect[d]) * nstride[d-1];
+            }
 
             // Handle the component offset if the input is the full N dimensions
             // and the last dimension is a component.
             if constexpr (last_dim_component && M == N) {
-                offset += iv.vect[N-1] * nstride[N-2];
+                offset += iv[N-1] * nstride[N-2];
             }
             return offset;
 #else
-            Long idx_term = iv.vect[0];
-            constexpr_for <1, idx>([&](int d) {
-                idx_term += static_cast<Long>(iv.vect[d]) * nstride[d-1];
-            });
+            Long idx_term = iv[0];
+            AMREX_UNROLL_LOOP(10)
+            for (int d = 1; d < idx; ++d) {
+                idx_term += static_cast<Long>(iv[d]) * nstride[d-1];
+            }
             if constexpr (last_dim_component && M == N) {
-                idx_term += static_cast<Long>(iv.vect[N-1]) * nstride[N-2];
+                idx_term += static_cast<Long>(iv[N-1]) * nstride[N-2];
             }
             // Compute the origin term separately.
             // This allows the compiler to calculate this once per nested loop.
             Long origin_term = begin.vect[0];
-            constexpr_for <1, idx>([&](int d) {
+            AMREX_UNROLL_LOOP(10)
+            for (int d = 1; d < idx; ++d) {
                 origin_term += static_cast<Long>(begin.vect[d]) * nstride[d-1];
-            });
+            }
             return idx_term - origin_term;
 #endif
         }
@@ -690,27 +695,30 @@ namespace amrex {
         template <int M, std::enable_if_t<last_dim_component
             && ((M + 1 == N) || (N == 4 && M == AMREX_SPACEDIM)), int> = 0>
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        constexpr Long get_offset (IntVectND<M> const& iv, int n) const noexcept
+        constexpr Long get_offset (const int (&iv)[M], int n) const noexcept
         {
 #if defined(AMREX_USE_GPU)
-            Long offset = iv.vect[0] - begin.vect[0];
-            constexpr_for<1, M>([&](int d) {
-                offset += (iv.vect[d] - begin.vect[d]) * nstride[d-1];
-            });
+            Long offset = iv[0] - begin.vect[0];
+            AMREX_UNROLL_LOOP(10)
+            for (int d = 1; d < M; ++d) {
+                offset += (iv[d] - begin.vect[d]) * nstride[d-1];
+            }
             offset += n * nstride[N-2];
             return offset;
 #else
-            Long idx_term = iv.vect[0];
-            constexpr_for <1, M>([&](int d) {
-                idx_term += static_cast<Long>(iv.vect[d]) * nstride[d-1];
-            });
+            Long idx_term = iv[0];
+            AMREX_UNROLL_LOOP(10)
+            for (int d = 1; d < M; ++d) {
+                idx_term += static_cast<Long>(iv[d]) * nstride[d-1];
+            }
             idx_term += static_cast<Long>(n) * nstride[N-2];
             // Compute the origin term separately.
             // This allows the compiler to calculate this once per nested loop.
             Long origin_term = begin.vect[0];
-            constexpr_for <1, M>([&](int d) {
+            AMREX_UNROLL_LOOP(10)
+            for (int d = 1; d < M; ++d) {
                 origin_term += static_cast<Long>(begin.vect[d]) * nstride[d-1];
-            });
+            }
             return idx_term - origin_term;
 #endif
         }

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -164,9 +164,9 @@ namespace amrex {
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         void device_print_impl2 (std::index_sequence<idx...>,
                                 std::index_sequence<idx2x...>,
-                                IntVectND<sizeof...(idx)> const& iv,
-                                IntVectND<sizeof...(idx)> const& begin,
-                                IntVectND<sizeof...(idx)> const& end)
+                                const int (&iv)[sizeof...(idx)],
+                                const int (&begin)[sizeof...(idx)],
+                                const int (&end)[sizeof...(idx)])
         {
             constexpr auto msg = make_oob_message_impl(std::index_sequence<idx...>{});
 
@@ -178,9 +178,9 @@ namespace amrex {
 
         template <int N, std::enable_if_t<(N>=1),int> = 0>
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void device_printf_impl (const IntVectND<N>& iv,
-                                const IntVectND<N>& begin,
-                                const IntVectND<N>& end)
+        void device_printf_impl (const int (&iv)[N],
+                                const int (&begin)[N],
+                                const int (&end)[N])
         {
             device_print_impl2(
                 std::make_index_sequence<N>{},
@@ -412,10 +412,10 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (idx... i) const noexcept {
             constexpr auto nidx = sizeof...(i);
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(IntVectND<nidx>{i...});
-#endif
             const int iv[nidx] = { static_cast<int>(i)... };
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+            index_assert(iv);
+#endif
             return p[get_offset(iv)];
         }
 
@@ -436,7 +436,7 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVectND<M> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(iv);
+            index_assert(iv.vect);
 #endif
             return p[get_offset(iv.vect)];
         }
@@ -457,7 +457,7 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         U& operator() (IntVectND<M> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(iv, n);
+            index_assert(iv.vect, n);
 #endif
             return p[get_offset(iv.vect, n)];
         }
@@ -499,10 +499,10 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (idx... i) const noexcept {
             constexpr auto nidx = sizeof...(i);
-#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(IntVectND<nidx>{i...});
-#endif
             const int iv[nidx] = { static_cast<int>(i)... };
+#if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
+            index_assert(iv);
+#endif
             return p + get_offset(iv);
         }
 
@@ -522,7 +522,7 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<M> const& iv) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(iv);
+            index_assert(iv.vect);
 #endif
             return p + get_offset(iv.vect);
         }
@@ -542,7 +542,7 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         T* ptr (IntVectND<M> const& iv, int n) const noexcept {
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)
-            index_assert(iv, n);
+            index_assert(iv.vect, n);
 #endif
             return p + get_offset(iv.vect, n);
         }
@@ -723,7 +723,7 @@ namespace amrex {
 #else
         AMREX_GPU_HOST_DEVICE inline
 #endif
-        void index_assert (IntVectND<N> const& iv) const
+        void index_assert (const int (&iv)[N]) const
         {
             bool out_of_bounds = false;
             for (int d = 0; d < N; ++d) {
@@ -733,7 +733,7 @@ namespace amrex {
             }
             if (out_of_bounds) {
                 AMREX_IF_ON_DEVICE((
-                    detail::device_printf_impl(iv, begin, end);
+                    detail::device_printf_impl(iv, begin.vect, end.vect);
                     amrex::Abort();
                 ))
                 AMREX_IF_ON_HOST((
@@ -759,9 +759,12 @@ namespace amrex {
         template <int M, std::enable_if_t<((M+1 == N) || (M == AMREX_SPACEDIM))
             && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE inline
-        void index_assert (IntVectND<M> const& iv) const
+        void index_assert (const int (&iv)[M]) const
         {
-            IntVectND<N> iv_full = iv.template expand<N>(0);
+            int iv_full[N];
+            for (int d = 0; d < M; ++d) {
+                iv_full[d] = iv[d];
+            }
             for (int d = M; d < N; ++d) {
                 iv_full[d] = begin[d];
             }
@@ -773,9 +776,12 @@ namespace amrex {
         template <int M, std::enable_if_t<((M+1 == N) || (M == AMREX_SPACEDIM))
             && last_dim_component,int> = 0>
         AMREX_GPU_HOST_DEVICE inline
-        void index_assert (IntVectND<M> const& iv, int n) const
+        void index_assert (const int (&iv)[M], int n) const
         {
-            IntVectND<N> iv_full = iv.template expand<N>(0);
+            int iv_full[N];
+            for (int d = 0; d < M; ++d) {
+                iv_full[d] = iv[d];
+            }
             for (int d = M; d < N-1; ++d) {
                 iv_full[d] = begin[d];
             }

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -654,20 +654,37 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr Long get_offset (IntVectND<M> const& iv) const noexcept
         {
-            Long offset = iv[0] - begin[0];
+            constexpr int idx = (last_dim_component && M == N) ? N - 1 : M;
+#if defined(AMREX_USE_GPU)
+            Long offset = iv.vect[0] - begin.vect[0];
             // If M == N and we have a component at the end, we only loop up to N-1 for spatial.
             // Otherwise, we loop up to M.
-            constexpr int idx = (last_dim_component && M == N) ? N - 1 : M;
             constexpr_for<1, idx>([&](int d) {
-                offset += (iv[d] - begin[d]) * nstride[d-1];
+                offset += (iv.vect[d] - begin.vect[d]) * nstride[d-1];
             });
 
             // Handle the component offset if the input is the full N dimensions
             // and the last dimension is a component.
             if constexpr (last_dim_component && M == N) {
-                offset += iv[N-1] * nstride[N-2];
+                offset += iv.vect[N-1] * nstride[N-2];
             }
             return offset;
+#else
+            Long idx_term = iv.vect[0];
+            constexpr_for <1, idx>([&](int d) {
+                idx_term += static_cast<Long>(iv.vect[d]) * nstride[d-1];
+            });
+            if constexpr (last_dim_component && M == N) {
+                idx_term += static_cast<Long>(iv.vect[N-1]) * nstride[N-2];
+            }
+            // Compute the origin term separately.
+            // This allows the compiler to calculate this once per nested loop.
+            Long origin_term = begin.vect[0];
+            constexpr_for <1, idx>([&](int d) {
+                origin_term += static_cast<Long>(begin.vect[d]) * nstride[d-1];
+            });
+            return idx_term - origin_term;
+#endif
         }
 
         template <int M, std::enable_if_t<last_dim_component
@@ -675,12 +692,27 @@ namespace amrex {
         [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         constexpr Long get_offset (IntVectND<M> const& iv, int n) const noexcept
         {
-            Long offset = iv[0] - begin[0];
+#if defined(AMREX_USE_GPU)
+            Long offset = iv.vect[0] - begin.vect[0];
             constexpr_for<1, M>([&](int d) {
-                offset += (iv[d] - begin[d]) * nstride[d-1];
+                offset += (iv.vect[d] - begin.vect[d]) * nstride[d-1];
             });
             offset += n * nstride[N-2];
             return offset;
+#else
+            Long idx_term = iv.vect[0];
+            constexpr_for <1, M>([&](int d) {
+                idx_term += static_cast<Long>(iv.vect[d]) * nstride[d-1];
+            });
+            idx_term += static_cast<Long>(n) * nstride[N-2];
+            // Compute the origin term separately.
+            // This allows the compiler to calculate this once per nested loop.
+            Long origin_term = begin.vect[0];
+            constexpr_for <1, M>([&](int d) {
+                origin_term += static_cast<Long>(begin.vect[d]) * nstride[d-1];
+            });
+            return idx_term - origin_term;
+#endif
         }
 
 #if defined(AMREX_DEBUG) || defined(AMREX_BOUND_CHECK)

--- a/Src/Base/AMReX_IntVect.H
+++ b/Src/Base/AMReX_IntVect.H
@@ -791,7 +791,7 @@ public:
     */
     static const IntVectND<dim> Unit;
 
-private:
+// private:
 
     int vect[dim] = {};
 };

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -976,7 +976,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             if(imf_arr(i,j,k,0)!=0)
             {
                 const auto idx = last_offset + offsets_ptr[
-                    imf_arr.get_offset({i,j,k})
+                    imf_arr.template get_offset<3>({i,j,k})
                 ];
 
                 dst.cpu(idx) = 0;

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -976,7 +976,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             if(imf_arr(i,j,k,0)!=0)
             {
                 const auto idx = last_offset + offsets_ptr[
-                    imf_arr.get_offset(IntVectND<3>{i,j,k})
+                    imf_arr.get_offset({i,j,k})
                 ];
 
                 dst.cpu(idx) = 0;


### PR DESCRIPTION
## Summary
Changes the order of calculation for `get_offset` in `ArrayND`. For CPU builds in Release mode, the compiler is able to hoist the invariant part of the offset calculation out of the nested loops. See #4900 for some performance comparison.

I have also removed the use of `constexpr_for` as it adds a slight performance penalty. 
## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
