### PR TITLE
Implement pure-SoA HDF5 particle IO

### DIFF
--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -31,18 +31,18 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 {
     Vector<int> write_real_comp;
     Vector<std::string> tmp_real_comp_names;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i )
+
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
         write_real_comp.push_back(1);
-        if (real_comp_names.size() == 0)
+        if (real_comp_names.empty())
         {
-            std::stringstream ss;
-            ss << "real_comp" << i;
-            tmp_real_comp_names.push_back(ss.str());
+            tmp_real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
         }
         else
         {
-            tmp_real_comp_names.push_back(real_comp_names[i]);
+            tmp_real_comp_names.push_back(real_comp_names[i-first_rcomp]);
         }
     }
 
@@ -51,11 +51,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
         write_int_comp.push_back(1);
-        if (int_comp_names.size() == 0)
+        if (int_comp_names.empty())
         {
-            std::stringstream ss;
-            ss << "int_comp" << i;
-            tmp_int_comp_names.push_back(ss.str());
+            tmp_int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
         }
         else
         {
@@ -81,12 +79,11 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 {
     Vector<int> write_real_comp;
     Vector<std::string> real_comp_names;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i )
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
         write_real_comp.push_back(1);
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
+        real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
     }
 
     Vector<int> write_int_comp;
@@ -94,9 +91,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
         write_int_comp.push_back(1);
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
@@ -699,10 +694,11 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     hsize_t        total_mfi = 0, total_real_size = 0, total_int_size = 0, real_file_offset = 0, int_file_offset = 0;
     hsize_t        my_int_offset, my_int_count, my_real_offset, my_real_count;
 
-    // Count total number of components written
+    // Count total number of components written (positions always included;
+    // write_real_comp covers the non-position components for pure SoA)
     int real_comp_count = AMREX_SPACEDIM; // position values
 
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i ) {
+    for (int i = 0; i < static_cast<int>(write_real_comp.size()); ++i ) {
         if (write_real_comp[i]) { ++real_comp_count; }
     }
 
@@ -1120,8 +1116,10 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         msg += aname;
         amrex::Abort(msg.c_str());
     }
-    if (nr != NStructReal + NumRealComps())
-        amrex::Abort("ParticleContainer::Restart(): nr != NStructReal + NumRealComps()");
+    int nrc = ParticleType::is_soa_particle ? NStructReal + NumRealComps() - AMREX_SPACEDIM : NStructReal + NumRealComps();
+    if (nr != nrc) {
+        amrex::Abort("ParticleContainer::RestartHDF5(): nr not the expected value");
+    }
 
     aname = "num_component_int";
     int ni;
@@ -1426,7 +1424,10 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     H5Sclose(int_dspace);
 
     // Then the real data in binary.
-    const int rChunkSize = AMREX_SPACEDIM + NStructReal + NumRealComps();
+    // For pure SoA, positions are stored in the first AMREX_SPACEDIM SoA real slots;
+    // there are no struct reals beyond positions, so total = NStructReal + NumRealComps().
+    const int rChunkSize = ParticleType::is_soa_particle ?
+        NStructReal + NumRealComps() : AMREX_SPACEDIM + NStructReal + NumRealComps();
     Vector<RTYPE> rstuff(cnt*rChunkSize);
     real_fspace = H5Dget_space(real_dset);
     hsize_t real_cnt = cnt*rChunkSize;
@@ -1446,7 +1447,9 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     int*   iptr = istuff.dataPtr();
     RTYPE* rptr = rstuff.dataPtr();
 
-    ParticleType p;
+    // Use a plain AoS-style particle struct for reading id/cpu/pos/struct data,
+    // regardless of whether the container is pure SoA.
+    Particle<NStructReal, NStructInt> ptemp;
     ParticleLocData pld;
 
     Vector<std::map<std::pair<int, int>, Gpu::HostVector<ParticleType> > > host_particles;
@@ -1463,7 +1466,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     host_int_attribs.reserve(15);
     host_int_attribs.resize(finest_level_in_file+1);
 
+    Vector<std::map<std::pair<int, int>, Gpu::HostVector<uint64_t> > > host_idcpu;
+    host_idcpu.reserve(15);
+    host_idcpu.resize(finest_level_in_file+1);
+
     for (hsize_t i = 0; i < cnt; i++) {
+        // note: for pure SoA particle layouts, we do write the id, cpu and positions as a struct
+        //       for backwards compatibility with readers
         if (convert_ids) {
             std::int32_t  xi, yi;
             std::uint32_t xu, yu;
@@ -1471,86 +1480,124 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             yi = iptr[1];
             std::memcpy(&xu, &xi, sizeof(xi));
             std::memcpy(&yu, &yi, sizeof(yi));
-            p.m_idcpu = ((std::uint64_t)xu) << 32 | yu;
+            ptemp.m_idcpu = ((std::uint64_t)xu) << 32 | yu;
         } else {
-            p.id()   = iptr[0];
-            p.cpu()  = iptr[1];
+            ptemp.id()   = iptr[0];
+            ptemp.cpu()  = iptr[1];
         }
         iptr += 2;
 
         for (int j = 0; j < NStructInt; j++)
         {
-            p.idata(j) = *iptr;
+            ptemp.idata(j) = *iptr;
             ++iptr;
         }
 
-        AMREX_ASSERT(p.id().is_valid());
+        AMREX_ASSERT(ptemp.id().is_valid());
 
-        AMREX_D_TERM(p.pos(0) = ParticleReal(rptr[0]);,
-                     p.pos(1) = ParticleReal(rptr[1]);,
-                     p.pos(2) = ParticleReal(rptr[2]););
+        AMREX_D_TERM(ptemp.pos(0) = ParticleReal(rptr[0]);,
+                     ptemp.pos(1) = ParticleReal(rptr[1]);,
+                     ptemp.pos(2) = ParticleReal(rptr[2]););
 
         rptr += AMREX_SPACEDIM;
 
         for (int j = 0; j < NStructReal; j++)
         {
-            p.rdata(j) = ParticleReal(*rptr);
+            ptemp.rdata(j) = ParticleReal(*rptr);
             ++rptr;
         }
 
-        locateParticle(p, pld, 0, finestLevel(), 0);
+        locateParticle(ptemp, pld, 0, finestLevel(), 0);
 
         std::pair<int, int> ind(grd, pld.m_tile);
 
         host_real_attribs[lev][ind].resize(NumRealComps());
         host_int_attribs[lev][ind].resize(NumIntComps());
 
-        // add the struct
-        host_particles[lev][ind].push_back(p);
+        if constexpr (!ParticleType::is_soa_particle)
+        {
+            // add the struct
+            host_particles[lev][ind].push_back(ptemp);
 
-        // add the real...
-        for (int icomp = 0; icomp < NumRealComps(); icomp++) {
-            host_real_attribs[lev][ind][icomp].push_back(ParticleReal(*rptr));
-            ++rptr;
-        }
+            // add the real...
+            for (int icomp = 0; icomp < NumRealComps(); icomp++) {
+                host_real_attribs[lev][ind][icomp].push_back(ParticleReal(*rptr));
+                ++rptr;
+            }
 
-        // ... and int array data
-        for (int icomp = 0; icomp < NumIntComps(); icomp++) {
-            host_int_attribs[lev][ind][icomp].push_back(*iptr);
-            ++iptr;
+            // ... and int array data
+            for (int icomp = 0; icomp < NumIntComps(); icomp++) {
+                host_int_attribs[lev][ind][icomp].push_back(*iptr);
+                ++iptr;
+            }
+        } else {
+            host_particles[lev][ind];
+
+            for (int j = 0; j < AMREX_SPACEDIM; j++) {
+                host_real_attribs[lev][ind][j].push_back(ptemp.pos(j));
+            }
+
+            host_idcpu[lev][ind].push_back(ptemp.m_idcpu);
+
+            // read remaining SoA real data (starting after positions)
+            for (int icomp = AMREX_SPACEDIM; icomp < NumRealComps(); icomp++) {
+                host_real_attribs[lev][ind][icomp].push_back(ParticleReal(*rptr));
+                ++rptr;
+            }
+
+            // ... and int array data
+            for (int icomp = 0; icomp < NumIntComps(); icomp++) {
+                host_int_attribs[lev][ind][icomp].push_back(*iptr);
+                ++iptr;
+            }
         }
     }
 
     for (int host_lev = 0; host_lev < static_cast<int>(host_particles.size()); ++host_lev)
-      {
+    {
         for (auto& kv : host_particles[host_lev]) {
-          auto grid = kv.first.first;
-          auto tile = kv.first.second;
-          const auto& src_tile = kv.second;
+            auto grid = kv.first.first;
+            auto tile = kv.first.second;
+            const auto& src_tile = kv.second;
 
-          auto& dst_tile = DefineAndReturnParticleTile(host_lev, grid, tile);
-          auto old_size = dst_tile.GetArrayOfStructs().size();
-          auto new_size = old_size + src_tile.size();
-          dst_tile.resize(new_size);
+            auto& dst_tile = DefineAndReturnParticleTile(host_lev, grid, tile);
+            auto old_size = dst_tile.size();
+            auto new_size = old_size;
+            if constexpr (!ParticleType::is_soa_particle)
+            {
+                new_size += src_tile.size();
+            } else {
+                amrex::ignore_unused(src_tile);
+                new_size += host_real_attribs[host_lev][std::make_pair(grid,tile)][0].size();
+            }
+            dst_tile.resize(new_size);
 
-          Gpu::copyAsync(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
-                         dst_tile.GetArrayOfStructs().begin() + old_size);
+            if constexpr (!ParticleType::is_soa_particle)
+            {
+                Gpu::copyAsync(Gpu::hostToDevice, src_tile.begin(), src_tile.end(),
+                               dst_tile.GetArrayOfStructs().begin() + old_size);
+            } else {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_idcpu[host_lev][std::make_pair(grid,tile)].begin(),
+                               host_idcpu[host_lev][std::make_pair(grid,tile)].end(),
+                               dst_tile.GetStructOfArrays().GetIdCPUData().begin() + old_size);
+            }
 
-          for (int i = 0; i < NumRealComps(); ++i) {
-              Gpu::copyAsync(Gpu::hostToDevice,
-                             host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                             host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                             dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
-          }
+            for (int i = 0; i < NumRealComps(); ++i) {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_real_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                               host_real_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                               dst_tile.GetStructOfArrays().GetRealData(i).begin() + old_size);
+            }
 
-          for (int i = 0; i < NumIntComps(); ++i) {
-              Gpu::copyAsync(Gpu::hostToDevice,
-                             host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
-                             host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
-                             dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
-          }
+            for (int i = 0; i < NumIntComps(); ++i) {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_int_attribs[host_lev][std::make_pair(grid,tile)][i].begin(),
+                               host_int_attribs[host_lev][std::make_pair(grid,tile)][i].end(),
+                               dst_tile.GetStructOfArrays().GetIntData(i).begin() + old_size);
+            }
         }
-      }
+    }
 
     Gpu::streamSynchronize();
 }

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -114,12 +114,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 {
     Vector<int> write_real_comp;
     Vector<std::string> real_comp_names;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i )
+    // skip the first spacedim comps for soa particles
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
         write_real_comp.push_back(1);
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
+        real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
     }
 
     Vector<int> write_int_comp;
@@ -127,9 +127,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
         write_int_comp.push_back(1);
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
@@ -150,11 +148,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                      const Vector<std::string>& int_comp_names,
                      const std::string& compression) const
 {
-    AMREX_ASSERT(real_comp_names.size() == NStructReal + NumRealComps());
-    AMREX_ASSERT( int_comp_names.size() == NStructInt  + NumIntComps() );
+    // skip the first spacedim comps for soa particles
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    AMREX_ALWAYS_ASSERT(static_cast<int>(real_comp_names.size()) == NStructReal + NumRealComps() - first_rcomp);
+    AMREX_ALWAYS_ASSERT(static_cast<int>(int_comp_names.size()) == NStructInt  + NumIntComps() );
 
     Vector<int> write_real_comp;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i) { write_real_comp.push_back(1); }
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i) { write_real_comp.push_back(1); }
 
     Vector<int> write_int_comp;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i) { write_int_comp.push_back(1); }
@@ -177,10 +177,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                      const Vector<std::string>& real_comp_names,
                      const std::string& compression) const
 {
-    AMREX_ASSERT(real_comp_names.size() == NStructReal + NumRealComps());
+    // skip the first spacedim comps for soa particles
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    AMREX_ALWAYS_ASSERT(static_cast<int>(real_comp_names.size()) == NStructReal + NumRealComps() - first_rcomp);
 
     Vector<int> write_real_comp;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i) write_real_comp.push_back(1);
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i) write_real_comp.push_back(1);
 
     Vector<int> write_int_comp;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i) write_int_comp.push_back(1);
@@ -188,9 +190,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     Vector<std::string> int_comp_names;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteHDF5ParticleData(dir, name,
@@ -213,23 +213,21 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                      const Vector<int>& write_int_comp,
                      const std::string& compression) const
 {
-    AMREX_ASSERT(write_real_comp.size() == NStructReal + NumRealComps());
-    AMREX_ASSERT(write_int_comp.size()  == NStructInt  + NArrayInt );
+    // skip the first spacedim comps for soa particles
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    AMREX_ALWAYS_ASSERT(static_cast<int>(write_real_comp.size()) == NStructReal + NumRealComps() - first_rcomp);
+    AMREX_ALWAYS_ASSERT(static_cast<int>(write_int_comp.size())  == NStructInt  + NArrayInt );
 
     Vector<std::string> real_comp_names;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i )
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
+        real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
     }
 
     Vector<std::string> int_comp_names;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
@@ -274,12 +272,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 {
     Vector<int> write_real_comp;
     Vector<std::string> real_comp_names;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i )
+    // skip the first spacedim comps for soa particles
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
         write_real_comp.push_back(1);
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
+        real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
     }
 
     Vector<int> write_int_comp;
@@ -287,9 +285,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
         write_int_comp.push_back(1);
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
@@ -307,11 +303,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                      const Vector<std::string>& int_comp_names,
                      const std::string& compression, F&& f) const
 {
-    AMREX_ASSERT(real_comp_names.size() == NStructReal + NumRealComps());
-    AMREX_ASSERT( int_comp_names.size() == NStructInt  + NArrayInt );
+    // skip the first spacedim comps for soa particles
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    AMREX_ALWAYS_ASSERT(static_cast<int>(real_comp_names.size()) == NStructReal + NumRealComps() - first_rcomp);
+    AMREX_ALWAYS_ASSERT(static_cast<int>(int_comp_names.size()) == NStructInt  + NArrayInt );
 
     Vector<int> write_real_comp;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i) { write_real_comp.push_back(1); }
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i) { write_real_comp.push_back(1); }
 
     Vector<int> write_int_comp;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i) { write_int_comp.push_back(1); }
@@ -331,10 +329,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                      const Vector<std::string>& real_comp_names,
                      const std::string& compression, F&& f) const
 {
-    AMREX_ASSERT(real_comp_names.size() == NStructReal + NumRealComps());
+    // skip the first spacedim comps for soa particles
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    AMREX_ALWAYS_ASSERT(static_cast<int>(real_comp_names.size()) == NStructReal + NumRealComps() - first_rcomp);
 
     Vector<int> write_real_comp;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i) { write_real_comp.push_back(1); }
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i) { write_real_comp.push_back(1); }
 
     Vector<int> write_int_comp;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i) { write_int_comp.push_back(1); }
@@ -342,9 +342,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     Vector<std::string> int_comp_names;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteHDF5ParticleData(dir, name,
@@ -364,23 +362,21 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                      const Vector<int>& write_int_comp,
                      const std::string& compression, F&& f) const
 {
-    AMREX_ASSERT(write_real_comp.size() == NStructReal + NumRealComps());
-    AMREX_ASSERT(write_int_comp.size()  == NStructInt  + NumIntComps() );
+    // skip the first spacedim comps for soa particles
+    int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
+    AMREX_ALWAYS_ASSERT(static_cast<int>(write_real_comp.size()) == NStructReal + NumRealComps() - first_rcomp);
+    AMREX_ALWAYS_ASSERT(static_cast<int>(write_int_comp.size())  == NStructInt  + NumIntComps() );
 
     Vector<std::string> real_comp_names;
-    for (int i = 0; i < NStructReal + NumRealComps(); ++i )
+    for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "real_comp" << i;
-        real_comp_names.push_back(ss.str());
+        real_comp_names.push_back(getDefaultCompNameReal<ParticleType>(i));
     }
 
     Vector<std::string> int_comp_names;
     for (int i = 0; i < NStructInt + NumIntComps(); ++i )
     {
-        std::stringstream ss;
-        ss << "int_comp" << i;
-        int_comp_names.push_back(ss.str());
+        int_comp_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
     WriteHDF5ParticleData(dir, name, write_real_comp, write_int_comp,
@@ -1533,6 +1529,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                 ++iptr;
             }
         } else {
+            // we need to create this map entry for the loop below
             host_particles[lev][ind];
 
             for (int j = 0; j < AMREX_SPACEDIM; j++) {

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -32,6 +32,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     Vector<int> write_real_comp;
     Vector<std::string> tmp_real_comp_names;
 
+    // skip the first spacedim comps for soa particles
     int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
     for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {
@@ -79,6 +80,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 {
     Vector<int> write_real_comp;
     Vector<std::string> real_comp_names;
+    // skip the first spacedim comps for soa particles
     int first_rcomp = ParticleType::is_soa_particle ? AMREX_SPACEDIM : 0;
     for (int i = first_rcomp; i < NStructReal + NumRealComps(); ++i )
     {

--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -138,7 +138,11 @@ void WriteHDF5ParticleDataSync (PC const& pc,
     const int NProcs = ParallelDescriptor::NProcs();
     const int IOProcNumber = ParallelDescriptor::IOProcessorNumber();
 
-    AMREX_ALWAYS_ASSERT(real_comp_names.size() == pc.NumRealComps() + NStructReal);
+    {
+        int nrc = PC::ParticleType::is_soa_particle ?
+            pc.NumRealComps() + NStructReal - AMREX_SPACEDIM : pc.NumRealComps() + NStructReal;
+        AMREX_ALWAYS_ASSERT(static_cast<int>(real_comp_names.size()) == nrc);
+    }
     AMREX_ALWAYS_ASSERT( int_comp_names.size() == pc.NumIntComps() + NStructInt);
 
 #ifdef AMREX_USE_HDF5_ASYNC
@@ -273,7 +277,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         CreateWriteHDF5AttrString(fid, "version_name", versionName.c_str());
 
         int num_output_real = 0;
-        for (int i = 0; i < pc.NumRealComps() + NStructReal; ++i) {
+        for (int i = 0; i < static_cast<int>(write_real_comp.size()); ++i) {
             if (write_real_comp[i]) { ++num_output_real; }
         }
 
@@ -298,7 +302,7 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         // Real component names
         int real_comp_count = AMREX_SPACEDIM; // position values
 
-        for (int i = 0; i < NStructReal + pc.NumRealComps(); ++i ) {
+        for (int i = 0; i < static_cast<int>(write_real_comp.size()); ++i ) {
             if (write_real_comp[i]) {
                 /* HdrFile << real_comp_names[i] << '\n'; */
                 snprintf(comp_name, sizeof comp_name, "real_component_%d", real_comp_count);

--- a/Tests/Particles/CheckpointRestartDualGridHDF5SOA/CMakeLists.txt
+++ b/Tests/Particles/CheckpointRestartDualGridHDF5SOA/CMakeLists.txt
@@ -1,0 +1,12 @@
+# This test requires particle support
+if (NOT AMReX_PARTICLES)
+   return()
+endif ()
+
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources main.cpp)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+endforeach()

--- a/Tests/Particles/CheckpointRestartDualGridHDF5SOA/GNUmakefile
+++ b/Tests/Particles/CheckpointRestartDualGridHDF5SOA/GNUmakefile
@@ -1,0 +1,34 @@
+AMREX_HOME = ../../../
+
+DEBUG	= FALSE
+
+DIM	= 3
+
+COMP    = gnu
+
+PRECISION = DOUBLE
+
+USE_MPI   = TRUE
+MPI_THREAD_MULTIPLE = FALSE
+
+USE_OMP   = FALSE
+
+TINY_PROFILE = TRUE
+
+USE_PARTICLES = TRUE
+
+USE_HDF5  = FALSE
+# Set HDF5_HOME to the root of your HDF5 installation, e.g.:
+# HDF5_HOME = /path/to/hdf5
+
+###################################################
+
+EBASE     = main
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Particles/CheckpointRestartDualGridHDF5SOA/Make.package
+++ b/Tests/Particles/CheckpointRestartDualGridHDF5SOA/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Particles/CheckpointRestartDualGridHDF5SOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartDualGridHDF5SOA/main.cpp
@@ -1,0 +1,320 @@
+/**
+ * Test for dual-grid particle checkpoint/restart capability using pure SoA
+ * particles and HDF5 I/O.
+ *
+ * Verifies that particles are preserved correctly when reading a
+ * checkpoint file into a ParticleContainerPureSoA with a different mesh structure,
+ * covering:
+ *   1. Restart with fewer AMR levels than the checkpoint
+ *   2. Restart with more AMR levels than the checkpoint
+ *   3. Restart with the same number of levels but different BoxArrays
+ */
+#include <AMReX.H>
+#include <AMReX_Particles.H>
+
+using namespace amrex;
+
+// Pure SoA particle type: 6 real components (including positions), 2 int components
+constexpr int NReal = 6;
+constexpr int NInt  = 2;
+
+using MyPC        = ParticleContainerPureSoA<NReal, NInt>;
+using ConstPTDType = typename MyPC::ConstPTDType;
+
+struct MeshData {
+    Vector<Box>                 domains;
+    Vector<BoxArray>            ba;
+    Vector<IntVect>             ref_ratio;
+    Vector<Geometry>            geom;
+    Vector<DistributionMapping> dmap;
+};
+
+/**
+ * Build a nested AMR hierarchy with `nlevs` levels over a [0,1]^d domain
+ * discretised by `ncells` cells in each direction. The coarse BoxArray is
+ * decomposed into boxes of at most `max_grid_size` cells; the fine level
+ * covers the central half of the domain.
+ */
+MeshData build_mesh (int ncells, int nlevs, int max_grid_size)
+{
+    AMREX_ALWAYS_ASSERT(nlevs >= 1 && nlevs <= 2);
+
+    MeshData m;
+
+    // Level-0 domain
+    IntVect lo(AMREX_D_DECL(0, 0, 0));
+    IntVect hi(AMREX_D_DECL(ncells-1, ncells-1, ncells-1));
+
+    m.domains.resize(nlevs);
+    m.domains[0].setSmall(lo);
+    m.domains[0].setBig(hi);
+
+    m.ref_ratio.resize(nlevs > 1 ? nlevs - 1 : 0);
+    for (int lev = 1; lev < nlevs; ++lev) {
+        m.ref_ratio[lev-1] = IntVect(AMREX_D_DECL(2, 2, 2));
+        m.domains[lev] = amrex::refine(m.domains[lev-1], m.ref_ratio[lev-1]);
+    }
+
+    m.ba.resize(nlevs);
+    m.ba[0].define(m.domains[0]);
+    m.ba[0].maxSize(max_grid_size);
+
+    if (nlevs > 1) {
+        // Refined region: the central 1/4 of the fine-level domain
+        int n_fine = ncells * 2; // ref_ratio == 2
+        IntVect rlo(AMREX_D_DECL(n_fine/4,   n_fine/4,   n_fine/4));
+        IntVect rhi(AMREX_D_DECL(3*n_fine/4-1, 3*n_fine/4-1, 3*n_fine/4-1));
+        m.ba[1].define(Box(rlo, rhi));
+        m.ba[1].maxSize(max_grid_size);
+    }
+
+    RealBox real_box;
+    for (int n = 0; n < AMREX_SPACEDIM; ++n) {
+        real_box.setLo(n, 0.0);
+        real_box.setHi(n, 1.0);
+    }
+    int is_per[] = {AMREX_D_DECL(1, 1, 1)};
+
+    m.geom.resize(nlevs);
+    m.geom[0].define(m.domains[0], &real_box, CoordSys::cartesian, is_per);
+    for (int lev = 1; lev < nlevs; ++lev) {
+        m.geom[lev].define(m.domains[lev], &real_box, CoordSys::cartesian, is_per);
+    }
+
+    m.dmap.resize(nlevs);
+    for (int lev = 0; lev < nlevs; ++lev) {
+        m.dmap[lev] = DistributionMapping{m.ba[lev]};
+    }
+
+    return m;
+}
+
+/**
+ * Assert that two ParticleContainerPureSoA hold identical particle data by
+ * comparing the total particle count and the component-wise sums of every
+ * real and integer attribute across all levels.
+ */
+void verify_same (MyPC& pc_orig, MyPC& pc_new)
+{
+    auto n_orig = pc_orig.TotalNumberOfParticles();
+    auto n_new  = pc_new.TotalNumberOfParticles();
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        n_orig == n_new,
+        "Particle count mismatch after restart");
+
+    // Skip position components (0..AMREX_SPACEDIM-1): they hold random values,
+    // and floating-point summation order may differ across level configurations.
+    for (int icomp = AMREX_SPACEDIM; icomp < NReal; ++icomp) {
+        auto sm_orig = amrex::ReduceSum(pc_orig,
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
+                return ptd.rdata(icomp)[i];
+            });
+        auto sm_new = amrex::ReduceSum(pc_new,
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
+                return ptd.rdata(icomp)[i];
+            });
+        ParallelDescriptor::ReduceRealSum(sm_orig);
+        ParallelDescriptor::ReduceRealSum(sm_new);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            sm_orig == sm_new,
+            "Real component sum mismatch after restart (comp " + std::to_string(icomp) + ")");
+    }
+
+    for (int icomp = 0; icomp < NInt; ++icomp) {
+        auto sm_orig = amrex::ReduceSum(pc_orig,
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
+                return static_cast<Real>(ptd.idata(icomp)[i]);
+            });
+        auto sm_new = amrex::ReduceSum(pc_new,
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
+                return static_cast<Real>(ptd.idata(icomp)[i]);
+            });
+        ParallelDescriptor::ReduceRealSum(sm_orig);
+        ParallelDescriptor::ReduceRealSum(sm_new);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            sm_orig == sm_new,
+            "Int component sum mismatch after restart (comp " + std::to_string(icomp) + ")");
+    }
+}
+
+/**
+ * Test 1: Write a 2-level HDF5 checkpoint, restart into a 1-level container.
+ * Particles that resided on the fine level must be redistributed to the
+ * coarse level; totals and component sums must be unchanged.
+ */
+void test_fewer_levels ()
+{
+    amrex::Print() << "Test 1: restart with fewer levels than checkpoint\n";
+
+    const int ncells         = 32;
+    const int max_grid_size  = 16;
+    const int nppc           = 2;
+    const int iseed          = 451;
+    const std::string chkdir = "chk_fewer_levels";
+
+    MyPC::ParticleInitData pdata = {{}, {}, {1.0, 2.0, 3.0, 4.0, 6.0, 7.0}, {5, 8}};
+
+    Vector<std::string> real_names, int_names;
+    for (int i = 0; i < NReal - AMREX_SPACEDIM; ++i) {
+        real_names.push_back("real_" + std::to_string(i));
+    }
+    for (int i = 0; i < NInt; ++i) {
+        int_names.push_back("int_" + std::to_string(i));
+    }
+
+    // --- write with 2 levels ---
+    auto mesh2 = build_mesh(ncells, 2, max_grid_size);
+    MyPC pc_write(mesh2.geom, mesh2.dmap, mesh2.ba, mesh2.ref_ratio);
+    pc_write.SetVerbose(false);
+    pc_write.InitRandom(nppc * AMREX_D_TERM(ncells, *ncells, *ncells),
+                        iseed, pdata, /*serialize=*/false);
+#ifdef AMREX_USE_HDF5
+    pc_write.CheckpointHDF5(chkdir, "particles", true, real_names, int_names);
+#else
+    pc_write.Checkpoint(chkdir, "particles", real_names, int_names);
+#endif
+
+    AsyncOut::Finish();
+    ParallelDescriptor::Barrier();
+
+    // --- restart with 1 level ---
+    auto mesh1 = build_mesh(ncells, 1, max_grid_size);
+    MyPC pc_read(mesh1.geom, mesh1.dmap, mesh1.ba, mesh1.ref_ratio);
+    pc_read.SetVerbose(false);
+#ifdef AMREX_USE_HDF5
+    pc_read.RestartHDF5(chkdir + "/particles", "particles");
+#else
+    pc_read.Restart(chkdir, "particles");
+#endif
+
+    verify_same(pc_write, pc_read);
+
+    amrex::Print() << "  PASSED\n";
+}
+
+/**
+ * Test 2: Write a 1-level HDF5 checkpoint, restart into a 2-level container.
+ * After restart, Redistribute() assigns particles inside the refined
+ * region to the finer level; totals and component sums must be unchanged.
+ */
+void test_more_levels ()
+{
+    amrex::Print() << "Test 2: restart with more levels than checkpoint\n";
+
+    const int ncells         = 32;
+    const int max_grid_size  = 16;
+    const int nppc           = 2;
+    const int iseed          = 451;
+    const std::string chkdir = "chk_more_levels";
+
+    MyPC::ParticleInitData pdata = {{}, {}, {1.0, 2.0, 3.0, 4.0, 6.0, 7.0}, {5, 8}};
+
+    Vector<std::string> real_names, int_names;
+    for (int i = 0; i < NReal - AMREX_SPACEDIM; ++i) {
+        real_names.push_back("real_" + std::to_string(i));
+    }
+    for (int i = 0; i < NInt; ++i) {
+        int_names.push_back("int_" + std::to_string(i));
+    }
+
+    // --- write with 1 level ---
+    auto mesh1 = build_mesh(ncells, 1, max_grid_size);
+    MyPC pc_write(mesh1.geom, mesh1.dmap, mesh1.ba, mesh1.ref_ratio);
+    pc_write.SetVerbose(false);
+    pc_write.InitRandom(nppc * AMREX_D_TERM(ncells, *ncells, *ncells),
+                        iseed, pdata, /*serialize=*/false);
+#ifdef AMREX_USE_HDF5
+    pc_write.CheckpointHDF5(chkdir, "particles", true, real_names, int_names);
+#else
+    pc_write.Checkpoint(chkdir, "particles", real_names, int_names);
+#endif
+
+    AsyncOut::Finish();
+    ParallelDescriptor::Barrier();
+
+    // --- restart with 2 levels ---
+    auto mesh2 = build_mesh(ncells, 2, max_grid_size);
+    MyPC pc_read(mesh2.geom, mesh2.dmap, mesh2.ba, mesh2.ref_ratio);
+    pc_read.SetVerbose(false);
+#ifdef AMREX_USE_HDF5
+    pc_read.RestartHDF5(chkdir + "/particles", "particles");
+#else
+    pc_read.Restart(chkdir, "particles");
+#endif
+
+    verify_same(pc_write, pc_read);
+
+    amrex::Print() << "  PASSED\n";
+}
+
+/**
+ * Test 3: Write an HDF5 checkpoint with one BoxArray decomposition, restart
+ * into a container with the same number of levels but a different BoxArray
+ * (different max_grid_size). This is the canonical dual-grid scenario: the
+ * Particle_H header written at checkpoint time differs from the BoxArray
+ * of the new container, so AMReX uses temporary grids while reading and
+ * calls Redistribute() to move particles onto the new decomposition.
+ */
+void test_different_boxarrays ()
+{
+    amrex::Print() << "Test 3: restart with same levels but different BoxArrays\n";
+
+    const int ncells         = 32;
+    const int nppc           = 2;
+    const int iseed          = 451;
+    const std::string chkdir = "chk_different_ba";
+
+    MyPC::ParticleInitData pdata = {{}, {}, {1.0, 2.0, 3.0, 4.0, 6.0, 7.0}, {5, 8}};
+
+    Vector<std::string> real_names, int_names;
+    for (int i = 0; i < NReal - AMREX_SPACEDIM; ++i) {
+        real_names.push_back("real_" + std::to_string(i));
+    }
+    for (int i = 0; i < NInt; ++i) {
+        int_names.push_back("int_" + std::to_string(i));
+    }
+
+    // --- write: coarse decomposition (few large boxes) ---
+    auto mesh_coarse = build_mesh(ncells, 1, ncells); // one box per rank at most
+    MyPC pc_write(mesh_coarse.geom, mesh_coarse.dmap, mesh_coarse.ba,
+                  mesh_coarse.ref_ratio);
+    pc_write.SetVerbose(false);
+    pc_write.InitRandom(nppc * AMREX_D_TERM(ncells, *ncells, *ncells),
+                        iseed, pdata, /*serialize=*/false);
+#ifdef AMREX_USE_HDF5
+    pc_write.CheckpointHDF5(chkdir, "particles", true, real_names, int_names);
+#else
+    pc_write.Checkpoint(chkdir, "particles", real_names, int_names);
+#endif
+
+    AsyncOut::Finish();
+    ParallelDescriptor::Barrier();
+
+    // --- restart: finer decomposition (many smaller boxes) ---
+    auto mesh_fine = build_mesh(ncells, 1, ncells / 4);
+    MyPC pc_read(mesh_fine.geom, mesh_fine.dmap, mesh_fine.ba,
+                 mesh_fine.ref_ratio);
+    pc_read.SetVerbose(false);
+#ifdef AMREX_USE_HDF5
+    pc_read.RestartHDF5(chkdir + "/particles", "particles");
+#else
+    pc_read.Restart(chkdir, "particles");
+#endif
+
+    verify_same(pc_write, pc_read);
+
+    amrex::Print() << "  PASSED\n";
+}
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+
+    test_fewer_levels();
+    test_more_levels();
+    test_different_boxarrays();
+
+    amrex::Print() << "All dual-grid HDF5 SOA restart tests PASSED\n";
+
+    amrex::Finalize();
+}

--- a/Tests/Particles/CheckpointRestartDualGridSOA/CMakeLists.txt
+++ b/Tests/Particles/CheckpointRestartDualGridSOA/CMakeLists.txt
@@ -1,0 +1,12 @@
+# This test requires particle support
+if (NOT AMReX_PARTICLES)
+   return()
+endif ()
+
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources main.cpp)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+endforeach()

--- a/Tests/Particles/CheckpointRestartDualGridSOA/GNUmakefile
+++ b/Tests/Particles/CheckpointRestartDualGridSOA/GNUmakefile
@@ -1,0 +1,30 @@
+AMREX_HOME = ../../../
+
+DEBUG	= FALSE
+
+DIM	= 3
+
+COMP    = gnu
+
+PRECISION = DOUBLE
+
+USE_MPI   = TRUE
+MPI_THREAD_MULTIPLE = FALSE
+
+USE_OMP   = FALSE
+
+TINY_PROFILE = TRUE
+
+USE_PARTICLES = TRUE
+
+###################################################
+
+EBASE     = main
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Particles/CheckpointRestartDualGridSOA/Make.package
+++ b/Tests/Particles/CheckpointRestartDualGridSOA/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Particles/CheckpointRestartDualGridSOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartDualGridSOA/main.cpp
@@ -1,0 +1,295 @@
+/**
+ * Test for dual-grid particle checkpoint/restart capability using pure SoA particles.
+ *
+ * Verifies that particles are preserved correctly when reading a
+ * checkpoint file into a ParticleContainerPureSoA with a different mesh structure,
+ * covering:
+ *   1. Restart with fewer AMR levels than the checkpoint
+ *   2. Restart with more AMR levels than the checkpoint
+ *   3. Restart with the same number of levels but different BoxArrays
+ */
+#include <AMReX.H>
+#include <AMReX_Particles.H>
+
+using namespace amrex;
+
+// Pure SoA particle type: 6 real components (including positions), 2 int components
+constexpr int NReal = 6;
+constexpr int NInt  = 2;
+
+using MyPC        = ParticleContainerPureSoA<NReal, NInt>;
+using ConstPTDType = typename MyPC::ConstPTDType;
+
+struct MeshData {
+    Vector<Box>                 domains;
+    Vector<BoxArray>            ba;
+    Vector<IntVect>             ref_ratio;
+    Vector<Geometry>            geom;
+    Vector<DistributionMapping> dmap;
+};
+
+/**
+ * Build a nested AMR hierarchy with `nlevs` levels over a [0,1]^d domain
+ * discretised by `ncells` cells in each direction. The coarse BoxArray is
+ * decomposed into boxes of at most `max_grid_size` cells; the fine level
+ * covers the central half of the domain.
+ */
+MeshData build_mesh (int ncells, int nlevs, int max_grid_size)
+{
+    AMREX_ALWAYS_ASSERT(nlevs >= 1 && nlevs <= 2);
+
+    MeshData m;
+
+    // Level-0 domain
+    IntVect lo(AMREX_D_DECL(0, 0, 0));
+    IntVect hi(AMREX_D_DECL(ncells-1, ncells-1, ncells-1));
+
+    m.domains.resize(nlevs);
+    m.domains[0].setSmall(lo);
+    m.domains[0].setBig(hi);
+
+    m.ref_ratio.resize(nlevs > 1 ? nlevs - 1 : 0);
+    for (int lev = 1; lev < nlevs; ++lev) {
+        m.ref_ratio[lev-1] = IntVect(AMREX_D_DECL(2, 2, 2));
+        m.domains[lev] = amrex::refine(m.domains[lev-1], m.ref_ratio[lev-1]);
+    }
+
+    m.ba.resize(nlevs);
+    m.ba[0].define(m.domains[0]);
+    m.ba[0].maxSize(max_grid_size);
+
+    if (nlevs > 1) {
+        // Refined region: the central 1/4 of the fine-level domain
+        int n_fine = ncells * 2; // ref_ratio == 2
+        IntVect rlo(AMREX_D_DECL(n_fine/4,   n_fine/4,   n_fine/4));
+        IntVect rhi(AMREX_D_DECL(3*n_fine/4-1, 3*n_fine/4-1, 3*n_fine/4-1));
+        m.ba[1].define(Box(rlo, rhi));
+        m.ba[1].maxSize(max_grid_size);
+    }
+
+    RealBox real_box;
+    for (int n = 0; n < AMREX_SPACEDIM; ++n) {
+        real_box.setLo(n, 0.0);
+        real_box.setHi(n, 1.0);
+    }
+    int is_per[] = {AMREX_D_DECL(1, 1, 1)};
+
+    m.geom.resize(nlevs);
+    m.geom[0].define(m.domains[0], &real_box, CoordSys::cartesian, is_per);
+    for (int lev = 1; lev < nlevs; ++lev) {
+        m.geom[lev].define(m.domains[lev], &real_box, CoordSys::cartesian, is_per);
+    }
+
+    m.dmap.resize(nlevs);
+    for (int lev = 0; lev < nlevs; ++lev) {
+        m.dmap[lev] = DistributionMapping{m.ba[lev]};
+    }
+
+    return m;
+}
+
+/**
+ * Assert that two ParticleContainerPureSoA hold identical particle data by
+ * comparing the total particle count and the component-wise sums of every
+ * real and integer attribute across all levels.
+ */
+void verify_same (MyPC& pc_orig, MyPC& pc_new)
+{
+    auto n_orig = pc_orig.TotalNumberOfParticles();
+    auto n_new  = pc_new.TotalNumberOfParticles();
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        n_orig == n_new,
+        "Particle count mismatch after restart");
+
+    // Skip position components (0..AMREX_SPACEDIM-1): they hold random values,
+    // and floating-point summation order may differ across level configurations.
+    for (int icomp = AMREX_SPACEDIM; icomp < NReal; ++icomp) {
+        auto sm_orig = amrex::ReduceSum(pc_orig,
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
+                return ptd.rdata(icomp)[i];
+            });
+        auto sm_new = amrex::ReduceSum(pc_new,
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
+                return ptd.rdata(icomp)[i];
+            });
+        ParallelDescriptor::ReduceRealSum(sm_orig);
+        ParallelDescriptor::ReduceRealSum(sm_new);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            sm_orig == sm_new,
+            "Real component sum mismatch after restart (comp " + std::to_string(icomp) + ")");
+    }
+
+    for (int icomp = 0; icomp < NInt; ++icomp) {
+        auto sm_orig = amrex::ReduceSum(pc_orig,
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
+                return static_cast<Real>(ptd.idata(icomp)[i]);
+            });
+        auto sm_new = amrex::ReduceSum(pc_new,
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
+                return static_cast<Real>(ptd.idata(icomp)[i]);
+            });
+        ParallelDescriptor::ReduceRealSum(sm_orig);
+        ParallelDescriptor::ReduceRealSum(sm_new);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            sm_orig == sm_new,
+            "Int component sum mismatch after restart (comp " + std::to_string(icomp) + ")");
+    }
+}
+
+/**
+ * Test 1: Write a 2-level checkpoint, restart into a 1-level container.
+ * Particles that resided on the fine level must be redistributed to the
+ * coarse level; totals and component sums must be unchanged.
+ */
+void test_fewer_levels ()
+{
+    amrex::Print() << "Test 1: restart with fewer levels than checkpoint\n";
+
+    const int ncells         = 32;
+    const int max_grid_size  = 16;
+    const int nppc           = 2;
+    const int iseed          = 451;
+    const std::string chkdir = "chk_fewer_levels";
+
+    MyPC::ParticleInitData pdata = {{}, {}, {1.0, 2.0, 3.0, 4.0, 6.0, 7.0}, {5, 8}};
+
+    Vector<std::string> real_names, int_names;
+    for (int i = 0; i < NReal - AMREX_SPACEDIM; ++i) {
+        real_names.push_back("real_" + std::to_string(i));
+    }
+    for (int i = 0; i < NInt; ++i) {
+        int_names.push_back("int_" + std::to_string(i));
+    }
+
+    // --- write with 2 levels ---
+    auto mesh2 = build_mesh(ncells, 2, max_grid_size);
+    MyPC pc_write(mesh2.geom, mesh2.dmap, mesh2.ba, mesh2.ref_ratio);
+    pc_write.SetVerbose(false);
+    pc_write.InitRandom(nppc * AMREX_D_TERM(ncells, *ncells, *ncells),
+                        iseed, pdata, /*serialize=*/false);
+    pc_write.Checkpoint(chkdir, "particles", real_names, int_names);
+
+    AsyncOut::Finish();
+    ParallelDescriptor::Barrier();
+
+    // --- restart with 1 level ---
+    auto mesh1 = build_mesh(ncells, 1, max_grid_size);
+    MyPC pc_read(mesh1.geom, mesh1.dmap, mesh1.ba, mesh1.ref_ratio);
+    pc_read.SetVerbose(false);
+    pc_read.Restart(chkdir, "particles");
+
+    verify_same(pc_write, pc_read);
+
+    amrex::Print() << "  PASSED\n";
+}
+
+/**
+ * Test 2: Write a 1-level checkpoint, restart into a 2-level container.
+ * After restart, Redistribute() assigns particles inside the refined
+ * region to the finer level; totals and component sums must be unchanged.
+ */
+void test_more_levels ()
+{
+    amrex::Print() << "Test 2: restart with more levels than checkpoint\n";
+
+    const int ncells         = 32;
+    const int max_grid_size  = 16;
+    const int nppc           = 2;
+    const int iseed          = 451;
+    const std::string chkdir = "chk_more_levels";
+
+    MyPC::ParticleInitData pdata = {{}, {}, {1.0, 2.0, 3.0, 4.0, 6.0, 7.0}, {5, 8}};
+
+    Vector<std::string> real_names, int_names;
+    for (int i = 0; i < NReal - AMREX_SPACEDIM; ++i) {
+        real_names.push_back("real_" + std::to_string(i));
+    }
+    for (int i = 0; i < NInt; ++i) {
+        int_names.push_back("int_" + std::to_string(i));
+    }
+
+    // --- write with 1 level ---
+    auto mesh1 = build_mesh(ncells, 1, max_grid_size);
+    MyPC pc_write(mesh1.geom, mesh1.dmap, mesh1.ba, mesh1.ref_ratio);
+    pc_write.SetVerbose(false);
+    pc_write.InitRandom(nppc * AMREX_D_TERM(ncells, *ncells, *ncells),
+                        iseed, pdata, /*serialize=*/false);
+    pc_write.Checkpoint(chkdir, "particles", real_names, int_names);
+
+    AsyncOut::Finish();
+    ParallelDescriptor::Barrier();
+
+    // --- restart with 2 levels ---
+    auto mesh2 = build_mesh(ncells, 2, max_grid_size);
+    MyPC pc_read(mesh2.geom, mesh2.dmap, mesh2.ba, mesh2.ref_ratio);
+    pc_read.SetVerbose(false);
+    pc_read.Restart(chkdir, "particles");
+
+    verify_same(pc_write, pc_read);
+
+    amrex::Print() << "  PASSED\n";
+}
+
+/**
+ * Test 3: Write a checkpoint with one BoxArray decomposition, restart
+ * into a container with the same number of levels but a different BoxArray
+ * (different max_grid_size). This is the canonical dual-grid scenario: the
+ * Particle_H header written at checkpoint time differs from the BoxArray
+ * of the new container, so AMReX uses temporary grids while reading and
+ * calls Redistribute() to move particles onto the new decomposition.
+ */
+void test_different_boxarrays ()
+{
+    amrex::Print() << "Test 3: restart with same levels but different BoxArrays\n";
+
+    const int ncells         = 32;
+    const int nppc           = 2;
+    const int iseed          = 451;
+    const std::string chkdir = "chk_different_ba";
+
+    MyPC::ParticleInitData pdata = {{}, {}, {1.0, 2.0, 3.0, 4.0, 6.0, 7.0}, {5, 8}};
+
+    Vector<std::string> real_names, int_names;
+    for (int i = 0; i < NReal - AMREX_SPACEDIM; ++i) {
+        real_names.push_back("real_" + std::to_string(i));
+    }
+    for (int i = 0; i < NInt; ++i) {
+        int_names.push_back("int_" + std::to_string(i));
+    }
+
+    // --- write: coarse decomposition (few large boxes) ---
+    auto mesh_coarse = build_mesh(ncells, 1, ncells); // one box per rank at most
+    MyPC pc_write(mesh_coarse.geom, mesh_coarse.dmap, mesh_coarse.ba,
+                  mesh_coarse.ref_ratio);
+    pc_write.SetVerbose(false);
+    pc_write.InitRandom(nppc * AMREX_D_TERM(ncells, *ncells, *ncells),
+                        iseed, pdata, /*serialize=*/false);
+    pc_write.Checkpoint(chkdir, "particles", real_names, int_names);
+
+    AsyncOut::Finish();
+    ParallelDescriptor::Barrier();
+
+    // --- restart: finer decomposition (many smaller boxes) ---
+    auto mesh_fine = build_mesh(ncells, 1, ncells / 4);
+    MyPC pc_read(mesh_fine.geom, mesh_fine.dmap, mesh_fine.ba,
+                 mesh_fine.ref_ratio);
+    pc_read.SetVerbose(false);
+    pc_read.Restart(chkdir, "particles");
+
+    verify_same(pc_write, pc_read);
+
+    amrex::Print() << "  PASSED\n";
+}
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+
+    test_fewer_levels();
+    test_more_levels();
+    test_different_boxarrays();
+
+    amrex::Print() << "All dual-grid SOA restart tests PASSED\n";
+
+    amrex::Finalize();
+}


### PR DESCRIPTION
This closes #5152. Although it's a bit worse than that issue indicated, HDF5 particle IO wasn't implemented for pure SoA at all. This PR does so.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
