### PR TITLE
CI: Restrict push triggered runs to development branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "development"

--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -1,6 +1,12 @@
 name: apps
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-apps

--- a/.github/workflows/ascent.yml
+++ b/.github/workflows/ascent.yml
@@ -1,6 +1,12 @@
 name: 🐧 Ascent
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-insituvis

--- a/.github/workflows/bittree.yml
+++ b/.github/workflows/bittree.yml
@@ -1,6 +1,12 @@
 name: bittree
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-bittree

--- a/.github/workflows/catalyst.yml
+++ b/.github/workflows/catalyst.yml
@@ -1,6 +1,12 @@
 name: 🐧 Catalyst
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-insituvis-catalyst

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,6 +1,12 @@
 name: LinuxClang
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-linux-clang

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,12 @@
 name: codespell
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-codespell

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -1,6 +1,12 @@
 name: cuda
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,12 @@
 name: Build and Deploy
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-docs

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -3,7 +3,13 @@
 
 name: LinuxGCC
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -1,6 +1,12 @@
 name: hip
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hip

--- a/.github/workflows/hypre.yml
+++ b/.github/workflows/hypre.yml
@@ -1,6 +1,12 @@
 name: Hypre
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hypre

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,6 +1,12 @@
 name: intel
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-intel

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,12 @@
 name: macos
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-macos

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -1,6 +1,12 @@
 name: PETSc
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-petsc

--- a/.github/workflows/sensei.yml
+++ b/.github/workflows/sensei.yml
@@ -2,7 +2,13 @@
 
 name: SENSEI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-sensei

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,6 +1,12 @@
 name: smoke
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-smoke

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,12 @@
 name: Style
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-style

--- a/.github/workflows/sundials.yml
+++ b/.github/workflows/sundials.yml
@@ -1,6 +1,12 @@
 name: SUNDIALS
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-sundials

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,12 @@
 name: windows
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - development
+  pull_request:
+    branches:
+      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-windows


### PR DESCRIPTION
This can avoid running CI twice when a PR branch is pushed by dependabot.
