### PR TITLE
SUNDIALS Stale Flag

### DIFF
--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -278,7 +278,7 @@ private:
         }
 
         // Set max number of steps between returns
-        ARKStepSetMaxNumSteps(arkode_mem, max_num_steps);
+        flag = ARKStepSetMaxNumSteps(arkode_mem, max_num_steps);
         AMREX_ALWAYS_ASSERT(flag == 0);
     }
 
@@ -352,7 +352,7 @@ private:
         AMREX_ALWAYS_ASSERT(flag == 0);
 
         // Set max number of steps between returns
-        ARKStepSetMaxNumSteps(arkode_fast_mem, max_num_steps);
+        flag = ARKStepSetMaxNumSteps(arkode_fast_mem, max_num_steps);
         AMREX_ALWAYS_ASSERT(flag == 0);
 
         // Wrap fast integrator as an inner stepper
@@ -443,7 +443,7 @@ private:
         }
 
         // Set max number of steps between returns
-        ARKStepSetMaxNumSteps(arkode_mem, max_num_steps);
+        flag = ARKStepSetMaxNumSteps(arkode_mem, max_num_steps);
         AMREX_ALWAYS_ASSERT(flag == 0);
     }
 


### PR DESCRIPTION
Calls to ARKStepSetMaxNumSteps do not assign their return value to flag, yet AMREX_ALWAYS_ASSERT(flag == 0) follows. The assert checks a stale value from a previous API call.

Fixes Issue #5045 

## Summary

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
