### PR TITLE
FFT: Early abort for unsupported path

### DIFF
--- a/Src/FFT/AMReX_FFT_R2C.H
+++ b/Src/FFT/AMReX_FFT_R2C.H
@@ -202,6 +202,9 @@ public:
     void forwardThenBackward (MF const& inmf, MF& outmf, F const& post_forward,
                               int incomp = 0, int outcomp = 0)
     {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            !m_info.twod_mode && m_info.batch_size == 1,
+            "FFT::R2C::forwardThenBackward(post_forward) currently supports only !twod_mode and batch_size==1");
         BL_PROFILE("FFT::R2C::forwardbackward");
         this->forward(inmf, incomp);
         this->post_forward_doit_0(post_forward);

--- a/Src/FFT/AMReX_FFT_R2X.H
+++ b/Src/FFT/AMReX_FFT_R2X.H
@@ -638,6 +638,9 @@ template <typename T>
 template <typename F>
 void R2X<T>::forwardThenBackward (MF const& inmf, MF& outmf, F const& post_forward)
 {
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        !m_info.twod_mode,
+        "FFT::R2X::forwardThenBackward(post_forward) does not support twod_mode yet");
     forwardThenBackward_doit_0(inmf, outmf, post_forward);
 }
 


### PR DESCRIPTION
Close #5050.
