### PR TITLE
Rename the `NonManagedVector` to `NonManagedDeviceVector`

### DIFF
--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -84,7 +84,7 @@ namespace amrex::Gpu {
     using HostVector = PODVector<T>;
 
     template <class T>
-    using NonManagedVector = PODVector<T>;
+    using NonManagedDeviceVector = PODVector<T>;
 
     template <class T>
     using ManagedVector = PODVector<T>;


### PR DESCRIPTION
## Summary

Typo on the CPU fallback, should read: `NonManagedDeviceVector`

## Additional background

Fix #5123

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
