### PR TITLE
Use Long instead of int for maxnextid in pre/post particle IO

### DIFF
--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1259,7 +1259,7 @@ public:
       return usePrePost;
     }
 
-    int GetMaxNextIDPrePost () const { return maxnextidPrePost; }
+    Long GetMaxNextIDPrePost () const { return maxnextidPrePost; }
     Long GetNParticlesPrePost () const { return nparticlesPrePost; }
 
     void SetUseUnlink (bool tf) const {
@@ -1419,7 +1419,7 @@ public:
     mutable bool levelDirectoriesCreated;
     mutable bool usePrePost;
     mutable bool doUnlink;
-    int maxnextidPrePost;
+    Long maxnextidPrePost;
     mutable int nOutFilesPrePost;
     Long nparticlesPrePost;
     Vector<Long> nParticlesAtLevelPrePost;

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -482,7 +482,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     ParallelDescriptor::ReduceLongMax(maxnextid, IOProcNumber);
 
     nparticlesPrePost = nparticles;
-    maxnextidPrePost  = int(maxnextid);
+    maxnextidPrePost  = maxnextid;
 
     nParticlesAtLevelPrePost.clear();
     nParticlesAtLevelPrePost.resize(finestLevel() + 1, 0);


### PR DESCRIPTION
Addresses Issue #5055 

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
