### PR TITLE
Fix host_idcpu to use finest_level_in_file when restarting [Particles] [IO]

### DIFF
--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -995,7 +995,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
     Vector<std::map<std::pair<int, int>, Gpu::HostVector<uint64_t> > > host_idcpu;
     host_idcpu.reserve(15);
-    host_idcpu.resize(finestLevel()+1);
+    host_idcpu.resize(finest_level_in_file+1);
 
     for (int i = 0; i < cnt; i++) {
         // note: for pure SoA particle layouts, we do write the id, cpu and positions as a struct


### PR DESCRIPTION
Fixes Issue #4964

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
