### PR TITLE
Avoid invalid in AMReX_MFInterp_3D_C.H

### DIFF
--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -233,7 +233,7 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int k, int ns, Array4<Real> 
         // This avoids the invalid signal from being triggered when
         // if-conversion optimization is done, where this code is
         // predictively executed even though dumax is zero.
-        dumax = dumax == 0. ? 1. : dumax;
+        dumax = dumax == Real(0.) ? Real(1.) : dumax;
         if (dumax * alpha > (umax - u(i,j,k,nu))) {
             alpha = (umax - u(i,j,k,nu)) / dumax;
         }

--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -230,9 +230,12 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int k, int ns, Array4<Real> 
             umax = amrex::max(umax, u(i+ioff,j+joff,k+koff,nu));
         }}}
         // This ensures that dumax is never zero for the divides below.
-        // This avoids the invalid signal from being triggered when
+        // This avoids triggering the invalid signal when
         // if-conversion optimization is done, where this code is
-        // predictively executed even though dumax is zero.
+        // predictively executed whether or not dumax is zero.
+        // In normal execution, dumax is always positive because at least
+        // one of the three terms in its definition is positive, so the
+        // following statement is effectively a no-op.
         dumax = dumax == Real(0.) ? Real(1.) : dumax;
         if (dumax * alpha > (umax - u(i,j,k,nu))) {
             alpha = (umax - u(i,j,k,nu)) / dumax;

--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -229,6 +229,11 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int k, int ns, Array4<Real> 
             umin = amrex::min(umin, u(i+ioff,j+joff,k+koff,nu));
             umax = amrex::max(umax, u(i+ioff,j+joff,k+koff,nu));
         }}}
+        // This ensures that dumax is never zero for the divides below.
+        // This avoids the invalid signal from being triggered when
+        // if-conversion optimization is done, where this code is
+        // predictively executed even though dumax is zero.
+        dumax = dumax == 0. ? 1. : dumax;
         if (dumax * alpha > (umax - u(i,j,k,nu))) {
             alpha = (umax - u(i,j,k,nu)) / dumax;
         }


### PR DESCRIPTION
## Summary

This PR is here to avoid a false positive invalid flag being raised in `AmrCore/AMReX_MFInterp_3D_C.H. The change ensures that dumax is never zero for the divides. This avoids the invalid signal from being triggered when if-conversion optimization is done, where this code is predictively executed even though dumax is zero.

Several checks demonstrate that the change does not break vectorization. Also, the change should have no effect on results since under normal conditions, the divide by dumax would never happen if dumax is zero.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
