### PR TITLE
Add missing include

### DIFF
--- a/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
+++ b/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
@@ -1,6 +1,7 @@
 #include <AMReX_VisMF.H>
 #include <AMReX_AsyncOut.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_PlotFileUtilHDF5.H>
 #include <AMReX_FPC.H>
 #include <AMReX_FabArrayUtility.H>
 


### PR DESCRIPTION
Fixes call to `WriteSingleLevelPlotfileHDF5` in my program:
```
.../amrex/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp: In function ”void amrex::WriteSingleLevelPlotfileHDF5(const std::string&, const MultiFab&, const Vector<std::__cxx11::basic_string<char> >&, const Geometry&, Real, int, const std::string&, const std::string&, const std::string&, const std::string&, const Vector<std::__cxx11::basic_string<char> >&)”:
.../amrex/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp:1297:5: virhe: ”WriteMultiLevelPlotfileHDF5” was not declared in this scope; did you mean ”WriteMultiLevelPlotfile”?
 1297 |     WriteMultiLevelPlotfileHDF5(plotfilename, 1, mfarr, varnames, geomarr, time, level_steps, ref_ratio,
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |     WriteMultiLevelPlotfile
make: *** [.../amrex/Tools/GNUMake/Make.rules:262: tmp_build_dir/o/3d.gnu.DEBUG.EXE/AMReX_PlotFileUtilHDF5.o] Error 1
```

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
