### PR TITLE
GitHub Actions: Ignore 'dependabot/**' branches

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -2,11 +2,9 @@ name: apps
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-apps

--- a/.github/workflows/ascent.yml
+++ b/.github/workflows/ascent.yml
@@ -2,11 +2,9 @@ name: 🐧 Ascent
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-insituvis

--- a/.github/workflows/bittree.yml
+++ b/.github/workflows/bittree.yml
@@ -2,11 +2,9 @@ name: bittree
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-bittree

--- a/.github/workflows/catalyst.yml
+++ b/.github/workflows/catalyst.yml
@@ -2,11 +2,9 @@ name: 🐧 Catalyst
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-insituvis-catalyst

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -2,11 +2,9 @@ name: LinuxClang
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-linux-clang

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,11 +2,9 @@ name: codespell
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-codespell

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -2,11 +2,9 @@ name: cuda
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,11 +2,9 @@ name: Build and Deploy
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-docs

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -5,11 +5,9 @@ name: LinuxGCC
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -2,11 +2,9 @@ name: hip
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hip

--- a/.github/workflows/hypre.yml
+++ b/.github/workflows/hypre.yml
@@ -2,11 +2,9 @@ name: Hypre
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hypre

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -2,11 +2,9 @@ name: intel
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-intel

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,11 +2,9 @@ name: macos
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-macos

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -2,11 +2,9 @@ name: PETSc
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-petsc

--- a/.github/workflows/sensei.yml
+++ b/.github/workflows/sensei.yml
@@ -4,11 +4,9 @@ name: SENSEI
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-sensei

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,11 +2,9 @@ name: smoke
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-smoke

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,11 +2,9 @@ name: Style
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-style

--- a/.github/workflows/sundials.yml
+++ b/.github/workflows/sundials.yml
@@ -2,11 +2,9 @@ name: SUNDIALS
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-sundials

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,11 +2,9 @@ name: windows
 
 on:
   push:
-    branches:
-      - development
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
-    branches:
-      - development
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-windows


### PR DESCRIPTION
The approach in #4916 disables CIs for pushes to all non-development branches, including branches on forks. That's not we want. In this PR, we only skip CIs for pushes to 'dependabot/**' branches.
