### PR TITLE
Fix Dual Grid restart with HDF5 format

### DIFF
--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -1238,7 +1238,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                              boxes[base+AMREX_SPACEDIM+2])});
                 bl.push_back(tmp);
             }
-            particle_box_arrays[lev] = BoxArray(bl);
+            particle_box_arrays[lev] = std::move(BoxArray(bl));
         }
 
         if (! particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev)))

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -1238,7 +1238,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                                              boxes[base+AMREX_SPACEDIM+2])});
                 bl.push_back(tmp);
             }
-            particle_box_arrays[lev] = std::move(BoxArray(bl));
+            particle_box_arrays[lev] = BoxArray(std::move(bl));
         }
 
         if (! particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev)))

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -1333,12 +1333,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
             const int rank = ParallelDescriptor::MyProc();
             const int NReaders = MaxReaders();
-            if (rank >= NReaders) {
-		H5Dclose(int_dset);
-		H5Dclose(real_dset);
-		H5Gclose(grp);
-		continue;
-	    }
+            if (rank >= NReaders) { return; }
 
             const int Navg = ngrids[lev] / NReaders;
             const int Nleft = ngrids[lev] - Navg * NReaders;

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -1221,12 +1221,24 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         H5Dclose(dset);
         H5Gclose(grp);
 
-        /* particle_box_arrays[lev].readFrom(phdr_file); */
-        particle_box_arrays[lev] = ParticleBoxArray(lev);
-        for (int i = 0; i < (int)ngrid; i++) {
-            Box tmp (IntVect{AMREX_D_DECL(boxes[i*AMREX_SPACEDIM], boxes[i*AMREX_SPACEDIM+1], boxes[i*AMREX_SPACEDIM+2])},
-                     IntVect{AMREX_D_DECL(boxes[i*AMREX_SPACEDIM*2], boxes[i*AMREX_SPACEDIM*2+1], boxes[i*AMREX_SPACEDIM*2+2])});
-            particle_box_arrays[lev][i] = tmp;
+        // Build the BoxArray from the boxes stored in the file.
+        // Note: the compound dtype lays out each box as
+        //   (lo_0, lo_1, lo_2, hi_0, hi_1, hi_2) stored consecutively,
+        // so lo[d] is at index i*2*AMREX_SPACEDIM+d and
+        //    hi[d] is at index i*2*AMREX_SPACEDIM+AMREX_SPACEDIM+d.
+        {
+            BoxList bl;
+            for (int i = 0; i < (int)ngrid; i++) {
+                const int base = i * 2 * AMREX_SPACEDIM;
+                Box tmp(IntVect{AMREX_D_DECL(boxes[base+0],
+                                             boxes[base+1],
+                                             boxes[base+2])},
+                        IntVect{AMREX_D_DECL(boxes[base+AMREX_SPACEDIM+0],
+                                             boxes[base+AMREX_SPACEDIM+1],
+                                             boxes[base+AMREX_SPACEDIM+2])});
+                bl.push_back(tmp);
+            }
+            particle_box_arrays[lev] = BoxArray(bl);
         }
 
         if (! particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev)))
@@ -1321,7 +1333,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
             const int rank = ParallelDescriptor::MyProc();
             const int NReaders = MaxReaders();
-            if (rank >= NReaders) { return; }
+            if (rank >= NReaders) {
+		H5Dclose(int_dset);
+		H5Dclose(real_dset);
+		H5Gclose(grp);
+		continue;
+	    }
 
             const int Navg = ngrids[lev] / NReaders;
             const int Nleft = ngrids[lev] - Navg * NReaders;

--- a/Tests/Particles/CheckpointRestartDualGrid/GNUmakefile
+++ b/Tests/Particles/CheckpointRestartDualGrid/GNUmakefile
@@ -17,6 +17,10 @@ TINY_PROFILE = TRUE
 
 USE_PARTICLES = TRUE
 
+USE_HDF5  = FALSE
+# Set HDF5_HOME to the root of your HDF5 installation, e.g.:
+# HDF5_HOME = /path/to/hdf5
+
 ###################################################
 
 EBASE     = main

--- a/Tests/Particles/CheckpointRestartDualGrid/main.cpp
+++ b/Tests/Particles/CheckpointRestartDualGrid/main.cpp
@@ -1,8 +1,9 @@
 /**
- * Test for dual-grid particle checkpoint/restart capability.
+ * Test for dual-grid particle checkpoint/restart capability..
  *
- * Verifies that particles are preserved correctly when reading a checkpoint
- * file into a ParticleContainer with a different mesh structure, covering:
+ * Verifies that particles are preserved correctly when reading a
+ * checkpoint file into a ParticleContainer with a different mesh structure,
+ * covering:
  *   1. Restart with fewer AMR levels than the checkpoint
  *   2. Restart with more AMR levels than the checkpoint
  *   3. Restart with the same number of levels but different BoxArrays
@@ -33,7 +34,7 @@ struct MeshData {
  * Build a nested AMR hierarchy with `nlevs` levels over a [0,1]^d domain
  * discretised by `ncells` cells in each direction. The coarse BoxArray is
  * decomposed into boxes of at most `max_grid_size` cells; the fine level
- * covers the central eighth of the domain.
+ * covers the central half of the domain.
  */
 MeshData build_mesh (int ncells, int nlevs, int max_grid_size)
 {
@@ -169,7 +170,11 @@ void test_fewer_levels ()
     pc_write.SetVerbose(false);
     pc_write.InitRandom(nppc * AMREX_D_TERM(ncells, *ncells, *ncells),
                         iseed, pdata, /*serialize=*/false);
+#ifdef AMREX_USE_HDF5
+    pc_write.CheckpointHDF5(chkdir, "particles", true, real_names, int_names);
+#else
     pc_write.Checkpoint(chkdir, "particles", real_names, int_names);
+#endif
 
     ParallelDescriptor::Barrier();
 
@@ -177,7 +182,11 @@ void test_fewer_levels ()
     auto mesh1 = build_mesh(ncells, 1, max_grid_size);
     MyPC pc_read(mesh1.geom, mesh1.dmap, mesh1.ba, mesh1.ref_ratio);
     pc_read.SetVerbose(false);
+#ifdef AMREX_USE_HDF5
+    pc_read.RestartHDF5(chkdir + "/particles", "particles");
+#else
     pc_read.Restart(chkdir, "particles");
+#endif
 
     verify_same(pc_write, pc_read);
 
@@ -218,7 +227,11 @@ void test_more_levels ()
     pc_write.SetVerbose(false);
     pc_write.InitRandom(nppc * AMREX_D_TERM(ncells, *ncells, *ncells),
                         iseed, pdata, /*serialize=*/false);
+#ifdef AMREX_USE_HDF5
+    pc_write.CheckpointHDF5(chkdir, "particles", true, real_names, int_names);
+#else
     pc_write.Checkpoint(chkdir, "particles", real_names, int_names);
+#endif
 
     ParallelDescriptor::Barrier();
 
@@ -226,7 +239,11 @@ void test_more_levels ()
     auto mesh2 = build_mesh(ncells, 2, max_grid_size);
     MyPC pc_read(mesh2.geom, mesh2.dmap, mesh2.ba, mesh2.ref_ratio);
     pc_read.SetVerbose(false);
+#ifdef AMREX_USE_HDF5
+    pc_read.RestartHDF5(chkdir + "/particles", "particles");
+#else
     pc_read.Restart(chkdir, "particles");
+#endif
 
     verify_same(pc_write, pc_read);
 
@@ -234,8 +251,8 @@ void test_more_levels ()
 }
 
 /**
- * Test 3: Write a checkpoint with one BoxArray decomposition, restart into
- * a container with the same number of levels but a different BoxArray
+ * Test 3: Write a checkpoint with one BoxArray decomposition, restart
+ * into a container with the same number of levels but a different BoxArray
  * (different max_grid_size). This is the canonical dual-grid scenario: the
  * Particle_H header written at checkpoint time differs from the BoxArray
  * of the new container, so AMReX uses temporary grids while reading and
@@ -270,7 +287,11 @@ void test_different_boxarrays ()
     pc_write.SetVerbose(false);
     pc_write.InitRandom(nppc * AMREX_D_TERM(ncells, *ncells, *ncells),
                         iseed, pdata, /*serialize=*/false);
+#ifdef AMREX_USE_HDF5
+    pc_write.CheckpointHDF5(chkdir, "particles", true, real_names, int_names);
+#else
     pc_write.Checkpoint(chkdir, "particles", real_names, int_names);
+#endif
 
     ParallelDescriptor::Barrier();
 
@@ -279,7 +300,11 @@ void test_different_boxarrays ()
     MyPC pc_read(mesh_fine.geom, mesh_fine.dmap, mesh_fine.ba,
                  mesh_fine.ref_ratio);
     pc_read.SetVerbose(false);
+#ifdef AMREX_USE_HDF5
+    pc_read.RestartHDF5(chkdir + "/particles", "particles");
+#else
     pc_read.Restart(chkdir, "particles");
+#endif
 
     verify_same(pc_write, pc_read);
 


### PR DESCRIPTION
This also modifies the test to optionally use HDF5.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
