### PR TITLE
Geometry: Exceptions

### DIFF
--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -148,7 +148,7 @@ public:
      * \param is_per pointer to memory space specifying periodicity in each coordinate direction.
      *        Optional. Default is non-periodic.
      */
-    void define (const Box& dom, const RealBox* rb = nullptr, int coord = -1, int const* is_per = nullptr) noexcept;
+    void define (const Box& dom, const RealBox* rb = nullptr, int coord = -1, int const* is_per = nullptr);
 
     /**
      * Defines a geometry object that describes the problem domain and coordinate system for rectangular problem
@@ -165,12 +165,12 @@ public:
      * \param is_per amrex::Array specifying periodicity in each coordinate direction. Optional.
      *        Default is non-periodic.
      */
-    void define (const Box& dom, const RealBox& rb, int coord, Array<int,AMREX_SPACEDIM> const& is_per) noexcept;
+    void define (const Box& dom, const RealBox& rb, int coord, Array<int,AMREX_SPACEDIM> const& is_per);
 
     //! Returns the problem domain.
     [[nodiscard]] const RealBox& ProbDomain () const noexcept { return prob_domain; }
     //! Sets the problem domain.
-    void ProbDomain (const RealBox& rb) noexcept
+    void ProbDomain (const RealBox& rb)
     {
         prob_domain = rb;
         computeRoundoffDomain();
@@ -210,7 +210,7 @@ public:
     //! Returns our rectangular domain.
     [[nodiscard]] const Box& Domain () const noexcept { return domain; }
     //! Sets our rectangular domain.
-    void Domain (const Box& bx) noexcept
+    void Domain (const Box& bx)
     {
         AMREX_ASSERT(bx.cellCentered());
         domain = bx;

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -61,14 +61,14 @@ Geometry::Geometry (const Box& dom, const RealBox& rb, int coord,
 
 void
 Geometry::define (const Box& dom, const RealBox& rb, int coord,
-                  Array<int,AMREX_SPACEDIM> const& is_per) noexcept
+                  Array<int,AMREX_SPACEDIM> const& is_per)
 {
     define(dom, &rb, coord, is_per.data());
 }
 
 void
 Geometry::define (const Box& dom, const RealBox* rb, int coord,
-                  int const* is_per) noexcept
+                  int const* is_per)
 {
     AMREX_ASSERT(dom.cellCentered());
 


### PR DESCRIPTION
## Summary

We use AMReX interactively with `amrex.throw_exception = true` to be able to handle user errors or convergence issues and act on them.

In Geometry, some methods are defined `noexcept` which breaks exception propagation in ImpactX
https://github.com/BLAST-ImpactX/impactx/issues/1348 and still aborts the process as a consequence.

This removes the `noexcept` where they are not guaranteed to be true at runtime. First seen in `computeRoundoffDomain` which is called from a couple of places.

Performance impact for this host-side code should be minimal / not a problem.

## Additional background

Throwing an actual abort in a Python script will abort the whole interpreter, resetting all its state, terminating the process. That is a big problem in interactive usage, e.g., Jupyter Notebooks, but also for general C++ - Python and back error handling logic.

https://github.com/BLAST-ImpactX/impactx/pull/1350

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
