### PR TITLE
Fix impicit MRI configuration calls

### DIFF
--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -313,10 +313,10 @@ private:
             if (fast_nonlinear_solver == "fixed-point") {
                 fast_NLS = SUNNonlinSol_FixedPoint(y_data, 0, sunctx);
                 AMREX_ALWAYS_ASSERT(fast_NLS != nullptr);
-                flag = ARKStepSetNonlinearSolver(arkode_mem, fast_NLS);
+                flag = ARKStepSetNonlinearSolver(arkode_fast_mem, fast_NLS);
                 AMREX_ALWAYS_ASSERT(flag == 0);
             }
-            flag = ARKStepSetMaxNonlinIters(arkode_mem, fast_max_nonlinear_iters);
+            flag = ARKStepSetMaxNonlinIters(arkode_fast_mem, fast_max_nonlinear_iters);
             AMREX_ALWAYS_ASSERT(flag == 0);
 
             if (fast_nonlinear_solver == "Newton") {
@@ -326,7 +326,7 @@ private:
                 }
                 fast_LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, fast_max_linear_iters, sunctx);
                 AMREX_ALWAYS_ASSERT(fast_LS != nullptr);
-                flag = ARKStepSetLinearSolver(arkode_mem, fast_LS, nullptr);
+                flag = ARKStepSetLinearSolver(arkode_fast_mem, fast_LS, nullptr);
                 AMREX_ALWAYS_ASSERT(flag == 0);
             }
         }
@@ -411,10 +411,10 @@ private:
             if (nonlinear_solver == "fixed-point") {
                 NLS = SUNNonlinSol_FixedPoint(y_data, 0, sunctx);
                 AMREX_ALWAYS_ASSERT(NLS != nullptr);
-                flag = ARKStepSetNonlinearSolver(arkode_mem, NLS);
+                flag = MRIStepSetNonlinearSolver(arkode_mem, NLS);
                 AMREX_ALWAYS_ASSERT(flag == 0);
             }
-            flag = ARKStepSetMaxNonlinIters(arkode_mem, max_nonlinear_iters);
+            flag = MRIStepSetMaxNonlinIters(arkode_mem, max_nonlinear_iters);
             AMREX_ALWAYS_ASSERT(flag == 0);
 
             if (nonlinear_solver == "Newton") {
@@ -424,7 +424,7 @@ private:
                 }
                 LS = SUNLinSol_SPGMR(y_data, SUN_PREC_NONE, max_linear_iters, sunctx);
                 AMREX_ALWAYS_ASSERT(LS != nullptr);
-                flag = ARKStepSetLinearSolver(arkode_mem, LS, nullptr);
+                flag = MRIStepSetLinearSolver(arkode_mem, LS, nullptr);
                 AMREX_ALWAYS_ASSERT(flag == 0);
             }
         }
@@ -438,12 +438,12 @@ private:
         // Set a stop time
         if (set_stop_time) {
             if (amrex::Verbose()) { amrex::Print() << "Stop time: " << stop_time << "\n"; }
-          flag = ARKStepSetStopTime(arkode_mem, stop_time);
+          flag = MRIStepSetStopTime(arkode_mem, stop_time);
           AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Set max number of steps between returns
-        ARKStepSetMaxNumSteps(arkode_mem, max_num_steps);
+        MRIStepSetMaxNumSteps(arkode_mem, max_num_steps);
         AMREX_ALWAYS_ASSERT(flag == 0);
     }
 


### PR DESCRIPTION
## Summary

Corrects `Set` function calls to configure the slow integrator with an implicit MRI method. This addresses the issues noted in #5044. The calls changed from `ARKStep` to `MRIStep` would work with SUNDIALS 7.1.0 or newer (when stepper specific `Set` functions were deprecated and replaced with common `ARKode` functions) but would fail with earlier versions of SUNDIALS.

Correct `Set` functions calls to configure an implicit fast integrator in an MRI method to use a fixed-point solver, modify the max number of iterations, or set the linear solver when using a Newton solver.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
