### PR TITLE
Fix a warning in Fortran module

### DIFF
--- a/Src/Base/AMReX_parmparse_mod.F90
+++ b/Src/Base/AMReX_parmparse_mod.F90
@@ -236,7 +236,11 @@ module amrex_parmparse_module
 
   interface amrex_parmparse_destroy
      module procedure amrex_parmparse_destroy
-  end interface amrex_parmparse_destroy
+#ifdef __NVCOMPILER
+interface amrex_parmparse_destroy
+module procedure amrex_parmparse_destroy
+end interface amrex_parmparse_destroy
+#endif
 
 contains
 

--- a/Src/Base/AMReX_parmparse_mod.F90
+++ b/Src/Base/AMReX_parmparse_mod.F90
@@ -252,7 +252,7 @@ contains
   end subroutine amrex_parmparse_build
 
   subroutine amrex_parmparse_destroy (this)
-    type(amrex_parmparse) :: this
+    type(amrex_parmparse), intent(inout) :: this
     if (this%owner) then
        if (c_associated(this%p)) then
           call amrex_delete_parmparse(this%p)

--- a/Src/Base/AMReX_parmparse_mod.F90
+++ b/Src/Base/AMReX_parmparse_mod.F90
@@ -234,12 +234,10 @@ module amrex_parmparse_module
      end subroutine amrex_parmparse_add_stringarr
   end interface
 
+#ifdef __NVCOMPILER
   interface amrex_parmparse_destroy
      module procedure amrex_parmparse_destroy
-#ifdef __NVCOMPILER
-interface amrex_parmparse_destroy
-module procedure amrex_parmparse_destroy
-end interface amrex_parmparse_destroy
+  end interface amrex_parmparse_destroy
 #endif
 
 contains


### PR DESCRIPTION
Flang does not like the interface block we added for NVFortran.

```
 /home/runner/work/amrex/amrex/Tests/EB/CNS/Exec/Sod/cns_prob.F90:21:28: warning: 'pp' of derived type 'amrex_parmparse' does not have a FINAL subroutine for its rank (0)
     type(amrex_parmparse) :: pp
                              ^^
 /home/runner/work/amrex/amrex/build/mod_files_3d/amrex_parmparse_module.mod:203:7: Declaration of derived type 'amrex_parmparse'
   type::amrex_parmparse
         ^^^^^^^^^^^^^^^
```
