### PR TITLE
Add Gpu::SyncAtExit and Gpu::streamSyncActive

### DIFF
--- a/Src/Base/AMReX_GpuControl.H
+++ b/Src/Base/AMReX_GpuControl.H
@@ -177,8 +177,8 @@ namespace Gpu {
 
     /**
      * This struct provides a RAII-style mechanism for disabling GPU
-     * synchronization in MFITer by default.  Note that explicit calls to
-     * Gpu::steramSynchronize and Gpu::deviceSynchronize still work.
+     * synchronization in MFIter by default.  Note that explicit calls to
+     * Gpu::streamSynchronize and Gpu::synchronize still work.
      */
     struct [[nodiscard]] NoSyncRegion
     {
@@ -188,7 +188,9 @@ namespace Gpu {
 
         ~NoSyncRegion () { in_nosync_region = m_prev_flag; }
 
-    private:
+        [[nodiscard]] bool inNoSyncRegionPreviously () const { return m_prev_flag; }
+
+    protected:
         bool m_prev_flag;
     };
 
@@ -217,7 +219,9 @@ namespace Gpu {
     [[nodiscard]] inline constexpr bool setSingleStreamRegion (bool) { return false; }
     [[nodiscard]] inline constexpr bool setNoSyncRegion (bool) { return true; }
     struct [[nodiscard]] SingleStreamRegion {};
-    struct [[nodiscard]] NoSyncRegion {};
+    struct [[nodiscard]] NoSyncRegion {
+        [[nodiscard]] constexpr bool inNoSyncRegionPreviously () const { return true; }
+    };
 
 #endif
 

--- a/Src/Base/AMReX_GpuControl.H
+++ b/Src/Base/AMReX_GpuControl.H
@@ -220,7 +220,7 @@ namespace Gpu {
     [[nodiscard]] constexpr bool setNoSyncRegion (bool) { return true; }
     struct [[nodiscard]] SingleStreamRegion {};
     struct [[nodiscard]] NoSyncRegion {
-        [[nodiscard]] constexpr bool inNoSyncRegionPreviously () const { return true; }
+        static constexpr bool inNoSyncRegionPreviously () { return true; }
     };
 
 #endif

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -119,6 +119,13 @@ public:
     static void streamSynchronize () noexcept;
 
     /**
+     * Halt execution of code until all active AMReX GPU streams have finished processing all
+     * previously requested tasks. If we are in single stream region, only stream 0 is
+     * considered active. Otherwise all streams are active.
+     */
+    static void streamSynchronizeActive () noexcept;
+
+    /**
      * Halt execution of code until all AMReX GPU streams have finished processing all
      * previously requested tasks.
      */
@@ -263,6 +270,12 @@ inline void
 streamSynchronize () noexcept
 {
     Device::streamSynchronize();
+}
+
+inline void
+streamSynchronizeActive () noexcept
+{
+    Device::streamSynchronizeActive();
 }
 
 inline void
@@ -437,6 +450,30 @@ void memcpy_from_device_global_to_host_async (void* dst, T const& dg,
     std::memcpy(dst, p+offset, nbytes);
 #endif
 }
+
+#ifdef AMREX_USE_GPU
+
+/**
+ * This struct provides a RAII-style mechanism for disabling GPU
+ * synchronization and calling Gpu::streamSynchronizeActive when going out
+ * of scope if we are in sync region previously. Note that explicit calls to
+ * Gpu::streamSynchronize and Gpu::synchronize still work.
+ */
+struct [[nodiscard]] SyncAtExitOnly
+    : public NoSyncRegion
+{
+    ~SyncAtExitOnly () {
+        if (! inNoSyncRegionPreviously())
+            Gpu::streamSynchronizeActive();
+        }
+    }
+};
+
+#else
+
+struct [[nodiscard]] SyncAtExitOnly {};
+
+#endif
 
 }
 

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -463,7 +463,7 @@ struct [[nodiscard]] SyncAtExitOnly
     : public NoSyncRegion
 {
     ~SyncAtExitOnly () {
-        if (! inNoSyncRegionPreviously())
+        if (! inNoSyncRegionPreviously()) {
             Gpu::streamSynchronizeActive();
         }
     }

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -766,6 +766,18 @@ Device::streamSynchronize () noexcept
 }
 
 void
+Device::streamSynchronizeActive () noexcept
+{
+#ifdef AMREX_USE_GPU
+    if (Gpu::inSingleStreamRegion()) {
+        Gpu::streamSynchronize();
+    } else {
+        Gpu::streamSynchronizeAll();
+    }
+#endif
+}
+
+void
 Device::streamSynchronizeAll () noexcept
 {
 #ifdef AMREX_USE_GPU


### PR DESCRIPTION
These could be potentially useful. It should not change any current behavior because they are not being used.