### PR TITLE
SUNDIALS: Fix a memory leak in N_VDestroy_MultiFab

### DIFF
--- a/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_NVector_MultiFab.cpp
@@ -203,11 +203,14 @@ N_Vector N_VClone_MultiFab(N_Vector w)
 
 void N_VDestroy_MultiFab(N_Vector v)
 {
+    if (v == nullptr) { return; }
     if (amrex::sundials::N_VGetOwnMF_MultiFab(v) == SUNTRUE)
     {
          delete amrex::sundials::getMFptr(v);
          amrex::sundials::getMFptr(v) = nullptr;
     }
+    std::free(v->content);
+    v->content = nullptr;
     N_VFreeEmpty(v);
 }
 


### PR DESCRIPTION
The issue was `N_VDestroy_MultiFab` did not free custom N_Vector content allocation.

Close #5037.
