### PR TITLE
Avoid undefined behavior in Random_int by having it always return 0 for n = 0.

### DIFF
--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -212,7 +212,7 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     unsigned int Random_int (unsigned int n, RandomEngine const& random_engine)
     {
-	if (n == 0) { return 0;}
+    if (n == 0) { return 0;}
 #if defined(__SYCL_DEVICE_ONLY__)
         mkl::rng::device::uniform<unsigned int> distr(0,n);
         return mkl::rng::device::generate(distr, *random_engine.engine);

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -200,7 +200,8 @@ namespace amrex
     /**
     * \ingroup amrex_utilities
     * \brief Generates one pseudorandom unsigned integer which is
-    *  uniformly distributed on [0,n-1]-interval for each call.
+    *  uniformly distributed on [0,n-1]-interval for each call. For
+    *  the special case of n = 0, it returns 0.
     *
     * The CPU version of this function uses C++11's mt19937.
     * The GPU version uses CURAND's XORWOW generator.
@@ -211,6 +212,7 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     unsigned int Random_int (unsigned int n, RandomEngine const& random_engine)
     {
+	if (n == 0) { return 0;}
 #if defined(__SYCL_DEVICE_ONLY__)
         mkl::rng::device::uniform<unsigned int> distr(0,n);
         return mkl::rng::device::generate(distr, *random_engine.engine);
@@ -234,7 +236,8 @@ namespace amrex
     /**
     * \ingroup amrex_utilities
     * \brief Generates one pseudorandom unsigned long which is
-    *  uniformly distributed on [0,n-1]-interval for each call.
+    *  uniformly distributed on [0,n-1]-interval for each call. For
+    *  the special case of n = 0, it returns 0.
     *
     * The CPU version of this function uses C++11's mt19937.
     * There is no GPU version.

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -143,6 +143,7 @@ Real RandomGamma (Real alpha, Real beta)
 
 unsigned int Random_int (unsigned int n)
 {
+    if (n == 0) {return 0;}
     std::uniform_int_distribution<unsigned int> distribution(0, n-1);
     int tid = OpenMP::get_thread_num();
     return distribution(generators[tid]);
@@ -150,6 +151,7 @@ unsigned int Random_int (unsigned int n)
 
 ULong Random_long (ULong n)
 {
+    if (n == 0) {return 0;}
     std::uniform_int_distribution<ULong> distribution(0, n-1);
     int tid = OpenMP::get_thread_num();
     return distribution(generators[tid]);


### PR DESCRIPTION
`amrex::Random_int(0, engine)` currently causes undefined behavior that was leading to a hang on Perlmutter. This avoids this by early exiting if n = 0.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
