### PR TITLE
Add external GPU stream override support

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1523,7 +1523,7 @@ it is reset, at which point AMReX restores the previous external stream.
   the previous external stream, if any.  Passing
   :cpp:`amrex::Gpu::ExternalStreamSync::No` to
   ``sync_stream``/``sync_on_exit`` skips the final
-  :cpp:`gpuStreamSynchronize` unless deferred frees recorded by
+  :cpp:`Gpu::streamSynchronize` unless deferred frees recorded by
   :cpp:`The_Async_Arena` are still pending, in which case AMReX forces a
   synchronization to keep the arena safe.
 * All asynchronous frees recorded through :cpp:`amrex::Gpu::freeAsync` and
@@ -1539,6 +1539,16 @@ Limitations and best practices:
   keeps :cpp:`MFIter` from trying to pipeline across multiple AMReX-managed
   streams, but it also means you cannot currently provide a *set* of external
   streams for MFIter to round-robin across.
+* Objects that use stream-ordered memory (for example, a :cpp:`BaseFab`
+  allocated from :cpp:`The_Async_Arena`) should generally be created and
+  destroyed within the same external-stream region.  In particular, avoid
+  creating or resizing such an object inside an external-stream region and
+  then destroying it after that region has exited, or creating it outside and
+  then resizing or destroying it inside the region.  Stream-ordered frees
+  remember the stream associated with the allocation, and AMReX requires that
+  stream to still be managed when the free occurs.  If that stream was
+  external and has already been popped, AMReX aborts instead of guessing where
+  to enqueue the deferred free.
 * Make sure the external stream remains valid for the duration of the override.
   Destroying it before the RAII guard goes out of scope is undefined behavior.
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1527,7 +1527,15 @@ it is reset, at which point AMReX restores the previous external stream.
   :cpp:`The_Async_Arena` are still pending, in which case AMReX forces a
   synchronization to keep the arena safe.  The external stream or queue must
   belong to the active AMReX device.  For SYCL, the queue must also use the
-  same SYCL context as AMReX and must be an in-order queue.
+  same SYCL context as AMReX and must be an in-order queue.  AMReX selects the
+  active GPU during :cpp:`amrex::Initialize`, whose overloads accept an
+  optional trailing :cpp:`int device_id` argument; pass the desired GPU there
+  if an external runtime needs AMReX to adopt a specific device before the
+  stream is created.  Conversely, if AMReX should drive the selection, query
+  :cpp:`amrex::Gpu::Device::deviceId()` and configure the external runtime
+  (for example, by calling :cpp:`cudaSetDevice` or :cpp:`hipSetDevice` before
+  constructing the stream) so that the stream is associated with the device
+  AMReX is already using.
 * All asynchronous frees recorded through :cpp:`amrex::Gpu::freeAsync` and
   The_Async_Arena continue to work because AMReX tracks the external stream with
   an internal :cpp:`StreamManager`.

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1525,7 +1525,9 @@ it is reset, at which point AMReX restores the previous external stream.
   ``sync_stream``/``sync_on_exit`` skips the final
   :cpp:`Gpu::streamSynchronize` unless deferred frees recorded by
   :cpp:`The_Async_Arena` are still pending, in which case AMReX forces a
-  synchronization to keep the arena safe.
+  synchronization to keep the arena safe.  The external stream or queue must
+  belong to the active AMReX device.  For SYCL, the queue must also use the
+  same SYCL context as AMReX and must be an in-order queue.
 * All asynchronous frees recorded through :cpp:`amrex::Gpu::freeAsync` and
   The_Async_Arena continue to work because AMReX tracks the external stream with
   an internal :cpp:`StreamManager`.
@@ -1535,6 +1537,10 @@ Limitations and best practices:
 * Entering or exiting the override inside an OpenMP parallel region is
   illegal and will trigger an assertion.  Configure the stream on the main
   thread before launching GPU work, if OpenMP threading is used.
+* Backend compatibility rules are checked when the override is installed.
+  CUDA and HIP external streams must be associated with the current
+  :cpp:`amrex::Gpu::Device::deviceId()`.  SYCL external queues must use
+  AMReX's SYCL device and SYCL context, and must be in-order.
 * While an override is active, :cpp:`Gpu::numGpuStreams()` reports ``1``.  This
   keeps :cpp:`MFIter` from trying to pipeline across multiple AMReX-managed
   streams, but it also means you cannot currently provide a *set* of external

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1556,6 +1556,12 @@ Limitations and best practices:
   read its final value before leaving that region.
 * Make sure the external stream remains valid for the duration of the override.
   Destroying it before the RAII guard goes out of scope is undefined behavior.
+* Using :cpp:`ExternalStreamSync::No` transfers synchronization responsibility
+  to the caller.  After :cpp:`resetExternalGpuStream(ExternalStreamSync::No)`,
+  AMReX no longer tracks that external stream, and later AMReX global
+  synchronization helpers are not guaranteed to wait for work already queued
+  on it.  It is the user's responsibility to synchronize that external stream
+  before any dependent teardown or finalization.
 
 Example: wrap AMReX work inside an externally created CUDA stream:
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1549,6 +1549,10 @@ Limitations and best practices:
   stream to still be managed when the free occurs.  If that stream was
   external and has already been popped, AMReX aborts instead of guessing where
   to enqueue the deferred free.
+* Likewise, reuse a given :cpp:`Reducer` or :cpp:`ReduceData` object only on a
+  single external stream.  Reusing the same object across different external
+  stream regions, or across an external stream and AMReX stream 0, is not
+  supported and triggers an assertion.
 * Make sure the external stream remains valid for the duration of the override.
   Destroying it before the RAII guard goes out of scope is undefined behavior.
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1501,6 +1501,76 @@ This approach suppresses implicit synchronization for all operations within
 the scoped region and restores the previous synchronization setting upon
 exiting.
 
+.. _sec:gpu:external-streams:
+
+External GPU Streams
+====================
+
+AMReX normally launches GPU kernels from an internal pool of GPU streams and
+round-robins across them inside :cpp:`MFIter` loops.  When an application
+needs to integrate with an externally managed stream, AMReX provides an
+override mechanism.  External-stream overrides form a stack and all calls
+must occur outside OpenMP parallel regions.  If you install a new external
+stream while another is already active, the new handle becomes current until
+it is reset, at which point AMReX restores the previous external stream.
+
+* Call :cpp:`amrex::Gpu::setExternalGpuStream(stream)` (or use the RAII
+  helper :cpp:`amrex::Gpu::ExternalGpuStreamRegion(stream,sync_on_exit)`) on
+  the host.  Every subsequent call to :cpp:`amrex::Gpu::gpuStream()` returns
+  the supplied stream.  Calls must be paired with
+  :cpp:`amrex::Gpu::resetExternalGpuStream(sync_stream)` (RAII helpers pass
+  the same flag via ``sync_on_exit``); popping the current stream restores
+  the previous external stream, if any.  Passing
+  :cpp:`amrex::Gpu::ExternalStreamSync::No` to
+  ``sync_stream``/``sync_on_exit`` skips the final
+  :cpp:`gpuStreamSynchronize` unless deferred frees recorded by
+  :cpp:`The_Async_Arena` are still pending, in which case AMReX forces a
+  synchronization to keep the arena safe.
+* All asynchronous frees recorded through :cpp:`amrex::Gpu::freeAsync` and
+  The_Async_Arena continue to work because AMReX tracks the external stream with
+  an internal :cpp:`StreamManager`.
+
+Limitations and best practices:
+
+* Entering or exiting the override inside an OpenMP parallel region is
+  illegal and will trigger an assertion.  Configure the stream on the main
+  thread before launching GPU work, if OpenMP threading is used.
+* While an override is active, :cpp:`Gpu::numGpuStreams()` reports ``1``.  This
+  keeps :cpp:`MFIter` from trying to pipeline across multiple AMReX-managed
+  streams, but it also means you cannot currently provide a *set* of external
+  streams for MFIter to round-robin across.
+* Make sure the external stream remains valid for the duration of the override.
+  Destroying it before the RAII guard goes out of scope is undefined behavior.
+
+Example: wrap AMReX work inside an externally created CUDA stream:
+
+.. code-block:: cpp
+
+   #ifdef AMREX_USE_CUDA
+     cudaStream_t external{};
+     AMREX_CUDA_SAFE_CALL(cudaStreamCreateWithFlags(&external, cudaStreamNonBlocking));
+   #endif
+     {
+       amrex::Gpu::ExternalGpuStreamRegion stream_scope(external);
+       MultiFab mf(...);
+       MFItInfo info;
+       info.DisableDeviceSync();
+       for (MFIter mfi(mf,info); mfi.isValid(); ++mfi) {
+         auto const& box = mfi.tilebox();
+         auto const arr = mf.array(mfi);
+         amrex::ParallelFor(box, [=] AMReX_GPU_DEVICE (int i, int j, int k) {
+           arr(i,j,k) = 0.0_rt;
+         });
+       }
+       // Optional: launch non-AMReX CUDA kernels on 'external' here.
+     }
+   #ifdef AMREX_USE_CUDA
+     AMREX_CUDA_SAFE_CALL(cudaStreamDestroy(external));
+   #endif
+
+The same pattern works for HIP streams and, in SYCL builds, with
+:cpp:`sycl::queue` objects.
+
 .. _sec:gpu:example:
 
 An Example of Migrating to GPU

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1552,7 +1552,9 @@ Limitations and best practices:
 * Likewise, reuse a given :cpp:`Reducer` or :cpp:`ReduceData` object only on a
   single external stream.  Reusing the same object across different external
   stream regions, or across an external stream and AMReX stream 0, is not
-  supported and triggers an assertion.
+  supported and triggers an assertion.  If a reduction is launched inside an
+  external-stream region with :cpp:`ExternalStreamSync::No`, read its final
+  value before leaving that region.
 * Make sure the external stream remains valid for the duration of the override.
   Destroying it before the RAII guard goes out of scope is undefined behavior.
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1552,9 +1552,8 @@ Limitations and best practices:
 * Likewise, reuse a given :cpp:`Reducer` or :cpp:`ReduceData` object only on a
   single external stream.  Reusing the same object across different external
   stream regions, or across an external stream and AMReX stream 0, is not
-  supported and triggers an assertion.  If a reduction is launched inside an
-  external-stream region with :cpp:`ExternalStreamSync::No`, read its final
-  value before leaving that region.
+  supported.  If a reduction is launched inside an external-stream region,
+  read its final value before leaving that region.
 * Make sure the external stream remains valid for the duration of the override.
   Destroying it before the RAII guard goes out of scope is undefined behavior.
 

--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -4,6 +4,9 @@
 
 #include <AMReX_BLassert.H>
 #include <AMReX_INT.H>
+#ifdef AMREX_USE_GPU
+#include <AMReX_GpuControl.H>
+#endif
 
 #ifdef AMREX_TINY_PROFILING
 #include <AMReX_TinyProfiler.H>
@@ -241,6 +244,7 @@ public:
 #ifdef AMREX_USE_GPU
     //! Is this GPU stream ordered memory allocator?
     [[nodiscard]] virtual bool isStreamOrderedArena () const { return false; }
+    virtual void streamOrderedFree (void* pt, gpuStream_t stream);
 #endif
 
     /**

--- a/Src/Base/AMReX_Arena.cpp
+++ b/Src/Base/AMReX_Arena.cpp
@@ -125,6 +125,21 @@ Arena::hasFreeDeviceMemory (std::size_t)
     return true;
 }
 
+#ifdef AMREX_USE_GPU
+void
+Arena::streamOrderedFree (void* pt, gpuStream_t stream)
+{
+    amrex::ignore_unused(stream);
+
+    if (!isStreamOrderedArena()) {
+        free(pt);
+    } else {
+        amrex::Abort("Arena::streamOrderedFree: arena reports stream-ordered semantics "
+                     "but does not override streamOrderedFree.");
+    }
+}
+#endif
+
 void
 Arena::registerForProfiling ([[maybe_unused]] const std::string& memory_name)
 {

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -11,6 +11,7 @@
 #include <AMReX_BoxList.H>
 #include <AMReX_BArena.H>
 #include <AMReX_CArena.H>
+#include <AMReX_PArena.H>
 #include <AMReX_SArena.H>
 #include <AMReX_DataAllocator.H>
 #include <AMReX_REAL.H>
@@ -1463,6 +1464,11 @@ BaseFab<T>::define ()
     AMREX_ASSERT(this->nvar >= 0);
     if (this->nvar == 0) { return; }
     AMREX_ASSERT(std::numeric_limits<Long>::max()/this->nvar > this->domain.numPts());
+#ifdef AMREX_USE_GPU
+    if (dynamic_cast<PArena*>(this->arena()) != nullptr) {
+        amrex::Abort("BaseFab does not support PArena.");
+    }
+#endif
 
     this->truesize  = this->nvar*this->domain.numPts();
     this->ptr_owner = true;

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -11,8 +11,6 @@
 #include <AMReX_BoxList.H>
 #include <AMReX_BArena.H>
 #include <AMReX_CArena.H>
-#include <AMReX_PArena.H>
-#include <AMReX_SArena.H>
 #include <AMReX_DataAllocator.H>
 #include <AMReX_REAL.H>
 #include <AMReX_BLProfiler.H>
@@ -1464,16 +1462,6 @@ BaseFab<T>::define ()
     AMREX_ASSERT(this->nvar >= 0);
     if (this->nvar == 0) { return; }
     AMREX_ASSERT(std::numeric_limits<Long>::max()/this->nvar > this->domain.numPts());
-#ifdef AMREX_USE_GPU
-    if (dynamic_cast<PArena*>(this->arena()) != nullptr &&
-        Gpu::Device::usingExternalStream() &&
-        Gpu::Device::memoryPoolsSupported())
-    {
-        // Intentional for now: BaseFab does not support PArena inside an
-        // external-stream region when PArena uses stream-ordered allocation.
-        amrex::Abort("BaseFab does not support PArena inside an external GPU stream region.");
-    }
-#endif
 
     this->truesize  = this->nvar*this->domain.numPts();
     this->ptr_owner = true;
@@ -1718,13 +1706,10 @@ BaseFab<T>::clear () noexcept
             placementDelete(this->dptr, this->truesize);
 
 #ifdef AMREX_USE_GPU
-            if (auto* s_arena = dynamic_cast<SArena*>(this->arena())) {
-                s_arena->streamOrderedFree(this->dptr, alloc_stream);
-            } else
+            this->arena()->streamOrderedFree(this->dptr, alloc_stream);
+#else
+            this->free(this->dptr);
 #endif
-            {
-                this->free(this->dptr);
-            }
 
             if (this->nvar > 1) {
                 amrex::update_fab_stats(-this->truesize/this->nvar, -this->truesize, sizeof(T));

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1465,10 +1465,13 @@ BaseFab<T>::define ()
     if (this->nvar == 0) { return; }
     AMREX_ASSERT(std::numeric_limits<Long>::max()/this->nvar > this->domain.numPts());
 #ifdef AMREX_USE_GPU
-    if (dynamic_cast<PArena*>(this->arena()) != nullptr) {
-        // Intentional for now: BaseFab does not support PArena in the
-        // external-stream work.
-        amrex::Abort("BaseFab does not support PArena.");
+    if (dynamic_cast<PArena*>(this->arena()) != nullptr &&
+        Gpu::Device::usingExternalStream() &&
+        Gpu::Device::memoryPoolsSupported())
+    {
+        // Intentional for now: BaseFab does not support PArena inside an
+        // external-stream region when PArena uses stream-ordered allocation.
+        amrex::Abort("BaseFab does not support PArena inside an external GPU stream region.");
     }
 #endif
 

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -11,6 +11,7 @@
 #include <AMReX_BoxList.H>
 #include <AMReX_BArena.H>
 #include <AMReX_CArena.H>
+#include <AMReX_SArena.H>
 #include <AMReX_DataAllocator.H>
 #include <AMReX_REAL.H>
 #include <AMReX_BLProfiler.H>
@@ -1706,13 +1707,13 @@ BaseFab<T>::clear () noexcept
             placementDelete(this->dptr, this->truesize);
 
 #ifdef AMREX_USE_GPU
-            auto current_stream = Gpu::Device::gpuStream();
-            Gpu::Device::setStream(alloc_stream);
+            if (auto* s_arena = dynamic_cast<SArena*>(this->arena())) {
+                s_arena->streamOrderedFree(this->dptr, alloc_stream);
+            } else
 #endif
-            this->free(this->dptr);
-#ifdef AMREX_USE_GPU
-            Gpu::Device::setStream(current_stream);
-#endif
+            {
+                this->free(this->dptr);
+            }
 
             if (this->nvar > 1) {
                 amrex::update_fab_stats(-this->truesize/this->nvar, -this->truesize, sizeof(T));

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1466,6 +1466,8 @@ BaseFab<T>::define ()
     AMREX_ASSERT(std::numeric_limits<Long>::max()/this->nvar > this->domain.numPts());
 #ifdef AMREX_USE_GPU
     if (dynamic_cast<PArena*>(this->arena()) != nullptr) {
+        // Intentional for now: BaseFab does not support PArena in the
+        // external-stream work.
         amrex::Abort("BaseFab does not support PArena.");
     }
 #endif

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -68,6 +68,7 @@ class StreamManager {
 public:
     [[nodiscard]] gpuStream_t& getStream ();
     [[nodiscard]] gpuStream_t const& getStream () const;
+    void drainFreeList ();
     void sync ();
     void free_async (Arena* arena, void* mem);
     std::size_t wait_list_size ();

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -54,12 +54,20 @@ namespace amrex {
 namespace amrex::Gpu {
 
 #ifdef AMREX_USE_GPU
+enum class ExternalStreamSync {
+    Yes,
+    No
+};
+#endif
+
+#ifdef AMREX_USE_GPU
 class StreamManager {
     gpuStream_t m_stream;
     std::mutex m_mutex;
     Vector<std::pair<Arena*, void*>> m_free_wait_list;
 public:
-    [[nodiscard]] gpuStream_t& get ();
+    [[nodiscard]] gpuStream_t& getStream ();
+    [[nodiscard]] gpuStream_t const& getStream () const;
     void sync ();
     void free_async (Arena* arena, void* mem);
     std::size_t wait_list_size ();
@@ -76,7 +84,13 @@ public:
 
 #if defined(AMREX_USE_GPU)
     static gpuStream_t gpuStream () noexcept {
-        return gpu_stream_pool[gpu_stream_index[OpenMP::get_thread_num()]].get();
+        if (!external_stream_stack.empty()) {
+            AMREX_ASSERT(external_stream_stack.back().manager != nullptr);
+            return external_stream_stack.back().manager->getStream();
+        } else {
+            int tid = OpenMP::get_thread_num();
+            return gpu_stream_pool[gpu_stream_index[tid]].getStream();
+        }
     }
 #ifdef AMREX_USE_CUDA
     /** for backward compatibility */
@@ -84,12 +98,16 @@ public:
 #endif
 #ifdef AMREX_USE_SYCL
     static sycl::queue& streamQueue () noexcept { return *(gpuStream().queue); }
-    static sycl::queue& streamQueue (int i) noexcept { return *(gpu_stream_pool[i].get().queue); }
+    static sycl::queue& streamQueue (int i) noexcept { return *(gpu_stream_pool[i].getStream().queue); }
 #endif
 #endif
 
     static int numGpuStreams () noexcept {
-        return inSingleStreamRegion() ? 1 : max_gpu_streams;
+#ifdef AMREX_USE_GPU
+        return (inSingleStreamRegion() || usingExternalStream()) ? 1 : max_gpu_streams;
+#else
+        return 1;
+#endif
     }
 
     static void setStreamIndex (int idx) noexcept;
@@ -100,6 +118,12 @@ public:
 
     static gpuStream_t setStream (gpuStream_t s) noexcept;
     static gpuStream_t resetStream () noexcept;
+
+    /** Override the current GPU stream with a user supplied stream. */
+    static void setExternalStream (gpuStream_t s);
+    /** Pop the current external stream and optionally synchronize it. */
+    static void resetExternalStream (ExternalStreamSync sync_stream = ExternalStreamSync::Yes) noexcept;
+    static bool usingExternalStream () noexcept;
 #endif
 
     static int deviceId () noexcept;
@@ -117,6 +141,9 @@ public:
      * previously requested tasks.
      */
     static void streamSynchronize () noexcept;
+#ifdef AMREX_USE_GPU
+    static void streamSynchronize (gpuStream_t s) noexcept;
+#endif
 
     /**
      * Halt execution of code until all active AMReX GPU streams have finished processing all
@@ -237,12 +264,19 @@ private:
     static AMREX_EXPORT int memory_pools_supported;
     static AMREX_EXPORT unsigned int max_blocks_per_launch;
 
+    struct ExternalStream
+    {
+        std::unique_ptr<StreamManager> manager;
+    };
+    static AMREX_EXPORT Vector<ExternalStream> external_stream_stack;
+
 #ifdef AMREX_USE_SYCL
     static AMREX_EXPORT std::unique_ptr<sycl::context> sycl_context;
     static AMREX_EXPORT std::unique_ptr<sycl::device>  sycl_device;
 #endif
 
     friend StreamManager;
+    friend struct ExternalGpuStreamRegion;
 #endif
 };
 
@@ -273,6 +307,14 @@ streamSynchronize () noexcept
 {
     Device::streamSynchronize();
 }
+
+#ifdef AMREX_USE_GPU
+inline void
+streamSynchronize (gpuStream_t s) noexcept
+{
+    Device::streamSynchronize(s);
+}
+#endif
 
 inline void
 streamSynchronizeActive () noexcept
@@ -309,6 +351,65 @@ clearFreeAsyncBuffer () noexcept
 {
     return Device::clearFreeAsyncBuffer();
 }
+
+#ifdef AMREX_USE_GPU
+
+/** \brief Provide a user-supplied GPU stream.
+ *
+ *  Nested calls form a stack.  Each new call makes the supplied stream
+ *  current for AMReX GPU launches until resetExternalGpuStream pops it and
+ *  restores the previous external stream, if any.  Calling this function
+ *  inside an OpenMP parallel region will trigger an assertion.
+ */
+inline void
+setExternalGpuStream (gpuStream_t stream)
+{
+    Device::setExternalStream(stream);
+}
+
+/** \brief Pop the current user-supplied GPU stream.
+ *
+ *  Must be called once for every preceding successful setExternalGpuStream
+ *  invocation (RAII helpers do this automatically).  When ``sync_stream``
+ *  is :cpp:`ExternalStreamSync::No` AMReX skips the stream-wide synchronize
+ *  unless deferred frees recorded by The_Async_Arena are pending, in which
+ *  case a synchronization is still forced for correctness.  If an older
+ *  external stream was active before the current one, it becomes current
+ *  again after the pop.  Not supported inside OpenMP parallel regions.
+ */
+inline void
+resetExternalGpuStream (ExternalStreamSync sync_stream = ExternalStreamSync::Yes) noexcept
+{
+    Device::resetExternalStream(sync_stream);
+}
+
+/** RAII helper that overrides the GPU stream for the current scope (optionally
+ *  skipping the synchronization on destruction when ``sync_on_exit`` is
+ *  :cpp:`ExternalStreamSync::No`).
+ */
+struct [[nodiscard]] ExternalGpuStreamRegion
+{
+    explicit ExternalGpuStreamRegion (gpuStream_t stream,
+                                      ExternalStreamSync sync_on_exit = ExternalStreamSync::Yes) noexcept
+        : m_sync_on_exit(sync_on_exit)
+    {
+        Device::setExternalStream(stream);
+    }
+
+    ExternalGpuStreamRegion (ExternalGpuStreamRegion&& rhs) noexcept = delete;
+    ExternalGpuStreamRegion& operator= (ExternalGpuStreamRegion&& rhs) noexcept = delete;
+    ExternalGpuStreamRegion (ExternalGpuStreamRegion const&) = delete;
+    ExternalGpuStreamRegion& operator= (ExternalGpuStreamRegion const&) = delete;
+
+    ~ExternalGpuStreamRegion ()
+    {
+        Device::resetExternalStream(m_sync_on_exit);
+    }
+
+private:
+    ExternalStreamSync m_sync_on_exit = ExternalStreamSync::Yes;
+};
+#endif
 
 #ifdef AMREX_USE_GPU
 

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -68,7 +68,6 @@ class StreamManager {
 public:
     [[nodiscard]] gpuStream_t& getStream ();
     [[nodiscard]] gpuStream_t const& getStream () const;
-    void drainFreeList ();
     void sync ();
     void free_async (Arena* arena, void* mem);
     std::size_t wait_list_size ();

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -159,6 +159,9 @@ public:
     static void streamSynchronizeAll () noexcept;
 
     static void freeAsync (Arena* arena, void* mem) noexcept;
+#ifdef AMREX_USE_GPU
+    static void streamOrderedFreeAsync (Arena* arena, void* mem, gpuStream_t stream) noexcept;
+#endif
 
     static bool clearFreeAsyncBuffer () noexcept;
 

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -270,6 +270,7 @@ private:
     struct ExternalStream
     {
         std::unique_ptr<StreamManager> manager;
+        int saved_stream_index = 0;
     };
     static AMREX_EXPORT Vector<ExternalStream> external_stream_stack;
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -770,6 +770,16 @@ Device::setExternalStream (gpuStream_t s)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!OpenMP::in_parallel(),
         "Gpu::setExternalGpuStream is not supported inside OpenMP parallel regions.");
+#ifdef AMREX_USE_SYCL
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(s.queue != nullptr,
+        "Gpu::setExternalGpuStream: null SYCL queue is not supported.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(s.queue->get_context() == Device::syclContext(),
+        "Gpu::setExternalGpuStream: external SYCL queue must use AMReX's SYCL context.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(s.queue->get_device() == Device::syclDevice(),
+        "Gpu::setExternalGpuStream: external SYCL queue must use AMReX's SYCL device.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(s.queue->has_property<sycl::property::queue::in_order>(),
+        "Gpu::setExternalGpuStream: external SYCL queue must be in-order.");
+#endif
     // External stream overrides intentionally do not try to synchronize
     // OpenACC stream state. AMReX does not support mixing OpenACC work into
     // these regions.

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -102,6 +102,9 @@ Vector<StreamManager>   Device::gpu_stream_pool;
 Vector<int>             Device::gpu_stream_index;
 gpuDeviceProp_t         Device::device_prop;
 int                     Device::memory_pools_supported = 0;
+#ifdef AMREX_USE_GPU
+Vector<Device::ExternalStream> Device::external_stream_stack;
+#endif
 
 constexpr int Device::warp_size;
 
@@ -143,7 +146,12 @@ namespace {
 }
 
 [[nodiscard]] gpuStream_t&
-StreamManager::get () {
+StreamManager::getStream () {
+    return m_stream;
+}
+
+gpuStream_t const&
+StreamManager::getStream () const {
     return m_stream;
 }
 
@@ -459,16 +467,16 @@ Device::Finalize ()
 
 #ifdef AMREX_USE_SYCL
     for (auto& s : gpu_stream_pool) {
-        delete s.get().queue;
-        s.get().queue = nullptr;
+        delete s.getStream().queue;
+        s.getStream().queue = nullptr;
     }
     sycl_context.reset();
     sycl_device.reset();
 #else
     for (int i = 0; i < max_gpu_streams; ++i)
     {
-        AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL( hipStreamDestroy(gpu_stream_pool[i].get()));,
-                          AMREX_CUDA_SAFE_CALL(cudaStreamDestroy(gpu_stream_pool[i].get())); );
+        AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL( hipStreamDestroy(gpu_stream_pool[i].getStream()));,
+                          AMREX_CUDA_SAFE_CALL(cudaStreamDestroy(gpu_stream_pool[i].getStream())); );
     }
 #endif
 
@@ -504,7 +512,7 @@ Device::initialize_gpu (bool minimal)
     // AMD devices do not support shared cache banking.
 
     for (int i = 0; i < max_gpu_streams; ++i) {
-        AMREX_HIP_SAFE_CALL(hipStreamCreate(&gpu_stream_pool[i].get()));
+        AMREX_HIP_SAFE_CALL(hipStreamCreate(&gpu_stream_pool[i].getStream()));
     }
 
 #ifdef AMREX_GPU_STREAM_ALLOC_SUPPORT
@@ -532,9 +540,9 @@ Device::initialize_gpu (bool minimal)
 #endif
 
     for (int i = 0; i < max_gpu_streams; ++i) {
-        AMREX_CUDA_SAFE_CALL(cudaStreamCreate(&gpu_stream_pool[i].get()));
+        AMREX_CUDA_SAFE_CALL(cudaStreamCreate(&gpu_stream_pool[i].getStream()));
 #ifdef AMREX_USE_ACC
-        acc_set_cuda_stream(i, gpu_stream_pool[i].get());
+        acc_set_cuda_stream(i, gpu_stream_pool[i].getStream());
 #endif
     }
 
@@ -547,7 +555,7 @@ Device::initialize_gpu (bool minimal)
         sycl_device = std::make_unique<sycl::device>(gpu_devices[device_id]);
         sycl_context = std::make_unique<sycl::context>(*sycl_device, amrex_sycl_error_handler);
         for (int i = 0; i < max_gpu_streams; ++i) {
-            gpu_stream_pool[i].get().queue = new sycl::queue(*sycl_context, *sycl_device,
+            gpu_stream_pool[i].getStream().queue = new sycl::queue(*sycl_context, *sycl_device,
                                          sycl::property_list{sycl::property::queue::in_order{}});
         }
     }
@@ -702,11 +710,11 @@ Device::streamIndex (gpuStream_t s) noexcept
 {
     const int N = gpu_stream_pool.size();
     for (int i = 0; i < N ; ++i) {
-        if (gpu_stream_pool[i].get() == s) {
+        if (gpu_stream_pool[i].getStream() == s) {
             return i;
         }
     }
-    return N;
+    return 0;
 }
 #endif
 
@@ -738,15 +746,52 @@ Device::setStream (gpuStream_t s) noexcept
     gpu_stream_index[OpenMP::get_thread_num()] = streamIndex(s);
     return r;
 }
+
+void
+Device::setExternalStream (gpuStream_t s)
+{
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!OpenMP::in_parallel(),
+        "Gpu::setExternalGpuStream is not supported inside OpenMP parallel regions.");
+    external_stream_stack.emplace_back(ExternalStream{std::make_unique<StreamManager>()});
+    external_stream_stack.back().manager->getStream() = s;
+}
+
+void
+Device::resetExternalStream (ExternalStreamSync sync_stream) noexcept
+{
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!OpenMP::in_parallel(),
+        "Gpu::resetExternalGpuStream is not supported inside OpenMP parallel regions.");
+
+    if (external_stream_stack.empty()) { return; }
+
+    auto manager = std::move(external_stream_stack.back().manager);
+    external_stream_stack.pop_back();
+    if (manager) {
+        if (sync_stream == ExternalStreamSync::Yes || manager->wait_list_size() > 0) {
+            manager->sync();
+        }
+    }
+}
+
+bool
+Device::usingExternalStream () noexcept
+{
+    return !external_stream_stack.empty();
+}
 #endif
 
 void
 Device::synchronize () noexcept
 {
 #ifdef AMREX_USE_SYCL
+    for (auto& ext : external_stream_stack) {
+        if (ext.manager) {
+            ext.manager->sync();
+        }
+    }
     for (auto& s : gpu_stream_pool) {
         try {
-            s.get().queue->wait_and_throw();
+            s.getStream().queue->wait_and_throw();
         } catch (sycl::exception const& ex) {
             amrex::Abort(std::string("synchronize: ")+ex.what()+"!!!!!");
         }
@@ -761,9 +806,54 @@ void
 Device::streamSynchronize () noexcept
 {
 #ifdef AMREX_USE_GPU
-    gpu_stream_pool[gpu_stream_index[OpenMP::get_thread_num()]].sync();
+    if (!external_stream_stack.empty()) {
+        AMREX_ASSERT(external_stream_stack.back().manager != nullptr);
+        external_stream_stack.back().manager->sync();
+    } else {
+        int tid = OpenMP::get_thread_num();
+        gpu_stream_pool[gpu_stream_index[tid]].sync();
+    }
 #endif
 }
+
+#ifdef AMREX_USE_GPU
+void
+Device::streamSynchronize (gpuStream_t s) noexcept
+{
+    bool found_external = false;
+    for (auto& ext : external_stream_stack) {
+        AMREX_ASSERT(ext.manager != nullptr);
+        if (ext.manager->getStream() == s) {
+            ext.manager->sync();
+            found_external = true;
+        }
+    }
+    if (found_external) {
+        return;
+    }
+    for (auto& mgr : gpu_stream_pool) {
+        if (mgr.getStream() == s) {
+            mgr.sync();
+            return;
+        }
+    }
+#if defined(AMREX_USE_SYCL)
+    if (s.queue != nullptr) {
+        try {
+            s.queue->wait_and_throw();
+        } catch (sycl::exception const& ex) {
+            amrex::Abort(std::string("streamSynchronize(stream): ")+ex.what()+"!!!!!");
+        }
+    } else {
+        amrex::Abort("streamSynchronize(stream): unknown SYCL stream.");
+    }
+#else
+    AMREX_HIP_OR_CUDA(
+        AMREX_HIP_SAFE_CALL(hipStreamSynchronize(s));,
+        AMREX_CUDA_SAFE_CALL(cudaStreamSynchronize(s)); )
+#endif
+}
+#endif
 
 void
 Device::streamSynchronizeActive () noexcept
@@ -781,6 +871,11 @@ void
 Device::streamSynchronizeAll () noexcept
 {
 #ifdef AMREX_USE_GPU
+    for (auto& ext : external_stream_stack) {
+        if (ext.manager) {
+            ext.manager->sync();
+        }
+    }
     for (auto& s : gpu_stream_pool) {
         s.sync();
     }
@@ -791,7 +886,13 @@ void
 Device::freeAsync (Arena* arena, void* mem) noexcept
 {
 #ifdef AMREX_USE_GPU
-    gpu_stream_pool[gpu_stream_index[OpenMP::get_thread_num()]].free_async(arena, mem);
+    if (!external_stream_stack.empty()) {
+        AMREX_ASSERT(external_stream_stack.back().manager != nullptr);
+        external_stream_stack.back().manager->free_async(arena, mem);
+    } else {
+        int tid = OpenMP::get_thread_num();
+        gpu_stream_pool[gpu_stream_index[tid]].free_async(arena, mem);
+    }
 #else
     arena->free(mem);
 #endif
@@ -805,6 +906,13 @@ Device::clearFreeAsyncBuffer () noexcept
     for (auto& s : gpu_stream_pool) {
         if (s.wait_list_size() > 0) {
             s.sync();
+            freed_memory = true;
+        }
+    }
+    for (auto& ext : external_stream_stack) {
+        AMREX_ASSERT(ext.manager != nullptr);
+        if (ext.manager->wait_list_size() > 0) {
+            ext.manager->sync();
             freed_memory = true;
         }
     }

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -785,6 +785,17 @@ Device::setExternalStream (gpuStream_t s)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!OpenMP::in_parallel(),
         "Gpu::setExternalGpuStream is not supported inside OpenMP parallel regions.");
+#ifdef AMREX_USE_HIP
+    int stream_device = -1;
+    AMREX_HIP_SAFE_CALL(hipStreamGetDevice(s, &stream_device));
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(stream_device == Device::deviceId(),
+        "Gpu::setExternalGpuStream: external HIP stream must belong to the active device.");
+#elif defined(AMREX_USE_CUDA)
+    int stream_device = -1;
+    AMREX_CUDA_SAFE_CALL(cudaStreamGetDevice(s, &stream_device));
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(stream_device == Device::deviceId(),
+        "Gpu::setExternalGpuStream: external CUDA stream must belong to the active device.");
+#endif
 #ifdef AMREX_USE_SYCL
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(s.queue != nullptr,
         "Gpu::setExternalGpuStream: null SYCL queue is not supported.");

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -771,13 +771,13 @@ Device::setExternalStream (gpuStream_t s)
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!OpenMP::in_parallel(),
         "Gpu::setExternalGpuStream is not supported inside OpenMP parallel regions.");
 #if defined(AMREX_USE_CUDA)
-#  if defined(CUDART_VERSION) && (CUDART_VERSION >= 12000)
+#  if defined(CUDART_VERSION) && (CUDART_VERSION >= 12080)
     int stream_device = -1;
     AMREX_CUDA_SAFE_CALL(cudaStreamGetDevice(s, &stream_device));
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(stream_device == Device::deviceId(),
         "Gpu::setExternalGpuStream: external CUDA stream must belong to the active device.");
 #  else
-    amrex::ignore_unused(s); // cudaStreamGetDevice arrived in CUDA 12.0.
+    amrex::ignore_unused(s); // cudaStreamGetDevice arrived in CUDA 12.8.
 #  endif
 #elif defined(AMREX_USE_HIP)
 #  if defined(HIP_VERSION_MAJOR) && defined(HIP_VERSION_MINOR) && \

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -708,13 +708,19 @@ int Device::numDevicePartners () noexcept
 int
 Device::streamIndex (gpuStream_t s) noexcept
 {
+    for (auto const& ext : external_stream_stack) {
+        AMREX_ASSERT(ext.manager != nullptr);
+        if (ext.manager->getStream() == s) {
+            return 0;
+        }
+    }
     const int N = gpu_stream_pool.size();
     for (int i = 0; i < N ; ++i) {
         if (gpu_stream_pool[i].getStream() == s) {
             return i;
         }
     }
-    return 0;
+    return N;
 }
 #endif
 
@@ -751,7 +757,11 @@ Device::setStream (gpuStream_t s) noexcept
             return r;
         }
     }
-    gpu_stream_index[tid] = streamIndex(s);
+    int const idx = streamIndex(s);
+    if (idx == static_cast<int>(gpu_stream_pool.size())) {
+        amrex::Abort("Gpu::Device::setStream: stream is not managed by AMReX.");
+    }
+    gpu_stream_index[tid] = idx;
     return r;
 }
 
@@ -777,13 +787,19 @@ Device::resetExternalStream (ExternalStreamSync sync_stream) noexcept
 
     if (external_stream_stack.empty()) { return; }
 
-    auto manager = std::move(external_stream_stack.back().manager);
-    external_stream_stack.pop_back();
-    if (manager) {
-        if (sync_stream == ExternalStreamSync::Yes || manager->wait_list_size() > 0) {
-            manager->sync();
+    auto& external_stream = external_stream_stack.back();
+    if (external_stream.manager) {
+        // ExternalStreamSync::No hands synchronization responsibility back to
+        // the caller. Once the stream is popped, AMReX no longer tracks it in
+        // global stream synchronization helpers, and it is the caller's
+        // responsibility to synchronize the external stream when needed.
+        if (sync_stream == ExternalStreamSync::Yes || external_stream.manager->wait_list_size() > 0) {
+            external_stream.manager->sync();
         }
     }
+    int const saved_stream_index = external_stream.saved_stream_index;
+    external_stream_stack.pop_back();
+    setStreamIndex(saved_stream_index);
 }
 
 bool
@@ -796,22 +812,12 @@ Device::usingExternalStream () noexcept
 void
 Device::synchronize () noexcept
 {
-#ifdef AMREX_USE_SYCL
-    for (auto& ext : external_stream_stack) {
-        if (ext.manager) {
-            ext.manager->sync();
-        }
-    }
-    for (auto& s : gpu_stream_pool) {
-        try {
-            s.getStream().queue->wait_and_throw();
-        } catch (sycl::exception const& ex) {
-            amrex::Abort(std::string("synchronize: ")+ex.what()+"!!!!!");
-        }
-    }
-#else
+#ifdef AMREX_USE_GPU
     AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL(hipDeviceSynchronize());,
                        AMREX_CUDA_SAFE_CALL(cudaDeviceSynchronize()); )
+    // After the device-wide sync completes, synchronizing all AMReX-managed
+    // streams is cheap and drains deferred frees queued on their managers.
+    streamSynchronizeAll();
 #endif
 }
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -156,21 +156,6 @@ StreamManager::getStream () const {
 }
 
 void
-StreamManager::drainFreeList () {
-    decltype(m_free_wait_list) new_empty_wait_list{};
-
-    {
-        // lock mutex before accessing and modifying member variables
-        std::lock_guard<std::mutex> lock(m_mutex);
-        m_free_wait_list.swap(new_empty_wait_list);
-    }
-    // unlock mutex before memory free to avoid deadlocks from the CArena mutex
-    for (auto [arena, mem] : new_empty_wait_list) {
-        arena->free(mem);
-    }
-}
-
-void
 StreamManager::sync () {
     decltype(m_free_wait_list) new_empty_wait_list{};
 
@@ -849,22 +834,11 @@ void
 Device::synchronize () noexcept
 {
 #ifdef AMREX_USE_GPU
-#ifdef AMREX_USE_SYCL
-    streamSynchronizeAll();
-#else
     AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL(hipDeviceSynchronize());,
                        AMREX_CUDA_SAFE_CALL(cudaDeviceSynchronize()); )
-    // The device-wide sync already completed all queued work, so only
-    // drain deferred frees instead of synchronizing each stream again.
-    for (auto& ext : external_stream_stack) {
-        if (ext.manager) {
-            ext.manager->drainFreeList();
-        }
-    }
-    for (auto& s : gpu_stream_pool) {
-        s.drainFreeList();
-    }
-#endif
+    // After the device-wide sync completes, synchronizing all AMReX-managed
+    // streams is cheap and drains deferred frees queued on their managers.
+    streamSynchronizeAll();
 #endif
 }
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -156,6 +156,21 @@ StreamManager::getStream () const {
 }
 
 void
+StreamManager::drainFreeList () {
+    decltype(m_free_wait_list) new_empty_wait_list{};
+
+    {
+        // lock mutex before accessing and modifying member variables
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_free_wait_list.swap(new_empty_wait_list);
+    }
+    // unlock mutex before memory free to avoid deadlocks from the CArena mutex
+    for (auto [arena, mem] : new_empty_wait_list) {
+        arena->free(mem);
+    }
+}
+
+void
 StreamManager::sync () {
     decltype(m_free_wait_list) new_empty_wait_list{};
 
@@ -823,11 +838,22 @@ void
 Device::synchronize () noexcept
 {
 #ifdef AMREX_USE_GPU
+#ifdef AMREX_USE_SYCL
+    streamSynchronizeAll();
+#else
     AMREX_HIP_OR_CUDA( AMREX_HIP_SAFE_CALL(hipDeviceSynchronize());,
                        AMREX_CUDA_SAFE_CALL(cudaDeviceSynchronize()); )
-    // After the device-wide sync completes, synchronizing all AMReX-managed
-    // streams is cheap and drains deferred frees queued on their managers.
-    streamSynchronizeAll();
+    // The device-wide sync already completed all queued work, so only
+    // drain deferred frees instead of synchronizing each stream again.
+    for (auto& ext : external_stream_stack) {
+        if (ext.manager) {
+            ext.manager->drainFreeList();
+        }
+    }
+    for (auto& s : gpu_stream_pool) {
+        s.drainFreeList();
+    }
+#endif
 #endif
 }
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -742,8 +742,16 @@ Device::resetStream () noexcept
 gpuStream_t
 Device::setStream (gpuStream_t s) noexcept
 {
+    int const tid = OpenMP::get_thread_num();
     gpuStream_t r = gpuStream();
-    gpu_stream_index[OpenMP::get_thread_num()] = streamIndex(s);
+    for (auto it = external_stream_stack.rbegin(); it != external_stream_stack.rend(); ++it) {
+        AMREX_ASSERT(it->manager != nullptr);
+        if (it->manager->getStream() == s) {
+            setStreamIndex(it->saved_stream_index);
+            return r;
+        }
+    }
+    gpu_stream_index[tid] = streamIndex(s);
     return r;
 }
 
@@ -755,7 +763,9 @@ Device::setExternalStream (gpuStream_t s)
     // External stream overrides intentionally do not try to synchronize
     // OpenACC stream state. AMReX does not support mixing OpenACC work into
     // these regions.
-    external_stream_stack.emplace_back(ExternalStream{std::make_unique<StreamManager>()});
+    external_stream_stack.emplace_back(
+        ExternalStream{std::make_unique<StreamManager>(),
+                       gpu_stream_index[OpenMP::get_thread_num()]});
     external_stream_stack.back().manager->getStream() = s;
 }
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -752,6 +752,9 @@ Device::setExternalStream (gpuStream_t s)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!OpenMP::in_parallel(),
         "Gpu::setExternalGpuStream is not supported inside OpenMP parallel regions.");
+    // External stream overrides intentionally do not try to synchronize
+    // OpenACC stream state. AMReX does not support mixing OpenACC work into
+    // these regions.
     external_stream_stack.emplace_back(ExternalStream{std::make_unique<StreamManager>()});
     external_stream_stack.back().manager->getStream() = s;
 }

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -770,16 +770,25 @@ Device::setExternalStream (gpuStream_t s)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!OpenMP::in_parallel(),
         "Gpu::setExternalGpuStream is not supported inside OpenMP parallel regions.");
-#ifdef AMREX_USE_HIP
-    int stream_device = -1;
-    AMREX_HIP_SAFE_CALL(hipStreamGetDevice(s, &stream_device));
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(stream_device == Device::deviceId(),
-        "Gpu::setExternalGpuStream: external HIP stream must belong to the active device.");
-#elif defined(AMREX_USE_CUDA)
+#if defined(AMREX_USE_CUDA)
+#  if defined(CUDART_VERSION) && (CUDART_VERSION >= 12000)
     int stream_device = -1;
     AMREX_CUDA_SAFE_CALL(cudaStreamGetDevice(s, &stream_device));
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(stream_device == Device::deviceId(),
         "Gpu::setExternalGpuStream: external CUDA stream must belong to the active device.");
+#  else
+    amrex::ignore_unused(s); // cudaStreamGetDevice arrived in CUDA 12.0.
+#  endif
+#elif defined(AMREX_USE_HIP)
+#  if defined(HIP_VERSION_MAJOR) && defined(HIP_VERSION_MINOR) && \
+      ((HIP_VERSION_MAJOR > 5) || (HIP_VERSION_MAJOR == 5 && HIP_VERSION_MINOR >= 6))
+    hipDevice_t stream_device = -1;
+    AMREX_HIP_SAFE_CALL(hipStreamGetDevice(s, &stream_device));
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(stream_device == Device::deviceId(),
+        "Gpu::setExternalGpuStream: external HIP stream must belong to the active device.");
+#  else
+    amrex::ignore_unused(s); // hipStreamGetDevice landed in ROCm 5.6.
+#  endif
 #endif
 #ifdef AMREX_USE_SYCL
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(s.queue != nullptr,

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -898,6 +898,31 @@ Device::freeAsync (Arena* arena, void* mem) noexcept
 #endif
 }
 
+#ifdef AMREX_USE_GPU
+void
+Device::streamOrderedFreeAsync (Arena* arena, void* mem, gpuStream_t stream) noexcept
+{
+    for (auto it = external_stream_stack.rbegin(); it != external_stream_stack.rend(); ++it) {
+        AMREX_ASSERT(it->manager != nullptr);
+        if (it->manager->getStream() == stream) {
+            it->manager->free_async(arena, mem);
+            return;
+        }
+    }
+
+    for (auto& mgr : gpu_stream_pool) {
+        if (mgr.getStream() == stream) {
+            mgr.free_async(arena, mem);
+            return;
+        }
+    }
+
+    amrex::Abort("Gpu::Device::streamOrderedFreeAsync: stream is not managed by AMReX. "
+                 "If this is an external stream, it must still be active when stream-ordered "
+                 "memory is freed.");
+}
+#endif
+
 bool
 Device::clearFreeAsyncBuffer () noexcept
 {

--- a/Src/Base/AMReX_PArena.H
+++ b/Src/Base/AMReX_PArena.H
@@ -40,6 +40,7 @@ public:
 #ifdef AMREX_USE_GPU
     //! Is this CUDA stream ordered memory allocator?
     [[nodiscard]] bool isStreamOrderedArena () const final { return true; }
+    void streamOrderedFree (void* p, gpuStream_t stream) override;
 #endif
 
 #ifdef AMREX_GPU_STREAM_ALLOC_SUPPORT

--- a/Src/Base/AMReX_PArena.cpp
+++ b/Src/Base/AMReX_PArena.cpp
@@ -120,6 +120,27 @@ PArena::free (void* p)
 #endif
 }
 
+#ifdef AMREX_USE_GPU
+void
+PArena::streamOrderedFree (void* p, gpuStream_t stream)
+{
+    if (p == nullptr) { return; }
+
+#if defined(AMREX_GPU_STREAM_ALLOC_SUPPORT)
+    if (Gpu::Device::memoryPoolsSupported()) {
+        m_profiler.profile_free(p);
+        AMREX_HIP_OR_CUDA(
+            AMREX_HIP_SAFE_CALL(hipFreeAsync(p, stream));,
+            AMREX_CUDA_SAFE_CALL(cudaFreeAsync(p, stream));
+        )
+    } else
+#endif
+    {
+        Gpu::Device::streamOrderedFreeAsync(The_Arena(), p, stream);
+    }
+}
+#endif
+
 bool
 PArena::isDeviceAccessible () const
 {

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -495,27 +495,45 @@ public:
 
     Type* devicePtr () { return m_device_tuple; }
     Type* devicePtr (gpuStream_t const& s) {
-        return m_device_tuple+(Gpu::Device::streamIndex(s))*m_max_blocks;
+        return m_device_tuple+streamIndexChecked(s)*m_max_blocks;
     }
 
     Type* hostPtr () { return m_host_tuple; }
 
     GpuArray<int,AMREX_GPU_MAX_STREAMS>& nBlocks () { return m_nblocks; }
-    int& nBlocks (gpuStream_t const& s) { return m_nblocks[Gpu::Device::streamIndex(s)]; }
+    int& nBlocks (gpuStream_t const& s) { return m_nblocks[streamIndexChecked(s)]; }
 
     int maxBlocks () const { return m_max_blocks; }
 
     int maxStreamIndex () const { return m_max_stream_index; }
     void updateMaxStreamIndex (gpuStream_t const& s) {
-        m_max_stream_index = std::max(m_max_stream_index,Gpu::Device::streamIndex(s));
+        m_max_stream_index = std::max(m_max_stream_index,streamIndexChecked(s));
     }
 
 private:
+    int streamIndexChecked (gpuStream_t const& s)
+    {
+        int const idx = Gpu::Device::streamIndex(s);
+        if (idx == 0) {
+            if (m_stream_index_zero_set) {
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_stream_index_zero == s,
+                    "ReduceData cannot be reused across different external GPU streams "
+                    "or between an external GPU stream and AMReX stream 0.");
+            } else {
+                m_stream_index_zero = s;
+                m_stream_index_zero_set = true;
+            }
+        }
+        return idx;
+    }
+
     int m_max_blocks;
     int m_max_stream_index = 0;
     Type* m_host_tuple = nullptr;
     Type* m_device_tuple = nullptr;
     GpuArray<int,AMREX_GPU_MAX_STREAMS> m_nblocks;
+    gpuStream_t m_stream_index_zero{};
+    bool m_stream_index_zero_set = false;
     std::function<Type()> m_fn_value;
 };
 

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -510,6 +510,16 @@ public:
         m_max_stream_index = std::max(m_max_stream_index,streamIndexChecked(s));
     }
 
+    void assertValueStream (gpuStream_t const& s) const
+    {
+        if (m_stream_index_zero_set) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_stream_index_zero == s,
+                "ReduceData::value() must be evaluated on the same stream that used "
+                "slot 0. Do not read a reduction result outside the external GPU "
+                "stream region that launched it.");
+        }
+    }
+
 private:
     int streamIndexChecked (gpuStream_t const& s)
     {
@@ -858,6 +868,7 @@ public:
 
         using ReduceTuple = typename D::Type;
         auto const& stream = Gpu::gpuStream();
+        reduce_data.assertValueStream(stream);
         auto dp = reduce_data.devicePtr();
         auto const& nblocks = reduce_data.nBlocks();
 #if defined(AMREX_USE_SYCL)

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -474,6 +474,8 @@ public:
 
     ~ReduceData () {
         The_Pinned_Arena()->free(m_host_tuple);
+        // Intentional limitation: ReduceData does not defer device-buffer
+        // lifetime to an external stream.
         The_Arena()->free(m_device_tuple);
     }
 
@@ -490,6 +492,8 @@ public:
     template <typename... Ps>
     Type value (ReduceOps<Ps...> & reduce_op)
     {
+        // Intentional limitation: if reduction work ran on an external stream,
+        // read the result before leaving that stream region.
         return reduce_op.value(*this);
     }
 
@@ -508,16 +512,6 @@ public:
     int maxStreamIndex () const { return m_max_stream_index; }
     void updateMaxStreamIndex (gpuStream_t const& s) {
         m_max_stream_index = std::max(m_max_stream_index,streamIndexChecked(s));
-    }
-
-    void assertValueStream (gpuStream_t const& s) const
-    {
-        if (m_stream_index_zero_set) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_stream_index_zero == s,
-                "ReduceData::value() must be evaluated on the same stream that used "
-                "slot 0. Do not read a reduction result outside the external GPU "
-                "stream region that launched it.");
-        }
     }
 
 private:
@@ -868,7 +862,6 @@ public:
 
         using ReduceTuple = typename D::Type;
         auto const& stream = Gpu::gpuStream();
-        reduce_data.assertValueStream(stream);
         auto dp = reduce_data.devicePtr();
         auto const& nblocks = reduce_data.nBlocks();
 #if defined(AMREX_USE_SYCL)

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -473,9 +473,10 @@ public:
     }
 
     ~ReduceData () {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            !m_used_external_stream || m_value_called,
+            "ReduceData used on an external GPU stream must call value() before destruction.");
         The_Pinned_Arena()->free(m_host_tuple);
-        // Intentional limitation: ReduceData does not defer device-buffer
-        // lifetime to an external stream.
         The_Arena()->free(m_device_tuple);
     }
 
@@ -486,15 +487,17 @@ public:
 
     Type value ()
     {
-        return m_fn_value();
+        Type r = m_fn_value();
+        m_value_called = true;
+        return r;
     }
 
     template <typename... Ps>
     Type value (ReduceOps<Ps...> & reduce_op)
     {
-        // Intentional limitation: if reduction work ran on an external stream,
-        // read the result before leaving that stream region.
-        return reduce_op.value(*this);
+        Type r = reduce_op.value(*this);
+        m_value_called = true;
+        return r;
     }
 
     Type* devicePtr () { return m_device_tuple; }
@@ -514,10 +517,13 @@ public:
         m_max_stream_index = std::max(m_max_stream_index,streamIndexChecked(s));
     }
 
+    void markValueCalled () noexcept { m_value_called = true; }
+
 private:
     int streamIndexChecked (gpuStream_t const& s)
     {
         int const idx = Gpu::Device::streamIndex(s);
+        m_used_external_stream = m_used_external_stream || Gpu::Device::usingExternalStream();
         if (idx == 0) {
             if (m_stream_index_zero_set) {
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_stream_index_zero == s,
@@ -538,6 +544,8 @@ private:
     GpuArray<int,AMREX_GPU_MAX_STREAMS> m_nblocks;
     gpuStream_t m_stream_index_zero{};
     bool m_stream_index_zero_set = false;
+    bool m_used_external_stream = false;
+    bool m_value_called = false;
     std::function<Type()> m_fn_value;
 };
 
@@ -857,6 +865,7 @@ public:
         auto hp = reduce_data.hostPtr();
 
         if (m_result_is_ready) {
+            reduce_data.markValueCalled();
             return *hp;
         }
 
@@ -933,6 +942,7 @@ public:
         }
 
         m_result_is_ready = true;
+        reduce_data.markValueCalled();
         return *hp;
     }
 

--- a/Src/Base/AMReX_SArena.H
+++ b/Src/Base/AMReX_SArena.H
@@ -3,6 +3,9 @@
 #include <AMReX_Config.H>
 
 #include <AMReX_Arena.H>
+#ifdef AMREX_USE_GPU
+#include <AMReX_GpuControl.H>
+#endif
 
 
 namespace amrex {
@@ -52,6 +55,7 @@ public:
 #ifdef AMREX_USE_GPU
     //! Is this a GPU stream ordered memory allocator?
     [[nodiscard]] bool isStreamOrderedArena () const final { return true; }
+    void streamOrderedFree (void* pt, gpuStream_t stream);
 #endif
 };
 

--- a/Src/Base/AMReX_SArena.H
+++ b/Src/Base/AMReX_SArena.H
@@ -55,7 +55,7 @@ public:
 #ifdef AMREX_USE_GPU
     //! Is this a GPU stream ordered memory allocator?
     [[nodiscard]] bool isStreamOrderedArena () const final { return true; }
-    void streamOrderedFree (void* pt, gpuStream_t stream);
+    void streamOrderedFree (void* pt, gpuStream_t stream) override;
 #endif
 };
 

--- a/Src/Base/AMReX_SArena.cpp
+++ b/Src/Base/AMReX_SArena.cpp
@@ -16,6 +16,16 @@ amrex::SArena::free (void* pt)
     amrex::Gpu::freeAsync(The_Arena(), pt);
 }
 
+#ifdef AMREX_USE_GPU
+void
+amrex::SArena::streamOrderedFree (void* pt, gpuStream_t stream)
+{
+    if (pt == nullptr) { return; }
+    m_profiler.profile_free(pt);
+    amrex::Gpu::Device::streamOrderedFreeAsync(The_Arena(), pt, stream);
+}
+#endif
+
 bool
 amrex::SArena::isDeviceAccessible () const
 {

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -141,9 +141,17 @@ namespace detail { void hip_execute (rocfft_plan plan, void **in, void **out); }
 /// \cond DOXYGEN_IGNORE
 namespace detail
 {
+inline void assert_no_external_stream ()
+{
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        !amrex::Gpu::Device::usingExternalStream(),
+        "SYCL FFT does not support external GPU streams.");
+}
+
 template <typename T, Direction direction, typename P, typename TI, typename TO>
 void sycl_execute (P* plan, TI* in, TO* out)
 {
+    assert_no_external_stream();
 #ifndef AMREX_USE_MKL_DFTI_2024
     std::int64_t workspaceSize = 0;
 #else
@@ -349,6 +357,7 @@ struct Plan
 #endif
         pp->set_value(oneapi::mkl::dft::config_param::WORKSPACE,
                       oneapi::mkl::dft::config_value::WORKSPACE_EXTERNAL);
+        detail::assert_no_external_stream();
         pp->commit(amrex::Gpu::Device::streamQueue());
         plan = pp;
 
@@ -509,6 +518,7 @@ struct Plan
 #endif
         pp->set_value(oneapi::mkl::dft::config_param::WORKSPACE,
                       oneapi::mkl::dft::config_value::WORKSPACE_EXTERNAL);
+        detail::assert_no_external_stream();
         pp->commit(amrex::Gpu::Device::streamQueue());
         plan = pp;
 
@@ -683,6 +693,7 @@ struct Plan
 #endif
         pp->set_value(oneapi::mkl::dft::config_param::WORKSPACE,
                       oneapi::mkl::dft::config_value::WORKSPACE_EXTERNAL);
+        detail::assert_no_external_stream();
         pp->commit(amrex::Gpu::Device::streamQueue());
         plan = pp;
 
@@ -1476,6 +1487,7 @@ void Plan<T>::init_r2c (IntVectND<M> const& fft_size, void* pbf, void* pbb, bool
 #endif
     pp->set_value(oneapi::mkl::dft::config_param::WORKSPACE,
                   oneapi::mkl::dft::config_value::WORKSPACE_EXTERNAL);
+    detail::assert_no_external_stream();
     pp->commit(amrex::Gpu::Device::streamQueue());
     plan = pp;
 

--- a/Tests/GPU/ExternalStream/CMakeLists.txt
+++ b/Tests/GPU/ExternalStream/CMakeLists.txt
@@ -1,0 +1,13 @@
+if (AMReX_GPU_BACKEND STREQUAL "NONE")
+    return()
+endif ()
+
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources main.cpp)
+    set(_input_files)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/GPU/ExternalStream/GNUmakefile
+++ b/Tests/GPU/ExternalStream/GNUmakefile
@@ -1,0 +1,15 @@
+AMREX_HOME ?= ../../../
+
+USE_MPI      = FALSE
+USE_OMP      = FALSE
+TINY_PROFILE = FALSE
+DIM          = 3
+
+USE_CUDA = TRUE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/GPU/ExternalStream/Make.package
+++ b/Tests/GPU/ExternalStream/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/GPU/ExternalStream/main.cpp
+++ b/Tests/GPU/ExternalStream/main.cpp
@@ -1,0 +1,175 @@
+#include <AMReX.H>
+#include <AMReX_iMultiFab.H>
+#include <AMReX_Print.H>
+#include <AMReX_Reduce.H>
+
+using namespace amrex;
+
+namespace {
+
+#ifdef AMREX_USE_GPU
+
+gpuStream_t make_external_stream ()
+{
+    gpuStream_t s;
+    AMREX_HIP_OR_CUDA_OR_SYCL(
+        AMREX_HIP_SAFE_CALL(hipStreamCreateWithFlags(&s, hipStreamNonBlocking)),
+        AMREX_CUDA_SAFE_CALL(cudaStreamCreateWithFlags(&s, cudaStreamNonBlocking)),
+        s.queue = new sycl::queue(Gpu::Device::streamQueue()));
+    return s;
+}
+
+void destroy_external_stream (gpuStream_t s)
+{
+#if defined(AMREX_USE_CUDA)
+    AMREX_CUDA_SAFE_CALL(cudaStreamDestroy(s));
+#elif defined(AMREX_USE_HIP)
+    AMREX_HIP_SAFE_CALL(hipStreamDestroy(s));
+#elif defined(AMREX_USE_SYCL)
+    if (s.queue != nullptr) {
+        s.queue->wait_and_throw();
+        delete s.queue;
+    }
+#endif
+}
+
+void test_external_stream_region (gpuStream_t external)
+{
+    constexpr int n = 64;
+    Gpu::DeviceVector<int> device_data(n, -1);
+    Vector<int> host(n, 0);
+
+    {
+        Gpu::ExternalGpuStreamRegion guard(
+            external, Gpu::ExternalStreamSync::No);
+        AMREX_ALWAYS_ASSERT(Gpu::Device::usingExternalStream());
+        AMREX_ALWAYS_ASSERT(Gpu::Device::gpuStream() == external);
+        AMREX_ALWAYS_ASSERT(Gpu::Device::numGpuStreams() == 1);
+
+        auto ptr = device_data.dataPtr();
+        ParallelFor(n, [ptr] AMREX_GPU_DEVICE (int i) noexcept {
+            ptr[i] = 2*i;
+        });
+    }
+
+    Gpu::streamSynchronize(external);
+
+    Gpu::dtoh_memcpy(host.data(), device_data.dataPtr(), n * sizeof(int));
+    for (int i = 0; i < n; ++i) {
+        AMREX_ALWAYS_ASSERT(host[i] == 2*i);
+    }
+
+    AMREX_ALWAYS_ASSERT(!Gpu::Device::usingExternalStream());
+
+    bool cleared_before = Gpu::clearFreeAsyncBuffer();
+    AMREX_ALWAYS_ASSERT(!cleared_before);
+
+    {
+        Gpu::ExternalGpuStreamRegion guard(
+            external, Gpu::ExternalStreamSync::No);
+        Gpu::AsyncVector<int> async_device_data(n);
+        Gpu::dtod_memcpy_async(async_device_data.data(), device_data.data(),
+                               n * sizeof(int));
+    }
+    // When The_Async_Arena is involved, the dtor of
+    // Gpu::ExternalGpuStreamRegion forces a stream sync. Thus the stream
+    // should not be active.
+    AMREX_ALWAYS_ASSERT(!Gpu::isStreamActive(external));
+
+    bool cleared_after = Gpu::clearFreeAsyncBuffer();
+    AMREX_ALWAYS_ASSERT(!cleared_after);
+}
+
+void test_explicit_reset (gpuStream_t external)
+{
+    auto* arena = The_Async_Arena();
+    void* tmp = arena->alloc(512);
+
+    Gpu::setExternalGpuStream(external);
+    AMREX_ALWAYS_ASSERT(Gpu::Device::usingExternalStream());
+    AMREX_ALWAYS_ASSERT(Gpu::Device::gpuStream() == external);
+
+    Gpu::freeAsync(arena, tmp);
+    Gpu::resetExternalGpuStream(Gpu::ExternalStreamSync::No);
+    AMREX_ALWAYS_ASSERT(!Gpu::Device::usingExternalStream());
+
+    Gpu::streamSynchronize(external);
+}
+
+void test_nested_external_stream_region (gpuStream_t outer, gpuStream_t inner)
+{
+    Gpu::ExternalGpuStreamRegion outer_guard(
+        outer, Gpu::ExternalStreamSync::No);
+    AMREX_ALWAYS_ASSERT(Gpu::Device::gpuStream() == outer);
+
+    {
+        Gpu::ExternalGpuStreamRegion inner_guard(
+            inner, Gpu::ExternalStreamSync::No);
+        AMREX_ALWAYS_ASSERT(Gpu::Device::gpuStream() == inner);
+    }
+
+    AMREX_ALWAYS_ASSERT(Gpu::Device::usingExternalStream());
+    AMREX_ALWAYS_ASSERT(Gpu::Device::gpuStream() == outer);
+}
+
+void test_mfiter_and_reducer (gpuStream_t external)
+{
+    constexpr int ncell = 16;
+    Box domain(IntVect(AMREX_D_DECL(0,0,0)),
+               IntVect(AMREX_D_DECL(ncell-1, ncell-1, ncell-1)));
+    BoxArray ba(domain);
+    ba.maxSize(8);
+    DistributionMapping dm(ba);
+    iMultiFab mf(ba, dm, 1, 0);
+
+    Long expected = 0;
+    LoopOnCpu(domain, [&expected] (int i, int j, int k) noexcept {
+        expected += Long(i + j + k);
+    });
+
+    Gpu::ExternalGpuStreamRegion guard(
+        external, Gpu::ExternalStreamSync::Yes);
+    MFItInfo info;
+    info.DisableDeviceSync();
+    for (MFIter mfi(mf, info); mfi.isValid(); ++mfi) {
+        const Box& bx = mfi.validbox();
+        auto arr = mf.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            arr(i,j,k) = i + j + k;
+        });
+    }
+
+    Long device_sum = mf.sum(0);
+    AMREX_ALWAYS_ASSERT(expected == device_sum);
+}
+
+void run_external_stream_tests ()
+{
+    gpuStream_t external = make_external_stream();
+    gpuStream_t nested_external = make_external_stream();
+    test_external_stream_region(external);
+    test_explicit_reset(external);
+    test_nested_external_stream_region(external, nested_external);
+    test_mfiter_and_reducer(external);
+    destroy_external_stream(nested_external);
+    destroy_external_stream(external);
+    amrex::Print() << "External GPU stream override test completed.\n";
+}
+
+#endif // AMREX_USE_GPU
+
+} // namespace
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+    {
+#ifdef AMREX_USE_GPU
+        run_external_stream_tests();
+#else
+        amrex::Print() << "External GPU stream test requires AMReX built with GPU support.\n";
+#endif
+    }
+    amrex::Finalize();
+    return 0;
+}


### PR DESCRIPTION
Expose APIs to install and reset a user-managed GPU stream, document the new behavior, and add a GPU test covering the external-stream execution path.
