### PR TITLE
Managed Arena: Do not pre-allocate if managed memory is not supported.

### DIFF
--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -239,6 +239,9 @@ Arena::allocate_system (std::size_t nbytes) // NOLINT(readability-make-member-fu
 
         if (arena_info.device_use_managed_memory)
         {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Gpu::Device::managedMemorySupported(),
+                                             "Managed memory is not supported on this system");
+
             AMREX_HIP_OR_CUDA_OR_SYCL(
                 auto ret = hipMallocManaged(&p, nbytes);
                 if (ret != hipSuccess) { p = nullptr; },
@@ -538,7 +541,11 @@ Arena::Initialize (bool minimal)
         the_device_arena->ResetMaxUsageCounter();
     }
 
-    if (the_managed_arena_init_size > 0 && the_managed_arena != the_arena) {
+    if (the_managed_arena_init_size > 0 && the_managed_arena != the_arena
+#ifdef AMREX_USE_GPU
+        && Gpu::Device::managedMemorySupported()
+#endif
+        ) {
         BL_PROFILE("The_Managed_Arena::Initialize()");
         void *p = the_managed_arena->alloc(the_managed_arena_init_size);
         the_managed_arena->free(p);

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -194,6 +194,8 @@ public:
 
 #ifdef AMREX_USE_GPU
 
+    static int managedMemorySupported () noexcept { return device_prop.managedMemory; }
+
     static int memoryPoolsSupported () noexcept { return memory_pools_supported; }
 
 #if defined(AMREX_USE_HIP)


### PR DESCRIPTION
On some systems, managed memory is not supported. Since amrex does not dependent on managed memory, there is no reason to fail at the initial allocation of the managed arena. If the user tries to use The_Managed_Arena() later or The_Arena() is set to use managed memory, this is still a hard error.
