### PR TITLE
Reapply "add a dependabot.yml to checkout github actions versions (#3704)" (#3710)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Dependabot configuration
+# ref: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This reverts commit 6f1c74f7a9295f7b217a2ef8a631cbe136bc689e.

We removed dependabot.yml because it pushed branch "main" to this repo. It's still not clear what happened. But we now have a rule in settings that restricts the creation of main. So hopefully this is no longer an issue.
