### PR TITLE
ParmParse: accept true/false t/f for int keys

### DIFF
--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -133,6 +133,19 @@ template <class T>
 bool
 is (const std::string& str, T& val)
 {
+    if constexpr (std::is_integral_v<T>) {
+        auto const lo_str = amrex::toLower(str);
+        if ( lo_str == "true" || lo_str == "t" )
+            {
+                val = 1;
+                return true;
+            }
+        else if ( lo_str == "false" || lo_str == "f" )
+            {
+                val = 0;
+                return true;
+            }
+    }
     return isT(str, val);
 }
 
@@ -186,48 +199,6 @@ is (const std::string& str, bool& val)
         return true;
     }
     return false;
-}
-
-template <typename T>
-bool
-is_bool_to_int (const std::string& str, T& val)
-{
-    auto const lo_str = amrex::toLower(str);
-    if ( lo_str == "true" || lo_str == "t" )
-    {
-        val = 1;
-        return true;
-    }
-    if ( lo_str == "false" || lo_str == "f" )
-    {
-        val = 0;
-        return true;
-    }
-    return false;
-}
-
-template <>
-bool
-is (const std::string& str, int& val)
-{
-    if (is_bool_to_int(str, val)) { return true; }
-    return isT(str, val);
-}
-
-template <>
-bool
-is (const std::string& str, long& val)
-{
-    if (is_bool_to_int(str, val)) { return true; }
-    return isT(str, val);
-}
-
-template <>
-bool
-is (const std::string& str, long long& val)
-{
-    if (is_bool_to_int(str, val)) { return true; }
-    return isT(str, val);
 }
 
 template <class T> const char* tok_name(const T&) { return typeid(T).name(); }

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -188,6 +188,48 @@ is (const std::string& str, bool& val)
     return false;
 }
 
+template <typename T>
+bool
+is_bool_to_int (const std::string& str, T& val)
+{
+    auto const lo_str = amrex::toLower(str);
+    if ( lo_str == "true" || lo_str == "t" )
+    {
+        val = 1;
+        return true;
+    }
+    if ( lo_str == "false" || lo_str == "f" )
+    {
+        val = 0;
+        return true;
+    }
+    return false;
+}
+
+template <>
+bool
+is (const std::string& str, int& val)
+{
+    if (is_bool_to_int(str, val)) { return true; }
+    return isT(str, val);
+}
+
+template <>
+bool
+is (const std::string& str, long& val)
+{
+    if (is_bool_to_int(str, val)) { return true; }
+    return isT(str, val);
+}
+
+template <>
+bool
+is (const std::string& str, long long& val)
+{
+    if (is_bool_to_int(str, val)) { return true; }
+    return isT(str, val);
+}
+
 template <class T> const char* tok_name(const T&) { return typeid(T).name(); }
 template <class T> const char* tok_name(std::vector<T>&) { return tok_name(T());}
 

--- a/Tests/ParmParse/inputs
+++ b/Tests/ParmParse/inputs
@@ -64,13 +64,13 @@ ny = nx
 
 do_this = 1
 
-# boolean strings queried as int
-bool_int.true_val = true
-bool_int.false_val = false
-bool_int.True_val = True
-bool_int.FALSE_val = FALSE
-bool_int.t_val = t
-bool_int.f_val = f
+# boolean strings
+bool.true_val = true
+bool.false_val = false
+bool.True_val = True
+bool.FALSE_val = FALSE
+bool.t_val = t
+bool.f_val = f
 
 # query bool with parser
 my_value = 10

--- a/Tests/ParmParse/inputs
+++ b/Tests/ParmParse/inputs
@@ -64,6 +64,14 @@ ny = nx
 
 do_this = 1
 
+# boolean strings queried as int
+bool_int.true_val = true
+bool_int.false_val = false
+bool_int.True_val = True
+bool_int.FALSE_val = FALSE
+bool_int.t_val = t
+bool_int.f_val = f
+
 # query bool with parser
 my_value = 10
 my_threshold = 3

--- a/Tests/ParmParse/main.cpp
+++ b/Tests/ParmParse/main.cpp
@@ -149,6 +149,32 @@ int main(int argc, char* argv[])
         pp.queryAsDouble("do_that", o_do_that);
         AMREX_ALWAYS_ASSERT(!o_do_that.has_value());
     }
+    { // boolean strings queried as int
+        ParmParse pp("bool_int");
+        int v = -1;
+        pp.get("true_val", v);
+        AMREX_ALWAYS_ASSERT(v == 1);
+        pp.get("false_val", v);
+        AMREX_ALWAYS_ASSERT(v == 0);
+        pp.get("True_val", v);
+        AMREX_ALWAYS_ASSERT(v == 1);
+        pp.get("FALSE_val", v);
+        AMREX_ALWAYS_ASSERT(v == 0);
+        pp.get("t_val", v);
+        AMREX_ALWAYS_ASSERT(v == 1);
+        pp.get("f_val", v);
+        AMREX_ALWAYS_ASSERT(v == 0);
+        long lv = -1;
+        pp.get("true_val", lv);
+        AMREX_ALWAYS_ASSERT(lv == 1);
+        pp.get("false_val", lv);
+        AMREX_ALWAYS_ASSERT(lv == 0);
+        long long llv = -1;
+        pp.get("true_val", llv);
+        AMREX_ALWAYS_ASSERT(llv == 1);
+        pp.get("false_val", llv);
+        AMREX_ALWAYS_ASSERT(llv == 0);
+    }
     {
         ParmParse pp;
         bool my_bool_flag_1 = false;

--- a/Tests/ParmParse/main.cpp
+++ b/Tests/ParmParse/main.cpp
@@ -150,7 +150,7 @@ int main(int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(!o_do_that.has_value());
     }
     { // boolean strings queried as int
-        ParmParse pp("bool_int");
+        ParmParse pp("bool");
         int v = -1;
         pp.get("true_val", v);
         AMREX_ALWAYS_ASSERT(v == 1);
@@ -174,6 +174,22 @@ int main(int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(llv == 1);
         pp.get("false_val", llv);
         AMREX_ALWAYS_ASSERT(llv == 0);
+    }
+    { // boolean strings queried as bool
+        ParmParse pp("bool");
+        bool v = false;
+        pp.get("true_val", v);
+        AMREX_ALWAYS_ASSERT(v == true);
+        pp.get("false_val", v);
+        AMREX_ALWAYS_ASSERT(v == false);
+        pp.get("True_val", v);
+        AMREX_ALWAYS_ASSERT(v == true);
+        pp.get("FALSE_val", v);
+        AMREX_ALWAYS_ASSERT(v == false);
+        pp.get("t_val", v);
+        AMREX_ALWAYS_ASSERT(v == true);
+        pp.get("f_val", v);
+        AMREX_ALWAYS_ASSERT(v == false);
     }
     {
         ParmParse pp;


### PR DESCRIPTION
## Summary
ParmParse complains about settings like
```
amrex.abort_on_out_of_gpu_memory = true
```
with a message
```
amrex::Error::0::ParmParse: failed to parse true due to unknown symbol true !!!
```
According to our MFIX-Exa users this is a recent regression.  The key documented as an integer but previous AMReX versions accepted true/false.  I'm not completly sure when this behavior changed.  The proposed patch reverts the behavior to accept "true" (case-insensitive) or "t" for the "1" value and "false/f" for 0.
 
## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
