### PR TITLE
Filter transform fix

### DIFF
--- a/Src/Particle/AMReX_ParticleTransformation.H
+++ b/Src/Particle/AMReX_ParticleTransformation.H
@@ -473,7 +473,7 @@ Index filterAndTransformParticles (DstTile& dst, const SrcTile& src, Index* mask
     {
         if (mask[i]) {
             f(dst_data, src_data, src_start+i,
-              dst_start+p_offsets[src_start+i]);
+              dst_start+p_offsets[i]);
         }
     });
 

--- a/Tests/Particles/ParticleTransformations/inputs
+++ b/Tests/Particles/ParticleTransformations/inputs
@@ -1,3 +1,3 @@
-reduce.size = (256, 256, 256)
-reduce.max_grid_size = 128
-reduce.num_ppc = 1
+transform.size = (64, 64, 64)
+transform.max_grid_size = 32
+transform.num_ppc = 1

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -464,6 +464,8 @@ template <typename PC>
 void testFilterAndTransformWithOffsets (const PC& pc)
 {
     using ParticleTileType = typename PC::ParticleTileType;
+    using ParticleTileDataType = typename ParticleTileType::ParticleTileDataType;
+    using ConstParticleTileDataType = typename ParticleTileType::ConstParticleTileDataType;
     using ParIter = typename PC::ParConstIterType;
 
     // Use non-zero offsets: src particles are read starting at src_start,
@@ -520,13 +522,14 @@ void testFilterAndTransformWithOffsets (const PC& pc)
             // iterations of the internal loop (where tile_index >= np - src_start).
             auto num_output = amrex::filterAndTransformParticles(
                 ptile_dst, ptile_src,
-                [src_start, np] AMREX_GPU_HOST_DEVICE (const auto& src, int i) noexcept
+                [src_start, np] AMREX_GPU_HOST_DEVICE (const ConstParticleTileDataType& src, int i) noexcept
                 {
                     const int tile_i = i - src_start;
                     if (tile_i >= np - src_start) { return false; }
                     return src.m_aos[tile_i].id() % 2 == 1;
                 },
-                [src_start, factor] AMREX_GPU_HOST_DEVICE (auto& dst, const auto& src,
+                [src_start, factor] AMREX_GPU_HOST_DEVICE (const ParticleTileDataType& dst,
+                                                            const ConstParticleTileDataType& src,
                                                             int src_i, int dst_i) noexcept
                 {
                     const int tile_i = src_i - src_start;
@@ -537,10 +540,10 @@ void testFilterAndTransformWithOffsets (const PC& pc)
                     for (int j = 0; j < dst.m_num_runtime_int; ++j) {
                         dst.m_runtime_idata[j][dst_i] = src.m_runtime_idata[j][tile_i];
                     }
-                    for (int j = 0; j < std::remove_reference_t<decltype(dst)>::NAR; ++j) {
+                    for (int j = 0; j < ParticleTileDataType::NAR; ++j) {
                         dst.m_rdata[j][dst_i] = src.m_rdata[j][tile_i];
                     }
-                    for (int j = 0; j < std::remove_reference_t<decltype(dst)>::NAI; ++j) {
+                    for (int j = 0; j < ParticleTileDataType::NAI; ++j) {
                         dst.m_idata[j][dst_i] = factor * src.m_idata[j][tile_i];
                     }
                 },
@@ -651,7 +654,7 @@ int main (int argc, char* argv[])
 {
     amrex::Initialize(argc,argv);
 
-    amrex::Print() << "Running particle reduction test \n";
+    amrex::Print() << "Running particle transformation test \n";
     testTransformations();
 
     amrex::Finalize();

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -522,15 +522,15 @@ void testFilterAndTransformWithOffsets (const PC& pc)
             // iterations of the internal loop (where tile_index >= np - src_start).
             auto num_output = amrex::filterAndTransformParticles(
                 ptile_dst, ptile_src,
-                [src_start, np] AMREX_GPU_HOST_DEVICE (const ConstParticleTileDataType& src, int i) noexcept
+                [=] AMREX_GPU_HOST_DEVICE (const ConstParticleTileDataType& src, int i) noexcept
                 {
                     const int tile_i = i - src_start;
                     if (tile_i >= np - src_start) { return false; }
                     return src.m_aos[tile_i].id() % 2 == 1;
                 },
-                [src_start, factor] AMREX_GPU_HOST_DEVICE (const ParticleTileDataType& dst,
-                                                            const ConstParticleTileDataType& src,
-                                                            int src_i, int dst_i) noexcept
+                [=] AMREX_GPU_HOST_DEVICE (const ParticleTileDataType& dst,
+                                           const ConstParticleTileDataType& src,
+                                           int src_i, int dst_i) noexcept
                 {
                     const int tile_i = src_i - src_start;
                     dst.m_aos[dst_i] = src.m_aos[tile_i];

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -461,6 +461,132 @@ void testFilter (const PC& pc)
 }
 
 template <typename PC>
+void testFilterAndTransformWithOffsets (const PC& pc)
+{
+    using ParticleTileType = typename PC::ParticleTileType;
+    using ParIter = typename PC::ParConstIterType;
+
+    // Use non-zero offsets: src particles are read starting at src_start,
+    // and written into dst starting at dst_start.
+    // The filter and transformer receive src_start+i as the src index,
+    // so they subtract src_start to get the actual tile index.
+    const int src_start = 3;
+    const int dst_start = 5;
+    const int factor = 4;
+
+    for (int lev = 0; lev <= pc.finestLevel(); ++lev)
+    {
+        for (ParIter pti(pc, lev); pti.isValid(); ++pti)
+        {
+            const auto& ptile_src = pc.ParticlesAt(lev, pti);
+            const int np = ptile_src.numParticles();
+
+            if (np == 0) { continue; }
+
+            // Count particles that pass the odd-id filter (to size the dst tile).
+            // Copy the AoS and idata to host so we can inspect them.
+            using ParticleType = typename PC::ParticleType;
+            Gpu::HostVector<ParticleType> h_src_aos(np);
+            Gpu::HostVector<int> h_src_idata(np);
+            Gpu::copyAsync(Gpu::deviceToHost,
+                           ptile_src.GetArrayOfStructs().begin(),
+                           ptile_src.GetArrayOfStructs().end(),
+                           h_src_aos.begin());
+            Gpu::copyAsync(Gpu::deviceToHost,
+                           ptile_src.GetStructOfArrays().GetIntData(NAI - 1).begin(),
+                           ptile_src.GetStructOfArrays().GetIntData(NAI - 1).end(),
+                           h_src_idata.begin());
+            Gpu::streamSynchronize();
+
+            // Only the first (np - src_start) particles are eligible due to
+            // the bounds guard in the filter (the last src_start iterations of
+            // the internal loop would access p_offsets out-of-bounds).
+            const int np_eligible = np - src_start;
+            AMREX_ALWAYS_ASSERT(np_eligible > 0);
+
+            int num_pass = 0;
+            for (int i = 0; i < np_eligible; ++i) {
+                if (h_src_aos[i].id() % 2 == 1) { ++num_pass; }
+            }
+
+            // Pre-allocate dst with dst_start slots (pre-existing) plus room for output.
+            ParticleTileType ptile_dst;
+            ptile_dst.resize(dst_start + num_pass);
+
+            // The filter and transformer receive i = src_start + tile_index,
+            // so they subtract src_start to index into the actual tile data.
+            // The guard (i - src_start < np - src_start) prevents accessing
+            // p_offsets[src_start+tile_index] out-of-bounds for the last src_start
+            // iterations of the internal loop (where tile_index >= np - src_start).
+            auto num_output = amrex::filterAndTransformParticles(
+                ptile_dst, ptile_src,
+                [src_start, np] AMREX_GPU_HOST_DEVICE (const auto& src, int i) noexcept
+                {
+                    const int tile_i = i - src_start;
+                    if (tile_i >= np - src_start) { return false; }
+                    return src.m_aos[tile_i].id() % 2 == 1;
+                },
+                [src_start, factor] AMREX_GPU_HOST_DEVICE (auto& dst, const auto& src,
+                                                            int src_i, int dst_i) noexcept
+                {
+                    const int tile_i = src_i - src_start;
+                    dst.m_aos[dst_i] = src.m_aos[tile_i];
+                    for (int j = 0; j < dst.m_num_runtime_real; ++j) {
+                        dst.m_runtime_rdata[j][dst_i] = src.m_runtime_rdata[j][tile_i];
+                    }
+                    for (int j = 0; j < dst.m_num_runtime_int; ++j) {
+                        dst.m_runtime_idata[j][dst_i] = src.m_runtime_idata[j][tile_i];
+                    }
+                    for (int j = 0; j < std::remove_reference_t<decltype(dst)>::NAR; ++j) {
+                        dst.m_rdata[j][dst_i] = src.m_rdata[j][tile_i];
+                    }
+                    for (int j = 0; j < std::remove_reference_t<decltype(dst)>::NAI; ++j) {
+                        dst.m_idata[j][dst_i] = factor * src.m_idata[j][tile_i];
+                    }
+                },
+                src_start, dst_start);
+
+            AMREX_ALWAYS_ASSERT(num_output == num_pass);
+
+            // Copy dst particle data to host for verification (src was already copied above).
+            Gpu::HostVector<ParticleType> h_dst_aos(ptile_dst.size());
+            Gpu::HostVector<int> h_dst_idata(ptile_dst.size());
+
+            Gpu::copyAsync(Gpu::deviceToHost,
+                           ptile_dst.GetArrayOfStructs().begin(),
+                           ptile_dst.GetArrayOfStructs().end(),
+                           h_dst_aos.begin());
+            Gpu::copyAsync(Gpu::deviceToHost,
+                           ptile_dst.GetStructOfArrays().GetIntData(NAI - 1).begin(),
+                           ptile_dst.GetStructOfArrays().GetIntData(NAI - 1).end(),
+                           h_dst_idata.begin());
+            Gpu::streamSynchronize();
+
+            // Verify: dst[dst_start..dst_start+num_pass-1] holds the
+            // filtered+transformed particles - all ids must be odd.
+            for (int k = dst_start; k < dst_start + num_pass; ++k) {
+                AMREX_ALWAYS_ASSERT(h_dst_aos[k].id() % 2 == 1);
+            }
+
+            // Check that every eligible odd-id source particle appears in dst
+            // (via id matching) and that its idata was multiplied by factor.
+            for (int i = 0; i < np_eligible; ++i) {
+                if (h_src_aos[i].id() % 2 == 0) { continue; }
+                bool found = false;
+                for (int k = dst_start; k < dst_start + num_pass; ++k) {
+                    if (h_dst_aos[k].id() == h_src_aos[i].id()) {
+                        AMREX_ALWAYS_ASSERT(h_dst_idata[k] == factor * h_src_idata[i]);
+                        found = true;
+                        break;
+                    }
+                }
+                AMREX_ALWAYS_ASSERT(found);
+            }
+        }
+    }
+}
+
+template <typename PC>
 void testFilterAndTransform (const PC& pc)
 {
     using PType = typename PC::SuperParticleType;
@@ -579,6 +705,8 @@ void testTransformations ()
     testFilter(pc);
 
     testFilterAndTransform(pc);
+
+    testFilterAndTransformWithOffsets(pc);
 
     testTwoWayTransform(pc);
 

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -669,7 +669,7 @@ void testTransformations ()
 {
     BL_PROFILE("testTransformations");
     TestParams params;
-    get_test_params(params, "reduce");
+    get_test_params(params, "transform");
 
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)


### PR DESCRIPTION
This fixes a bug in amrex::filterAndTransformParticles when `src_start` is non-zero. It also adds a new test that covers this case.

Closes #5160.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
