### PR TITLE
[LinearSolvers] Fix bug in setBCoeffs(Vector)

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -391,7 +391,7 @@ MLABecLaplacianT<MF>::setBCoeffs (int amrlev, Vector<T> const& beta)
     const int ncomp = this->getNComp();
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         for (int icomp = 0; icomp < ncomp; ++icomp) {
-            m_b_coeffs[amrlev][0][idim].setVal(RT(beta[icomp]));
+            m_b_coeffs[amrlev][0][idim].setVal(RT(beta[icomp], icomp, 1, 0));
         }
     }
     m_needs_update = true;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -180,7 +180,7 @@ MLEBABecLap::setBCoeffs (int amrlev, Vector<Real> const& beta)
     const int ncomp = getNComp();
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         for (int icomp = 0; icomp < ncomp; ++icomp) {
-            m_b_coeffs[amrlev][0][idim].setVal(beta[icomp]);
+            m_b_coeffs[amrlev][0][idim].setVal(beta[icomp], icomp, 1, 0);
         }
     }
     m_needs_update = true;


### PR DESCRIPTION
Close #4961
