### PR TITLE
Update to new rocsparse

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -48,9 +48,9 @@ Nvidia-H100-single-precision:
 AMD-MI300A:
   extends: .dependency-n-fetch-pr
   tags: [amd-mi300]
-  image: rocm/dev-ubuntu-24.04:6.4.3-complete
+  image: rocm/dev-ubuntu-24.04:7.2-complete
   script:
-    - export ROCM_PATH=/opt/rocm-6.4.3
+    - export ROCM_PATH=/opt/rocm-7.2
     - export PATH=$ROCM_PATH/bin:$ROCM_PATH/llvm/bin:$PATH
     - export LD_LIBRARY_PATH=$ROCM_PATH/lib:$ROCM_PATH/lib64:$LD_LIBRARY_PATH
     - export HIP_PATH=$ROCM_PATH

--- a/Src/LinearSolvers/AMReX_SpMV.H
+++ b/Src/LinearSolvers/AMReX_SpMV.H
@@ -7,8 +7,6 @@
 #include <AMReX_GpuComplex.H>
 #include <AMReX_SpMatrix.H>
 
-#include <algorithm>
-
 namespace amrex {
 
 template <typename T>
@@ -127,52 +125,52 @@ void SpMV (Long nrows, Long ncols, T* AMREX_RESTRICT py, CsrView<T const> const&
     AMREX_ROCSPARSE_SAFE_CALL(rocsparse_create_spmv_descr(&spmv_descr));
 
 
-    rocsparse_error error{};
+    rocsparse_error p_error[1] = {};
 
     const rocsparse_spmv_alg spmv_alg = rocsparse_spmv_alg_csr_adaptive;
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_alg,
-                                 &spmv_alg, sizeof(spmv_alg), &error));
+                                 &spmv_alg, sizeof(spmv_alg), p_error));
 
     const rocsparse_operation spmv_operation = rocsparse_operation_none;
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_operation,
-                                 &spmv_operation, sizeof(spmv_operation), &error));
+                                 &spmv_operation, sizeof(spmv_operation), p_error));
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_scalar_datatype,
-                                 &data_type, sizeof(data_type), &error));
+                                 &data_type, sizeof(data_type), p_error));
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_compute_datatype,
-                                 &data_type, sizeof(data_type), &error));
+                                 &data_type, sizeof(data_type), p_error));
 
     std::size_t buffer_size = 0;
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv_buffer_size(handle, spmv_descr, mat_descr, x_descr, y_descr,
                                       rocsparse_v2_spmv_stage_analysis, // buffer size for analysis
-                                      &buffer_size, &error));
+                                      &buffer_size, p_error));
 
     void* pbuffer = (void*)The_Arena()->alloc(buffer_size);
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv(handle, spmv_descr, &alpha, mat_descr, x_descr, &beta, y_descr,
                           rocsparse_v2_spmv_stage_analysis, // analysis stage
-                          buffer_size, pbuffer, &error));
+                          buffer_size, pbuffer, p_error));
 
     The_Arena()->free(pbuffer);
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv_buffer_size(handle, spmv_descr, mat_descr, x_descr, y_descr,
                                       rocsparse_v2_spmv_stage_compute, // buffer size for compute
-                                      &buffer_size, &error));
+                                      &buffer_size, p_error));
 
     pbuffer = (void*)The_Arena()->alloc(buffer_size);
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv(handle, spmv_descr, &alpha, mat_descr, x_descr, &beta, y_descr,
                           rocsparse_v2_spmv_stage_compute, // compute stage
-                          buffer_size, pbuffer, &error));
+                          buffer_size, pbuffer, p_error));
 
 #elif (HIP_VERSION_MAJOR == 6)
 
@@ -217,7 +215,7 @@ void SpMV (Long nrows, Long ncols, T* AMREX_RESTRICT py, CsrView<T const> const&
     Gpu::streamSynchronize();
 
 #if (HIP_VERSION_MAJOR >= 7)
-    AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_error(error));
+    AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_error(p_error[0]));
     AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_spmv_descr(spmv_descr));
 #endif
     AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_spmat_descr(mat_descr));

--- a/Src/LinearSolvers/AMReX_SpMV.H
+++ b/Src/LinearSolvers/AMReX_SpMV.H
@@ -151,21 +151,30 @@ void SpMV (Long nrows, Long ncols, T* AMREX_RESTRICT py, CsrView<T const> const&
                                       rocsparse_v2_spmv_stage_analysis, // buffer size for analysis
                                       &buffer_size, p_error));
 
-    void* pbuffer = (void*)The_Arena()->alloc(buffer_size);
+    void* pbuffer = nullptr;
+    if (buffer_size > 0) {
+        pbuffer = (void*)The_Arena()->alloc(buffer_size);
+    }
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv(handle, spmv_descr, &alpha, mat_descr, x_descr, &beta, y_descr,
                           rocsparse_v2_spmv_stage_analysis, // analysis stage
                           buffer_size, pbuffer, p_error));
 
-    The_Arena()->free(pbuffer);
+    if (pbuffer) {
+        The_Arena()->free(pbuffer);
+    }
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv_buffer_size(handle, spmv_descr, mat_descr, x_descr, y_descr,
                                       rocsparse_v2_spmv_stage_compute, // buffer size for compute
                                       &buffer_size, p_error));
 
-    pbuffer = (void*)The_Arena()->alloc(buffer_size);
+    if (buffer_size > 0) {
+        pbuffer = (void*)The_Arena()->alloc(buffer_size);
+    } else {
+        pbuffer = nullptr;
+    }
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv(handle, spmv_descr, &alpha, mat_descr, x_descr, &beta, y_descr,
@@ -174,14 +183,17 @@ void SpMV (Long nrows, Long ncols, T* AMREX_RESTRICT py, CsrView<T const> const&
 
 #elif (HIP_VERSION_MAJOR == 6)
 
-    std::size_t buffer_size;
+    std::size_t buffer_size = 0;
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
                        &beta, y_descr, data_type, rocsparse_spmv_alg_default,
                        rocsparse_spmv_stage_buffer_size, // buffer size stage
                        &buffer_size, nullptr));
 
-    void* pbuffer = (void*)The_Arena()->alloc(buffer_size);
+    void* pbuffer = nullptr;
+    if (buffer_size > 0) {
+        pbuffer = (void*)The_Arena()->alloc(buffer_size);
+    }
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
@@ -197,13 +209,16 @@ void SpMV (Long nrows, Long ncols, T* AMREX_RESTRICT py, CsrView<T const> const&
 
 #else /* HIP_VERSION_MAJOR < 6 */
 
-    std::size_t buffer_size;
+    std::size_t buffer_size = 0;
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
                        &beta, y_descr, data_type, rocsparse_spmv_alg_default,
                        &buffer_size, nullptr));
 
-    void* pbuffer = (void*)The_Arena()->alloc(buffer_size);
+    void* pbuffer = nullptr;
+    if (buffer_size > 0) {
+        pbuffer = (void*)The_Arena()->alloc(buffer_size);
+    }
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
@@ -222,7 +237,9 @@ void SpMV (Long nrows, Long ncols, T* AMREX_RESTRICT py, CsrView<T const> const&
     AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_dnvec_descr(x_descr));
     AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_dnvec_descr(y_descr));
     AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_handle(handle));
-    The_Arena()->free(pbuffer);
+    if (pbuffer) {
+        The_Arena()->free(pbuffer);
+    }
 
 #elif defined(AMREX_USE_SYCL)
 

--- a/Src/LinearSolvers/AMReX_SpMV.H
+++ b/Src/LinearSolvers/AMReX_SpMV.H
@@ -7,6 +7,8 @@
 #include <AMReX_GpuComplex.H>
 #include <AMReX_SpMatrix.H>
 
+#include <algorithm>
+
 namespace amrex {
 
 template <typename T>
@@ -120,45 +122,101 @@ void SpMV (Long nrows, Long ncols, T* AMREX_RESTRICT py, CsrView<T const> const&
     T beta = T(0.0);
 
 #if (HIP_VERSION_MAJOR >= 7)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
+
+    rocsparse_spmv_descr spmv_descr;
+    AMREX_ROCSPARSE_SAFE_CALL(rocsparse_create_spmv_descr(&spmv_descr));
+
+
+    rocsparse_error error{};
+
+    const rocsparse_spmv_alg spmv_alg = rocsparse_spmv_alg_csr_adaptive;
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_alg,
+                                 &spmv_alg, sizeof(spmv_alg), &error));
+
+    const rocsparse_operation spmv_operation = rocsparse_operation_none;
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_operation,
+                                 &spmv_operation, sizeof(spmv_operation), &error));
+
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_scalar_datatype,
+                                 &data_type, sizeof(data_type), &error));
+
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_compute_datatype,
+                                 &data_type, sizeof(data_type), &error));
+
+    std::size_t buffer_size_1 = 0;
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_v2_spmv_buffer_size(handle, spmv_descr, mat_descr, x_descr, y_descr,
+                                      rocsparse_v2_spmv_stage_analysis, // buffer size for analysis
+                                      &buffer_size_1, &error));
+
+    std::size_t buffer_size_2 = 0;
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_v2_spmv_buffer_size(handle, spmv_descr, mat_descr, x_descr, y_descr,
+                                      rocsparse_v2_spmv_stage_compute, // buffer size for compute
+                                      &buffer_size_2, &error));
+
+    void* pbuffer = (void*)The_Arena()->alloc(std::max(buffer_size_1,buffer_size_2));
+
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_v2_spmv(handle, spmv_descr, &alpha, mat_descr, x_descr, &beta, y_descr,
+                          rocsparse_v2_spmv_stage_analysis, // analysis stage
+                          buffer_size_1, pbuffer, &error));
+
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_v2_spmv(handle, spmv_descr, &alpha, mat_descr, x_descr, &beta, y_descr,
+                          rocsparse_v2_spmv_stage_compute, // compute stage
+                          buffer_size_2, pbuffer, &error));
+
+#elif (HIP_VERSION_MAJOR == 6)
 
     std::size_t buffer_size;
-    auto err0 =
-        rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
-                       &beta, y_descr, data_type, rocsparse_spmv_alg_default,
-#if (HIP_VERSION_MAJOR >= 6)
-                       rocsparse_spmv_stage_buffer_size,
-#endif
-                       &buffer_size, nullptr);
-    AMREX_ROCSPARSE_SAFE_CALL(err0);
-
-    void* pbuffer = (void*)The_Arena()->alloc(buffer_size);
-
-#if (HIP_VERSION_MAJOR >= 6)
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
                        &beta, y_descr, data_type, rocsparse_spmv_alg_default,
-                       rocsparse_spmv_stage_preprocess, &buffer_size, pbuffer));
-#endif
+                       rocsparse_spmv_stage_buffer_size, // buffer size stage
+                       &buffer_size, nullptr));
 
-    auto err1 =
+    void* pbuffer = (void*)The_Arena()->alloc(buffer_size);
+
+    AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
                        &beta, y_descr, data_type, rocsparse_spmv_alg_default,
-#if (HIP_VERSION_MAJOR >= 6)
-                       rocsparse_spmv_stage_compute,
-#endif
-                       &buffer_size, pbuffer);
-    AMREX_ROCSPARSE_SAFE_CALL(err1);
+                       rocsparse_spmv_stage_preprocess, // preprocess stage
+                       &buffer_size, pbuffer));
 
-#if (HIP_VERSION_MAJOR >= 7)
-// xxxxx HIP TODO: rocsparse_spmv has been deprecated.
-#pragma clang diagnostic pop
-#endif
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
+                       &beta, y_descr, data_type, rocsparse_spmv_alg_default,
+                       rocsparse_spmv_stage_compute, // compute stage
+                       &buffer_size, pbuffer));
+
+#else /* HIP_VERSION_MAJOR < 6 */
+
+    std::size_t buffer_size;
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
+                       &beta, y_descr, data_type, rocsparse_spmv_alg_default,
+                       &buffer_size, nullptr));
+
+    void* pbuffer = (void*)The_Arena()->alloc(buffer_size);
+
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_spmv(handle, rocsparse_operation_none, &alpha, mat_descr, x_descr,
+                       &beta, y_descr, data_type, rocsparse_spmv_alg_default,
+                       &buffer_size, pbuffer));
+
+#endif /* HIP_VERSION_MAJOR */
 
     Gpu::streamSynchronize();
 
+#if (HIP_VERSION_MAJOR >= 7)
+    AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_error(error));
+    AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_spmv_descr(spmv_descr));
+#endif
     AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_spmat_descr(mat_descr));
     AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_dnvec_descr(x_descr));
     AMREX_ROCSPARSE_SAFE_CALL(rocsparse_destroy_dnvec_descr(y_descr));

--- a/Src/LinearSolvers/AMReX_SpMV.H
+++ b/Src/LinearSolvers/AMReX_SpMV.H
@@ -147,29 +147,32 @@ void SpMV (Long nrows, Long ncols, T* AMREX_RESTRICT py, CsrView<T const> const&
         rocsparse_spmv_set_input(handle, spmv_descr, rocsparse_spmv_input_compute_datatype,
                                  &data_type, sizeof(data_type), &error));
 
-    std::size_t buffer_size_1 = 0;
+    std::size_t buffer_size = 0;
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv_buffer_size(handle, spmv_descr, mat_descr, x_descr, y_descr,
                                       rocsparse_v2_spmv_stage_analysis, // buffer size for analysis
-                                      &buffer_size_1, &error));
+                                      &buffer_size, &error));
 
-    std::size_t buffer_size_2 = 0;
-    AMREX_ROCSPARSE_SAFE_CALL(
-        rocsparse_v2_spmv_buffer_size(handle, spmv_descr, mat_descr, x_descr, y_descr,
-                                      rocsparse_v2_spmv_stage_compute, // buffer size for compute
-                                      &buffer_size_2, &error));
-
-    void* pbuffer = (void*)The_Arena()->alloc(std::max(buffer_size_1,buffer_size_2));
+    void* pbuffer = (void*)The_Arena()->alloc(buffer_size);
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv(handle, spmv_descr, &alpha, mat_descr, x_descr, &beta, y_descr,
                           rocsparse_v2_spmv_stage_analysis, // analysis stage
-                          buffer_size_1, pbuffer, &error));
+                          buffer_size, pbuffer, &error));
+
+    The_Arena()->free(pbuffer);
+
+    AMREX_ROCSPARSE_SAFE_CALL(
+        rocsparse_v2_spmv_buffer_size(handle, spmv_descr, mat_descr, x_descr, y_descr,
+                                      rocsparse_v2_spmv_stage_compute, // buffer size for compute
+                                      &buffer_size, &error));
+
+    pbuffer = (void*)The_Arena()->alloc(buffer_size);
 
     AMREX_ROCSPARSE_SAFE_CALL(
         rocsparse_v2_spmv(handle, spmv_descr, &alpha, mat_descr, x_descr, &beta, y_descr,
                           rocsparse_v2_spmv_stage_compute, // compute stage
-                          buffer_size_2, pbuffer, &error));
+                          buffer_size, pbuffer, &error));
 
 #elif (HIP_VERSION_MAJOR == 6)
 


### PR DESCRIPTION
Since ROCm 7.0, rocsparse_spmv has been deprecated. The new version is rocsparse_v2_spmv.
