### PR TITLE
Fix assertion in bisect

### DIFF
--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -177,7 +177,7 @@ namespace amrex
             ++n;
         }
 
-        AMREX_ASSERT_WITH_MESSAGE(n < max_iter,
+        AMREX_ASSERT_WITH_MESSAGE(n <= max_iter,
             "Error - maximum number of iterations reached in bisect.");
 
         return mi;


### PR DESCRIPTION
`bisect` post-loop assertion had off-by-one error, triggered on valid last-iteration convergence.

Close #5168.
