### PR TITLE
Fix bug in `bisect`

### DIFF
--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -156,8 +156,8 @@ namespace amrex
         T flo = f(lo);
         T fhi = f(hi);
 
-        if (flo == T(0)) { return flo; }
-        if (fhi == T(0)) { return fhi; }
+        if (flo == T(0)) { return lo; }
+        if (fhi == T(0)) { return hi; }
 
         AMREX_ASSERT_WITH_MESSAGE(flo * fhi <= T(0),
             "Error - calling bisect but lo and hi don't bracket a root.");


### PR DESCRIPTION
It mistakenly returned function value instead of root location when endpoint was exact root.

Close #5166.
