### PR TITLE
Generalize SIMD Single Source Design

### DIFF
--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -222,6 +222,7 @@ namespace Gpu {
 #include <AMReX_GpuLaunchFunctsC.H>
 #include <AMReX_SIMD.H>
 #endif
+#include <AMReX_GpuLaunchFunctsSIMD.H>
 
 #include <AMReX_GpuLaunch.nolint.H>
 

--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -220,6 +220,25 @@ void ParallelForSIMD (N n, L const& f) noexcept
     }
 }
 
+/** ParallelFor with a SIMD Width (derived from a type w/ fallback to non-SIMD)
+ *
+ * SIMD load/Write-back operations need to be performed before/after calling this.
+ *
+ * @tparam T a type that implements amrex::simd::Vectorized (or not)
+ * @tparam N index type (integer)
+ * @tparam L function/functor to call per SIMD set of elements
+ */
+template <typename T, typename N, typename L, typename M=std::enable_if_t<std::is_integral_v<N>> >
+AMREX_ATTRIBUTE_FLATTEN_FOR
+void ParallelForSIMD (N n, L && f) noexcept
+{
+    if constexpr (amrex::simd::is_vectorized<T>) {
+        amrex::ParallelForSIMD<T::simd_width>(n, std::forward<L>(f));
+    } else {
+        amrex::ParallelForSIMD<1, N>(n, std::forward<L>(f));
+    }
+}
+
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >
 void ParallelFor (Gpu::KernelInfo const&, T n, L&& f) noexcept
 {

--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -4,24 +4,6 @@
 
 namespace amrex {
 
-/** Helper type to store/access the SIMD width in ParallelForSIMD lambdas
- *
- * Use instead of int as the running index i. Used to pass the
- * SIMD WIDTH as compile-time meta-data into a called function/method.
- *
- * @tparam WIDTH SIMD width in elements
- * @tparam N index type (integer)
- */
-template<int WIDTH, class N=int>
-struct SIMDindex
-{
-    /** SIMD width in elements */
-    static constexpr int width = WIDTH;
-
-    /** The linear loop index of ParallelFor(SIMD) */
-    N index = 0;
-};
-
 /// \cond DOXYGEN_IGNORE
 namespace detail {
 
@@ -193,50 +175,6 @@ void ParallelFor (T n, L&& f) noexcept
 {
     amrex::ignore_unused(MT);
     ParallelFor(n, std::forward<L>(f));
-}
-
-/** ParallelFor with a SIMD Width (in elements)
- *
- * SIMD load/Write-back operations need to be performed before/after calling this.
- *
- * @tparam WIDTH SIMD width in elements
- * @tparam N index type (integer)
- * @tparam L function/functor to call per SIMD set of elements
- */
-template <int WIDTH, typename N, typename L, typename M=std::enable_if_t<std::is_integral_v<N>> >
-AMREX_ATTRIBUTE_FLATTEN_FOR
-void ParallelForSIMD (N n, L const& f) noexcept
-{
-    N i = 0;
-    // vectorize full lanes
-    for (; i + WIDTH <= n; i+=WIDTH) {
-        f(SIMDindex<WIDTH, N>{i});
-    }
-    // scalar handling of the remainder
-    // note: we could make the remainder calls faster, by repeatedly
-    //       decreasing the SIMD width by 2 until we reach 1
-    for (; i < n; ++i) {
-        f(SIMDindex<1, N>{i});
-    }
-}
-
-/** ParallelFor with a SIMD Width (derived from a type w/ fallback to non-SIMD)
- *
- * SIMD load/Write-back operations need to be performed before/after calling this.
- *
- * @tparam T a type that implements amrex::simd::Vectorized (or not)
- * @tparam N index type (integer)
- * @tparam L function/functor to call per SIMD set of elements
- */
-template <typename T, typename N, typename L, typename M=std::enable_if_t<std::is_integral_v<N>> >
-AMREX_ATTRIBUTE_FLATTEN_FOR
-void ParallelForSIMD (N n, L && f) noexcept
-{
-    if constexpr (amrex::simd::is_vectorized<T>) {
-        amrex::ParallelForSIMD<T::simd_width>(n, std::forward<L>(f));
-    } else {
-        amrex::ParallelForSIMD<1, N>(n, std::forward<L>(f));
-    }
 }
 
 template <typename T, typename L, typename M=std::enable_if_t<std::is_integral_v<T>> >

--- a/Src/Base/AMReX_GpuLaunchFunctsSIMD.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsSIMD.H
@@ -1,0 +1,81 @@
+#ifndef AMREX_GPU_LAUNCH_FUNCTS_SIMD_H_
+#define AMREX_GPU_LAUNCH_FUNCTS_SIMD_H_
+
+#include <AMReX_Config.H>
+#include <AMReX_Extension.H>
+#include <AMReX_SIMD.H>
+
+#include <type_traits>
+
+
+namespace amrex
+{
+
+/** Helper type to store/access the SIMD width in ParallelForSIMD lambdas
+ *
+ * Use instead of int as the running index i. Used to pass the
+ * SIMD WIDTH as compile-time meta-data into a called function/method.
+ *
+ * @tparam WIDTH SIMD width in elements
+ * @tparam N index type (integer)
+ */
+template<int WIDTH, class N=int>
+struct SIMDindex
+{
+    /** SIMD width in elements */
+    static constexpr int width = WIDTH;
+
+    /** The linear loop index of ParallelFor(SIMD) */
+    N index = 0;
+};
+
+/** ParallelFor with a SIMD Width (in elements)
+ *
+ * SIMD load/Write-back operations need to be performed before/after calling this.
+ *
+ * @tparam WIDTH SIMD width in elements
+ * @tparam N index type (integer)
+ * @tparam L function/functor to call per SIMD set of elements
+ */
+template <int WIDTH, typename N, typename L, typename M=std::enable_if_t<std::is_integral_v<N>> >
+AMREX_ATTRIBUTE_FLATTEN_FOR
+void ParallelForSIMD (N n, L const& f) noexcept
+{
+    N i = 0;
+    // vectorize full lanes
+    for (; i + WIDTH <= n; i+=WIDTH) {
+        f(SIMDindex<WIDTH, N>{i});
+    }
+    // scalar handling of the remainder
+    // note: we could make the remainder calls faster, by repeatedly
+    //       decreasing the SIMD width by 2 until we reach 1
+    for (; i < n; ++i) {
+        f(SIMDindex<1, N>{i});
+    }
+}
+
+/** ParallelFor with a SIMD Width (derived from a type w/ fallback to non-SIMD)
+ *
+ * SIMD load/Write-back operations need to be performed before/after calling this.
+ *
+ * @tparam T a type that implements amrex::simd::Vectorized (or not)
+ * @tparam N index type (integer)
+ * @tparam L function/functor to call per SIMD set of elements
+ */
+template <typename T, typename N, typename L, typename M=std::enable_if_t<std::is_integral_v<N>> >
+AMREX_ATTRIBUTE_FLATTEN_FOR
+void ParallelForSIMD (N n, L && f) noexcept
+{
+#ifdef AMREX_USE_SIMD
+    if constexpr (amrex::simd::is_vectorized<T>) {
+        amrex::ParallelForSIMD<T::simd_width>(n, std::forward<L>(f));
+    } else
+#endif
+    {
+        amrex::ParallelFor(n, std::forward<L>(f));
+    }
+}
+
+} // namespace amrex
+
+#endif

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -3,6 +3,7 @@
 
 #include <AMReX_Config.H>
 
+#include <AMReX.H>  // amrex::ignore_unused
 #include <AMReX_REAL.H>
 
 #ifdef AMREX_USE_SIMD
@@ -51,7 +52,11 @@ namespace amrex::simd
     template<int SIMD_WIDTH = native_simd_size_particlereal>
     using SIMDParticleReal = stdx::fixed_size_simd<amrex::ParticleReal, SIMD_WIDTH>;
 
-    // Type that has the same amount of IdCpu SIMD elements as the SIMDParticleReal type
+    // Type that has the same number of int SIMD elements as the SIMDParticleReal type
+    template<typename T_ParticleReal = SIMDParticleReal<>>
+    using SIMDInt = stdx::rebind_simd_t<int, T_ParticleReal>;
+
+    // Type that has the same number of IdCpu SIMD elements as the SIMDParticleReal type
     template<typename T_ParticleReal = SIMDParticleReal<>>
     using SIMDIdCpu = stdx::rebind_simd_t<std::uint64_t, T_ParticleReal>;
 #else
@@ -64,7 +69,11 @@ namespace amrex::simd
     template<int SIMD_WIDTH = native_simd_size_particlereal>
     using SIMDParticleReal = amrex::ParticleReal;
 
-    // Type that has the same amount of IdCpu SIMD elements as the SIMDParticleReal type
+    // Type that has the same number of int SIMD elements as the SIMDParticleReal type
+    template<typename T_ParticleReal = SIMDParticleReal<>>
+    using SIMDInt = int;
+
+    // Type that has the same number of IdCpu SIMD elements as the SIMDParticleReal type
     template<typename T_ParticleReal = SIMDParticleReal<>>
     using SIMDIdCpu = std::uint64_t;
 #endif
@@ -154,6 +163,93 @@ namespace amrex::simd
     {
         constexpr bool val_arr[sizeof...(Args)] {!std::is_const_v<std::remove_reference_t<Args>>...};
         return val_arr[n];
+    }
+
+    /** Load 1D contiguous data from array pointers
+     *
+     * On GPU and CPU w/o SIMD, this dereferences a 1D array element at the
+     * index position i.
+     * On CPU with SIMD, this loads a SIMD register at the IndexType::width
+     * SIMD-wide index position i.
+     *
+     * @tparam T data type (amrex::ParticleReal or int or uint64_t)
+     * @tparam IndexType int or amrex::SIMDindex<SIMD_WIDTH, int>
+     * @param ptr pointer to the array data
+     * @param i index or SIMD index
+     * @return a reference to the (scalar) data OR a new SIMD variable (register) loaded with data
+     */
+    template <typename T, typename IndexType>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    decltype(auto) load_1d (T* ptr, IndexType const i)
+    {
+        if constexpr (std::is_integral_v<IndexType>) {
+            return ptr[i];
+        } else if constexpr (IndexType::width == 1) {
+            return ptr[i.index];
+        } else {
+#ifdef AMREX_USE_SIMD
+            using DataType = stdx::fixed_size_simd<std::decay_t<T>, IndexType::width>;
+
+            // initialize vector register
+            // TODO stdx::vector_aligned needs alignment guarantees
+            //      https://github.com/AMReX-Codes/amrex/issues/4592
+            //      https://en.cppreference.com/w/cpp/experimental/simd/simd/copy_from
+            DataType val;
+            val.copy_from(&ptr[i.index], stdx::element_aligned);
+            return val;
+
+#else
+            static_assert(IndexType::width == 1, "SIMD width must be 1 for non-SIMD builds");
+            return ptr[i.index];
+#endif
+        }
+    }
+
+    /** Store SIMD register data back to a 1D contiguous array in RAM
+     *
+     * On GPU and CPU without SIMD, this does nothing because we already
+     * modified the (global) RAM directly via pointer.
+     *
+     * On CPU with SIMD, this performs a conditional writeback of a SIMD register
+     * to RAM (index in pointer array), but only if the argument was not passed
+     * as const and thus was likely changed.
+     *
+     * Good optimizing compilers can eliminate writebacks of unchanged values
+     * themselves, but we better help a little for robustness. Background:
+     * https://github.com/AMReX-Codes/amrex/pull/4520#issuecomment-3064064215
+     *
+     * @tparam P_Method pointer to the method that used the data (for is_nth_arg_non_const)
+     * @tparam N the argument index (for is_nth_arg_non_const)
+     * @tparam T data type
+     * @tparam IndexType int or SIMD index
+     * @tparam ValType the type of the value to store
+     * @param val the value to store
+     * @param ptr pointer to contiguous 1D array data
+     * @param i index or SIMD index
+     */
+    template <auto P_Method, int N, typename T, typename IndexType, typename ValType>
+    AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+    void store_1d (
+        ValType const & AMREX_RESTRICT val,
+        T * const AMREX_RESTRICT ptr,
+        IndexType const i
+    )
+    {
+        // SIMD uses special vector register types in ValType that need to be copied back to RAM array type T
+        if constexpr (!std::is_same_v<ValType, T>) {
+            if constexpr (amrex::simd::is_nth_arg_non_const(P_Method, N)) {
+#ifdef AMREX_USE_SIMD
+                // write back to memory
+                // TODO stdx::vector_aligned needs alignment guarantees
+                //      https://github.com/AMReX-Codes/amrex/issues/4592
+                //      https://en.cppreference.com/w/cpp/experimental/simd/simd/copy_from
+                val.copy_to(&ptr[i.index], amrex::simd::stdx::element_aligned);
+#else
+                amrex::Abort("store_1d: ValType val must alias T ptr data (to make this a no-OP).");
+#endif
+            }
+        }
+        amrex::ignore_unused(val, ptr, i);
     }
 
 } // namespace amrex::simd

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -224,6 +224,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_GpuLaunchMacrosC.nolint.H
        AMReX_GpuLaunchFunctsG.H
        AMReX_GpuLaunchFunctsC.H
+       AMReX_GpuLaunchFunctsSIMD.H
        AMReX_GpuError.H
        AMReX_GpuDevice.H
        AMReX_GpuDevice.cpp

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -83,7 +83,7 @@ C$(AMREX_BASE)_headers += AMReX_GpuKernelInfo.H
 
 C$(AMREX_BASE)_headers += AMReX_GpuLaunchMacrosG.H AMReX_GpuLaunchFunctsG.H
 C$(AMREX_BASE)_headers += AMReX_GpuLaunchMacrosG.nolint.H
-C$(AMREX_BASE)_headers += AMReX_GpuLaunchMacrosC.H AMReX_GpuLaunchFunctsC.H
+C$(AMREX_BASE)_headers += AMReX_GpuLaunchMacrosC.H AMReX_GpuLaunchFunctsC.H AMReX_GpuLaunchFunctsSIMD.H
 C$(AMREX_BASE)_headers += AMReX_GpuLaunchMacrosC.nolint.H
 C$(AMREX_BASE)_headers += AMReX_GpuLaunchGlobal.H
 C$(AMREX_BASE)_headers += AMReX_GpuLaunch.H


### PR DESCRIPTION
## Add `ParallelForSIMD<T>`

This adds another template overload to `ParallelForSIMD`.

A typical user pattern for maximum controls so far is:
```C++
#ifdef AMREX_USE_SIMD
if constexpr (amrex::simd::is_vectorized<T>) {
    amrex::ParallelForSIMD<T::simd_width>(np, pushSingleParticle);
} else
#endif
{
    amrex::ParallelFor(np, pushSingleParticle);  // GPU & non-SIMD CPU
}
```

This simplifies it to:
```C++
amrex::ParallelForSIMD<T>(np, pushSingleParticle);
```
indicating there _might_ be a SIMD path if `T` (e.g., a functor) implements it.

One can still call `ParallelForSIMD` with an explicit SIMD width (int), as before.

## Generalized Particle Load/Store

A typical SIMD user pattern for particle SoA kernels was:
```C++
SIMDParticleReal<SIMD_WIDTH> part_x;
part_x.copy_from(&m_part_x[i], stdx::element_aligned);

el.compute(part_x);

#ifdef AMREX_USE_SIMD
if constexpr (is_nth_arg_non_const<&el::compute, n>)
    part_x.copy_to(&m_part_x[i], stdx::element_aligned);
#endif
```

This simplifies it to:
```C++
decltype(auto) x = load_1d(m_part_x, i);

el.compute(x);

store_1d<&el::compute, 0>(x, m_part_x, i);
```
and can now also be used for the GPU path, where for now the load is a transparent pointer forward/deref and the store is a no-OP.

## Combined

Using these patterns together, one can now write single-source SIMD-CPU/non-SIMD-CPU/GPU kernels, e.g., https://github.com/BLAST-ImpactX/impactx/pull/1279

Follow-up to #4520

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
