### PR TITLE
Fix: AMReX w/ OpenMP and Ignore FFTW OMP

### DIFF
--- a/Src/FFT/AMReX_FFT.cpp
+++ b/Src/FFT/AMReX_FFT.cpp
@@ -21,7 +21,7 @@ void Initialize ()
     {
 #if defined(AMREX_USE_HIP) && defined(AMREX_USE_FFT)
         AMREX_ROCFFT_SAFE_CALL(rocfft_setup());
-#elif !defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP) && defined(AMREX_USE_FFT)
+#elif !defined(AMREX_USE_GPU) && defined(AMREX_USE_MULTI_THREADED_FFTW)
         fftw_init_threads();
         fftwf_init_threads();
         fftw_plan_with_nthreads(amrex::OpenMP::get_max_threads());

--- a/Tools/CMake/AMReX_Config_ND.H.in
+++ b/Tools/CMake/AMReX_Config_ND.H.in
@@ -42,6 +42,7 @@
 #cmakedefine BL_FORT_USE_UPPERCASE
 #cmakedefine BL_NO_FORT
 #cmakedefine AMREX_USE_FFT
+#cmakedefine AMREX_USE_MULTI_THREADED_FFTW
 #cmakedefine AMREX_USE_SENSEI_INSITU
 #cmakedefine AMREX_NO_SENSEI_AMR_INST
 #cmakedefine AMREX_USE_CONDUIT

--- a/Tools/CMake/FindAMReXFFTW.cmake
+++ b/Tools/CMake/FindAMReXFFTW.cmake
@@ -46,20 +46,20 @@ mark_as_advanced(AMReX_FFTW_IGNORE_OMP)
 set(AMReX_FFTW_OMP_SUFFIX omp CACHE STRING "FFTW3's Thread Support variant (omp/threads)")
 mark_as_advanced(AMReX_FFTW_OMP_SUFFIX)
 
-# Set the AMREX_FFTW_OMP=1 define on AMReX::FFTW if TRUE and print
+# Set the AMREX_USE_MULTI_THREADED_FFTW=1 define on AMReX::FFTW if TRUE and print
 # a message
 #
 function(fftw_add_define HAS_FFTW_OMP_LIB)
     if(HAS_FFTW_OMP_LIB)
         message(STATUS "FFTW: Found OpenMP support")
-        target_compile_definitions(AMReX::FFTW INTERFACE AMREX_FFTW_OMP=1)
+        target_compile_definitions(AMReX::FFTW INTERFACE AMREX_USE_MULTI_THREADED_FFTW=1)
     else()
         message(STATUS "FFTW: Could NOT find OpenMP support")
     endif()
 endfunction()
 
 # Check if the found FFTW install location has an _omp library, e.g.,
-# libfftw3(f)_omp.(a|so) shipped and if yes, set the AMREX_FFTW_OMP=1 define.
+# libfftw3(f)_omp.(a|so) shipped and if yes, set the AMREX_USE_MULTI_THREADED_FFTW=1 define.
 #
 function(fftw_require_omp library_paths fftw_precision_suffix)
     find_library(HAS_FFTW_OMP_LIB${fftw_precision_suffix} fftw3${fftw_precision_suffix}_${AMReX_FFTW_OMP_SUFFIX}

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -635,6 +635,7 @@ ifeq ($(USE_FFT),TRUE)
       LIBRARIES += -Wl,-rpath,$(FFTW_HOME)/lib
     endif
     ifeq ($(USE_OMP),TRUE)
+      CPPFLAGS += -DAMREX_USE_MULTI_THREADED_FFTW
       LIBRARIES += -lfftw3f_omp -lfftw3_omp
     endif
     LIBRARIES += -lfftw3f -lfftw3


### PR DESCRIPTION
## Summary

In some corner cases, we sometimes work around broken FFTW installs: for some (temporary) reason we cannot have any threading in FFTW, neither with OpenMP nor threads.

In those cases, when we still want to thread the rest of AMReX with OpenMP, we can set our AMReX transitive FFTW OpenMP requirements explicitly off, e.g., via CMake `-DAMReX_FFTW_IGNORE_OMP=ON`. But this is not yet implemented consistently and since #4861 exposes undefined FFTW symbols when used.

This enables this work-around.

- [x] macro
- [x] CMake
- [x] GNUmake
- [x] `AMReX_Config.H`

## Additional background

https://github.com/AMReX-Codes/amrex/pull/4861#issuecomment-3863046390

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
