### PR TITLE
ParmParse: Preserve quotes when printing strings

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -652,7 +652,21 @@ run with:
 
 ::
 
-        myexecutable myinputsfile ncells="64 32 16" hydro.cfl=0.9
+        myexecutable myinputsfile ncells="64 32 16" hydro.cfl=0.9 my_string=\"A String\"
+
+Note that the shell strips the quoting characters before the arguments reach
+:cpp:`main(int argc, char** argv)`. The quotes in ``ncells="64 32 16"`` only
+ensure that the spaces stay inside a single argument; the literal ``"``
+never arrives in :cpp:`argv`. If you actually need to pass a single string
+to the code (e.g., for :cpp:`my_string`), you must escape them as shown
+above. The example command line is equivalent to putting the following
+entries in an inputs file:
+
+.. code-block:: none
+
+   ncells = 64 32 16
+   hydro.cfl = 0.9
+   my_string = "A String"
 
 
 Setting Default Via Environment Variable

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1706,11 +1706,11 @@ public:
     static int Verbose ();
     static void SetVerbose (int v);
 
-    //! Write the contents of the table in ASCII to the ostream.
+    //! Write the contents of the table in ASCII to the ostream (diagnostic only, not valid ParmParse syntax).
     static void dumpTable (std::ostream& os, bool prettyPrint = false);
 
-    //! Write all entries in the table in a pretty way to the ostream. If there are
-    //! duplicates, only the last one is printed.
+    //! Write all entries in ParmParse syntax suitable for re-reading. If
+    //! there are duplicates, only the last one is printed.
     static void prettyPrintTable (std::ostream& os);
 
     //! Write unused inputs in a pretty way to the ostream. If there are
@@ -1735,12 +1735,19 @@ public:
     //! Returns [prefix.]* parameters.
     [[nodiscard]] static std::set<std::string> getEntries (const std::string& prefix = std::string());
 
+    enum class QuoteType : unsigned char {
+        None = 0,
+        Double,
+        Triple
+    };
+
     struct PP_entry {
         // There can be multiple occurrences for a given name (e.g.,
         // multiple lines starting with `foo =` in inputs. For each
         // occurrence, there can be multiple values. Thus, the use of
         // vector<vector<std::string>>.
         std::vector<std::vector<std::string>> m_vals;
+        std::vector<std::vector<QuoteType>>   m_quotes;
         mutable Long                          m_count = 0;
         mutable std::variant<
             std::string*,

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -73,7 +73,7 @@ std::string pp_to_pretty_string (std::string const& name,
                 ss << " \"" << v << "\"";
                 break;
             case ParmParse::QuoteType::Triple:
-                ss << " \"\"\"" << v << "\"\"\"";
+                ss << R"( """)" << v << R"(""")";
                 break;
             case ParmParse::QuoteType::None:
             default:
@@ -1364,7 +1364,7 @@ saddarr (const std::string& name, const std::vector<T>& ref)
     auto& entry = g_table[name];
     auto arr_size = arr.size();
     entry.m_vals.emplace_back(std::move(arr));
-    entry.m_quotes.emplace_back(std::vector<ParmParse::QuoteType>(arr_size, ParmParse::QuoteType::None));
+    entry.m_quotes.emplace_back(arr_size, ParmParse::QuoteType::None);
     ++entry.m_count;
     using T_ptr = std::decay_t<T>*;
     entry.m_typehint = static_cast<T_ptr>(nullptr);
@@ -1595,7 +1595,7 @@ ParmParse::addfile (std::string const& filename) {
     // add the file
     auto file = FileKeyword;
     std::vector<std::string> val{{filename}};
-    std::vector<ParmParse::QuoteType> val_quotes{{ParmParse::QuoteType::None}};
+    std::vector<ParmParse::QuoteType> val_quotes{ParmParse::QuoteType::None};
     addDefn(file, val, val_quotes, g_table);
 
     g_toml_table_key.clear();

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -54,15 +54,32 @@ bool is_toml_array (std::string const& token);
 
 std::string pp_to_pretty_string (std::string const& name,
                                  std::vector<std::string> const& vals,
+                                 std::vector<ParmParse::QuoteType> const* quotes,
                                  ParmParse::PP_entry const* entry)
 {
     std::stringstream ss;
     ss << name << " =";
-    for (auto const& v : vals) {
+    for (std::size_t i = 0; i < vals.size(); ++i) {
+        auto const& v = vals[i];
         if (is_toml_array(v)) {
             ss << " " << v.substr(5); // length of $$ARR is 5.
         } else {
-            ss << " " << v;
+            ParmParse::QuoteType quote = ParmParse::QuoteType::None;
+            if (quotes != nullptr && i < quotes->size()) {
+                quote = (*quotes)[i];
+            }
+            switch (quote) {
+            case ParmParse::QuoteType::Double:
+                ss << " \"" << v << "\"";
+                break;
+            case ParmParse::QuoteType::Triple:
+                ss << " \"\"\"" << v << "\"\"\"";
+                break;
+            case ParmParse::QuoteType::None:
+            default:
+                ss << " " << v;
+                break;
+            }
         }
     }
     if (entry && entry->m_parsed && ! entry->m_last_vals.empty()) {
@@ -291,12 +308,13 @@ void eat_comment (const char*& str)
 
 PType
 getToken (const char*& str, std::string& ostr, int& num_linefeeds,
-          bool& newline_from_comment)
+          bool& newline_from_comment, ParmParse::QuoteType& quote_type)
 {
    //
    // Eat white space and comments.
    //
    num_linefeeds = eat_garbage(str, &newline_from_comment);
+   quote_type = ParmParse::QuoteType::None;
     //
     // Check for end of file.
     //
@@ -338,9 +356,11 @@ getToken (const char*& str, std::string& ostr, int& num_linefeeds,
                         ++str;
                     }
                     state = lexState::TRIPLY_QUOTED_STRING;
+                    quote_type = ParmParse::QuoteType::Triple;
                 } else {
                     str++;
                     state = lexState::QUOTED_STRING;
+                    quote_type = ParmParse::QuoteType::Double;
                 }
             }
             else if ( ch == '(' )
@@ -704,7 +724,8 @@ read_file (const char* fname, ParmParse::Table& tab)
 }
 
 void
-addDefn (std::string& def, std::vector<std::string>& val, ParmParse::Table& tab)
+addDefn (std::string& def, std::vector<std::string>& val,
+         std::vector<ParmParse::QuoteType>& val_quotes, ParmParse::Table& tab)
 {
     //
     // Check that defn exists.
@@ -722,6 +743,7 @@ addDefn (std::string& def, std::vector<std::string>& val, ParmParse::Table& tab)
         amrex::ErrorStream() << "ParmParse::addDefn(): no values for definition " << def << "\n";
         amrex::Abort();
     }
+    AMREX_ALWAYS_ASSERT(val.size() == val_quotes.size());
     //
     // Check if this defn is a file include directive.
     //
@@ -745,8 +767,10 @@ addDefn (std::string& def, std::vector<std::string>& val, ParmParse::Table& tab)
             key.append(g_toml_table_key).append(".").append(def);
         }
         tab[key].m_vals.push_back(val);
+        tab[key].m_quotes.push_back(val_quotes);
     }
     val.clear();
+    val_quotes.clear();
     def = std::string();
 }
 
@@ -755,6 +779,7 @@ bldTable (const char*& str, ParmParse::Table& tab)
 {
     std::string              cur_value;
     std::vector<std::string> cur_list;
+    std::vector<ParmParse::QuoteType> cur_quotes;
     std::vector<int>         cur_linefeeds;
 
     for (;;)
@@ -762,8 +787,9 @@ bldTable (const char*& str, ParmParse::Table& tab)
         std::string tokvalue;
         int num_linefeeds;
         bool newline_from_comment = false;
+        ParmParse::QuoteType tok_quote = ParmParse::QuoteType::None;
 
-        PType toktype = getToken(str, tokvalue, num_linefeeds, newline_from_comment);
+        PType toktype = getToken(str, tokvalue, num_linefeeds, newline_from_comment, tok_quote);
 
         switch (toktype)
         {
@@ -779,7 +805,7 @@ bldTable (const char*& str, ParmParse::Table& tab)
                 error_message.append(". Must use \\ for line continuation.");
                 amrex::Abort(error_message);
             }
-            addDefn(cur_value,cur_list,tab);
+            addDefn(cur_value,cur_list,cur_quotes,tab);
             return;
         }
         case PType::EQ_sign:
@@ -791,6 +817,7 @@ bldTable (const char*& str, ParmParse::Table& tab)
                 //
                 auto tmp_str = cur_list.back();
                 cur_list.pop_back();
+                cur_quotes.pop_back();
                 cur_linefeeds.pop_back();
                 if (std::accumulate(cur_linefeeds.begin(), cur_linefeeds.end(), int(0)) > 0)
                 {
@@ -802,7 +829,7 @@ bldTable (const char*& str, ParmParse::Table& tab)
                     error_message.append(". Must use \\ for line continuation.");
                     amrex::Abort(error_message);
                 }
-                addDefn(cur_value,cur_list,tab);
+                addDefn(cur_value,cur_list,cur_quotes,tab);
                 cur_value = std::move(tmp_str);
             }
             cur_linefeeds.clear();
@@ -827,10 +854,11 @@ bldTable (const char*& str, ParmParse::Table& tab)
             if (cur_value.empty() && cur_list.empty() && !table_key.empty()) {
                 g_toml_table_key = std::move(table_key);
             } else if ((table_header_on_newline) && !cur_list.empty() && !table_key.empty()) {
-                addDefn(cur_value,cur_list,tab);
+                addDefn(cur_value,cur_list,cur_quotes,tab);
                 g_toml_table_key = std::move(table_key);
             } else {
                 cur_list.push_back(std::move(tokvalue));
+                cur_quotes.push_back(tok_quote);
                 cur_linefeeds.push_back(num_linefeeds);
             }
             break;
@@ -1315,6 +1343,7 @@ saddval (const std::string& name, const T& ref)
 
     auto& entry = g_table[name];
     entry.m_vals.emplace_back(std::vector<std::string>{val.str()});
+    entry.m_quotes.emplace_back(std::vector<ParmParse::QuoteType>{ParmParse::QuoteType::None});
     ++entry.m_count;
     using T_ptr = std::decay_t<T>*;
     entry.m_typehint = static_cast<T_ptr>(nullptr);
@@ -1333,7 +1362,9 @@ saddarr (const std::string& name, const std::vector<T>& ref)
     }
 
     auto& entry = g_table[name];
+    auto arr_size = arr.size();
     entry.m_vals.emplace_back(std::move(arr));
+    entry.m_quotes.emplace_back(std::vector<ParmParse::QuoteType>(arr_size, ParmParse::QuoteType::None));
     ++entry.m_count;
     using T_ptr = std::decay_t<T>*;
     entry.m_typehint = static_cast<T_ptr>(nullptr);
@@ -1380,6 +1411,9 @@ ppinit (int argc, char** argv, const char* parfile, ParmParse::Table& table)
             auto& src = arg_entry.m_vals;
             auto& dst = table[name].m_vals;
             std::move(std::begin(src), std::end(src), std::back_inserter(dst));
+            auto& src_quotes = arg_entry.m_quotes;
+            auto& dst_quotes = table[name].m_quotes;
+            std::move(std::begin(src_quotes), std::end(src_quotes), std::back_inserter(dst_quotes));
         }
     }
     initialized = true;
@@ -1561,7 +1595,8 @@ ParmParse::addfile (std::string const& filename) {
     // add the file
     auto file = FileKeyword;
     std::vector<std::string> val{{filename}};
-    addDefn(file, val, g_table);
+    std::vector<ParmParse::QuoteType> val_quotes{{ParmParse::QuoteType::None}};
+    addDefn(file, val, val_quotes, g_table);
 
     g_toml_table_key.clear();
 }
@@ -1699,6 +1734,7 @@ ParmParse::SetParserPrefix (std::string a_prefix)
     ParmParse::ParserPrefix = std::move(a_prefix);
 }
 
+// dumpTable is a diagnostic view and its output is not intended to be fed back to ParmParse.
 void
 ParmParse::dumpTable (std::ostream& os, bool prettyPrint)
 {
@@ -1712,8 +1748,11 @@ ParmParse::dumpTable (std::ostream& os, bool prettyPrint)
     for (auto const& name : sorted_names) {
         auto const& entry = g_table[name];
         if (prettyPrint && entry.m_count > 0) {
-            for (auto const& vals : entry.m_vals) {
-                os << pp_to_pretty_string(name, vals, nullptr) << '\n';
+            for (std::size_t i = 0; i < entry.m_vals.size(); ++i) {
+                auto const& vals = entry.m_vals[i];
+                auto const* quotes = (i < entry.m_quotes.size())
+                    ? &(entry.m_quotes[i]) : nullptr;
+                os << pp_to_pretty_string(name, vals, quotes, nullptr) << '\n';
             }
         }
         else {
@@ -1748,14 +1787,18 @@ void pretty_print_table (std::ostream& os, PPFlag pp_flag)
     for (auto const& name : sorted_names) {
         auto const& entry = g_table[name];
         if (! entry.m_vals.empty()) {
-            auto const& val = entry.m_vals.back();
-            os << pp_to_pretty_string(name, val, &entry) << '\n';
+            auto const idx = entry.m_vals.size() - 1;
+            auto const& val = entry.m_vals[idx];
+            auto const* quotes = (idx < entry.m_quotes.size())
+                ? &(entry.m_quotes[idx]) : nullptr;
+            os << pp_to_pretty_string(name, val, quotes, &entry) << '\n';
         }
     }
 }
 
 }
 
+// prettyPrintTable emits valid ParmParse syntax that can be parsed again.
 void
 ParmParse::prettyPrintTable (std::ostream& os)
 {

--- a/Tests/ParmParse/inputs
+++ b/Tests/ParmParse/inputs
@@ -7,6 +7,10 @@ amrex.v = 0
 name = "I am w" \
        "line 2"
 
+# string arrays
+sa = abc xyz 123
+sb = "abc" "xyz" "123"
+
 b = ((1, 2, 3) (7, 8,9) (1,0,   1))
 
 # three numbers. whitespaces inside `""` are okay.

--- a/Tests/ParmParse/main.cpp
+++ b/Tests/ParmParse/main.cpp
@@ -37,6 +37,12 @@ int main(int argc, char* argv[])
         pp.query("name", name, 1);
         AMREX_ALWAYS_ASSERT(name == "line 2");
 
+        std::vector<std::string> sa;
+        std::vector<std::string> sb;
+        pp.getarr("sa", sa);
+        pp.getarr("sa", sb);
+        AMREX_ALWAYS_ASSERT(sa == sb && (sa == std::vector<std::string>{"abc","xyz","123"}));
+
         Box box;
         pp.query("b", box);
         AMREX_ALWAYS_ASSERT(box == Box(IntVect(AMREX_D_DECL(1,2,3)),


### PR DESCRIPTION
If the original strings are quoted, we will preserve them when printing with ParmParse::prettyPrintTable. In this way, we will be able to read them back without altering the meaning.

Close #5181.
