### PR TITLE
CSR: Miss streamSynchronize in SYCL version of sortCSR

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -102,7 +102,7 @@ jobs:
             -DAMReX_ENABLE_TESTS=ON                        \
             -DAMReX_FORTRAN=OFF                            \
             -DAMReX_GPU_BACKEND=SYCL                       \
-            -DAMReX_SYCL_AOT=ON                            \
+            -DAMReX_SYCL_AOT=OFF                           \
             -DAMReX_INTEL_ARCH=pvc                         \
             -DCMAKE_C_COMPILER=$(which icx)                \
             -DCMAKE_CXX_COMPILER=$(which icpx)             \

--- a/Src/LinearSolvers/AMReX_CSR.H
+++ b/Src/LinearSolvers/AMReX_CSR.H
@@ -232,6 +232,7 @@ void CSR<T,V>::sort ()
     // xxxxx TODO SYCL: Let's not worry about performance for now.
     CSR<T,Gpu::PinnedVector> h_csr;
     duplicateCSR(Gpu::deviceToHost, h_csr, *this);
+    Gpu::streamSynchronize();
     h_csr.sort_on_host();
     duplicateCSR(Gpu::hostToDevice, *this, h_csr);
     Gpu::streamSynchronize();

--- a/Tests/Algebra/Transpose/main.cpp
+++ b/Tests/Algebra/Transpose/main.cpp
@@ -89,27 +89,27 @@ int main (int argc, char *argv[])
             auto const& csr = matt.const_parcsr();
             auto err = Reduce::Sum<int>(matt.numLocalRows(),
                                         [=] AMREX_GPU_DEVICE (Long i)
-           {
-               int r = 0;
-               for (auto idx = csr.csr0.row_offset[i]; idx < csr.csr0.row_offset[i+1]; ++idx) {
-                   auto v1 = csr.csr0.mat[idx];
-                   auto v2 = value(csr.csr0.col_index[idx]+csr.col_begin, i+csr.row_begin);
-                   if (! amrex::almostEqual(v1,v2)) {
-                       ++r;
-                   }
-               }
-               if (csr.row_map && csr.row_map[i] >= 0) {
-                   auto ii = csr.row_map[i];
-                   for (auto idx = csr.csr1.row_offset[ii]; idx < csr.csr1.row_offset[ii+1]; ++idx) {
-                       auto v1 = csr.csr1.mat[idx];
-                       auto v2 = value(csr.col_map[csr.csr1.col_index[idx]], i+csr.row_begin);
-                       if (! amrex::almostEqual(v1,v2)) {
-                           ++r;
-                       }
-                   }
-               }
-               return r;
-           });
+            {
+                int r = 0;
+                for (auto idx = csr.csr0.row_offset[i]; idx < csr.csr0.row_offset[i+1]; ++idx) {
+                    auto v1 = csr.csr0.mat[idx];
+                    auto v2 = value(csr.csr0.col_index[idx]+csr.col_begin, i+csr.row_begin);
+                    if (! amrex::almostEqual(v1,v2)) {
+                        ++r;
+                    }
+                }
+                if (csr.row_map && csr.row_map[i] >= 0) {
+                    auto ii = csr.row_map[i];
+                    for (auto idx = csr.csr1.row_offset[ii]; idx < csr.csr1.row_offset[ii+1]; ++idx) {
+                        auto v1 = csr.csr1.mat[idx];
+                        auto v2 = value(csr.col_map[csr.csr1.col_index[idx]], i+csr.row_begin);
+                        if (! amrex::almostEqual(v1,v2)) {
+                            ++r;
+                        }
+                    }
+                }
+                return r;
+            });
 
             AMREX_ALWAYS_ASSERT(err == 0);
 


### PR DESCRIPTION
Disable AOT in oneAPI SYCL tests w/ EB. With AOT, the test now takes more than 2.5 hours. (If needed, we can run the HPSF Gitlab CI.)

Also fix indentation.
