### PR TITLE
add ReduceToPlaneMF2Patchy

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -471,7 +471,8 @@ namespace amrex
      * \tparam F   callable type like a lambda function
      *
      * \param direction normal direction of the plane (e.g., 0, 1 and 2)
-     * \param domain    domain Box
+     * \param domain    domain Box. For patchy inputs this must cover the full
+     *                  extent of mf.boxArray() (subdomains are not supported).
      * \param mf        a FabArray/MultiFab object specifying the iteration space
      * \param f         a callable object returning data for reduction. It takes
      *                  four ints, where the first int is the local box index and
@@ -1457,12 +1458,15 @@ template <typename Op, typename FA, typename F,
 std::pair<FA,FA>
 ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf, F const& f)
 {
-    using T = typename FA::value_type;
-
-    T initval;
-    Op().init(initval);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(mf.is_cell_centered(), "ReduceToPlaneMF2Patchy: only cell-centered data is supported.");
 
     Box const ndomain = amrex::convert(domain, mf.ixType());
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ndomain.contains(mf.boxArray().minimalBox()),
+        "ReduceToPlaneMF2Patchy: subdomains are not supported; domain must cover the full extent of mf.boxArray().");
+
+    using T = typename FA::value_type;
+    T initval;
+    Op().init(initval);
 
     BoxList bl_patch2d = mf.boxArray().boxList();
     for (auto& b : bl_patch2d) {

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -457,6 +457,39 @@ namespace amrex
     ReduceToPlaneMF2 (int direction, Box const& domain, FA const& mf, F const& f);
 
     /**
+     * \brief Reduce FabArray/MultiFab data to plane FabArray for patchy BoxArrays
+     *
+     * This function is similar to ReduceToPlaneMF2, but it supports
+     * non-rectangular (patchy) input BoxArrays. The return data are a pair
+     * of FabArrays. The first FA stores local per-box reduction results on
+     * a projected BoxArray that can contain overlapping Boxes. The second
+     * FA stores globally accumulated results on a unique projected 2D
+     * BoxArray.
+     *
+     * \tparam Op  reduce operator (Must be ReduceSum for now.)
+     * \tparam FA  Type of FabArray
+     * \tparam F   callable type like a lambda function
+     *
+     * \param direction normal direction of the plane (e.g., 0, 1 and 2)
+     * \param domain    domain Box
+     * \param mf        a FabArray/MultiFab object specifying the iteration space
+     * \param f         a callable object returning data for reduction. It takes
+     *                  four ints, where the first int is the local box index and
+     *                  the others are spatial indices for x, y, and z-directions.
+     *
+     * \return reduction result (std::pair<FA,FA>)
+     */
+    template <typename Op, typename FA, typename F,
+              std::enable_if_t<IsMultiFabLike_v<FA>
+#ifndef AMREX_USE_CUDA
+                               && IsCallableR<typename FA::value_type,
+                                              F,int,int,int,int>::value
+#endif
+                               , int> FOO = 0>
+    std::pair<FA,FA>
+    ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf, F const& f);
+
+    /**
      * \brief Sum MultiFab data to line
      *
      * Return a HostVector that contains the sum of the given MultiFab data in the plane
@@ -1404,6 +1437,55 @@ ReduceToPlaneMF2 (int direction, Box const& domain, FA const& mf, F const& f)
 
     BoxArray ba2d(std::move(bl2d));
     DistributionMapping dm2d(std::move(procmap2d));
+
+    FA mf2d(ba2d, dm2d, 1, 0);
+    mf2d.setVal(initval);
+
+    static_assert(std::is_same_v<Op, ReduceOpSum>, "Currently only ReduceOpSum is supported.");
+    mf2d.ParallelAdd(tmpmf);
+
+    return std::make_pair(std::move(tmpmf), std::move(mf2d));
+}
+
+template <typename Op, typename FA, typename F,
+          std::enable_if_t<IsMultiFabLike_v<FA>
+#ifndef AMREX_USE_CUDA
+                           && IsCallableR<typename FA::value_type,
+                                          F,int,int,int,int>::value
+#endif
+                           , int> FOO>
+std::pair<FA,FA>
+ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf, F const& f)
+{
+    using T = typename FA::value_type;
+
+    T initval;
+    Op().init(initval);
+
+    Box const ndomain = amrex::convert(domain, mf.ixType());
+
+    BoxList bl_patch2d = mf.boxArray().boxList();
+    for (auto& b : bl_patch2d) {
+        b.setRange(direction, 0);
+    }
+    BoxArray ba_patch2d(std::move(bl_patch2d));
+    FA tmpmf(ba_patch2d, mf.DistributionMap(), 1, 0);
+    tmpmf.setVal(initval);
+
+    for (MFIter mfi(mf); mfi.isValid(); ++mfi)
+    {
+        Box bx = mfi.validbox() & ndomain;
+        if (bx.ok()) {
+            int box_no = mfi.LocalIndex();
+            detail::reduce_to_plane<Op, T>(tmpmf.array(mfi), direction, bx, box_no, f);
+        }
+    }
+
+    BoxList bl_unique = ba_patch2d.boxList();
+    bl_unique.simplify();
+    BoxArray ba2d(std::move(bl_unique));
+    ba2d.removeOverlap();
+    DistributionMapping dm2d(ba2d);
 
     FA mf2d(ba2d, dm2d, 1, 0);
     mf2d.setVal(initval);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -127,7 +127,7 @@ else()
    #
    set( AMREX_TESTS_SUBDIRS Amr ArrayND AsyncOut CallNoinline CLZ CommType CTOParFor DeviceGlobal
                             Enum HeatEquation MultiBlock MultiPeriod ParmParse Parser
-                            Parser2 ParserUserFn Reducer Reinit RoundoffDomain SIMD SmallMatrix SumBoundary)
+                            Parser2 ParserUserFn Reducer ReduceToPlanePatchy Reinit RoundoffDomain SIMD SmallMatrix SumBoundary)
 
    if (AMReX_PARTICLES)
      list(APPEND AMREX_TESTS_SUBDIRS Particles)

--- a/Tests/ReduceToPlanePatchy/CMakeLists.txt
+++ b/Tests/ReduceToPlanePatchy/CMakeLists.txt
@@ -1,0 +1,9 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources     main.cpp)
+    set(_input_files)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/ReduceToPlanePatchy/GNUmakefile
+++ b/Tests/ReduceToPlanePatchy/GNUmakefile
@@ -1,0 +1,24 @@
+AMREX_HOME := ../..
+
+DEBUG	= FALSE
+
+DIM	= 3
+
+COMP    = gcc
+
+USE_MPI   = FALSE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+USE_HIP   = FALSE
+USE_SYCL  = FALSE
+
+BL_NO_FORT = TRUE
+
+TINY_PROFILE = FALSE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/ReduceToPlanePatchy/Make.package
+++ b/Tests/ReduceToPlanePatchy/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/ReduceToPlanePatchy/main.cpp
+++ b/Tests/ReduceToPlanePatchy/main.cpp
@@ -1,0 +1,84 @@
+#include <AMReX.H>
+#include <AMReX_Array4.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_MFIter.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_MultiFabUtil.H>
+#include <algorithm>
+#include <cmath>
+
+using namespace amrex;
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+
+    {
+        constexpr int dir = 0;
+        const Box domain(IntVect(0), IntVect(AMREX_D_DECL(7, 7, 7)));
+
+        // Patchy BoxArray: leaves a gap in x so this is not a rectangular domain coverage.
+        BoxList bl;
+        bl.push_back(Box(IntVect(AMREX_D_DECL(0, 0, 0)), IntVect(AMREX_D_DECL(1, 7, 7))));
+        bl.push_back(Box(IntVect(AMREX_D_DECL(4, 0, 0)), IntVect(AMREX_D_DECL(5, 7, 7))));
+        bl.push_back(Box(IntVect(AMREX_D_DECL(6, 0, 0)), IntVect(AMREX_D_DECL(7, 7, 7))));
+
+        BoxArray ba(std::move(bl));
+        DistributionMapping dm(ba);
+        MultiFab mf(ba, dm, 1, 0);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(mf); mfi.isValid(); ++mfi) {
+            auto const& a = mf.array(mfi);
+            Box const& bx = mfi.validbox();
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                a(i,j,k) = static_cast<Real>(1 + i + 10*j + 100*k);
+            });
+        }
+
+        auto const& ma = mf.const_arrays();
+
+        // Reference: BaseFab plane reduction (works on patchy layouts).
+        auto ref_plane = ReduceToPlane<ReduceOpSum,Real>(dir, domain, mf,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) -> Real
+            {
+                return ma[box_no](i,j,k);
+            });
+
+        auto [plane_patch, plane_unique] = ReduceToPlaneMF2Patchy<ReduceOpSum>(dir, domain, mf,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) -> Real
+            {
+                return ma[box_no](i,j,k);
+            });
+
+        // Sanity: one projected FAB per input FAB.
+        AMREX_ALWAYS_ASSERT(plane_patch.size() == mf.size());
+
+        Gpu::streamSynchronize();
+
+        // Compare unique sparse result to reference plane on overlapping cells.
+        Real max_err = 0.0;
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion()) reduction(max:max_err)
+#endif
+        for (MFIter mfi(plane_unique); mfi.isValid(); ++mfi) {
+            auto const& pa = plane_unique.const_array(mfi);
+            Box const& bx = mfi.validbox();
+            Real local_max = 0.0;
+            AMREX_LOOP_3D(bx, i, j, k,
+            {
+                local_max = std::max(local_max, std::abs(pa(i,j,k) - ref_plane(IntVect(AMREX_D_DECL(i, j, k)))));
+            });
+            max_err = std::max(max_err, local_max);
+        }
+
+        AMREX_ALWAYS_ASSERT(max_err == 0.0);
+    }
+
+    amrex::Finalize();
+    return 0;
+}

--- a/Tests/ReduceToPlanePatchy/main.cpp
+++ b/Tests/ReduceToPlanePatchy/main.cpp
@@ -28,9 +28,6 @@ int main (int argc, char* argv[])
         DistributionMapping dm(ba);
         MultiFab mf(ba, dm, 1, 0);
 
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
         for (MFIter mfi(mf); mfi.isValid(); ++mfi) {
             auto const& a = mf.array(mfi);
             Box const& bx = mfi.validbox();
@@ -64,9 +61,6 @@ int main (int argc, char* argv[])
 
         // Compare unique sparse result to reference plane on overlapping cells.
         Real max_err = 0.0;
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (Gpu::notInLaunchRegion()) reduction(max:max_err)
-#endif
         for (MFIter mfi(plane_unique); mfi.isValid(); ++mfi) {
             auto const& pa = plane_unique.const_array(mfi);
             Box const& bx = mfi.validbox();

--- a/Tests/ReduceToPlanePatchy/main.cpp
+++ b/Tests/ReduceToPlanePatchy/main.cpp
@@ -48,6 +48,8 @@ int main (int argc, char* argv[])
             {
                 return ma[box_no](i,j,k);
             });
+        ParallelDescriptor::ReduceRealSum(ref_plane.dataPtr(),
+                                          static_cast<int>(ref_plane.box().numPts()));
 
         auto [plane_patch, plane_unique] = ReduceToPlaneMF2Patchy<ReduceOpSum>(dir, domain, mf,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) -> Real


### PR DESCRIPTION
## Summary
Adds `ReduceToPlaneMF2Patchy` to reduce a sparse 3D MultiFab to a sparse 2D MultiFab without constructing a full-domain 2D BaseFab. This should produce the same result as `ReduceToPlane` up to machine precision, but with less memory usage.

## Additional background
`ReduceToPlane` does not work in practice if the 2D plane is larger than INT_MAX (unless the MPI implementation is fully compliant with the MPI-4 large count specification). Even in this case, the memory usage may be excessive.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
