### PR TITLE
SIMD: Add where and ternary operator

### DIFF
--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -31,8 +31,57 @@ namespace amrex::simd
 #else
         // fallback implementations for functions that are commonly used in portable code paths
 
+        /** True if the boolean value is true (scalar identity fallback for simd any_of)
+         *
+         * Example:
+         * ```cpp
+         * // Works for both simd_mask and scalar bool:
+         * auto mask = a > b;
+         * if (amrex::simd::stdx::any_of(mask)) { ... }
+         * ```
+         *
+         * @see https://en.cppreference.com/w/cpp/experimental/simd/any_of
+         */
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         bool any_of (bool const v) { return v; }
+
+        /// \cond DOXYGEN_IGNORE
+        namespace detail {
+            template <typename T>
+            struct where_expression {
+                bool mask;
+                T& value;
+
+                AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+                void operator= (T const& new_val)
+                {
+                    if (mask) { value = new_val; }
+                }
+            };
+        }
+        /// \endcond
+
+        /** Masked assignment expression (scalar fallback for simd where)
+         *
+         * Returns an expression object whose assignment operator conditionally
+         * updates value only when mask is true.
+         *
+         * Example:
+         * ```cpp
+         * // Works for both simd<T> and scalar T:
+         * auto mask = b > T(0);
+         * T result = T(0);
+         * amrex::simd::stdx::where(mask, result) = a / b;
+         * ```
+         *
+         * @see https://en.cppreference.com/w/cpp/experimental/simd/where
+         */
+        template <typename T>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        detail::where_expression<T> where (bool const mask, T& value)
+        {
+            return {mask, value};
+        }
 #endif
     }
 
@@ -164,6 +213,46 @@ namespace amrex::simd
         constexpr bool val_arr[sizeof...(Args)] {!std::is_const_v<std::remove_reference_t<Args>>...};
         return val_arr[n];
     }
+
+    /** Vectorized ternary operator: condition(mask, true_val, false_val)
+     *
+     * Selects elements from true_val where mask is true and from false_val where
+     * mask is false. Analogous to (mask ? true_val : false_val) for scalars.
+     *
+     * Note: both true_val and false_val are eagerly evaluated (function arguments).
+     * To guard against operations like division by zero, sanitize inputs before
+     * the operation rather than relying on conditional selection.
+     *
+     * Example:
+     * ```cpp
+     * template <typename T>
+     * T compute (T const& a, T const& b)
+     * {
+     *     auto safe_b = amrex::simd::condition(b != T(0), b, T(1));
+     *     return amrex::simd::condition(b != T(0), a / safe_b, T(0));
+     * }
+     * ```
+     */
+#ifdef AMREX_USE_SIMD
+    template <typename T, typename Abi>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    stdx::simd<T, Abi> condition (
+        typename stdx::simd<T, Abi>::mask_type const& mask,
+        stdx::simd<T, Abi> const& true_val,
+        stdx::simd<T, Abi> const& false_val)
+    {
+        stdx::simd<T, Abi> result = false_val;
+        stdx::where(mask, result) = true_val;
+        return result;
+    }
+#else
+    template <typename T>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    T condition (bool const mask, T const& true_val, T const& false_val)
+    {
+        return mask ? true_val : false_val;
+    }
+#endif
 
     /** Load 1D contiguous data from array pointers
      *

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -28,6 +28,44 @@ namespace amrex::simd
 #   if __cplusplus >= 202002L
         using vir::cvt;
 #   endif
+
+        /** Vectorized ternary operator: select(mask, true_val, false_val)
+         *
+         * Selects elements from true_val where mask is true and from false_val
+         * where mask is false. Analogous to (mask ? true_val : false_val) for
+         * scalars.
+         *
+         * Note: both true_val and false_val are eagerly evaluated (function
+         * arguments). To guard against operations like division by zero,
+         * sanitize inputs before the operation rather than relying on
+         * conditional selection.
+         *
+         * Example:
+         * ```cpp
+         * template <typename T>
+         * T compute (T const& a, T const& b)
+         * {
+         *     auto safe_b = amrex::simd::stdx::select(b != T(0), b, T(1));
+         *     return amrex::simd::stdx::select(b != T(0), a / safe_b, T(0));
+         * }
+         * ```
+         *
+         * @see C++26 std::simd select
+         *
+         * @todo Remove when SIMD provider (vir-simd / C++26) provides select.
+         *       https://github.com/mattkretz/vir-simd/issues/49
+         */
+        template <typename T, typename Abi>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        vir::stdx::simd<T, Abi> select (
+            typename vir::stdx::simd<T, Abi>::mask_type const& mask,
+            vir::stdx::simd<T, Abi> const& true_val,
+            vir::stdx::simd<T, Abi> const& false_val)
+        {
+            vir::stdx::simd<T, Abi> result = false_val;
+            where(mask, result) = true_val;
+            return result;
+        }
 #else
         // fallback implementations for functions that are commonly used in portable code paths
 
@@ -81,6 +119,18 @@ namespace amrex::simd
         detail::where_expression<T> where (bool const mask, T& value)
         {
             return {mask, value};
+        }
+
+        /** Vectorized ternary operator (scalar fallback for simd select)
+         *
+         * @see select in the AMREX_USE_SIMD path above
+         * @see C++26 std::simd select
+         */
+        template <typename T>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T select (bool const mask, T const& true_val, T const& false_val)
+        {
+            return mask ? true_val : false_val;
         }
 #endif
     }
@@ -213,48 +263,6 @@ namespace amrex::simd
         constexpr bool val_arr[sizeof...(Args)] {!std::is_const_v<std::remove_reference_t<Args>>...};
         return val_arr[n];
     }
-
-    /** Vectorized ternary operator: select(mask, true_val, false_val)
-     *
-     * Selects elements from true_val where mask is true and from false_val where
-     * mask is false. Analogous to (mask ? true_val : false_val) for scalars.
-     *
-     * Note: both true_val and false_val are eagerly evaluated (function arguments).
-     * To guard against operations like division by zero, sanitize inputs before
-     * the operation rather than relying on conditional selection.
-     *
-     * Example:
-     * ```cpp
-     * template <typename T>
-     * T compute (T const& a, T const& b)
-     * {
-     *     auto safe_b = amrex::simd::select(b != T(0), b, T(1));
-     *     return amrex::simd::select(b != T(0), a / safe_b, T(0));
-     * }
-     * ```
-     *
-     * @see C++26 std::datapar::select
-     */
-#ifdef AMREX_USE_SIMD
-    template <typename T, typename Abi>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    stdx::simd<T, Abi> select (
-        typename stdx::simd<T, Abi>::mask_type const& mask,
-        stdx::simd<T, Abi> const& true_val,
-        stdx::simd<T, Abi> const& false_val)
-    {
-        stdx::simd<T, Abi> result = false_val;
-        stdx::where(mask, result) = true_val;
-        return result;
-    }
-#else
-    template <typename T>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T select (bool const mask, T const& true_val, T const& false_val)
-    {
-        return mask ? true_val : false_val;
-    }
-#endif
 
     /** Load 1D contiguous data from array pointers
      *

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -214,7 +214,7 @@ namespace amrex::simd
         return val_arr[n];
     }
 
-    /** Vectorized ternary operator: condition(mask, true_val, false_val)
+    /** Vectorized ternary operator: select(mask, true_val, false_val)
      *
      * Selects elements from true_val where mask is true and from false_val where
      * mask is false. Analogous to (mask ? true_val : false_val) for scalars.
@@ -228,15 +228,17 @@ namespace amrex::simd
      * template <typename T>
      * T compute (T const& a, T const& b)
      * {
-     *     auto safe_b = amrex::simd::condition(b != T(0), b, T(1));
-     *     return amrex::simd::condition(b != T(0), a / safe_b, T(0));
+     *     auto safe_b = amrex::simd::select(b != T(0), b, T(1));
+     *     return amrex::simd::select(b != T(0), a / safe_b, T(0));
      * }
      * ```
+     *
+     * @see C++26 std::datapar::select
      */
 #ifdef AMREX_USE_SIMD
     template <typename T, typename Abi>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    stdx::simd<T, Abi> condition (
+    stdx::simd<T, Abi> select (
         typename stdx::simd<T, Abi>::mask_type const& mask,
         stdx::simd<T, Abi> const& true_val,
         stdx::simd<T, Abi> const& false_val)
@@ -248,7 +250,7 @@ namespace amrex::simd
 #else
     template <typename T>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    T condition (bool const mask, T const& true_val, T const& false_val)
+    T select (bool const mask, T const& true_val, T const& false_val)
     {
         return mask ? true_val : false_val;
     }

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -88,12 +88,13 @@ namespace amrex::simd
             template <typename T>
             struct where_expression {
                 bool mask;
-                T& value;
+                T* value;
 
                 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-                void operator= (T const& new_val)
+                where_expression& operator= (T const& new_val)
                 {
-                    if (mask) { value = new_val; }
+                    if (mask) { *value = new_val; }
+                    return *this;
                 }
             };
         }
@@ -118,7 +119,7 @@ namespace amrex::simd
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         detail::where_expression<T> where (bool const mask, T& value)
         {
-            return {mask, value};
+            return {mask, &value};
         }
 
         /** Vectorized ternary operator (scalar fallback for simd select)

--- a/Tests/SIMD/main.cpp
+++ b/Tests/SIMD/main.cpp
@@ -427,26 +427,26 @@ int main (int argc, char* argv[])
 
         // ================================================================
         // Test 14: any_of, where, select — portable single-source
-        //   Uses SIMDReal<>, which is a SIMD vector when AMREX_USE_SIMD=ON
+        //   Uses SIMDParticleReal<>, which is a SIMD vector when AMREX_USE_SIMD=ON
         //   and a plain scalar when OFF.  The same code path exercises
         //   both the real SIMD and the scalar fallback implementations.
         // ================================================================
         {
-            using Real_t = simd::SIMDReal<>;
+            using PReal_t = simd::SIMDParticleReal<>;
 
             // safe reciprocal: 1/b where b != 0, else 0
-            Real_t b(ParticleReal(2));
-            auto mask = b != Real_t(ParticleReal(0));
-            auto safe_b = simd::stdx::select(mask, b, Real_t(ParticleReal(1)));
+            auto b = PReal_t(2);
+            auto mask = b != PReal_t(0);
+            auto safe_b = simd::stdx::select(mask, b, PReal_t(1));
             auto recip  = simd::stdx::select(mask,
-                              Real_t(ParticleReal(1)) / safe_b,
-                              Real_t(ParticleReal(0)));
+                              PReal_t(1) / safe_b,
+                              PReal_t(0));
 
             // any_of: at least one lane should be nonzero
             AMREX_ALWAYS_ASSERT(simd::stdx::any_of(mask));
 
             // where: masked assignment
-            Real_t acc(ParticleReal(0));
+            auto acc = PReal_t(0);
             simd::stdx::where(mask, acc) = recip;
 
             // verify: b=2 everywhere → recip=0.5, acc=0.5
@@ -455,7 +455,7 @@ int main (int argc, char* argv[])
                 if (std::abs(got - expected) > ParticleReal(1.e-10)) { ++err; }
             };
 #ifdef AMREX_USE_SIMD
-            for (int lane = 0; lane < static_cast<int>(Real_t::size()); ++lane) {
+            for (int lane = 0; lane < static_cast<int>(PReal_t::size()); ++lane) {
                 check(recip[lane], ParticleReal(0.5));
                 check(acc[lane],   ParticleReal(0.5));
             }

--- a/Tests/SIMD/main.cpp
+++ b/Tests/SIMD/main.cpp
@@ -426,7 +426,7 @@ int main (int argc, char* argv[])
         }
 
         // ================================================================
-        // Test 14: any_of, where, condition — portable single-source
+        // Test 14: any_of, where, select — portable single-source
         //   Uses SIMDReal<>, which is a SIMD vector when AMREX_USE_SIMD=ON
         //   and a plain scalar when OFF.  The same code path exercises
         //   both the real SIMD and the scalar fallback implementations.
@@ -437,8 +437,8 @@ int main (int argc, char* argv[])
             // safe reciprocal: 1/b where b != 0, else 0
             Real_t b(ParticleReal(2));
             auto mask = b != Real_t(ParticleReal(0));
-            auto safe_b = simd::select(mask, b, Real_t(ParticleReal(1)));
-            auto recip  = simd::select(mask,
+            auto safe_b = simd::stdx::select(mask, b, Real_t(ParticleReal(1)));
+            auto recip  = simd::stdx::select(mask,
                               Real_t(ParticleReal(1)) / safe_b,
                               Real_t(ParticleReal(0)));
 

--- a/Tests/SIMD/main.cpp
+++ b/Tests/SIMD/main.cpp
@@ -426,6 +426,50 @@ int main (int argc, char* argv[])
         }
 
         // ================================================================
+        // Test 14: any_of, where, condition — portable single-source
+        //   Uses SIMDReal<>, which is a SIMD vector when AMREX_USE_SIMD=ON
+        //   and a plain scalar when OFF.  The same code path exercises
+        //   both the real SIMD and the scalar fallback implementations.
+        // ================================================================
+        {
+            using Real_t = simd::SIMDReal<>;
+
+            // safe reciprocal: 1/b where b != 0, else 0
+            Real_t b(ParticleReal(2));
+            auto mask = b != Real_t(ParticleReal(0));
+            auto safe_b = simd::condition(mask, b, Real_t(ParticleReal(1)));
+            auto recip  = simd::condition(mask,
+                              Real_t(ParticleReal(1)) / safe_b,
+                              Real_t(ParticleReal(0)));
+
+            // any_of: at least one lane should be nonzero
+            AMREX_ALWAYS_ASSERT(simd::stdx::any_of(mask));
+
+            // where: masked assignment
+            Real_t acc(ParticleReal(0));
+            simd::stdx::where(mask, acc) = recip;
+
+            // verify: b=2 everywhere → recip=0.5, acc=0.5
+            int err = 0;
+            auto check = [&] (ParticleReal got, ParticleReal expected) {
+                if (std::abs(got - expected) > ParticleReal(1.e-10)) { ++err; }
+            };
+#ifdef AMREX_USE_SIMD
+            for (int lane = 0; lane < static_cast<int>(Real_t::size()); ++lane) {
+                check(recip[lane], ParticleReal(0.5));
+                check(acc[lane],   ParticleReal(0.5));
+            }
+#else
+            check(recip, ParticleReal(0.5));
+            check(acc,   ParticleReal(0.5));
+#endif
+
+            nerrors += err;
+            Print() << "any_of + where + condition (portable): "
+                    << (err == 0 ? "PASSED" : "FAILED") << "\n";
+        }
+
+        // ================================================================
         // Final report
         // ================================================================
         if (nerrors > 0) {

--- a/Tests/SIMD/main.cpp
+++ b/Tests/SIMD/main.cpp
@@ -437,8 +437,8 @@ int main (int argc, char* argv[])
             // safe reciprocal: 1/b where b != 0, else 0
             Real_t b(ParticleReal(2));
             auto mask = b != Real_t(ParticleReal(0));
-            auto safe_b = simd::condition(mask, b, Real_t(ParticleReal(1)));
-            auto recip  = simd::condition(mask,
+            auto safe_b = simd::select(mask, b, Real_t(ParticleReal(1)));
+            auto recip  = simd::select(mask,
                               Real_t(ParticleReal(1)) / safe_b,
                               Real_t(ParticleReal(0)));
 
@@ -465,7 +465,7 @@ int main (int argc, char* argv[])
 #endif
 
             nerrors += err;
-            Print() << "any_of + where + condition (portable): "
+            Print() << "any_of + where + select (portable): "
                     << (err == 0 ? "PASSED" : "FAILED") << "\n";
         }
 


### PR DESCRIPTION
## Summary

To write more portable code, add a scalar fallback for `std::simd::where` for non-SIMD code. Expose both as `amrex::simd::stdx`.

Add Doxygen string to existing scalar `amrex::simd::std::any_of` fallback.

Add a new implementation for a portable ternary operator, inspired by Kokkos [condition](https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/SIMD.html#ternary-operator) as `amrex::simd::stdx::select`. (We call it `select` because that is the likely ISO C++26 name: https://en.cppreference.com/w/cpp/numeric/simd.html )

Demonstrate usage in doc strings and new test cases.

## Additional background

These are patterns I commonly see needed in [BLAST-ImpactX](https://github.com/BLAST-ImpactX/impactx), e.g. [here](https://github.com/BLAST-ImpactX/impactx/blob/26.02/src/elements/mixin/spintransport.H#L68-L79).

This will help to write more complex SIMD code like #4649 in a cleaner way, too.

Follow up to #4520 #4938 #4924

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
