### PR TITLE
SUNDIALS alloc-failure-output-pointer

### DIFF
--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
@@ -56,7 +56,7 @@ namespace {
         }
         else {
             std::free(mem);
-            memptr = nullptr;
+            *memptr = nullptr;
             return -1;
         }
 


### PR DESCRIPTION
Fix for #5041 

In Alloc, on arena failure the code assigns memptr = nullptr instead of *memptr = nullptr.

## Summary

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
