### PR TITLE
Avoid clang warnings with -Wshadow-field

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -200,13 +200,13 @@ public:
 
 protected:
 
-    bool m_needs_update = true;
-
     Vector<int> m_is_singular;
 
     [[nodiscard]] bool supportRobinBC () const noexcept override { return true; }
 
 private:
+
+    bool m_needs_update = true;
 
     int m_ncomp = 1;
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.H
@@ -140,8 +140,6 @@ protected:
 
     int m_ncomp = 1;
 
-    bool m_needs_update = true;
-
     Location m_beta_loc; // Location of coefficients: face centers or face centroids
     Location m_phi_loc;  // Location of solution variable: cell centers or cell centroids
 
@@ -168,6 +166,11 @@ protected:
     [[nodiscard]] bool supportRobinBC () const noexcept override { return true; }
 
     mutable Vector<Vector<TagVector<MLMGABCEBTag<RT>>>> m_eb_bc_tags;
+
+private:
+
+    bool m_needs_update = true;
+
 };
 
 /// \cond DOXYGEN_IGNORE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
@@ -93,13 +93,15 @@ public:
 
 protected:
 
-    bool m_needs_update = true;
-
     bool m_has_kappa = false;
     bool m_has_eb_kappa = false;
     Vector<Vector<Array<MultiFab,AMREX_SPACEDIM> > > m_kappa;
     Vector<Vector<MultiFab> > m_eb_kappa;
     mutable Vector<Vector<Array<MultiFab,AMREX_SPACEDIM> > > m_tauflux;
+
+private:
+
+    bool m_needs_update = true;
 
 public: // for cuda
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
@@ -93,10 +93,12 @@ public:
 
 protected:
 
-    bool m_needs_update = true;
-
     bool m_has_kappa = false;
     Vector<Vector<Array<MultiFab,AMREX_SPACEDIM> > > m_kappa;
+
+private:
+
+    bool m_needs_update = true;
 
 public: // for cuda
 


### PR DESCRIPTION
## Summary

Compiling with clang++ and -Wshadow-field I get warnings:
```
AMReX_MLEBTensorOp.H:96:10: error: non-static data member 'm_needs_update' of 'MLEBTensorOp' shadows member inherited from type 'MLEBABecLap' [-Werror,-Wshadow-field]
```
Each class in the LinearSolvers/MLMG/ hierarchy has its own `m_needs_update`.  Some of these are `protected` and some are `private`.  Inheriting from the `protected` ones causes the shadowing warning.  This patch makes them all `private` which resolves the warnings.  (I don't believe there's a reason for them to be `protected` rather than `private` as they are accessed in subclasses through the `needsUpdate` function rather than direct member access.)

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
