### PR TITLE
Workaround for deprecation warnings on Perlmutter

### DIFF
--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -16,9 +16,8 @@
 
 #if defined(AMREX_USE_CUB)
 #include <cub/cub.cuh>
-// CUB 2.6.0 corresponds to CCCL 3.0.0
-#if (defined(CCCL_MAJOR_VERSION) && (CCCL_MAJOR_VERSION >= 3)) || (defined(CUB_VERSION) && (CUB_VERSION >= 200600))
-#define AMREX_CUDA_CCCL_VER_GE_3 1
+#if defined(CCCL_MAJOR_VERSION) && defined(CCCL_MINOR_VERSION) && ((CCCL_MAJOR_VERSION >= 3) || ((CCCL_MAJOR_VERSION >= 2) && (CCCL_MINOR_VERSION >= 8)))
+#define AMREX_CUDA_CCCL_VER_GE_2_8 1
 #endif
 #elif defined(AMREX_USE_HIP)
 #include <rocprim/rocprim.hpp>
@@ -426,7 +425,7 @@ T blockReduceMin (T source) noexcept
     // we do it always to be safe.
     __syncthreads();
 
-#ifdef AMREX_CUDA_CCCL_VER_GE_3
+#ifdef AMREX_CUDA_CCCL_VER_GE_2_8
     return BlockReduce(temp_storage).Reduce(source, cuda::minimum<T>{});
 #else
     return BlockReduce(temp_storage).Reduce(source, cub::Min());
@@ -480,7 +479,7 @@ T blockReduceMax (T source) noexcept
     // and since we don't know how many times the user is calling it,
     // we do it always to be safe.
     __syncthreads();
-#ifdef AMREX_CUDA_CCCL_VER_GE_3
+#ifdef AMREX_CUDA_CCCL_VER_GE_2_8
     return BlockReduce(temp_storage).Reduce(source, cuda::maximum<T>());
 #else
     return BlockReduce(temp_storage).Reduce(source, cub::Max());

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -16,7 +16,8 @@
 
 #if defined(AMREX_USE_CUB)
 #include <cub/cub.cuh>
-#if defined(CCCL_MAJOR_VERSION) && (CCCL_MAJOR_VERSION >= 3)
+// CUB 2.6.0 corresponds to CCCL 3.0.0
+#if (defined(CCCL_MAJOR_VERSION) && (CCCL_MAJOR_VERSION >= 3)) || (defined(CUB_VERSION) && (CUB_VERSION >= 200600))
 #define AMREX_CUDA_CCCL_VER_GE_3 1
 #endif
 #elif defined(AMREX_USE_HIP)

--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -8,7 +8,7 @@
 
 #if defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
 #  include <cub/cub.cuh>
-#  ifdef AMREX_CUDA_CCCL_VER_GE_3
+#  ifdef AMREX_CUDA_CCCL_VER_GE_2_8
 #  include <thrust/iterator/transform_iterator.h>
 #  endif
 #elif defined(AMREX_USE_HIP)
@@ -849,7 +849,7 @@ T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = ret
         using BlockScan = cub::BlockScan<T, nthreads, cub::BLOCK_SCAN_WARP_SCANS>;
         using BlockExchange = cub::BlockExchange<T, nthreads, nelms_per_thread>;
 
-#ifdef AMREX_CUDA_CCCL_VER_GE_3
+#ifdef AMREX_CUDA_CCCL_VER_GE_2_8
         using Sum = cuda::std::plus<T>;
 #else
         using Sum = cub::Sum;
@@ -876,7 +876,7 @@ T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = ret
         N iend = amrex::min(static_cast<N>(ibegin+nelms_per_block), n);
 
         auto input_lambda = [&] (N i) -> T { return fin(i+ibegin); };
-#ifdef AMREX_CUDA_CCCL_VER_GE_3
+#ifdef AMREX_CUDA_CCCL_VER_GE_2_8
         thrust::transform_iterator<decltype(input_lambda),thrust::counting_iterator<N> >
             input_begin(thrust::counting_iterator<N>(0), input_lambda);
 #else


### PR DESCRIPTION
After a recent upgrade on Perlmutter, the following warnings were present:

```
/global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Base/AMReX_Scan.H(855): warning #1444-D: type "cub::CUB_200802_SM_800::Sum" was declared deprecated ("use cuda::std::plus instead")
          using Sum = cub::Sum;
                ^
/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/targets/x86_64-linux/include/cub/thread/thread_operators.cuh(95): note #3287-D: because of a "deprecated" attribute
  using Sum [[deprecated("use cuda::std::plus instead")]] = ::cuda::std::plus<>;
              ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Base/AMReX_Scan.H(857): warning #1444-D: type "cub::CUB_200802_SM_800::Sum" was declared deprecated ("use cuda::std::plus instead")
          using TilePrefixCallbackOp = cub::TilePrefixCallbackOp<T, Sum, ScanTileState>;
                ^
/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/targets/x86_64-linux/include/cub/thread/thread_operators.cuh(95): note #3287-D: because of a "deprecated" attribute
  using Sum [[deprecated("use cuda::std::plus instead")]] = ::cuda::std::plus<>;
              ^
          detected during instantiation of "T amrex::Scan::PrefixSum<T,N,FIN,FOUT,TYPE,M>(N, const FIN &, const FOUT &, TYPE, amrex::Scan::RetSum) [with T=int, N=int, FIN=lambda [](int)->int, FOUT=lambda [](int, const int &)->void, TYPE=amrex::Scan::Type::Exclusive, M=void]" at line 220 of /global/homes/a/atmyers/ExaEpi/src/CensusData.cpp

/global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Base/AMReX_Scan.H(857): warning #1444-D: type "cub::CUB_200802_SM_800::Sum" was declared deprecated ("use cuda::std::plus instead")
          using TilePrefixCallbackOp = cub::TilePrefixCallbackOp<T, Sum, ScanTileState>;
                ^
/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/targets/x86_64-linux/include/cub/thread/thread_operators.cuh(95): note #3287-D: because of a "deprecated" attribute
  using Sum [[deprecated("use cuda::std::plus instead")]] = ::cuda::std::plus<>;
              ^
          detected during instantiation of "T amrex::Scan::PrefixSum<T,N,FIN,FOUT,TYPE,M>(N, const FIN &, const FOUT &, TYPE, amrex::Scan::RetSum) [with T=int, N=int, FIN=lambda [](int)->int, FOUT=lambda [](int, const int &)->void, TYPE=amrex::Scan::Type::Exclusive, M=void]" at line 235 of /global/homes/a/atmyers/ExaEpi/src/CensusData.cpp

/global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Base/AMReX_Scan.H(884): warning #1444-D: class "cub::CUB_200802_SM_800::CountingInputIterator<int, ptrdiff_t>" was declared deprecated ("Use thrust::counting_iterator instead")
              input_begin(cub::CountingInputIterator<N>(0), input_lambda);
              ^
/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/targets/x86_64-linux/include/cub/iterator/counting_input_iterator.cuh(93): note #3287-D: because of a "deprecated" attribute
  class [[deprecated("Use thrust::counting_iterator instead")]] CountingInputIterator
          ^
          detected during instantiation of "T amrex::Scan::PrefixSum<T,N,FIN,FOUT,TYPE,M>(N, const FIN &, const FOUT &, TYPE, amrex::Scan::RetSum) [with T=int, N=int, FIN=lambda [](int)->int, FOUT=lambda [](int, const int &)->void, TYPE=amrex::Scan::Type::Exclusive, M=void]" at line 235 of /global/homes/a/atmyers/ExaEpi/src/CensusData.cpp

/global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Base/AMReX_Scan.H(855): warning #1444-D: type "cub::CUB_200802_SM_800::Sum" was declared deprecated ("use cuda::std::plus instead")
          using Sum = cub::Sum;
                ^
/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/targets/x86_64-linux/include/cub/thread/thread_operators.cuh(95): note #3287-D: because of a "deprecated" attribute
  using Sum [[deprecated("use cuda::std::plus instead")]] = ::cuda::std::plus<>;
              ^
          detected during:
            instantiation of "int amrex::partitionParticles(PTile &, const ParFunc &) [with PTile=amrex::ParticleTile<amrex::Particle<0, 0>, 0, 22, amrex::DefaultAllocator>, ParFunc=lambda [](auto &, int)->__nv_bool]" at line 716 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleUtil.H
            instantiation of "int amrex::partitionParticlesByDest(PTile &, const PLocator &, const CellAssignor &, const amrex::ParticleBufferMap &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<int, 2U> &, int, int, int, int, int, int, __nv_bool) [with PTile=amrex::ParticleTile<amrex::Particle<0, 0>, 0, 22, amrex::DefaultAllocator>, PLocator=amrex::AmrAssignGrid<amrex::DenseBinIteratorFactory<amrex::Box>>, CellAssignor=amrex::DefaultAssignor]" at line 1503 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleContainerI.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::RedistributeGPU(int, int, int, int, __nv_bool) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 1243 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleContainerI.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::Redistribute(int, int, int, int, __nv_bool) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 230 of /global/homes/a/atmyers/ExaEpi/src/AgentContainer.cpp

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Base/AMReX_Scan.H(857): warning #1444-D: type "cub::CUB_200802_SM_800::Sum" was declared deprecated ("use cuda::std::plus instead")
          using TilePrefixCallbackOp = cub::TilePrefixCallbackOp<T, Sum, ScanTileState>;
                ^
/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/targets/x86_64-linux/include/cub/thread/thread_operators.cuh(95): note #3287-D: because of a "deprecated" attribute
  using Sum [[deprecated("use cuda::std::plus instead")]] = ::cuda::std::plus<>;
              ^
          detected during:
            instantiation of "T amrex::Scan::PrefixSum<T,N,FIN,FOUT,TYPE,M>(N, const FIN &, const FOUT &, TYPE, amrex::Scan::RetSum) [with T=int, N=int, FIN=lambda [](int)->int, FOUT=lambda [](int, const int &)->void, TYPE=amrex::Scan::Type::Exclusive, M=void]" at line 537 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleUtil.H
            instantiation of "int amrex::partitionParticles(PTile &, const ParFunc &) [with PTile=amrex::ParticleTile<amrex::Particle<0, 0>, 0, 22, amrex::DefaultAllocator>, ParFunc=lambda [](auto &, int)->__nv_bool]" at line 716 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleUtil.H
            instantiation of "int amrex::partitionParticlesByDest(PTile &, const PLocator &, const CellAssignor &, const amrex::ParticleBufferMap &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<int, 2U> &, int, int, int, int, int, int, __nv_bool) [with PTile=amrex::ParticleTile<amrex::Particle<0, 0>, 0, 22, amrex::DefaultAllocator>, PLocator=amrex::AmrAssignGrid<amrex::DenseBinIteratorFactory<amrex::Box>>, CellAssignor=amrex::DefaultAssignor]" at line 1503 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleContainerI.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::RedistributeGPU(int, int, int, int, __nv_bool) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 1243 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleContainerI.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::Redistribute(int, int, int, int, __nv_bool) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 230 of /global/homes/a/atmyers/ExaEpi/src/AgentContainer.cpp

/global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Base/AMReX_Scan.H(855): warning #1444-D: type "cub::CUB_200802_SM_800::Sum" was declared deprecated ("use cuda::std::plus instead")
          using Sum = cub::Sum;
                ^
/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/targets/x86_64-linux/include/cub/thread/thread_operators.cuh(95): note #3287-D: because of a "deprecated" attribute
  using Sum [[deprecated("use cuda::std::plus instead")]] = ::cuda::std::plus<>;
              ^
          detected during:
            instantiation of "int amrex::partitionParticles(PTile &, const ParFunc &) [with PTile=amrex::ParticleTile<amrex::Particle<0, 0>, 0, 22, amrex::DefaultAllocator>, ParFunc=lambda [](auto &, int)->__nv_bool]" at line 716 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleUtil.H
            instantiation of "int amrex::partitionParticlesByDest(PTile &, const PLocator &, const CellAssignor &, const amrex::ParticleBufferMap &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<int, 2U> &, int, int, int, int, int, int, __nv_bool) [with PTile=amrex::ParticleTile<amrex::Particle<0, 0>, 0, 22, amrex::DefaultAllocator>, PLocator=amrex::AmrAssignGrid<amrex::DenseBinIteratorFactory<amrex::Box>>, CellAssignor=amrex::DefaultAssignor]" at line 1503 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleContainerI.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::RedistributeGPU(int, int, int, int, __nv_bool) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 1243 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleContainerI.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::Redistribute(int, int, int, int, __nv_bool) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 939 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleIO.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::Restart(const std::string &, const std::string &) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 268 of /global/homes/a/atmyers/ExaEpi/src/IO.cpp

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Base/AMReX_Scan.H(857): warning #1444-D: type "cub::CUB_200802_SM_800::Sum" was declared deprecated ("use cuda::std::plus instead")
          using TilePrefixCallbackOp = cub::TilePrefixCallbackOp<T, Sum, ScanTileState>;
                ^
/opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/targets/x86_64-linux/include/cub/thread/thread_operators.cuh(95): note #3287-D: because of a "deprecated" attribute
  using Sum [[deprecated("use cuda::std::plus instead")]] = ::cuda::std::plus<>;
              ^
          detected during:
            instantiation of "T amrex::Scan::PrefixSum<T,N,FIN,FOUT,TYPE,M>(N, const FIN &, const FOUT &, TYPE, amrex::Scan::RetSum) [with T=int, N=int, FIN=lambda [](int)->int, FOUT=lambda [](int, const int &)->void, TYPE=amrex::Scan::Type::Exclusive, M=void]" at line 537 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleUtil.H
            instantiation of "int amrex::partitionParticles(PTile &, const ParFunc &) [with PTile=amrex::ParticleTile<amrex::Particle<0, 0>, 0, 22, amrex::DefaultAllocator>, ParFunc=lambda [](auto &, int)->__nv_bool]" at line 716 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleUtil.H
            instantiation of "int amrex::partitionParticlesByDest(PTile &, const PLocator &, const CellAssignor &, const amrex::ParticleBufferMap &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<amrex::Real, 2U> &, const amrex::GpuArray<int, 2U> &, int, int, int, int, int, int, __nv_bool) [with PTile=amrex::ParticleTile<amrex::Particle<0, 0>, 0, 22, amrex::DefaultAllocator>, PLocator=amrex::AmrAssignGrid<amrex::DenseBinIteratorFactory<amrex::Box>>, CellAssignor=amrex::DefaultAssignor]" at line 1503 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleContainerI.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::RedistributeGPU(int, int, int, int, __nv_bool) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 1243 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleContainerI.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::Redistribute(int, int, int, int, __nv_bool) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 939 of /global/homes/a/atmyers/ExaEpi/build/_deps/amrex-src/Src/Particle/AMReX_ParticleIO.H
            instantiation of "void amrex::ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, T_CellAssignor>::Restart(const std::string &, const std::string &) [with T_ParticleType=amrex::Particle<0, 0>, T_NArrayReal=0, T_NArrayInt=22, Allocator=amrex::DefaultAllocator, T_CellAssignor=amrex::DefaultAssignor]" at line 268 of /global/homes/a/atmyers/ExaEpi/src/IO.cpp
```

Apparently the `CCCL_MAJOR_VERSION` macro was not being set. This removes the warnings by also looking for `CUB_VERSION`.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
