### PR TITLE
Fix BaseFab::contains

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -334,7 +334,7 @@ public:
     */
     [[nodiscard]] bool contains (const BaseFab<T>& fab) const noexcept
     {
-        return box().contains(fab.box()) && this->nvar <= fab.nvar;
+        return box().contains(fab.box()) && this->nvar >= fab.nvar;
     }
 
     /**


### PR DESCRIPTION
`BaseFab::contains(BaseFab)` had wrong comparison direction for component count.

Close #5170.

