### PR TITLE
Parser: fix self assignment of locals

### DIFF
--- a/Src/Base/Parser/AMReX_IParser_Exe.cpp
+++ b/Src/Base/Parser/AMReX_IParser_Exe.cpp
@@ -528,8 +528,8 @@ iparser_compile_exe_size (struct iparser_node* node, char*& p, std::size_t& exe_
     case IPARSER_ASSIGN:
     {
         auto *asgn = (struct iparser_assign*)node;
-        local_variables.push_back(asgn->s->name);
         iparser_compile_exe_size(asgn->v, p, exe_size, max_stack_size, stack_size, local_variables);
+        local_variables.push_back(asgn->s->name);
         break;
     }
     case IPARSER_LIST:

--- a/Src/Base/Parser/AMReX_Parser_Exe.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Exe.cpp
@@ -606,9 +606,9 @@ parser_compile_exe_size (struct parser_node* node, char*& p, std::size_t& exe_si
     case PARSER_ASSIGN:
     {
         auto *asgn = (struct parser_assign*)node;
-        local_variables.push_back(asgn->s->name);
         parser_compile_exe_size(asgn->v, p, exe_size, max_stack_size, stack_size,
                                 local_variables, ufs);
+        local_variables.push_back(asgn->s->name);
         break;
     }
     case PARSER_LIST:

--- a/Tests/Parser/main.cpp
+++ b/Tests/Parser/main.cpp
@@ -186,7 +186,7 @@ int main (int argc, char* argv[])
                         {-1., -1., -1.0}, {1.0, 1.0, 1.0}, 100,
                         1.e-12, 1.e-15);
 
-        nerror += test3("r2=(z-zc)*(z-zc)+(y-yc)*(y-yc)+(x-xc)*(x-xc); r=sqrt(r2); if(r < (r_star-dR), 0.0, if(r <= r_star, dens, 0.0))",
+        nerror += test3("r=(z-zc)*(z-zc)+(y-yc)*(y-yc)+(x-xc)*(x-xc); r=sqrt(r); if(r < (r_star-dR), 0.0, if(r <= r_star, dens, 0.0))",
                         {{"xc", 0.1}, {"yc", -1.0}, {"zc", 0.2}, {"r_star", 0.73}, {"dR", 0.57}, {"dens", 12.}},
                         {"x","y","z"},
                         [=] (double x, double y, double z) -> double {


### PR DESCRIPTION
When a local variable appeared on both sides of an assignment (e.g., `r = x*x + y*y; r = sqrt(r);`), the parser would compile the RHS while the new `r` slot was already active, so the RHS saw the uninitialized version of `r`. We now compile the RHS first and only add/update the local slot after, so self-referential assignments evaluate correctly.
