### PR TITLE
prevent auto-converting const char * to bool in ParmParse::add

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -614,6 +614,8 @@ public:
     //! Add a key 'name' with value 'val' to the end of the PP table.
     void add (std::string_view name, const std::string& val);
 
+    //! Convert const char * to string, to prevent auto-conversion to bool
+    void add(const char* name, const char* val) { add(name, std::string(val)); }
 
     //! Similar to get() but store the whole line including empty spaces in
     //! the middle if present as a single string. For example, `foo = a b c`

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -617,12 +617,6 @@ public:
     //! Convert const char * to string, to prevent auto-conversion to bool
     void add (std::string_view name, const char* val) { add(name, std::string(val)); }
 
-    //! Special overload for 0 to avoid issues with add("key", 0) calling
-    //! the const char* version.
-    void add (std::string_view name, std::integral_constant<int, 0>) {
-        add(name, int(0));
-    }
-
     //! Similar to get() but store the whole line including empty spaces in
     //! the middle if present as a single string. For example, `foo = a b c`
     //! is treated by this function as a single string "a b c", whereas

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -617,8 +617,8 @@ public:
     //! Convert const char * to string, to prevent auto-conversion to bool
     void add (std::string_view name, const char* val) { add(name, std::string(val)); }
 
-    //! Special overload for 0 to avoid issues with add("key", 0) calling                                                                                                    
-    //! the const char* version.                                                                                                                                             
+    //! Special overload for 0 to avoid issues with add("key", 0) calling
+    //! the const char* version.
     void add (std::string_view name, std::integral_constant<int, 0>) {
         add(name, int(0));
     }

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -615,7 +615,13 @@ public:
     void add (std::string_view name, const std::string& val);
 
     //! Convert const char * to string, to prevent auto-conversion to bool
-    void add(const char* name, const char* val) { add(name, std::string(val)); }
+    void add (std::string_view name, const char* val) { add(name, std::string(val)); }
+
+    //! Special overload for 0 to avoid issues with add("key", 0) calling                                                                                                    
+    //! the const char* version.                                                                                                                                             
+    void add (std::string_view name, std::integral_constant<int, 0>) {
+        add(name, int(0));
+    }
 
     //! Similar to get() but store the whole line including empty spaces in
     //! the middle if present as a single string. For example, `foo = a b c`


### PR DESCRIPTION
## Summary
`ParmParse::add("key", "value")` will result in adding a boolean value (1) due to C++ converting pointer to bool.  This is almost certainly not intended.  Users must write
`add("key", std::string("value")` which is cumbersome and easy to forget.  Adding explicit `const char * -> std::string` overload removes this pitfall 

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
