### PR TITLE
`FindAMReXFFTW.cmake` Support Native Threading

### DIFF
--- a/Tools/CMake/FindAMReXFFTW.cmake
+++ b/Tools/CMake/FindAMReXFFTW.cmake
@@ -76,7 +76,7 @@ function(fftw_require_omp library_paths fftw_precision_suffix)
     else()
         message(FATAL_ERROR
             "AMReX_OMP and AMReX_FFT are set, but provided FFTW does not provide OpenMP! "
-            "Re-compile FFTW or set AMReX_FFTW_IGNORE_OMP=OFF"
+            "Re-compile FFTW or set AMReX_FFTW_IGNORE_OMP=ON"
         )
     endif()
 

--- a/Tools/CMake/FindAMReXFFTW.cmake
+++ b/Tools/CMake/FindAMReXFFTW.cmake
@@ -22,6 +22,11 @@ Options/Control Variables
 ``AMReX_FFTW_IGNORE_OMP``
   Ignore FFTW3 OpenMP support, even if found.
 
+``AMReX_FFTW_OMP_SUFFIX``
+  Usually we want to use the same threads from OpenMP for AMReX and FFTW.
+  In a ditch, you can change this from "omp" to "threads" to use FFTW
+  with native threads implementation.
+
 Result Variables
 ^^^^^^^^^^^^^^^^
 
@@ -38,6 +43,8 @@ This will also create an imported target, AMReX::FFTW.
 #
 option(AMReX_FFTW_IGNORE_OMP "Ignore FFTW3's OpenMP support, even if found" OFF)
 mark_as_advanced(AMReX_FFTW_IGNORE_OMP)
+set(AMReX_FFTW_OMP_SUFFIX omp CACHE STRING "FFTW3's Thread Support variant (omp/threads)")
+mark_as_advanced(AMReX_FFTW_OMP_SUFFIX)
 
 # Set the AMREX_FFTW_OMP=1 define on AMReX::FFTW if TRUE and print
 # a message
@@ -55,7 +62,7 @@ endfunction()
 # libfftw3(f)_omp.(a|so) shipped and if yes, set the AMREX_FFTW_OMP=1 define.
 #
 function(fftw_require_omp library_paths fftw_precision_suffix)
-    find_library(HAS_FFTW_OMP_LIB${fftw_precision_suffix} fftw3${fftw_precision_suffix}_omp
+    find_library(HAS_FFTW_OMP_LIB${fftw_precision_suffix} fftw3${fftw_precision_suffix}_${AMReX_FFTW_OMP_SUFFIX}
         PATHS ${library_paths}
         # this is intentional, so we don't mix different FFTW installs
         # and only check what is in the location hinted by the


### PR DESCRIPTION
## Summary

- FFTW: Support Native Threading: Add an advanced `AMReX_FFTW_OMP_SUFFIX` flag to control alternate FFTW threading libs. Not ideal, but ok in a ditch.
- Fix FindAMReXFFTW.cmake Message: The message for `AMReX_FFTW_IGNORE_OMP` was indicating the wrong value to ignore OMP search.

## Additional background

See https://github.com/conda-forge/amrex-feedstock/pull/72#issuecomment-3839123510
Close https://github.com/conda-forge/amrex-feedstock/issues/73

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
