### PR TITLE
Fix GCC warning in AllGatherBoxes

### DIFF
--- a/Src/Base/AMReX_Box.cpp
+++ b/Src/Base/AMReX_Box.cpp
@@ -164,7 +164,7 @@ AllGatherBoxes (Vector<Box>& bxs, int n_extra_reserve)
     MPI_Gather(&count, 1, MPI_INT, countvec.data(), 1, MPI_INT, root, comm);
 
     Long count_tot = 0L;
-    Vector<int> offset(countvec.size(),0);
+    Vector<int> offset(nprocs, 0);
     if (myproc == root) {
         count_tot = countvec[0];
         for (int i = 1, N = static_cast<int>(offset.size()); i < N; ++i) {


### PR DESCRIPTION
## Summary

GCC 12.2.0 (with NVCC 12.8.93) was giving this warning for some reason.
```
[ 25%] Building CUDA object _deps/localamrex-build/Src/CMakeFiles/amrex_3d.dir/Base/AMReX_Box.cpp.o
In member function ‘void std::__new_allocator<_Tp>::deallocate(_Tp*, size_type) [with _Tp = int]’,
    inlined from ‘static void std::allocator_traits<std::allocator<_Tp1> >::deallocate(allocator_type&, pointer, size_type) [with _Tp = int]’ at /software/gcc/12.2.0/include/c++/12.2.0/bits/alloc_traits.h:496:17,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_deallocate(pointer, std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /software/gcc/12.2.0/include/c++/12.2.0/bits/stl_vector.h:387:16,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::~_Vector_base() [with _Tp = int; _Alloc = std::allocator<int>]’ at /software/gcc/12.2.0/include/c++/12.2.0/bits/stl_vector.h:366:14,
    inlined from ‘std::vector<_Tp, _Alloc>::~vector() [with _Tp = int; _Alloc = std::allocator<int>]’ at /software/gcc/12.2.0/include/c++/12.2.0/bits/stl_vector.h:733:1,
    inlined from ‘amrex::Vector<int>::~Vector()’ at /home/asinn/amrex/Src/Base/AMReX_Vector.H:25:7,
    inlined from ‘void amrex::AllGatherBoxes(Vector<BoxND<3> >&, int)’ at /home/asinn/amrex/Src/Base/AMReX_Box.cpp:200:1:
/software/gcc/12.2.0/include/c++/12.2.0/bits/new_allocator.h:158:25: warning: ‘void operator delete(void*, std::size_t)’ called on pointer ‘<unknown>’ with nonzero offset [1, 9223372036854775804] [-Wfree-nonheap-object]
  158 |         _GLIBCXX_OPERATOR_DELETE(_GLIBCXX_SIZED_DEALLOC(__p, __n));
      |         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = int]’,
    inlined from ‘static _Tp* std::allocator_traits<std::allocator<_Tp1> >::allocate(allocator_type&, size_type) [with _Tp = int]’ at /software/gcc/12.2.0/include/c++/12.2.0/bits/alloc_traits.h:464:22,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /software/gcc/12.2.0/include/c++/12.2.0/bits/stl_vector.h:378:36,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_create_storage(std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /software/gcc/12.2.0/include/c++/12.2.0/bits/stl_vector.h:395:41,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::_Vector_base(std::size_t, const allocator_type&) [with _Tp = int; _Alloc = std::allocator<int>]’ at /software/gcc/12.2.0/include/c++/12.2.0/bits/stl_vector.h:332:20,
    inlined from ‘std::vector<_Tp, _Alloc>::vector(size_type, const value_type&, const allocator_type&) [with _Tp = int; _Alloc = std::allocator<int>]’ at /software/gcc/12.2.0/include/c++/12.2.0/bits/stl_vector.h:565:67,
    inlined from ‘amrex::Vector<int>::Vector(std::vector<int, std::allocator<int> >::size_type, const std::vector<int, std::allocator<int> >::value_type&, const std::vector<int, std::allocator<int> >::allocator_type&) [inherited from std::vector<int, std::allocator<int> >]’ at /home/asinn/amrex/Src/Base/AMReX_Vector.H:31:44,
    inlined from ‘void amrex::AllGatherBoxes(Vector<BoxND<3> >&, int)’ at /home/asinn/amrex/Src/Base/AMReX_Box.cpp:167:40:
/software/gcc/12.2.0/include/c++/12.2.0/bits/new_allocator.h:137:49: note: returned from ‘void* operator new(std::size_t)’
  137 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                   ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
```

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
