### PR TITLE
Fix bug in multi-ghost FillBoundary for the Alamo code

### DIFF
--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -1322,17 +1322,24 @@ BoxList
 BoxArray::complementIn (const Box& bx, const Periodicity& period) const
 {
     BoxList bl(bx.ixType());
+    BoxList bl2(bx.ixType());
+    BoxList bltmp(bx.ixType());
     complementIn(bl, bx);
     auto const& pshifts = period.shiftIntVect();
     for (auto const& pit : pshifts) {
+        if (bl.isEmpty()) { break; }
         if (pit != 0) {
-            auto bltmp = complementIn(bx+pit);
-            if (bltmp.isNotEmpty()) {
-                for (auto& btmp : bltmp) {
-                    btmp -= pit;
+            bl2.clear();
+            for (auto const& b : bl) {
+                complementIn(bltmp, amrex::shift(b, pit));
+                if (bltmp.isNotEmpty()) {
+                    for (auto& btmp : bltmp) {
+                        btmp -= pit;
+                    }
+                    bl2.join(bltmp);
                 }
-                bl.join(bltmp);
             }
+            std::swap(bl, bl2);
         }
     }
     return bl;

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -1767,8 +1767,8 @@ MLMGT<MF>::interpCorrection (int alev)
         nghost = IntVect(linop.getNGrow(alev));
     }
 
-    MF const& crse_cor = cor[alev-1][0];
-    MF      & fine_cor = cor[alev  ][0];
+    MF & crse_cor = cor[alev-1][0];
+    MF & fine_cor = cor[alev  ][0];
 
     const Geometry& crse_geom = linop.Geom(alev-1,0);
 
@@ -1778,6 +1778,11 @@ MLMGT<MF>::interpCorrection (int alev)
     {
         ng_src = linop.getNGrow(alev-1);
         ng_dst = linop.getNGrow(alev-1);
+        if constexpr (IsMultiFabLike_v<MF>) {
+            crse_cor.FillBoundary(0, ncomp, IntVect(ng_src), crse_geom.periodicity());
+        } else {
+            amrex::Abort("MLMG: CFStrategy::ghostnodes not supported for non-MultiFab like types");
+        }
     }
 
     MF cfine = linop.makeCoarseAmr(alev, IntVect(ng_dst));


### PR DESCRIPTION
This also adds a FillBoundary call for Alamo's linear solver that uses the multi-ghost mode.