### PR TITLE
ParmParse::add: Improve TOML compatibility

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1707,10 +1707,13 @@ public:
     static void SetVerbose (int v);
 
     //! Write the contents of the table in ASCII to the ostream (diagnostic only, not valid ParmParse syntax).
+    //! Diagnostic view of the internal table. This text is not valid ParmParse syntax
+    //! and is meant for debugging only; use prettyPrintTable() for canonical, re-readable output.
     static void dumpTable (std::ostream& os, bool prettyPrint = false);
 
     //! Write all entries in ParmParse syntax suitable for re-reading. If
-    //! there are duplicates, only the last one is printed.
+    //! there are duplicates, only the last one is printed; the output can be fed
+    //! back to ParmParse via addfile/Initialize.
     static void prettyPrintTable (std::ostream& os);
 
     //! Write unused inputs in a pretty way to the ostream. If there are

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -9,6 +9,7 @@
 #include <AMReX_Utility.H>
 
 #include <algorithm>
+#include <cmath>
 #include <cctype>
 #include <cstdlib>
 #include <iostream>
@@ -172,8 +173,25 @@ is (const std::string& str, T& val)
                 val = 0;
                 return true;
             }
+        if (isT(str, val)) {
+            return true;
+        }
+        double dbl_val = 0.0;
+        if (is_floating_point(str, dbl_val)) {
+            if (std::isfinite(dbl_val)) {
+                auto const truncated = std::trunc(dbl_val);
+                auto const lo = static_cast<long double>(std::numeric_limits<T>::min());
+                auto const hi = static_cast<long double>(std::numeric_limits<T>::max());
+                if (truncated == dbl_val && truncated >= lo && truncated <= hi) {
+                    val = static_cast<T>(truncated);
+                    return true;
+                }
+            }
+        }
+        return false;
+    } else {
+        return isT(str, val);
     }
-    return isT(str, val);
 }
 
 template <>
@@ -1335,15 +1353,44 @@ sgetarr (const ParmParse::Table& table,
 }
 
 template <class T>
+std::string to_toml_value (const T& ref)
+{
+    using TT = std::remove_reference_t<T>;
+    if constexpr (std::is_floating_point_v<TT>) {
+        if (std::isnan(ref)) {
+            return "nan";
+        }
+        if (std::isinf(ref)) {
+            return std::signbit(ref) ? "-inf" : "inf";
+        }
+    }
+    std::stringstream ss;
+    if constexpr (std::is_floating_point_v<TT>) {
+        ss << std::setprecision(std::numeric_limits<TT>::max_digits10);
+    } else if constexpr (std::is_same_v<TT,bool>) {
+        ss << std::boolalpha;
+    }
+    ss << ref;
+    std::string s = ss.str();
+    if constexpr (std::is_floating_point_v<TT>) {
+        // If it has neither a decimal point nor exponent, TOML would parse it as integer.
+        if (s.find_first_of(".eE") == std::string::npos) {
+            s += ".0";
+        }
+    }
+    return s;
+}
+
+template <class T>
 void
 saddval (const std::string& name, const T& ref)
 {
-    std::stringstream val;
-    val << std::setprecision(17) << ref;
-
+    std::string s = to_toml_value(ref);
     auto& entry = g_table[name];
-    entry.m_vals.emplace_back(std::vector<std::string>{val.str()});
-    entry.m_quotes.emplace_back(std::vector<ParmParse::QuoteType>{ParmParse::QuoteType::None});
+    entry.m_vals.emplace_back(1, std::move(s));
+    auto qt = std::is_same_v<std::remove_reference_t<T>,std::string>
+        ? ParmParse::QuoteType::Double : ParmParse::QuoteType::None;
+    entry.m_quotes.emplace_back(1, qt);
     ++entry.m_count;
     using T_ptr = std::decay_t<T>*;
     entry.m_typehint = static_cast<T_ptr>(nullptr);
@@ -1356,15 +1403,15 @@ saddarr (const std::string& name, const std::vector<T>& ref)
     std::vector<std::string> arr;
     arr.reserve(ref.size());
     for (auto const& item : ref) {
-        std::stringstream val;
-        val << std::setprecision(17) << item;
-        arr.push_back(val.str());
+        arr.push_back(to_toml_value(item));
     }
 
     auto& entry = g_table[name];
     auto arr_size = arr.size();
     entry.m_vals.emplace_back(std::move(arr));
-    entry.m_quotes.emplace_back(arr_size, ParmParse::QuoteType::None);
+    auto qt = std::is_same_v<std::remove_reference_t<T>,std::string>
+        ? ParmParse::QuoteType::Double : ParmParse::QuoteType::None;
+    entry.m_quotes.emplace_back(arr_size, qt);
     ++entry.m_count;
     using T_ptr = std::decay_t<T>*;
     entry.m_typehint = static_cast<T_ptr>(nullptr);
@@ -1594,8 +1641,8 @@ ParmParse::addfile (std::string const& filename) {
 
     // add the file
     auto file = FileKeyword;
-    std::vector<std::string> val{{filename}};
-    std::vector<ParmParse::QuoteType> val_quotes{ParmParse::QuoteType::None};
+    std::vector<std::string> val(1, filename);
+    std::vector<ParmParse::QuoteType> val_quotes(1, ParmParse::QuoteType::None);
     addDefn(file, val, val_quotes, g_table);
 
     g_toml_table_key.clear();
@@ -1735,6 +1782,7 @@ ParmParse::SetParserPrefix (std::string a_prefix)
 }
 
 // dumpTable is a diagnostic view and its output is not intended to be fed back to ParmParse.
+// Use prettyPrintTable when you need canonical, re-readable ParmParse syntax.
 void
 ParmParse::dumpTable (std::ostream& os, bool prettyPrint)
 {

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -176,19 +176,24 @@ is (const std::string& str, T& val)
         if (isT(str, val)) {
             return true;
         }
-        double dbl_val = 0.0;
-        if (is_floating_point(str, dbl_val)) {
-            if (std::isfinite(dbl_val)) {
-                auto const truncated = std::trunc(dbl_val);
-                auto const lo = static_cast<long double>(std::numeric_limits<T>::min());
-                auto const hi = static_cast<long double>(std::numeric_limits<T>::max());
-                if (truncated == dbl_val && truncated >= lo && truncated <= hi) {
-                    val = static_cast<T>(truncated);
-                    return true;
-                }
-            }
+        // Treat 123., 123.0, 123.00 etc. as integer.
+        auto dec = str.find('.');
+        if (dec == std::string::npos) {
+            return false;
         }
-        return false;
+        if (dec+1 == str.size()) {
+            std::string stripped = str;
+            stripped.pop_back();
+            return isT(stripped, val);
+        }
+        auto begin_it = str.begin() + static_cast<std::ptrdiff_t>(dec+1);
+        auto end_it = str.end();
+        if (!std::all_of(begin_it, end_it, [] (char c) { return c == '0'; })) {
+            return false;
+        }
+        std::string stripped = str;
+        stripped.erase(dec);
+        return isT(stripped, val);
     } else {
         return isT(str, val);
     }

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1361,14 +1361,6 @@ template <class T>
 std::string to_toml_value (const T& ref)
 {
     using TT = std::remove_reference_t<T>;
-    if constexpr (std::is_floating_point_v<TT>) {
-        if (std::isnan(ref)) {
-            return "nan";
-        }
-        if (std::isinf(ref)) {
-            return std::signbit(ref) ? "-inf" : "inf";
-        }
-    }
     std::stringstream ss;
     if constexpr (std::is_floating_point_v<TT>) {
         ss << std::setprecision(std::numeric_limits<TT>::max_digits10);
@@ -1378,8 +1370,8 @@ std::string to_toml_value (const T& ref)
     ss << ref;
     std::string s = ss.str();
     if constexpr (std::is_floating_point_v<TT>) {
-        // If it has neither a decimal point nor exponent, TOML would parse it as integer.
-        if (s.find_first_of(".eE") == std::string::npos) {
+        const std::regex digits_only(R"([+-]?\d+)");
+        if (std::regex_match(s, digits_only)) {
             s += ".0";
         }
     }

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -159,20 +159,28 @@ is_floating_point (const std::string& str, T& val)
 
 template <class T>
 bool
+is_literal_bool (const std::string& str, T& val)
+{
+    auto const lo_str = amrex::toLower(str);
+    if ( lo_str == "true" || lo_str == "t" ) {
+        val = static_cast<T>(1);
+        return true;
+    } else if ( lo_str == "false" || lo_str == "f" ) {
+        val = static_cast<T>(0);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+template <class T>
+bool
 is (const std::string& str, T& val)
 {
     if constexpr (std::is_integral_v<T>) {
-        auto const lo_str = amrex::toLower(str);
-        if ( lo_str == "true" || lo_str == "t" )
-            {
-                val = 1;
-                return true;
-            }
-        else if ( lo_str == "false" || lo_str == "f" )
-            {
-                val = 0;
-                return true;
-            }
+        if (is_literal_bool(str, val)) {
+            return true;
+        }
         if (isT(str, val)) {
             return true;
         }
@@ -194,23 +202,14 @@ is (const std::string& str, T& val)
         std::string stripped = str;
         stripped.erase(dec);
         return isT(stripped, val);
+    } else if constexpr (std::is_floating_point_v<T>) {
+        if (is_literal_bool(str, val)) {
+            return true;
+        }
+        return is_floating_point(str, val);
     } else {
         return isT(str, val);
     }
-}
-
-template <>
-bool
-is (const std::string& str, float& val)
-{
-    return is_floating_point(str, val);
-}
-
-template <>
-bool
-is (const std::string& str, double& val)
-{
-    return is_floating_point(str, val);
 }
 
 template <>
@@ -225,15 +224,7 @@ template <>
 bool
 is (const std::string& str, bool& val)
 {
-    auto const lo_str = amrex::toLower(str);
-    if ( lo_str == "true" || lo_str == "t" )
-    {
-        val = true;
-        return true;
-    }
-    if ( lo_str == "false" || lo_str == "f" )
-    {
-        val = false;
+    if (is_literal_bool(str, val)) {
         return true;
     }
     int int_val;

--- a/Tests/Enum/inputs
+++ b/Tests/Enum/inputs
@@ -7,3 +7,5 @@ color5 = Blue
 color6 = G-r-e-e.n
 
 colors = cyan yellow orange
+
+colors_quoted = "cyan" "yellow" "orange"

--- a/Tests/Enum/main.cpp
+++ b/Tests/Enum/main.cpp
@@ -98,6 +98,17 @@ int main (int argc, char* argv[])
                                 color[0] == my_namespace::MyColor::cyan &&
                                 color[1] == my_namespace::MyColor::yellow &&
                                 color[2] == my_namespace::MyColor::orange);
+            pp.getarr("colors_quoted", color);
+            AMREX_ALWAYS_ASSERT(color.size() == 3 &&
+                                color[0] == my_namespace::MyColor::cyan &&
+                                color[1] == my_namespace::MyColor::yellow &&
+                                color[2] == my_namespace::MyColor::orange);
+            pp.queryarr("colors_quoted", color2);
+            AMREX_ALWAYS_ASSERT(color.size() == 3 &&
+                                color == color2 &&
+                                color[0] == my_namespace::MyColor::cyan &&
+                                color[1] == my_namespace::MyColor::yellow &&
+                                color[2] == my_namespace::MyColor::orange);
             amrex::Print() << "colors:";
             for (auto const& c : color) {
                 amrex::Print() << " " << amrex::getEnumNameString(c);
@@ -166,6 +177,10 @@ int main (int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(amrex::getEnumNameString(Location::entry) == "entry");
         AMREX_ALWAYS_ASSERT(amrex::getEnumNameString(Location::exit) == "exit");
         AMREX_ALWAYS_ASSERT(amrex::getEnumNameString(Location::after_exit) == "after_exit");
+    }
+
+    {
+        amrex::Print() << "SUCCESS\n";
     }
 
     amrex::Finalize();

--- a/Tests/ParmParse/inputs
+++ b/Tests/ParmParse/inputs
@@ -12,6 +12,7 @@ sa = abc xyz 123
 sb = "abc" "xyz" "123"
 
 b = ((1, 2, 3) (7, 8,9) (1,0,   1))
+b2 = "((1, 2, 3)(7,8,9)(1,0,1))"
 
 # three numbers. whitespaces inside `""` are okay.
 f = 3+4  99  "5 + 6"

--- a/Tests/ParmParse/main.cpp
+++ b/Tests/ParmParse/main.cpp
@@ -48,6 +48,9 @@ int main(int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(box == Box(IntVect(AMREX_D_DECL(1,2,3)),
                                        IntVect(AMREX_D_DECL(7,8,9)),
                                        IntVect(AMREX_D_DECL(1,0,1))));
+        Box box2;
+        pp.get("b2", box2);
+        AMREX_ALWAYS_ASSERT(box == box2);
 
         double f0 = -1;
         pp.query("f", f0);
@@ -284,6 +287,53 @@ int main(int argc, char* argv[])
 #else
         AMREX_ALWAYS_ASSERT(foo == 32 && bar == "use_cpu" && spacedim == AMREX_SPACEDIM);
 #endif
+    }
+    { // add & addarr
+        ParmParse pp;
+        pp.add("bt", true);
+        pp.add("bf", false);
+        std::string s;
+        pp.get("bt", s); // It is intentional to read bool as string
+        AMREX_ALWAYS_ASSERT(s == "true");
+        pp.get("bf", s); // It is intentional to read bool as string
+        AMREX_ALWAYS_ASSERT(s == "false");
+
+        pp.add("doubleone",double(1));
+        pp.get("doubleone", s); // It is intentional to read double as string
+        AMREX_ALWAYS_ASSERT(s == "1.0");
+        int intone;
+        pp.query("doubleone", intone); // We are allowed to read 1.0 as 1.
+        AMREX_ALWAYS_ASSERT(intone == 1);
+
+        pp.add("string_scalar", "An string with white spaces");
+        pp.get("string_scalar", s);
+        AMREX_ALWAYS_ASSERT(s == "An string with white spaces");
+
+        std::vector<std::string> sv{"string a", " string b", " string c ", "string-d"};
+        pp.addarr("string_vector", sv);
+        for (int i = 0; i < int(sv.size()); ++i) {
+            pp.get("string_vector", s, i);
+            AMREX_ALWAYS_ASSERT(s == sv[i]);
+        }
+    }
+    if (ParallelDescriptor::IOProcessor()) // print & addfile
+    {
+        {
+            ParmParse pp;
+            pp.add("string-for-testing-addfile", "string for testing addfile");
+            pp.add("string-for-testing-addfile", "string for testing addfile");
+            int n = pp.countname("string-for-testing-addfile");
+            AMREX_ALWAYS_ASSERT(n==2);
+        }
+        std::ofstream ofs("my-inputs");
+        ParmParse::prettyPrintTable(ofs);
+        ofs.close();
+        ParmParse::addfile("my-inputs");
+        std::string s;
+        ParmParse pp;
+        pp.get("string-for-testing-addfile", s);
+        int n = pp.countname("string-for-testing-addfile");
+        AMREX_ALWAYS_ASSERT(n==3 && s == "string for testing addfile");
     }
     {
         amrex::Print() << "SUCCESS\n";


### PR DESCRIPTION
Make sure a string scalar with white spaces does not get split, when it's printed out by `prettyPrintTable`.

For bool, we save them as `true` or `false`, instead of 1 or 0.

For floating point numbers, we use TOML-compatible format (e.g., 1.0 not 1).

Note that `addarr` remains incompatible with TOML, because ParmParse array differs from TOML array.

Close #5182 