### PR TITLE
CI: Fix clang-tidy cache

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,12 @@
 Checks: >
     '-*,
      bugprone-*,
+       -bugprone-branch-clone,
        -bugprone-casting-through-void,
+       -bugprone-easily-swappable-parameters,
        -bugprone-exception-escape,
        -bugprone-implicit-widening-of-multiplication-result,
+       -bugprone-multi-level-implicit-pointer-conversion,
      clang-analyzer-*,
        -clang-analyzer-optin.mpi.MPI-Checker,
      clang-diagnostic-*,
@@ -20,6 +23,7 @@ Checks: >
        -cppcoreguidelines-non-private-member-variables-in-classes,
        -cppcoreguidelines-owning-memory,
        -cppcoreguidelines-pro-*,
+       -cppcoreguidelines-use-enum-class,
      google-build-explicit-make-pair,
      google-build-namespaces,
      google-global-names-in-headers,
@@ -32,10 +36,15 @@ Checks: >
        -modernize-avoid-c-arrays,
        -modernize-macro-to-enum,
        -modernize-return-braced-init-list,
+       -modernize-use-constraints,
+       -modernize-use-designated-initializers,
        -modernize-use-trailing-return-type,
      performance-*,
+       -performance-enum-size,
      portability-*,
+       -portability-template-virtual-member-function,
      readability-*,
+       -readability-avoid-nested-conditional-operator,
        -readability-avoid-unconditional-preprocessor-if,
        -readability-else-after-return,
        -readability-function-cognitive-complexity,
@@ -46,6 +55,8 @@ Checks: >
        -readability-magic-numbers,
        -readability-math-missing-parentheses,
        -readability-named-parameter,
+       -readability-redundant-casting,
+       -readability-static-accessed-through-instance,
        -readability-simplify-boolean-expr,
        -readability-use-concise-preprocessor-directives,
      mpi-*
@@ -56,3 +67,7 @@ HeaderFilterRegex: '([^n].....|[^o]....|[^l]...|[^i]..|[^n].|[^t])\.H$'
 
 # Only available in clang-tidy >= 17
 HeaderFileExtensions: ['', "H", 'h', 'hh', 'hpp', 'hxx']
+
+# We will try to modernize this after switching to C++20
+# -modernize-use-constraints
+# -modernize-use-designated-initializers

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -296,11 +296,10 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         make -j 4
 
-        # Let's not use clang-tidy for this test because it wants to use C++20.
-        # ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
-        # make -j4 -k -f clang-tidy-ccache-misses.mak \
-        #     CLANG_TIDY=clang-tidy-21 \
-        #     CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j4 -k -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-21 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
 
         ctest --output-on-failure
 

--- a/Src/AmrCore/AMReX_Cluster.cpp
+++ b/Src/AmrCore/AMReX_Cluster.cpp
@@ -289,10 +289,7 @@ Cluster::chop ()
     for (int n = 0; n < AMREX_SPACEDIM; n++)
     {
         cut[n] = FindCut(hist[n].data(), lo[n], hi[n], status[n]);
-        if (status[n] < mincut)
-        {
-            mincut = status[n];
-        }
+        mincut = std::min(status[n], mincut);
     }
     BL_ASSERT(mincut != InvalidCut);
     //
@@ -371,10 +368,7 @@ Cluster::new_chop ()
            if (n != invalid_dir)
            {
               cut[n] = FindCut(hist[n].data(), lo[n], hi[n], status[n]);
-              if (status[n] < mincut)
-              {
-                  mincut = status[n];
-              }
+              mincut = std::min(status[n], mincut);
            }
        }
        BL_ASSERT(mincut != InvalidCut);

--- a/Src/AmrCore/AMReX_FluxRegister.cpp
+++ b/Src/AmrCore/AMReX_FluxRegister.cpp
@@ -211,11 +211,11 @@ FluxRegister::CrseInit (const MultiFab& mflx,
 
         if (op == FluxRegister::COPY)
         {
-            bndry[face].copyFrom(mf,0,0,destcomp,numcomp);
+            bndry[face].copyFrom(mf,0,0,destcomp,numcomp); // NOLINT(clang-analyzer-security.ArrayBound)
         }
         else
         {
-            FabSet fs(bndry[face].boxArray(),bndry[face].DistributionMap(),numcomp);
+            FabSet fs(bndry[face].boxArray(),bndry[face].DistributionMap(),numcomp);  // NOLINT(clang-analyzer-security.ArrayBound)
 
             fs.setVal(0);
 
@@ -331,7 +331,7 @@ FluxRegister::CrseAdd (const MultiFab& mflx,
     for (int pass = 0; pass < 2; pass++)
     {
         const Orientation face = ((pass == 0) ? face_lo : face_hi);
-        bndry[face].plusFrom(mf,0,0,destcomp,numcomp,geom.periodicity());
+        bndry[face].plusFrom(mf,0,0,destcomp,numcomp,geom.periodicity()); // NOLINT(clang-analyzer-security.ArrayBound)
     }
 }
 
@@ -405,8 +405,8 @@ FluxRegister::FineAdd (const FArrayBox& flux,
     BL_ASSERT(srccomp >= 0 && srccomp+numcomp <= flux.nComp());
     BL_ASSERT(destcomp >= 0 && destcomp+numcomp <= ncomp);
 
-    FArrayBox& loreg = bndry[Orientation(dir,Orientation::low)][boxno];
-    FArrayBox& hireg = bndry[Orientation(dir,Orientation::high)][boxno];
+    FArrayBox& loreg = bndry[Orientation(dir,Orientation::low)][boxno]; // NOLINT(clang-analyzer-security.ArrayBound)
+    FArrayBox& hireg = bndry[Orientation(dir,Orientation::high)][boxno]; // NOLINT(clang-analyzer-security.ArrayBound)
     const Box& lobox = loreg.box();
     const Box& hibox = hireg.box();
 
@@ -453,8 +453,8 @@ FluxRegister::FineAdd (const FArrayBox& flux,
     BL_ASSERT(srccomp >= 0 && srccomp+numcomp <= flux.nComp());
     BL_ASSERT(destcomp >= 0 && destcomp+numcomp <= ncomp);
 
-    FArrayBox& loreg = bndry[Orientation(dir,Orientation::low)][boxno];
-    FArrayBox& hireg = bndry[Orientation(dir,Orientation::high)][boxno];
+    FArrayBox& loreg = bndry[Orientation(dir,Orientation::low)][boxno]; // NOLINT(clang-analyzer-security.ArrayBound)
+    FArrayBox& hireg = bndry[Orientation(dir,Orientation::high)][boxno]; // NOLINT(clang-analyzer-security.ArrayBound)
     const Box& lobox = loreg.box();
     const Box& hibox = hireg.box();
 
@@ -502,7 +502,7 @@ FluxRegister::FineSetVal (int              dir,
 {
     BL_ASSERT(destcomp >= 0 && destcomp+numcomp <= ncomp);
 
-    FArrayBox& loreg = bndry[Orientation(dir,Orientation::low)][boxno];
+    FArrayBox& loreg = bndry[Orientation(dir,Orientation::low)][boxno]; // NOLINT(clang-analyzer-security.ArrayBound)
     BL_ASSERT(numcomp <= loreg.nComp());
     if ((runon == RunOn::Gpu) && Gpu::inLaunchRegion()) {
         loreg.setVal<RunOn::Device>(val, loreg.box(), destcomp, numcomp);
@@ -510,7 +510,7 @@ FluxRegister::FineSetVal (int              dir,
         loreg.setVal<RunOn::Host>(val, loreg.box(), destcomp, numcomp);
     }
 
-    FArrayBox& hireg = bndry[Orientation(dir,Orientation::high)][boxno];
+    FArrayBox& hireg = bndry[Orientation(dir,Orientation::high)][boxno]; // NOLINT(clang-analyzer-security.ArrayBound)
     BL_ASSERT(numcomp <= hireg.nComp());
     if ((runon == RunOn::Gpu) && Gpu::inLaunchRegion()) {
         hireg.setVal<RunOn::Device>(val, hireg.box(), destcomp, numcomp);
@@ -602,7 +602,7 @@ FluxRegister::Reflux (MultiFab& mf, const MultiFab& volume, Orientation face,
                   mf.DistributionMap(), nc, 0, MFInfo(), mf.Factory());
     flux.setVal(0.0);
 
-    bndry[face].copyTo(flux, 0, scomp, 0, nc, geom.periodicity());
+    bndry[face].copyTo(flux, 0, scomp, 0, nc, geom.periodicity()); // NOLINT(clang-analyzer-security.ArrayBound)
 
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion() && mf.isFusingCandidate()) {

--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -56,6 +56,7 @@ namespace amrex
         extern AMREX_EXPORT bool handle_sigint;
         extern AMREX_EXPORT bool handle_sigabrt;
         extern AMREX_EXPORT bool handle_sigfpe;
+        extern AMREX_EXPORT bool handle_sigill;
 
         extern AMREX_EXPORT bool call_addr2line;
         extern AMREX_EXPORT bool throw_exception;
@@ -342,6 +343,7 @@ namespace amrex
     [[nodiscard]] inline FPExcept operator| (FPExcept a, FPExcept b)
     {
         using T = std::underlying_type_t<FPExcept>;
+        // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
         return static_cast<FPExcept>(static_cast<T>(a) | static_cast<T>(b));
     }
 

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -106,11 +106,11 @@ namespace amrex
     constexpr const T& Clamp (const T& v, const T& lo, const T& hi)
     {
         if (v < lo) {
-            return lo;
+            return lo; // NOLINT(bugprone-return-const-ref-from-parameter)
         } else if (hi < v) {
-            return hi;
+            return hi; // NOLINT(bugprone-return-const-ref-from-parameter)
         } else {
-            return v;
+            return v; // NOLINT(bugprone-return-const-ref-from-parameter)
         }
     }
 

--- a/Src/Base/AMReX_BackgroundThread.cpp
+++ b/Src/Base/AMReX_BackgroundThread.cpp
@@ -37,14 +37,14 @@ void BackgroundThread::do_job ()
 
 void BackgroundThread::Submit (std::function<void()>&& a_f)
 {
-    std::lock_guard<std::mutex> lck(m_mutx);
+    std::scoped_lock lck(m_mutx);
     m_func.emplace(std::move(a_f));
     m_job_cond.notify_one();
 }
 
 void BackgroundThread::Submit (std::function<void()> const& a_f)
 {
-    std::lock_guard<std::mutex> lck(m_mutx);
+    std::scoped_lock lck(m_mutx);
     m_func.emplace(a_f);
     m_job_cond.notify_one();
 }

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -28,7 +28,7 @@ CArena::~CArena ()
 void*
 CArena::alloc (std::size_t nbytes)
 {
-    std::lock_guard<std::mutex> lock(carena_mutex);
+    std::scoped_lock lock(carena_mutex);
     nbytes = Arena::align(nbytes == 0 ? 1 : nbytes);
     return alloc_protected(nbytes);
 }
@@ -162,7 +162,7 @@ CArena::alloc_protected (std::size_t nbytes)
 std::pair<void*,std::size_t>
 CArena::alloc_in_place (void* pt, std::size_t szmin, std::size_t szmax)
 {
-    std::lock_guard<std::mutex> lock(carena_mutex);
+    std::scoped_lock lock(carena_mutex);
 
     std::size_t nbytes_max = Arena::align(szmax == 0 ? 1 : szmax);
 
@@ -239,7 +239,7 @@ CArena::shrink_in_place (void* pt, std::size_t new_size)
 
     new_size = Arena::align(new_size);
 
-    std::lock_guard<std::mutex> lock(carena_mutex);
+    std::scoped_lock lock(carena_mutex);
 
     auto busy_it = m_busylist.find(Node(pt,nullptr,0));
     if (busy_it == m_busylist.end()) {
@@ -300,7 +300,7 @@ CArena::free (void* vp)
         return;
     }
 
-    std::lock_guard<std::mutex> lock(carena_mutex);
+    std::scoped_lock lock(carena_mutex);
 
     //
     // `vp' had better be in the busy list.
@@ -368,6 +368,7 @@ CArena::free (void* vp)
 
     void* addr = static_cast<char*>((*free_it).block()) + (*free_it).size();
 
+    // NOLINTNEXTLINE(bugprone-inc-dec-in-conditions)
     if (++hi_it != m_freelist.end() && addr == (*hi_it).block() && hi_it->coalescable(*free_it))
     {
         //
@@ -383,7 +384,7 @@ CArena::free (void* vp)
 std::size_t
 CArena::freeUnused ()
 {
-    std::lock_guard<std::mutex> lock(carena_mutex);
+    std::scoped_lock lock(carena_mutex);
     return freeUnused_protected();
 }
 
@@ -446,7 +447,7 @@ CArena::hasFreeDeviceMemory (std::size_t sz)
 {
 #ifdef AMREX_USE_GPU
     if (isDevice() || isManaged()) {
-        std::lock_guard<std::mutex> lock(carena_mutex);
+        std::scoped_lock lock(carena_mutex);
 
         std::size_t nbytes = Arena::align(sz == 0 ? 1 : sz);
 

--- a/Src/Base/AMReX_DistributionMapping.H
+++ b/Src/Base/AMReX_DistributionMapping.H
@@ -126,7 +126,7 @@ class DistributionMapping
     [[nodiscard]] const Vector<int>& ProcessorMap () const noexcept;
 
     //! Length of the underlying processor map.
-    [[nodiscard]] Long size () const noexcept { return Long(m_ref->m_pmap.size()); }
+    [[nodiscard]] Long size () const noexcept { return m_ref->m_pmap.size(); }
     [[nodiscard]] Long capacity () const noexcept { return Long(m_ref->m_pmap.capacity()); }
     [[nodiscard]] bool empty () const noexcept { return m_ref->m_pmap.empty(); }
 

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -1455,7 +1455,7 @@ DistributionMapping::SFCProcessorMapDoIt (const BoxArray&          boxes,
         for (int i = 0; i < nteams; ++i)
         {
             const Long W = LIpairV[i].first;
-            if (W > max_wgt) { max_wgt = W; }
+            max_wgt = std::max(W, max_wgt);
             sum_wgt += W;
         }
         Real efficiency = static_cast<Real>(sum_wgt)/static_cast<Real>(nteams*max_wgt);

--- a/Src/Base/AMReX_FArrayBox.H
+++ b/Src/Base/AMReX_FArrayBox.H
@@ -63,7 +63,7 @@ public:
     * FAB_NATIVE_32: write out values in the native 32 bit format.
     *
     */
-    enum Format
+    enum Format // NOLINT(readability-enum-initial-value)
     {
         FAB_ASCII,
         FAB_IEEE,

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1817,7 +1817,7 @@ FabArray<FAB>::build_arrays () const
         m_hp_arrays = (void*)The_Pinned_Arena()->alloc(n*2*sizeof(A));
         m_dp_arrays = (void*)The_Arena()->alloc(n*2*sizeof(A));
 #else
-        m_hp_arrays = (void*)std::malloc(n*2*sizeof(A));
+        m_hp_arrays = std::malloc(n*2*sizeof(A));
 #endif
         for (int li = 0; li < n; ++li) {
             if (m_fabs_v[li]) {
@@ -2061,7 +2061,7 @@ template <class FAB>
 FabArray<FAB>::FabArray (FabArray<FAB>&& rhs) noexcept
     : FabArrayBase (static_cast<FabArrayBase&&>(rhs))
     , m_factory    (std::move(rhs.m_factory))
-    , m_dallocator (std::move(rhs.m_dallocator))
+    , m_dallocator (rhs.m_dallocator)
     , m_single_chunk_arena(std::move(rhs.m_single_chunk_arena))
     , m_single_chunk_size(std::exchange(rhs.m_single_chunk_size,0))
     , define_function_called(rhs.define_function_called)
@@ -2097,7 +2097,7 @@ FabArray<FAB>::operator= (FabArray<FAB>&& rhs) noexcept
 
         FabArrayBase::operator=(static_cast<FabArrayBase&&>(rhs));
         m_factory = std::move(rhs.m_factory);
-        m_dallocator = std::move(rhs.m_dallocator);
+        m_dallocator = rhs.m_dallocator;
         m_single_chunk_arena = std::move(rhs.m_single_chunk_arena);
         std::swap(m_single_chunk_size, rhs.m_single_chunk_size);
         define_function_called = rhs.define_function_called;

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -124,10 +124,7 @@ FabArrayBase::Initialize ()
     }
 
     pp.query("maxcomp", FabArrayBase::MaxComp);
-
-    if (MaxComp < 1) {
-        MaxComp = 1;
-    }
+    MaxComp = std::max(MaxComp, 1);
 
     ParmParse ppmf("amrex.mf");
     ppmf.queryAdd("alloc_single_chunk", FabArrayBase::m_alloc_single_chunk);

--- a/Src/Base/AMReX_FabConv.cpp
+++ b/Src/Base/AMReX_FabConv.cpp
@@ -372,11 +372,11 @@ template <int NB>
 void
 _pd_btrvout (char* out, Long  nitems)
 {
-    for (int jl = 0, nbo2 = NB >> 1; jl < nbo2; jl++)
+    for (int jlo = 0, nbo2 = NB >> 1; jlo < nbo2; jlo++)
     {
-        int jh  = NB - jl - 1;
-        char* p1 = out + jh;
-        char* p2 = out + jl;
+        int jhi  = NB - jlo - 1;
+        char* p1 = out + jhi;
+        char* p2 = out + jlo;
         for (Long i = 0L; i < nitems; i++)
         {
             char tmp = *p1;

--- a/Src/Base/AMReX_FileSystem.cpp
+++ b/Src/Base/AMReX_FileSystem.cpp
@@ -83,7 +83,7 @@ CreateDirectories (std::string const& path, mode_t mode, bool verbose)
 
     const char* path_sep_str = "/";
 
-    if (path.length() == 0 || path == path_sep_str) {
+    if (path.empty() || path == path_sep_str) {
         return true;
     }
 

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -76,7 +76,7 @@ Geometry::define (const Box& dom, const RealBox* rb, int coord,
 
     Geometry* gg = AMReX::top()->getDefaultGeometry();
 
-    if (coord == -1) {
+    if (coord <= -1 || coord > 2) {
         c_sys = gg->Coord();
     } else {
         c_sys = static_cast<CoordType>(coord);
@@ -200,7 +200,7 @@ Geometry::ResetDefaultCoord (int coord) noexcept
 {
     AMREX_ASSERT(coord >= -1 && coord <= 2);
     Geometry* gg = AMReX::top()->getDefaultGeometry();
-    gg->SetCoord(static_cast<CoordType>(coord));
+    gg->SetCoord(static_cast<CoordType>(coord)); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
 }
 
 void

--- a/Src/Base/AMReX_GpuControl.H
+++ b/Src/Base/AMReX_GpuControl.H
@@ -66,7 +66,7 @@
 #endif
 
 namespace amrex {
-    enum struct RunOn { Gpu, Cpu, Device=Gpu, Host=Cpu };
+    enum struct RunOn { Gpu, Cpu, Device=Gpu, Host=Cpu }; // NOLINT(readability-enum-initial-value)
 }
 
 #ifdef AMREX_USE_GPU
@@ -194,13 +194,13 @@ namespace Gpu {
 
 #else
 
-    [[nodiscard]] inline constexpr bool inLaunchRegion () { return false; }
-    [[nodiscard]] inline constexpr bool notInLaunchRegion () { return true; }
-    [[nodiscard]] inline constexpr bool setLaunchRegion (bool) { return false; }
+    [[nodiscard]] constexpr bool inLaunchRegion () { return false; }
+    [[nodiscard]] constexpr bool notInLaunchRegion () { return true; }
+    [[nodiscard]] constexpr bool setLaunchRegion (bool) { return false; }
 
-    [[nodiscard]] inline constexpr bool inGraphRegion () { return false; }
-    [[nodiscard]] inline constexpr bool notInGraphRegion () { return true; }
-    [[nodiscard]] inline constexpr bool setGraphRegion (bool) { return false; }
+    [[nodiscard]] constexpr bool inGraphRegion () { return false; }
+    [[nodiscard]] constexpr bool notInGraphRegion () { return true; }
+    [[nodiscard]] constexpr bool setGraphRegion (bool) { return false; }
 
     struct [[nodiscard]] LaunchSafeGuard
     {
@@ -212,10 +212,10 @@ namespace Gpu {
         explicit GraphSafeGuard (bool) {}
     };
 
-    [[nodiscard]] inline constexpr bool inSingleStreamRegion () { return false; }
-    [[nodiscard]] inline constexpr bool inNoSyncRegion () { return true; }
-    [[nodiscard]] inline constexpr bool setSingleStreamRegion (bool) { return false; }
-    [[nodiscard]] inline constexpr bool setNoSyncRegion (bool) { return true; }
+    [[nodiscard]] constexpr bool inSingleStreamRegion () { return false; }
+    [[nodiscard]] constexpr bool inNoSyncRegion () { return true; }
+    [[nodiscard]] constexpr bool setSingleStreamRegion (bool) { return false; }
+    [[nodiscard]] constexpr bool setNoSyncRegion (bool) { return true; }
     struct [[nodiscard]] SingleStreamRegion {};
     struct [[nodiscard]] NoSyncRegion {};
 

--- a/Src/Base/AMReX_GpuLaunch.H
+++ b/Src/Base/AMReX_GpuLaunch.H
@@ -84,11 +84,11 @@ namespace amrex {
 namespace Gpu {
 
 #ifdef AMREX_USE_GPU
-    inline constexpr std::size_t numThreadsPerBlockParallelFor () {
+    constexpr std::size_t numThreadsPerBlockParallelFor () {
         return AMREX_GPU_MAX_THREADS;
     }
 #else
-    inline constexpr std::size_t numThreadsPerBlockParallelFor () { return 0; }
+    constexpr std::size_t numThreadsPerBlockParallelFor () { return 0; }
 #endif
 
     AMREX_GPU_HOST_DEVICE

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -11,7 +11,7 @@ namespace amrex {
 #ifdef AMREX_USE_GPU
     inline bool TilingIfNotGPU () noexcept { return Gpu::notInLaunchRegion(); }
 #else
-    inline constexpr bool TilingIfNotGPU () noexcept { return true; }
+    constexpr bool TilingIfNotGPU () noexcept { return true; }
 #endif
 
 template<class T> class FabArray;

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -634,6 +634,7 @@ namespace amrex
                             crse_value, fine_value);
     }
 
+    namespace {
     template <typename FAB>
     void makeFineMask_doit (FabArray<FAB>& mask, const BoxArray& fba,
                             const IntVect& ratio, Periodicity const& period,
@@ -690,6 +691,7 @@ namespace amrex
             tag.dfab(i,j,k,n) = fine_value;
         });
 #endif
+    }
     }
 
     iMultiFab makeFineMask (const BoxArray& cba, const DistributionMapping& cdm,

--- a/Src/Base/AMReX_Order.H
+++ b/Src/Base/AMReX_Order.H
@@ -4,7 +4,6 @@
 
 namespace amrex
 {
-    enum struct Order { C, F, RowMajor=C, ColumnMajor=F };
+    enum struct Order { C, F, RowMajor=C, ColumnMajor=F }; // NOLINT(readability-enum-initial-value)
 }
 #endif
-

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -1495,7 +1495,7 @@ void
 ReadAndBcastFile (const std::string& filename, Vector<char>& charBuf,
                   bool bExitOnError, const MPI_Comm&comm)
 {
-    enum { IO_Buffer_Size = 262144 * 8 };
+    constexpr int IO_Buffer_Size = 262144 * 8;
 
 #ifdef BL_SETBUF_SIGNED_CHAR
     using Setbuf_Char_Type = signed char;

--- a/Src/Base/AMReX_ParallelReduce.H
+++ b/Src/Base/AMReX_ParallelReduce.H
@@ -14,7 +14,7 @@ namespace amrex {
 /// \cond DOXYGEN_IGNORE
 namespace detail {
 
-    enum ReduceOp : int {
+    enum class ReduceOp : int {
         max = 0,
         min,
         sum,
@@ -196,7 +196,7 @@ namespace ParallelAllReduce {
     }
     /// \ingroup amrex_mpi
     template<typename T>
-    void Max (Vector<std::reference_wrapper<T> > v, MPI_Comm comm) {
+    void Max (Vector<std::reference_wrapper<T> > v, MPI_Comm comm) { // NOLINT(performance-unnecessary-value-param)
         detail::Reduce<T>(detail::ReduceOp::max, v, -1, comm);
     }
 
@@ -212,7 +212,7 @@ namespace ParallelAllReduce {
     }
     /// \ingroup amrex_mpi
     template<typename T>
-    void Min (Vector<std::reference_wrapper<T> > v, MPI_Comm comm) {
+    void Min (Vector<std::reference_wrapper<T> > v, MPI_Comm comm) { // NOLINT(performance-unnecessary-value-param)
         detail::Reduce<T>(detail::ReduceOp::min, v, -1, comm);
     }
 
@@ -228,7 +228,7 @@ namespace ParallelAllReduce {
     }
     /// \ingroup amrex_mpi
     template<typename T>
-    void Sum (Vector<std::reference_wrapper<T> > v, MPI_Comm comm) {
+    void Sum (Vector<std::reference_wrapper<T> > v, MPI_Comm comm) { // NOLINT(performance-unnecessary-value-param)
         detail::Reduce<T>(detail::ReduceOp::sum, v, -1, comm);
     }
 
@@ -327,7 +327,7 @@ namespace ParallelReduce {
     }
     /// \ingroup amrex_mpi
     template<typename T>
-    void Max (Vector<std::reference_wrapper<T> > v, int root, MPI_Comm comm) {
+    void Max (Vector<std::reference_wrapper<T> > v, int root, MPI_Comm comm) { // NOLINT(performance-unnecessary-value-param)
         detail::Reduce<T>(detail::ReduceOp::max, v, root, comm);
     }
 
@@ -343,7 +343,7 @@ namespace ParallelReduce {
     }
     /// \ingroup amrex_mpi
     template<typename T>
-    void Min (Vector<std::reference_wrapper<T> > v, int root, MPI_Comm comm) {
+    void Min (Vector<std::reference_wrapper<T> > v, int root, MPI_Comm comm) { // NOLINT(performance-unnecessary-value-param)
         detail::Reduce<T>(detail::ReduceOp::min, v, root, comm);
     }
 
@@ -359,7 +359,7 @@ namespace ParallelReduce {
     }
     /// \ingroup amrex_mpi
     template<typename T>
-    void Sum (Vector<std::reference_wrapper<T> > v, int root, MPI_Comm comm) {
+    void Sum (Vector<std::reference_wrapper<T> > v, int root, MPI_Comm comm) { // NOLINT(performance-unnecessary-value-param)
         detail::Reduce<T>(detail::ReduceOp::sum, v, root, comm);
     }
 

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1665,7 +1665,7 @@ public:
     */
     static void Initialize (int argc, char** argv, const char* parfile);
     static void Initialize (int argc, char** argv, const std::string& parfile) {
-        return Initialize(argc, argv, parfile.c_str());
+        Initialize(argc, argv, parfile.c_str());
     }
     /**
     * \brief The destructor.  The internal static table will only be deleted

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -89,11 +89,11 @@ std::string pp_to_string (std::string const& name,
     return ss.str();
 }
 
-enum PType
+enum class PType
 {
-    pDefn,
-    pEQ_sign,
-    pValue,
+    Defn,
+    EQ_sign,
+    Value,
     pEOF
 };
 
@@ -194,7 +194,7 @@ template <class T> const char* tok_name(std::vector<T>&) { return tok_name(T());
 // Simple lexical analyser.
 //
 
-enum lexState
+enum class lexState
 {
     START,
     STRING,
@@ -271,12 +271,12 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds)
    //
    if ( *str == 0 )
    {
-       return pEOF;
+       return PType::pEOF;
    }
    //
    // Start token scan.
    //
-   lexState state = START;
+   lexState state = lexState::START;
    int      pcnt  = 0; // Tracks nested parens
    int      cbcnt = 0; // Tracks nested curly braces
    while (true)
@@ -288,54 +288,54 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds)
        }
        switch (state)
        {
-       case START:
+       case lexState::START:
            if ( ch == '=' )
            {
                ostr += ch; str++;
-               return pEQ_sign;
+               return PType::EQ_sign;
            }
            else if ( ch == '"' )
            {
                str++;
-               state = QUOTED_STRING;
+               state = lexState::QUOTED_STRING;
            }
            else if ( ch == '(' )
            {
                ostr += ch; str++; pcnt = 1;
-               state = LIST;
+               state = lexState::LIST;
            }
            else if ( ch == '{' )
            {
                ostr += ch; str++; cbcnt = 1;
-               state = INITIALIZER;
+               state = lexState::INITIALIZER;
            }
            else if ( std::isalpha(ch) )
            {
                ostr += ch; str++;
-               state = IDENTIFIER;
+               state = lexState::IDENTIFIER;
            }
            else
            {
                ostr += ch; str++;
-               state = STRING;
+               state = lexState::STRING;
            }
            break;
-       case IDENTIFIER:
+       case lexState::IDENTIFIER:
            if ( std::isalnum(ch) || ch == '_' || ch == '.' || ch == '[' || ch == ']' || ch == '+' || ch == '-' )
            {
                ostr += ch; str++;
            }
            else if ( std::isspace(ch) || ch == '=' )
            {
-               return pDefn;
+               return PType::Defn;
            }
            else
            {
                ostr += ch; str++;
-               state = STRING;
+               state = lexState::STRING;
            }
            break;
-       case LIST:
+       case lexState::LIST:
            eat_comment(str);
            ch = *str;
            if ( ch == '(' )
@@ -347,7 +347,7 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds)
                ostr += ch; str++; pcnt--;
                if ( pcnt == 0 && cbcnt == 0 )
                {
-                   return pValue;
+                   return PType::Value;
                }
            }
            else
@@ -355,7 +355,7 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds)
                ostr += ch; str++;
            }
            break;
-       case INITIALIZER:
+       case lexState::INITIALIZER:
            eat_garbage(str);
            ch = *str;
            if ( ch == '{' )
@@ -367,7 +367,7 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds)
                ostr += ch; str++; cbcnt--;
                if ( cbcnt == 0 && pcnt == 0 )
                {
-                   return pValue;
+                   return PType::Value;
                }
            }
            else
@@ -375,21 +375,21 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds)
                ostr += ch; str++;
            }
            break;
-       case STRING:
+       case lexState::STRING:
            if ( std::isspace(ch) || ch == '=' )
            {
-               return pValue;
+               return PType::Value;
            }
            else
            {
                ostr += ch; str++;
            }
            break;
-       case QUOTED_STRING:
+       case lexState::QUOTED_STRING:
            if ( ch == '"' )
            {
                str++;
-               return pValue;
+               return PType::Value;
            }
            else
            {
@@ -637,7 +637,7 @@ bldTable (const char*& str, ParmParse::Table& tab)
 
         switch (token)
         {
-        case pEOF:
+        case PType::pEOF:
         {
             if (std::accumulate(cur_linefeeds.begin(), cur_linefeeds.end(), int(0)) > 0)
             {
@@ -652,7 +652,7 @@ bldTable (const char*& str, ParmParse::Table& tab)
             addDefn(cur_name,cur_list,tab);
             return;
         }
-        case pEQ_sign:
+        case PType::EQ_sign:
         {
             if ( !cur_list.empty() )
             {
@@ -678,7 +678,7 @@ bldTable (const char*& str, ParmParse::Table& tab)
             cur_linefeeds.clear();
             break;
         }
-        case pDefn:
+        case PType::Defn:
         {
             if ( cur_name.empty() )
             {
@@ -690,7 +690,7 @@ bldTable (const char*& str, ParmParse::Table& tab)
             //
             AMREX_FALLTHROUGH;
         }
-        case pValue:
+        case PType::Value:
         {
             cur_list.push_back(std::move(tokname));
             cur_linefeeds.push_back(num_linefeeds);

--- a/Src/Base/AMReX_RealBox.H
+++ b/Src/Base/AMReX_RealBox.H
@@ -13,6 +13,8 @@
 #include <iosfwd>
 #include <array>
 
+//NOLINTBEGIN(clang-analyzer-security.ArrayBound)
+
 namespace amrex {
 
 /**
@@ -160,5 +162,7 @@ bool AlmostEqual (const RealBox& box1,
                   Real eps = 0.0) noexcept;
 
 }
+
+//NOLINTEND(clang-analyzer-security.ArrayBound)
 
 #endif /*_RealBox_H_*/

--- a/Src/Base/AMReX_RealVect.H
+++ b/Src/Base/AMReX_RealVect.H
@@ -119,7 +119,7 @@ class RealVectND {
         Returns a modifiable lvalue reference to the <i>i</i>'th coordinate of the
         RealVectND.
     */
-    AMREX_GPU_HOST_DEVICE inline constexpr
+    AMREX_GPU_HOST_DEVICE constexpr
     Real& operator[] (int i) & noexcept {
         AMREX_ASSERT(i >= 0 && i < dim);
         return vect[i];
@@ -129,7 +129,7 @@ class RealVectND {
     /**
         Returns the <i>i</i>'th coordinate of the RealVectND.
     */
-    AMREX_GPU_HOST_DEVICE inline constexpr
+    AMREX_GPU_HOST_DEVICE constexpr
     const Real& operator[] (int i) const& noexcept {
         AMREX_ASSERT(i >= 0 && i < dim);
         return vect[i];
@@ -145,7 +145,7 @@ class RealVectND {
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE constexpr
     const Real& get () const noexcept {static_assert(0<=i && i<dim); return vect[i];}
 
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline constexpr
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE constexpr
     GpuArray<Real, dim> to_array () const noexcept {
         GpuArray<Real, dim> retval{};
         for (int i = 0; i < dim; ++i) {
@@ -165,28 +165,28 @@ class RealVectND {
     /**
         Return pointer to the first component.
     */
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline constexpr
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE constexpr
     Real* begin () noexcept { return vect; }
 
     ///
     /**
         Return pointer to the first component.
     */
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline constexpr
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE constexpr
     const Real* begin () const noexcept { return vect; }
 
     ///
     /**
         Return pointer to the one past last component
     */
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline constexpr
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE constexpr
     Real* end () noexcept { return vect + dim; }
 
     ///
     /**
         Return pointer to the one past last component
     */
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline constexpr
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE constexpr
     const Real* end () const noexcept {
         return vect + dim;
     }

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -1527,8 +1527,7 @@ public:
     static_assert(sizeof...(Ops) == sizeof...(Ts));
 
     ReducerImpl ()
-        : m_reduce_op{},
-          m_reduce_data(m_reduce_op)
+        : m_reduce_data(m_reduce_op)
         {}
 
 protected:

--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -515,7 +515,7 @@ struct std::tuple_element<std::size_t{0}, amrex::GpuTuple<T, Ts...>> {
 
 template<std::size_t s, typename T, typename... Ts>
 struct std::tuple_element<s, amrex::GpuTuple<T, Ts...>> {
-    using type = typename std::tuple_element<s-1, amrex::GpuTuple<Ts...>>::type;
+    using type = typename std::tuple_element_t<s-1, amrex::GpuTuple<Ts...>>;
 };
 
 #endif /*AMREX_TUPLE_H_*/

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -256,7 +256,7 @@ namespace amrex
     /// \cond DOXYGEN_IGNORE
     namespace detail {
         template<typename T>
-        inline constexpr bool is_convertible(T) {return true;}
+        constexpr bool is_convertible(T) {return true;}
 
         template <typename T, typename U, typename Enable = void>
         struct IsConvertibleImp : std::false_type {};

--- a/Src/Base/AMReX_Utility.H
+++ b/Src/Base/AMReX_Utility.H
@@ -427,7 +427,7 @@ namespace amrex::detail {
 
     // Determine if type has a specialization for std::tuple_size
     template <class T>
-    constexpr decltype((std::tuple_size<T>::value, true)) HasTupleSize() {
+    constexpr decltype((std::tuple_size<T>::value, true)) HasTupleSize() { // NOLINT(modernize-type-traits)
         return true;
     }
     template <class T, class... Args>

--- a/Src/Base/AMReX_VisMFBuffer.H
+++ b/Src/Base/AMReX_VisMFBuffer.H
@@ -13,7 +13,7 @@ class VisMFBuffer
 {
 public:
     //! We try to do I/O with buffers of this size.
-    enum { IO_Buffer_Size = 262144 * 8 };
+    static constexpr int  IO_Buffer_Size = 262144 * 8;
     //! The type of a char buffer required by [p]setbuf().
 #ifdef BL_SETBUF_SIGNED_CHAR
     using Setbuf_Char_Type = signed char;

--- a/Src/Base/Parser/AMReX_Parser_Exe.H
+++ b/Src/Base/Parser/AMReX_Parser_Exe.H
@@ -233,31 +233,31 @@ namespace parser_detail
     AMREX_GPU_HOST_DEVICE AMREX_NO_INLINE
     void call_user_fn (ParserExeUserFn* p, Stack<T,N>& pstack)
     {
-        short argc = ((ParserExeUserFn*)p)->argc;
+        short argc = p->argc;
         if (argc == 1) {
-            AMREX_IF_ON_HOST  (( pstack.top() = ParserUserFn1(((ParserExeUserFn*)p)->fh)(pstack.top()); ))
+            AMREX_IF_ON_HOST  (( pstack.top() = ParserUserFn1(p->fh)(pstack.top()); ))
 #if !defined(AMREX_USE_SYCL)
-            AMREX_IF_ON_DEVICE(( pstack.top() = ParserUserFn1(((ParserExeUserFn*)p)->fd)(pstack.top()); ))
+            AMREX_IF_ON_DEVICE(( pstack.top() = ParserUserFn1(p->fd)(pstack.top()); ))
 #endif
         } else if (argc == 2) {
             T a1 = pstack.top(); // NOLINT
             pstack.pop();
-            AMREX_IF_ON_HOST  (( pstack.top() = ParserUserFn2(((ParserExeUserFn*)p)->fh)(pstack.top(),a1); ))
+            AMREX_IF_ON_HOST  (( pstack.top() = ParserUserFn2(p->fh)(pstack.top(),a1); ))
 #if defined(AMREX_USE_SYCL)
             amrex::ignore_unused(a1);
 #else
-            AMREX_IF_ON_DEVICE(( pstack.top() = ParserUserFn2(((ParserExeUserFn*)p)->fd)(pstack.top(),a1); ))
+            AMREX_IF_ON_DEVICE(( pstack.top() = ParserUserFn2(p->fd)(pstack.top(),a1); ))
 #endif
         } else if (argc == 3) {
             T a2 = pstack.top(); // NOLINT
             pstack.pop();
             T a1 = pstack.top(); // NOLINT
             pstack.pop();
-            AMREX_IF_ON_HOST  (( pstack.top() = ParserUserFn3(((ParserExeUserFn*)p)->fh)(pstack.top(),a1,a2); ))
+            AMREX_IF_ON_HOST  (( pstack.top() = ParserUserFn3(p->fh)(pstack.top(),a1,a2); ))
 #if defined(AMREX_USE_SYCL)
             amrex::ignore_unused(a1,a2);
 #else
-            AMREX_IF_ON_DEVICE(( pstack.top() = ParserUserFn3(((ParserExeUserFn*)p)->fd)(pstack.top(),a1,a2); ))
+            AMREX_IF_ON_DEVICE(( pstack.top() = ParserUserFn3(p->fd)(pstack.top(),a1,a2); ))
 #endif
         } else if (argc == 4) {
             T a3 = pstack.top(); // NOLINT
@@ -266,11 +266,11 @@ namespace parser_detail
             pstack.pop();
             T a1 = pstack.top(); // NOLINT
             pstack.pop();
-            AMREX_IF_ON_HOST  (( pstack.top() = ParserUserFn4(((ParserExeUserFn*)p)->fh)(pstack.top(),a1,a2,a3); ))
+            AMREX_IF_ON_HOST  (( pstack.top() = ParserUserFn4(p->fh)(pstack.top(),a1,a2,a3); ))
 #if defined(AMREX_USE_SYCL)
             amrex::ignore_unused(a1,a2,a3);
 #else
-            AMREX_IF_ON_DEVICE(( pstack.top() = ParserUserFn4(((ParserExeUserFn*)p)->fd)(pstack.top(),a1,a2,a3); ))
+            AMREX_IF_ON_DEVICE(( pstack.top() = ParserUserFn4(p->fd)(pstack.top(),a1,a2,a3); ))
 #endif
         }
     }

--- a/Src/Base/Parser/AMReX_Parser_Exe.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Exe.cpp
@@ -664,11 +664,11 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
 }
 
 namespace {
-    enum paren_t {
-        paren_plusminus,
-        paren_muldiv,
-        paren_pow,
-        paren_atom
+    enum class paren_t {
+        plusminus,
+        muldiv,
+        pow,
+        atom
     };
 
     std::pair<bool,bool> need_parens (paren_t lhs, paren_t op, paren_t rhs)
@@ -677,7 +677,7 @@ namespace {
         if (lhs < op) {
             r.first = true;
         } else if (lhs == op) {
-            if (op == paren_pow) {
+            if (op == paren_t::pow) {
                 r.first = true;
             } else {
                 r.first = false;
@@ -688,7 +688,7 @@ namespace {
         if (op < rhs) {
             r.second = false;
         } else if (op == rhs) {
-            if (op == paren_pow) {
+            if (op == paren_t::pow) {
                 r.second = false;
             } else {
                 r.second = true;
@@ -727,7 +727,7 @@ namespace {
     {
         std::string r{f};
         r.append("(").append(a).append(")");
-        return {r,paren_atom};
+        return {r,paren_t::atom};
     }
 
     std::pair<std::string,paren_t> make_f2_string (std::string_view const& f, std::string const& a,
@@ -735,7 +735,7 @@ namespace {
     {
         std::string r{f};
         r.append("(").append(a).append(",").append(b).append(")");
-        return {r,paren_atom};
+        return {r,paren_t::atom};
     }
 }
 
@@ -750,15 +750,15 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
     auto get_sym = [&] (int i) -> std::pair<std::string,paren_t>
     {
         if (i >= AMREX_PARSER_LOCAL_IDX0) {
-            return {locals[i-AMREX_PARSER_LOCAL_IDX0],paren_atom};
+            return {locals[i-AMREX_PARSER_LOCAL_IDX0],paren_t::atom};
         } else {
-            return {vars[i],paren_atom};
+            return {vars[i],paren_t::atom};
         }
     };
 
     auto get_val = [&] (double v) -> std::pair<std::string,paren_t>
     {
-        return {std::to_string(v), paren_atom};
+        return {std::to_string(v), paren_t::atom};
     };
 
     while (*((parser_exe_t*)p) != PARSER_EXE_NULL) { // NOLINT
@@ -794,7 +794,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_ADD:
         {
             auto n = pstack.size();
-            pstack[n-2] = make_op_string(pstack[n-2],{"+",paren_plusminus}, pstack[n-1]); // NOLINT
+            pstack[n-2] = make_op_string(pstack[n-2],{"+",paren_t::plusminus}, pstack[n-1]); // NOLINT
             pstack.pop_back();
             os << std::setw(3) << count++
                << std::setw(16) << "add"
@@ -807,7 +807,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_SUB_F:
         {
             auto n = pstack.size();
-            pstack[n-2] = make_op_string(pstack[n-2], {"-",paren_plusminus}, pstack[n-1]); // NOLINT
+            pstack[n-2] = make_op_string(pstack[n-2], {"-",paren_t::plusminus}, pstack[n-1]); // NOLINT
             pstack.pop_back();
             os << std::setw(3) << count++
                << std::setw(16) << "sub"
@@ -820,7 +820,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_SUB_B:
         {
             auto n = pstack.size();
-            pstack[n-2] = make_op_string(pstack[n-1], {"-",paren_plusminus}, pstack[n-2]); // NOLINT
+            pstack[n-2] = make_op_string(pstack[n-1], {"-",paren_t::plusminus}, pstack[n-2]); // NOLINT
             pstack.pop_back();
             os << std::setw(3) << count++
                << std::setw(16) << "rsub"
@@ -833,7 +833,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_MUL:
         {
             auto n = pstack.size();
-            pstack[n-2] = make_op_string(pstack[n-2], {"*",paren_muldiv}, pstack[n-1]); // NOLINT
+            pstack[n-2] = make_op_string(pstack[n-2], {"*",paren_t::muldiv}, pstack[n-1]); // NOLINT
             pstack.pop_back();
             os << std::setw(3) << count++
                << std::setw(16) << "mul"
@@ -846,7 +846,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_DIV_F:
         {
             auto n = pstack.size();
-            pstack[n-2] = make_op_string(pstack[n-2], {"/",paren_muldiv}, pstack[n-1]); // NOLINT
+            pstack[n-2] = make_op_string(pstack[n-2], {"/",paren_t::muldiv}, pstack[n-1]); // NOLINT
             pstack.pop_back();
             os << std::setw(3) << count++
                << std::setw(16) << "div"
@@ -859,7 +859,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_DIV_B:
         {
             auto n = pstack.size();
-            pstack[n-2] = make_op_string(pstack[n-1], {"/",paren_muldiv}, pstack[n-2]); // NOLINT
+            pstack[n-2] = make_op_string(pstack[n-1], {"/",paren_t::muldiv}, pstack[n-2]); // NOLINT
             pstack.pop_back();
             os << std::setw(3) << count++
                << std::setw(16) << "rdiv"
@@ -914,7 +914,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         {
             int i = ((ParserExeADD_VP*)p)->i;
             auto v = ((ParserExeADD_VP*)p)->v;
-            pstack.push_back(make_op_string(get_val(v), {"+",paren_plusminus}, get_sym(i)));
+            pstack.push_back(make_op_string(get_val(v), {"+",paren_t::plusminus}, get_sym(i)));
             os << std::setw(3) << count++
                << std::setw(16) << "addvp"
                << std::setw(12) << pstack.size()
@@ -927,7 +927,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         {
             int i = ((ParserExeSUB_VP*)p)->i;
             auto v = ((ParserExeSUB_VP*)p)->v;
-            pstack.push_back(make_op_string(get_val(v), {"-",paren_plusminus}, get_sym(i)));
+            pstack.push_back(make_op_string(get_val(v), {"-",paren_t::plusminus}, get_sym(i)));
             os << std::setw(3) << count++
                << std::setw(16) << "subvp"
                << std::setw(12) << pstack.size()
@@ -940,7 +940,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         {
             int i = ((ParserExeMUL_VP*)p)->i;
             auto v = ((ParserExeMUL_VP*)p)->v;
-            pstack.push_back(make_op_string(get_val(v), {"*",paren_muldiv}, get_sym(i)));
+            pstack.push_back(make_op_string(get_val(v), {"*",paren_t::muldiv}, get_sym(i)));
             os << std::setw(3) << count++
                << std::setw(16) << "mulvp"
                << std::setw(12) << pstack.size()
@@ -953,7 +953,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         {
             int i = ((ParserExeDIV_VP*)p)->i;
             auto v = ((ParserExeDIV_VP*)p)->v;
-            pstack.push_back(make_op_string(get_val(v), {"/",paren_muldiv}, get_sym(i)));
+            pstack.push_back(make_op_string(get_val(v), {"/",paren_t::muldiv}, get_sym(i)));
             os << std::setw(3) << count++
                << std::setw(16) << "divvp"
                << std::setw(12) << pstack.size()
@@ -966,7 +966,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         {
             int i = ((ParserExeADD_PP*)p)->i1;
             int j = ((ParserExeADD_PP*)p)->i2;
-            pstack.push_back(make_op_string(get_sym(i), {"+",paren_plusminus}, get_sym(j)));
+            pstack.push_back(make_op_string(get_sym(i), {"+",paren_t::plusminus}, get_sym(j)));
             os << std::setw(3) << count++
                << std::setw(16) << "addpp"
                << std::setw(12) << pstack.size()
@@ -979,7 +979,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         {
             int i = ((ParserExeSUB_PP*)p)->i1;
             int j = ((ParserExeSUB_PP*)p)->i2;
-            pstack.push_back(make_op_string(get_sym(i), {"-",paren_plusminus}, get_sym(j)));
+            pstack.push_back(make_op_string(get_sym(i), {"-",paren_t::plusminus}, get_sym(j)));
             os << std::setw(3) << count++
                << std::setw(16) << "subpp"
                << std::setw(12) << pstack.size()
@@ -992,7 +992,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         {
             int i = ((ParserExeMUL_PP*)p)->i1;
             int j = ((ParserExeMUL_PP*)p)->i2;
-            pstack.push_back(make_op_string(get_sym(i), {"*",paren_muldiv}, get_sym(j)));
+            pstack.push_back(make_op_string(get_sym(i), {"*",paren_t::muldiv}, get_sym(j)));
             os << std::setw(3) << count++
                << std::setw(16) << "mulpp"
                << std::setw(12) << pstack.size()
@@ -1005,7 +1005,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         {
             int i = ((ParserExeDIV_PP*)p)->i1;
             int j = ((ParserExeDIV_PP*)p)->i2;
-            pstack.push_back(make_op_string(get_sym(i), {"/",paren_muldiv}, get_sym(j)));
+            pstack.push_back(make_op_string(get_sym(i), {"/",paren_t::muldiv}, get_sym(j)));
             os << std::setw(3) << count++
                << std::setw(16) << "divpp"
                << std::setw(12) << pstack.size()
@@ -1017,7 +1017,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_ADD_VN:
         {
             auto v = ((ParserExeADD_VN*)p)->v;
-            pstack.back() = make_op_string(get_val(v), {"+",paren_plusminus}, pstack.back());
+            pstack.back() = make_op_string(get_val(v), {"+",paren_t::plusminus}, pstack.back());
             os << std::setw(3) << count++
                << std::setw(16) << "addvn"
                << std::setw(12) << pstack.size()
@@ -1029,7 +1029,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_SUB_VN:
         {
             auto v = ((ParserExeSUB_VN*)p)->v;
-            pstack.back() = make_op_string(get_val(v), {"-",paren_plusminus}, pstack.back());
+            pstack.back() = make_op_string(get_val(v), {"-",paren_t::plusminus}, pstack.back());
             os << std::setw(3) << count++
                << std::setw(16) << "subvn"
                << std::setw(12) << pstack.size()
@@ -1041,7 +1041,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_MUL_VN:
         {
             auto v = ((ParserExeMUL_VN*)p)->v;
-            pstack.back() = make_op_string(get_val(v), {"*",paren_muldiv}, pstack.back());
+            pstack.back() = make_op_string(get_val(v), {"*",paren_t::muldiv}, pstack.back());
             os << std::setw(3) << count++
                << std::setw(16) << "mulvn"
                << std::setw(12) << pstack.size()
@@ -1053,7 +1053,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_DIV_VN:
         {
             auto v = ((ParserExeDIV_VN*)p)->v;
-            pstack.back() = make_op_string(get_val(v), {"/",paren_muldiv}, pstack.back());
+            pstack.back() = make_op_string(get_val(v), {"/",paren_t::muldiv}, pstack.back());
             os << std::setw(3) << count++
                << std::setw(16) << "divvn"
                << std::setw(12) << pstack.size()
@@ -1065,7 +1065,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_ADD_PN:
         {
             int i = ((ParserExeADD_PN*)p)->i;
-            pstack.back() = make_op_string(get_sym(i), {"+",paren_plusminus}, pstack.back());
+            pstack.back() = make_op_string(get_sym(i), {"+",paren_t::plusminus}, pstack.back());
             os << std::setw(3) << count++
                << std::setw(16) << "addpn"
                << std::setw(12) << pstack.size()
@@ -1080,9 +1080,9 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
             auto sign = ((ParserExeSUB_PN*)p)->sign;
             std::string op;
             if (sign > 0.0) {
-                pstack.back() = make_op_string(get_sym(i), {"-",paren_plusminus}, pstack.back());
+                pstack.back() = make_op_string(get_sym(i), {"-",paren_t::plusminus}, pstack.back());
             } else {
-                pstack.back() = make_op_string(pstack.back(), {"-",paren_plusminus}, get_sym(i));
+                pstack.back() = make_op_string(pstack.back(), {"-",paren_t::plusminus}, get_sym(i));
                 op = "r";
             }
             op.append("subpn");
@@ -1097,7 +1097,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_MUL_PN:
         {
             int i = ((ParserExeMUL_PN*)p)->i;
-            pstack.back() = make_op_string(get_sym(i), {"*",paren_muldiv}, pstack.back());
+            pstack.back() = make_op_string(get_sym(i), {"*",paren_t::muldiv}, pstack.back());
             os << std::setw(3) << count++
                << std::setw(16) << "mulpn"
                << std::setw(12) << pstack.size()
@@ -1111,10 +1111,10 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
             int i = ((ParserExeDIV_PN*)p)->i;
             std::string op;
             if (((ParserExeDIV_PN*)p)->reverse) {
-                pstack.back() = make_op_string(pstack.back(), {"/",paren_muldiv}, get_sym(i));
+                pstack.back() = make_op_string(pstack.back(), {"/",paren_t::muldiv}, get_sym(i));
                 op = "r";
             } else {
-                pstack.back() = make_op_string(get_sym(i), {"/",paren_muldiv}, pstack.back());
+                pstack.back() = make_op_string(get_sym(i), {"/",paren_t::muldiv}, pstack.back());
             }
             op.append("divpn");
             os << std::setw(3) << count++
@@ -1127,7 +1127,7 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         }
         case PARSER_EXE_SQUARE:
         {
-            pstack.back() = make_op_string(pstack.back(), {"^",paren_pow}, {"2",paren_atom});
+            pstack.back() = make_op_string(pstack.back(), {"^",paren_t::pow}, {"2",paren_t::atom});
             os << std::setw(3) << count++
                << std::setw(16) << "square"
                << std::setw(12) << pstack.size()
@@ -1139,8 +1139,8 @@ void parser_exe_print(char const* p, Vector<std::string> const& vars,
         case PARSER_EXE_POWI:
         {
             int n = ((ParserExePOWI*)p)->i;
-            pstack.back() = make_op_string(pstack.back(), {"^",paren_pow},
-                                           {std::to_string(n),paren_atom});
+            pstack.back() = make_op_string(pstack.back(), {"^",paren_t::pow},
+                                           {std::to_string(n),paren_t::atom});
             os << std::setw(3) << count++
                << std::setw(16) << "powi"
                << std::setw(12) << pstack.size()

--- a/Src/Base/Parser/AMReX_Parser_Y.H
+++ b/Src/Base/Parser/AMReX_Parser_Y.H
@@ -529,7 +529,13 @@ parser_call_f2 (enum parser_f2_t type, double a, double b)
     case PARSER_OR:
         return ((a != 0.0) || (b != 0.0)) ? 1.0 : 0.0;
     case PARSER_HEAVISIDE:
-        return (a < 0.0) ? 0.0 : ((a > 0.0) ? 1.0 : b);
+        if (a < 0.0) {
+            return 0.0;
+        } else if (a > 0.0) {
+            return 1.0;
+        } else {
+            return b;
+        }
     case PARSER_JN:
         return parser_math_jn<double>(int(a),b);
     case PARSER_YN:

--- a/Src/EB/AMReX_EB2_IF_Box.H
+++ b/Src/EB/AMReX_EB2_IF_Box.H
@@ -24,7 +24,7 @@ public:
           m_sign( a_inside ? 1.0 : -1.0 )
         {}
 
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         Real r = std::numeric_limits<Real>::lowest();
@@ -34,7 +34,7 @@ public:
         return r*m_sign;
     }
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         return this->operator() (AMREX_D_DECL(p[0], p[1], p[2]));
     }

--- a/Src/EB/AMReX_EB2_IF_Complement.H
+++ b/Src/EB/AMReX_EB2_IF_Complement.H
@@ -18,13 +18,13 @@ public:
 
     ComplementIF (F a_f) : m_f(std::move(a_f)) {}
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         return -m_f(p);
     }
 
     template<class U=F, std::enable_if_t<IsGPUable<U>::value,int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         return -m_f(AMREX_D_DECL(x,y,z));

--- a/Src/EB/AMReX_EB2_IF_Cylinder.H
+++ b/Src/EB/AMReX_EB2_IF_Cylinder.H
@@ -37,7 +37,7 @@ public:
             AMREX_ASSERT(m_direction < AMREX_SPACEDIM);
         }
 
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
 #if (AMREX_SPACEDIM == 3)
@@ -92,7 +92,7 @@ public:
         }
     }
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         return this->operator() (AMREX_D_DECL(p[0], p[1], p[2]));
     }

--- a/Src/EB/AMReX_EB2_IF_Difference.H
+++ b/Src/EB/AMReX_EB2_IF_Difference.H
@@ -23,7 +23,7 @@ public:
           m_g(std::move(a_g))
         {}
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         Real r1 = m_f(p);
         Real r2 = m_g(p);
@@ -33,7 +33,7 @@ public:
     template <class U=F, class V=G,
               std::enable_if_t<IsGPUable<U>::value &&
                                       IsGPUable<V>::value, int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         Real r1 = m_f(AMREX_D_DECL(x,y,z));

--- a/Src/EB/AMReX_EB2_IF_Ellipsoid.H
+++ b/Src/EB/AMReX_EB2_IF_Ellipsoid.H
@@ -21,7 +21,7 @@ public:
           m_sign( a_inside ? 1.0_rt : -1.0_rt )
         {}
 
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept {
         Real d2 = AMREX_D_TERM(  (x-m_center.x)*(x-m_center.x) / (m_radii.x*m_radii.x),
                                + (y-m_center.y)*(y-m_center.y) / (m_radii.y*m_radii.y),
@@ -29,7 +29,7 @@ public:
         return m_sign*(d2-1.0_rt);
     }
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept {
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept {
         return this->operator()(AMREX_D_DECL(p[0],p[1],p[2]));
     }
 

--- a/Src/EB/AMReX_EB2_IF_Extrusion.H
+++ b/Src/EB/AMReX_EB2_IF_Extrusion.H
@@ -21,7 +21,7 @@ public:
           m_direction(direction)
         {}
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const
     {
         RealArray x = p;
         x[m_direction] = 0.0;
@@ -29,7 +29,7 @@ public:
     }
 
     template <class U=F, std::enable_if_t<IsGPUable<U>::value,int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         switch (m_direction)

--- a/Src/EB/AMReX_EB2_IF_Intersection.H
+++ b/Src/EB/AMReX_EB2_IF_Intersection.H
@@ -18,26 +18,26 @@ namespace amrex::EB2 {
 /// \cond DOXYGEN_IGNORE
 namespace IIF_detail {
     template <typename F>
-    [[nodiscard]] inline Real do_min (const RealArray& p, F&& f) noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real do_min (const RealArray& p, F&& f) noexcept
     {
         return std::forward<F>(f)(p);
     }
 
     template <typename F, typename... Fs>
-    [[nodiscard]] inline Real do_min (const RealArray& p, F&& f, Fs&... fs) noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real do_min (const RealArray& p, F&& f, Fs&... fs) noexcept
     {
         return amrex::min(std::forward<F>(f)(p), do_min(p, std::forward<Fs>(fs)...));
     }
 
     template <typename F>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real do_min (AMREX_D_DECL(Real x, Real y, Real z), F&& f) noexcept
     {
         return std::forward<F>(f)(AMREX_D_DECL(x,y,z));
     }
 
     template <typename F, typename... Fs>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real do_min (AMREX_D_DECL(Real x, Real y, Real z), F&& f, Fs&... fs)
     {
         return amrex::min(std::forward<F>(f)(AMREX_D_DECL(x,y,z)), do_min(AMREX_D_DECL(x,y,z), std::forward<Fs>(fs)...));
@@ -52,13 +52,13 @@ class IntersectionIF
 public:
     using GpuTuple<Fs...>::GpuTuple;
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         return op_impl(p, std::make_index_sequence<sizeof...(Fs)>());
     }
 
     template <class U=IntersectionIF<Fs...>, std::enable_if_t<IsGPUable<U>::value,int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         return op_impl(AMREX_D_DECL(x,y,z), std::make_index_sequence<sizeof...(Fs)>());
@@ -67,13 +67,13 @@ public:
 protected:
 
     template <std::size_t... Is>
-    [[nodiscard]] inline Real op_impl (const RealArray& p, std::index_sequence<Is...>) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real op_impl (const RealArray& p, std::index_sequence<Is...>) const noexcept
     {
         return IIF_detail::do_min(p, amrex::get<Is>(*this)...);
     }
 
     template <std::size_t... Is>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real op_impl (AMREX_D_DECL(Real x, Real y, Real z), std::index_sequence<Is...>) const noexcept
     {
         return IIF_detail::do_min(AMREX_D_DECL(x,y,z), amrex::get<Is>(*this)...);

--- a/Src/EB/AMReX_EB2_IF_Lathe.H
+++ b/Src/EB/AMReX_EB2_IF_Lathe.H
@@ -19,7 +19,7 @@ public:
 
     LatheIF (F a_f) : m_f(std::move(a_f)) {}
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         Real r = std::hypot(p[0],p[1]);
 #if (AMREX_SPACEDIM == 2)
@@ -30,7 +30,7 @@ public:
     }
 
     template <class U=F, std::enable_if_t<IsGPUable<U>::value,int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         Real r = std::hypot(x,y);

--- a/Src/EB/AMReX_EB2_IF_Parser.H
+++ b/Src/EB/AMReX_EB2_IF_Parser.H
@@ -17,7 +17,7 @@ public:
         : m_parser(a_parser)
         {}
 
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator() (AMREX_D_DECL(amrex::Real x, amrex::Real y,
                                          amrex::Real z)) const noexcept {
 #if (AMREX_SPACEDIM == 2)
@@ -27,7 +27,7 @@ public:
 #endif
     }
 
-    [[nodiscard]] inline amrex::Real operator() (const amrex::RealArray& p) const noexcept {
+    [[nodiscard]] AMREX_FORCE_INLINE amrex::Real operator() (const amrex::RealArray& p) const noexcept {
         return this->operator()(AMREX_D_DECL(p[0],p[1],p[2]));
     }
 

--- a/Src/EB/AMReX_EB2_IF_Plane.H
+++ b/Src/EB/AMReX_EB2_IF_Plane.H
@@ -20,7 +20,7 @@ public:
           m_sign( a_inside ? 1.0 : -1.0 )
     {}
 
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         return AMREX_D_TERM( (x-m_point.x)*m_normal.x*m_sign,
@@ -28,7 +28,7 @@ public:
                             +(z-m_point.z)*m_normal.z*m_sign );
     }
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         return this->operator()(AMREX_D_DECL(p[0],p[1],p[2]));
     }

--- a/Src/EB/AMReX_EB2_IF_Polynomial.H
+++ b/Src/EB/AMReX_EB2_IF_Polynomial.H
@@ -41,7 +41,7 @@ public:
           m_sign( a_inside ? 1.0_rt : -1.0_rt )
     {}
 
-    AMREX_GPU_HOST_DEVICE inline
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         Real retval = 0.0_rt;
@@ -53,7 +53,7 @@ public:
         return m_sign*retval;
     }
 
-    inline Real operator() (const RealArray& p) const noexcept {
+    AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept {
         return this->operator()(AMREX_D_DECL(p[0],p[1],p[2]));
     }
 
@@ -81,7 +81,7 @@ public:
     PolynomialIF& operator= (const PolynomialIF& rhs) = delete;
     PolynomialIF& operator= (PolynomialIF&& rhs) = delete;
 
-    [[nodiscard]] inline
+    [[nodiscard]] AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         Real retval = 0.0_rt;
@@ -93,7 +93,7 @@ public:
         return m_sign*retval;
     }
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept {
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept {
         return this->operator()(AMREX_D_DECL(p[0],p[1],p[2]));
     }
 

--- a/Src/EB/AMReX_EB2_IF_Rotation.H
+++ b/Src/EB/AMReX_EB2_IF_Rotation.H
@@ -25,7 +25,7 @@ public:
 
 // Note that angle is measured in radians
 #if (AMREX_SPACEDIM==2)
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         Real x =  p[0]*m_cos_angle + p[1]*m_sin_angle;
         Real y = -p[0]*m_sin_angle + p[1]*m_cos_angle;
@@ -33,7 +33,7 @@ public:
     }
 
     template <class U=F, std::enable_if_t<IsGPUable<U>::value,int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (Real x, Real y) const noexcept
     {
         return m_f( x*m_cos_angle + y*m_sin_angle,
@@ -42,7 +42,7 @@ public:
 #endif
 
 #if (AMREX_SPACEDIM==3)
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         switch(m_dir) {
         case(0):
@@ -67,7 +67,7 @@ public:
     }
 
     template <class U=F, std::enable_if_t<IsGPUable<U>::value,int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (Real x, Real y, Real z) const noexcept
     {
         switch(m_dir) {

--- a/Src/EB/AMReX_EB2_IF_Scale.H
+++ b/Src/EB/AMReX_EB2_IF_Scale.H
@@ -26,7 +26,7 @@ public:
         {}
 
     template <class U=F, std::enable_if_t<IsGPUable<U>::value,int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         return m_f(AMREX_D_DECL(x*m_sfinv.x,
@@ -34,7 +34,7 @@ public:
                                 z*m_sfinv.z));
     }
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         return m_f({AMREX_D_DECL(p[0]*m_sfinv.x,
                                  p[1]*m_sfinv.y,

--- a/Src/EB/AMReX_EB2_IF_Sphere.H
+++ b/Src/EB/AMReX_EB2_IF_Sphere.H
@@ -21,7 +21,7 @@ public:
           m_sign( a_inside ? 1.0 : -1.0 )
         {}
 
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept {
         Real d2 = AMREX_D_TERM(  (x-m_center.x)*(x-m_center.x),
                                + (y-m_center.y)*(y-m_center.y),
@@ -29,7 +29,7 @@ public:
         return m_sign*(d2-m_radius*m_radius);
     }
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept {
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept {
         return this->operator()(AMREX_D_DECL(p[0],p[1],p[2]));
     }
 

--- a/Src/EB/AMReX_EB2_IF_Torus.H
+++ b/Src/EB/AMReX_EB2_IF_Torus.H
@@ -23,7 +23,7 @@ public:
           m_sign( a_inside ? 1.0 : -1.0 )
         {}
 
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept {
         Real d = std::hypot(x-m_center.x, y-m_center.y);
 #if (AMREX_SPACEDIM == 2)
@@ -36,7 +36,7 @@ public:
 #endif
     }
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept {
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept {
         return this->operator()(AMREX_D_DECL(p[0],p[1],p[2]));
     }
 

--- a/Src/EB/AMReX_EB2_IF_Translation.H
+++ b/Src/EB/AMReX_EB2_IF_Translation.H
@@ -21,7 +21,7 @@ public:
           m_offset(makeXDim3(a_offset))
         {}
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         return m_f({AMREX_D_DECL(p[0]-m_offset.x,
                                  p[1]-m_offset.y,
@@ -29,7 +29,7 @@ public:
     }
 
     template <class U=F, std::enable_if_t<IsGPUable<U>::value,int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         return m_f(AMREX_D_DECL(x-m_offset.x,

--- a/Src/EB/AMReX_EB2_IF_Union.H
+++ b/Src/EB/AMReX_EB2_IF_Union.H
@@ -18,26 +18,26 @@ namespace amrex::EB2 {
 /// \cond DOXYGEN_IGNORE
 namespace UIF_detail {
     template <typename F>
-    [[nodiscard]] inline Real do_max (const RealArray& p, F&& f) noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real do_max (const RealArray& p, F&& f) noexcept
     {
         return std::forward<F>(f)(p);
     }
 
     template <typename F, typename... Fs>
-    [[nodiscard]] inline Real do_max (const RealArray& p, F&& f, Fs&... fs) noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real do_max (const RealArray& p, F&& f, Fs&... fs) noexcept
     {
         return amrex::max(std::forward<F>(f)(p), do_max(p, std::forward<Fs>(fs)...));
     }
 
     template <typename F>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real do_max (AMREX_D_DECL(Real x, Real y, Real z), F&& f) noexcept
     {
         return std::forward<F>(f)(AMREX_D_DECL(x,y,z));
     }
 
     template <typename F, typename... Fs>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real do_max (AMREX_D_DECL(Real x, Real y, Real z), F&& f, Fs&... fs) noexcept
     {
         return amrex::max(std::forward<F>(f)(AMREX_D_DECL(x,y,z)), do_max(AMREX_D_DECL(x,y,z), std::forward<Fs>(fs)...));
@@ -52,13 +52,13 @@ class UnionIF
 public:
     using GpuTuple<Fs...>::GpuTuple;
 
-    [[nodiscard]] inline Real operator() (const RealArray& p) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real operator() (const RealArray& p) const noexcept
     {
         return op_impl(p, std::make_index_sequence<sizeof...(Fs)>());
     }
 
     template <class U=UnionIF<Fs...>, std::enable_if_t<IsGPUable<U>::value,int> = 0>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real operator() (AMREX_D_DECL(Real x, Real y, Real z)) const noexcept
     {
         return op_impl(AMREX_D_DECL(x,y,z), std::make_index_sequence<sizeof...(Fs)>());
@@ -67,13 +67,13 @@ public:
 protected:
 
     template <std::size_t... Is>
-    [[nodiscard]] inline Real op_impl (const RealArray& p, std::index_sequence<Is...>) const noexcept
+    [[nodiscard]] AMREX_FORCE_INLINE Real op_impl (const RealArray& p, std::index_sequence<Is...>) const noexcept
     {
         return UIF_detail::do_max(p, amrex::get<Is>(*this)...);
     }
 
     template <std::size_t... Is>
-    [[nodiscard]] AMREX_GPU_HOST_DEVICE inline
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real op_impl (AMREX_D_DECL(Real x, Real y, Real z), std::index_sequence<Is...>) const noexcept
     {
         return UIF_detail::do_max(AMREX_D_DECL(x,y,z), amrex::get<Is>(*this)...);

--- a/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
@@ -449,6 +449,7 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
           Real a1_jj = d0_jj / (d0_jj + d1_jj);                                // coefficient of phi(i-1,jj,k,n)
 
           Real phi01    = a0    *   phi(i, j,k,n)  + a1    *   phi(ii, j,k,n); // interpolation of phi   in x-direction
+          // NOLINTNEXTLINE(misc-confusable-identifiers)
           Real y01      = a0    * ccent(i, j,k,1)  + a1    * ccent(ii, j,k,1); // interpolation of y-loc in x-direction
 
           Real phi01_jj = a0_jj *   phi(i,jj,k,n)  + a1_jj *   phi(ii,jj,k,n); // interpolation of phi   in x-direction

--- a/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
@@ -739,6 +739,7 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
           Real a1_jj_kk = Real(1.0) - a0_jj_kk;                             // coefficient of phi(i-1,jj,kk,n)
 
           Real phi01       = a0       *   phi(i, j, k,n)  + a1       *   phi(i-1, j, k,n); // interpolation in x-dir of phi
+          // NOLINTNEXTLINE(misc-confusable-identifiers)
           Real y01         = a0       * ccent(i, j, k,1)  + a1       * ccent(i-1, j, k,1); // interpolation in x-dir of y-loc
           Real z01         = a0       * ccent(i, j, k,2)  + a1       * ccent(i-1, j, k,2); // interpolation in x-dir of z-loc
 

--- a/Src/EB/AMReX_EB_Redistribution.cpp
+++ b/Src/EB/AMReX_EB_Redistribution.cpp
@@ -14,6 +14,7 @@ namespace amrex {
     //
     // Do small cell redistribution on one FAB
     //
+    namespace {
     void apply_eb_redistribution ( const Box& bx,
                                    MultiFab& div_mf,
                                    MultiFab& divc_mf,
@@ -53,6 +54,7 @@ namespace amrex {
         auto const&        vfrac = volfrac->array(*mfi);
 
         apply_flux_redistribution ( bx, div, divc, wt, icomp, ncomp, flags, vfrac, geom, use_wts_in_divnc);
+    }
     }
 
     //

--- a/Src/EB/AMReX_EB_STL_utils.H
+++ b/Src/EB/AMReX_EB_STL_utils.H
@@ -26,13 +26,13 @@ public:
         [[nodiscard]] Real cent (int d) const
         {
             static_assert(sizeof(XDim3) == sizeof(Real)*3);
-            return Real(1./3.)*((&v1.x)[d] + (&v2.x)[d] + (&v3.x)[d]);
+            return Real(1./3.)*((&v1.x)[d] + (&v2.x)[d] + (&v3.x)[d]); // NOLINT(clang-analyzer-security.ArrayBound)
         }
 
         [[nodiscard]] std::pair<Real,Real> minmax (int d) const
         {
             static_assert(sizeof(XDim3) == sizeof(Real)*3);
-            return std::minmax({(&v1.x)[d], (&v2.x)[d], (&v3.x)[d]});
+            return std::minmax({(&v1.x)[d], (&v2.x)[d], (&v3.x)[d]}); // NOLINT(clang-analyzer-security.ArrayBound)
         }
     };
     /// \endcond

--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -472,8 +472,8 @@ STLtools::read_binary_stl_file (std::string const& fname, Real scale,
             RealDescriptor::convertToNativeFormat(p, 9, tmp+12, real32_descr);
             for (int j = 0; j < 3; ++j) {
                 p[0] = p[0] * scale + center[0];
-                p[1] = p[1] * scale + center[1];
-                p[2] = p[2] * scale + center[2];
+                p[1] = p[1] * scale + center[1]; // NOLINT(clang-analyzer-security.ArrayBound)
+                p[2] = p[2] * scale + center[2]; // NOLINT(clang-analyzer-security.ArrayBound)
                 p += 3;
             }
             if (reverse_normal) {

--- a/Src/EB/AMReX_EB_Slopes_2D_K.H
+++ b/Src/EB/AMReX_EB_Slopes_2D_K.H
@@ -675,8 +675,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
         for(int jj(0); jj<=1; jj++){
             for(int ii(-1); ii<=1; ii++){
                 if ( flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0) ) {
-                    if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                    if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                    q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                    q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                 }
             }
         }
@@ -698,8 +698,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
         for(int jj(-1); jj<=0; jj++){
             for(int ii(-1); ii<=1; ii++){
                 if ( flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0) ) {
-                    if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                    if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                    q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                    q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                 }
             }
         }
@@ -720,8 +720,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
         for(int jj(-1); jj<=1; jj++){
             for(int ii(0); ii<=1; ii++){
                 if ( flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0) ) {
-                    if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                    if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                    q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                    q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                 }
             }
         }
@@ -742,8 +742,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
         for(int jj(-1); jj<=1; jj++){
             for(int ii(-1); ii<=0; ii++){
                 if( flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0)) {
-                    if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                    if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                    q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                    q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                 }
             }
         }

--- a/Src/EB/AMReX_EB_Slopes_3D_K.H
+++ b/Src/EB/AMReX_EB_Slopes_3D_K.H
@@ -815,8 +815,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
             for(int jj(0); jj<=1; jj++){
                 for(int ii(-1); ii<=1; ii++){
                     if (flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0 && kk==0)) {
-                        if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                        if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                        q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                        q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                     }
                 }
             }
@@ -843,8 +843,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
             for(int jj(-1); jj<=0; jj++){
                 for(int ii(-1); ii<=1; ii++){
                     if (flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0 && kk==0)) {
-                        if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                        if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                        q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                        q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                     }
                 }
             }
@@ -871,8 +871,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
             for(int jj(-1); jj<=1; jj++){
                 for(int ii(0); ii<=1; ii++){
                     if (flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0 && kk==0)) {
-                        if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                        if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                        q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                        q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                     }
                 }
             }
@@ -899,8 +899,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
             for(int jj(-1); jj<=1; jj++){
                 for(int ii(-1); ii<=0; ii++){
                     if (flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0 && kk==0)) {
-                        if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                        if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                        q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                        q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                     }
                 }
             }
@@ -926,8 +926,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
             for(int jj(-1); jj<=1; jj++){
                 for(int ii(-1); ii<=1; ii++){
                     if (flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0 && kk==0)) {
-                        if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                        if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                        q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                        q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                     }
                 }
             }
@@ -953,8 +953,8 @@ amrex_calc_alpha_limiter(int i, int j, int k, int n,
             for(int jj(-1); jj<=1; jj++){
                 for(int ii(-1); ii<=1; ii++){
                     if (flag(i,j,k).isConnected(ii,jj,kk) && !(ii==0 && jj==0 && kk==0)) {
-                        if (state(i+ii,j+jj,k+kk,n) > q_max) { q_max = state(i+ii,j+jj,k+kk,n); }
-                        if (state(i+ii,j+jj,k+kk,n) < q_min) { q_min = state(i+ii,j+jj,k+kk,n); }
+                        q_max = std::max(state(i+ii,j+jj,k+kk,n), q_max);
+                        q_min = std::min(state(i+ii,j+jj,k+kk,n), q_min);
                     }
                 }
             }

--- a/Src/EB/AMReX_EB_chkpt_file.cpp
+++ b/Src/EB/AMReX_EB_chkpt_file.cpp
@@ -145,9 +145,9 @@ ChkptFile::read_from_chkpt_file (BoxArray& cut_grids, BoxArray& covered_grids,
         int i = 0;
         while (lis >> word) {
 #ifdef AMREX_USE_FLOAT
-            prob_lo[i++] = std::stof(word);
+            prob_lo[i++] = std::stof(word); // NOLINT(clang-analyzer-security.ArrayBound)
 #else
-            prob_lo[i++] = std::stod(word);
+            prob_lo[i++] = std::stod(word); // NOLINT(clang-analyzer-security.ArrayBound)
 #endif
         }
     }
@@ -158,9 +158,9 @@ ChkptFile::read_from_chkpt_file (BoxArray& cut_grids, BoxArray& covered_grids,
         int i = 0;
         while (lis >> word) {
 #ifdef AMREX_USE_FLOAT
-            prob_hi[i++] = std::stof(word);
+            prob_hi[i++] = std::stof(word); // NOLINT(clang-analyzer-security.ArrayBound)
 #else
-            prob_hi[i++] = std::stod(word);
+            prob_hi[i++] = std::stod(word); // NOLINT(clang-analyzer-security.ArrayBound)
 #endif
         }
     }

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -19,7 +19,7 @@ void FillSignedDistance (MultiFab& mf, bool fluid_has_positive_sign)
 }
 
 /// \cond DOXYGEN_IGNORE
-namespace detail
+namespace
 {
 // Purpose: Given a collision between particle and EB surface, and
 // given that a neighbour cell owns the EB surface, a collision between
@@ -382,7 +382,7 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
                         AMREX_D_TERM(vi_x = static_cast<int>(std::floor(eb_min_x * dxinv));,
                                      vi_y = static_cast<int>(std::floor(eb_min_y * dyinv));,
                                      vi_z = static_cast<int>(std::floor(eb_min_z * dzinv)));
-                        auto c_vec = detail::facets_nearest_pt
+                        auto c_vec = facets_nearest_pt
                             ({AMREX_D_DECL(vi_x,vi_y,vi_z)}, {AMREX_D_DECL(vi_cx, vi_cy, vi_cz)},
                              {AMREX_D_DECL(x,y,z)}, {AMREX_D_DECL(nx,ny,nz)},
                              {AMREX_D_DECL(cx,cy,cz)}, dx_eb);

--- a/Src/Extern/Bittree/AMReX_Bittree.cpp
+++ b/Src/Extern/Bittree/AMReX_Bittree.cpp
@@ -118,10 +118,12 @@ void btUnit::btCalculateLevel (BittreeAmr* const mesh, int lev,
       //Get coordinates and morton index.
       auto b = tree1->locate(i);
 
+#if 0
       if(b.level != lev) {
           std::string msg = "Error identifying block in btCalculateGrids";
           //throw error?
       }
+#endif
 
       IntVect coordVec{AMREX_D_DECL(static_cast<int>(b.coord[0]),
                                     static_cast<int>(b.coord[1]),

--- a/Src/Extern/HYPRE/AMReX_Hypre.H
+++ b/Src/Extern/HYPRE/AMReX_Hypre.H
@@ -42,7 +42,13 @@ public:
 
     static HYPRE_Int ispow2 (HYPRE_Int i)
     {
-        return (i == 1) ? 1 : (((i <= 0) || (i & 1)) ? 0 : ispow2(i / 2));
+        if (i == 1) {
+            return 1;
+        } else if ((i <= 0) || (i & 1)) {
+            return 0;
+        } else {
+            return ispow2(i/2);
+        }
     }
 
     static Array<HYPRE_Int,AMREX_SPACEDIM> loV (const Box& b) {

--- a/Src/Extern/HYPRE/AMReX_HypreMLABecLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreMLABecLap.cpp
@@ -318,7 +318,7 @@ void HypreMLABecLap::addNonStencilEntriesToGraph ()
             Gpu::streamSynchronize();
 #endif
             AMREX_ASSERT(c2f_total_to < Long(std::numeric_limits<int>::max()));
-            m_c2f_total_from[clev][mfi] = int(c2f_total_from);
+            m_c2f_total_from[clev][mfi] = c2f_total_from;
             m_c2f_total_to[clev][mfi] = int(c2f_total_to);
         }
 
@@ -1184,7 +1184,7 @@ void HypreMLABecLap::commBCoefs (int flev, Array<MultiFab const*,AMREX_SPACEDIM>
             {
                 IntVect ivm(AMREX_D_DECL(i,j,k));
                 ivm[idim] -= 1;
-                int is_cf = (fmask_a(i,j,k) != fmask_a(ivm));
+                bool is_cf = (fmask_a(i,j,k) != fmask_a(ivm));
                 int psum = tot;
                 tot += int(is_cf);
                 offset_a(i,j,k) = is_cf ? psum*nfaces : -1;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -6302,14 +6302,14 @@ void mlndlap_fillijmat_sten_cpu (Box const& ndbx,
                                  Real* mat, // NOLINT(readability-non-const-parameter)
                                  Array4<Real const> const& sten) noexcept
 {
-    constexpr int ist_000 = 1-1;
-    constexpr int ist_p00 = 2-1;
-    constexpr int ist_0p0 = 3-1;
-    constexpr int ist_00p = 4-1;
-    constexpr int ist_pp0 = 5-1;
-    constexpr int ist_p0p = 6-1;
-    constexpr int ist_0pp = 7-1;
-    constexpr int ist_ppp = 8-1;
+    constexpr int ist_000 = 0;
+    constexpr int ist_p00 = 1;
+    constexpr int ist_0p0 = 2;
+    constexpr int ist_00p = 3;
+    constexpr int ist_pp0 = 4;
+    constexpr int ist_p0p = 5;
+    constexpr int ist_0pp = 6;
+    constexpr int ist_ppp = 7;
 
     constexpr auto gidmax = std::numeric_limits<AtomicInt>::max();
     HypreInt nelems = 0;

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1474,7 +1474,7 @@ public:
 #include "AMReX_ParticlesHDF5.H"
 #endif
 
-public:
+public: // NOLINT(readability-redundant-access-specifiers)
     /** Overwrite the default names for the compile-time SoA components */
     void SetSoACompileTimeNames (std::vector<std::string> const & rdata_name, std::vector<std::string> const & idata_name);
 

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -84,7 +84,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             for (int i=0; i<AMREX_SPACEDIM; ++i) { tile_size[i] = tilesize[i]; }
         }
 
-        static_assert(std::is_standard_layout<ParticleType>::value,
+        static_assert(std::is_standard_layout_v<ParticleType>,
                       "Particle type must be standard layout");
         //                   && std::is_trivial<ParticleType>::value,
         //                      "Particle type must be standard layout and trivial.");
@@ -856,7 +856,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         return;
     }
 
-    std::string aggregation_type = AggregationType();
+    std::string const& aggregation_type = AggregationType();
     int aggregation_buffer = AggregationBuffer();
 
     if (aggregation_type == "None")

--- a/Tests/LinearSolvers/CellEB/MyEB.H
+++ b/Tests/LinearSolvers/CellEB/MyEB.H
@@ -24,7 +24,7 @@ public:
           m_sign(a_inside ? 1.0 : -1.0)
         {}
 
-    AMREX_GPU_HOST_DEVICE inline
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator() (AMREX_D_DECL(amrex::Real x, amrex::Real y, amrex::Real))
         const noexcept
     {
@@ -35,7 +35,7 @@ public:
         return m_sign*(r - m_r - m_dr * std::cos(m_npetals*theta));
     }
 
-    inline amrex::Real operator() (const amrex::RealArray& p) const noexcept
+    AMREX_FORCE_INLINE amrex::Real operator() (const amrex::RealArray& p) const noexcept
     {
         return this->operator() (AMREX_D_DECL(p[0], p[1], p[2]));
     }

--- a/Tests/LinearSolvers/CellEB2/MyEB.H
+++ b/Tests/LinearSolvers/CellEB2/MyEB.H
@@ -29,7 +29,7 @@ public:
     FlowerIF& operator= (const FlowerIF& rhs) = delete;
     FlowerIF& operator= (FlowerIF&& rhs) = delete;
 
-    AMREX_GPU_HOST_DEVICE inline
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator() (AMREX_D_DECL(amrex::Real x, amrex::Real y, amrex::Real z))
         const noexcept
     {
@@ -40,7 +40,7 @@ public:
         return m_sign*(r - m_r - m_dr * std::cos(m_npetals*theta));
     }
 
-    inline amrex::Real operator() (const amrex::RealArray& p) const noexcept
+    AMREX_FORCE_INLINE amrex::Real operator() (const amrex::RealArray& p) const noexcept
     {
         return this->operator() (AMREX_D_DECL(p[0], p[1], p[2]));
     }

--- a/Tests/LinearSolvers/EBConvergenceTest/MyEB.H
+++ b/Tests/LinearSolvers/EBConvergenceTest/MyEB.H
@@ -29,7 +29,7 @@ public:
     FlowerIF& operator= (const FlowerIF& rhs) = delete;
     FlowerIF& operator= (FlowerIF&& rhs) = delete;
 
-    AMREX_GPU_HOST_DEVICE inline
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator() (AMREX_D_DECL(amrex::Real x, amrex::Real y, amrex::Real z))
         const noexcept
     {
@@ -40,7 +40,7 @@ public:
         return m_sign*(r - m_r - m_dr * std::cos(m_npetals*theta));
     }
 
-    inline amrex::Real operator() (const amrex::RealArray& p) const noexcept
+    AMREX_FORCE_INLINE amrex::Real operator() (const amrex::RealArray& p) const noexcept
     {
         return this->operator() (AMREX_D_DECL(p[0], p[1], p[2]));
     }

--- a/Tests/LinearSolvers/EBflux_grad/MyEB.H
+++ b/Tests/LinearSolvers/EBflux_grad/MyEB.H
@@ -29,7 +29,7 @@ public:
     FlowerIF& operator= (const FlowerIF& rhs) = delete;
     FlowerIF& operator= (FlowerIF&& rhs) = delete;
 
-    AMREX_GPU_HOST_DEVICE inline
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator() (AMREX_D_DECL(amrex::Real x, amrex::Real y, amrex::Real z))
         const noexcept
     {
@@ -40,7 +40,7 @@ public:
         return m_sign*(r - m_r - m_dr * std::cos(m_npetals*theta));
     }
 
-    inline amrex::Real operator() (const amrex::RealArray& p) const noexcept
+    AMREX_FORCE_INLINE amrex::Real operator() (const amrex::RealArray& p) const noexcept
     {
         return this->operator() (AMREX_D_DECL(p[0], p[1], p[2]));
     }

--- a/Tests/LinearSolvers/LeastSquares/MyEB.H
+++ b/Tests/LinearSolvers/LeastSquares/MyEB.H
@@ -29,7 +29,7 @@ public:
     FlowerIF& operator= (const FlowerIF& rhs) = delete;
     FlowerIF& operator= (FlowerIF&& rhs) = delete;
 
-    AMREX_GPU_HOST_DEVICE inline
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::Real operator() (AMREX_D_DECL(amrex::Real x, amrex::Real y, amrex::Real z))
         const noexcept
     {
@@ -40,7 +40,7 @@ public:
         return m_sign*(r - m_r - m_dr * std::cos(m_npetals*theta));
     }
 
-    inline amrex::Real operator() (const amrex::RealArray& p) const noexcept
+    AMREX_FORCE_INLINE amrex::Real operator() (const amrex::RealArray& p) const noexcept
     {
         return this->operator() (AMREX_D_DECL(p[0], p[1], p[2]));
     }

--- a/Tools/C_scripts/mmclt.py
+++ b/Tools/C_scripts/mmclt.py
@@ -35,12 +35,12 @@ def mmclt(argv):
     fout.write("clang-tidy: $$(all_targets)\n")
     fout.write("\t@echo SUCCESS\n\n")
 
-    exe_re = re.compile(r" Executing .*? (-.*{}.*) -c .* -o .* (\S*)".format(args.identifier))
+    exe_re = re.compile(r" Executing .*? (-.*{}.*) -c(?: \S+)* -o .* (\S*)".format(args.identifier))
 
     count = 0
     for line in fin.readlines():
         ret_exe_re = exe_re.search(line)
-        if (ret_exe_re):
+        if ret_exe_re:
             fout.write("target_{}: {}\n".format(count, ret_exe_re.group(2)))
             fout.write("\t$(CLANG_TIDY) $(CLANG_TIDY_ARGS) $< -- {}\n".format
                        (ret_exe_re.group(1)))


### PR DESCRIPTION
ccache 4.12 has a slight new different format in its log. So We have to update our python script processing and generating makefile for clang-tidy.

Fix new warnings from clang-tidy-21. We missed them because we switched to ccache-4.12 before switching to clang-tidy-21.

Also enable clang-tidy for the C++20 test.
