### PR TITLE
Add an implementation of ParticleCopyPlan::doHandShake that uses one-sided communication from MPI-3

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -10,6 +10,7 @@
 #include <AMReX_Scan.H>
 #include <AMReX_TypeTraits.H>
 #include <AMReX_MakeParticle.H>
+#include <AMReX_ParmParse.H>
 
 #include <map>
 
@@ -137,6 +138,8 @@ struct ParticleCopyPlan
         BL_PROFILE("ParticleCopyPlan::build");
 
         m_local = local;
+        ParmParse pp("particles");
+        pp.query("do_one_sided_comms", m_do_one_sided_comms);
 
         const int ngrow = 1;  // note - fix
 
@@ -294,14 +297,21 @@ private:
     // In the global version, we don't know who we'll receive from, so we
     // need to do some collective communication first.
     //
-    static void doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>& Rcvs);
+    static void doHandShakeReduceScatter (const Vector<Long>& Snds, Vector<Long>& Rcvs);
+
+    //
+    // Another version of the global handshake implemented with MPI-3
+    // one-sided communication.
+    //
+    static void doHandShakeOneSided (const Vector<Long>& Snds, Vector<Long>& Rcvs);
 
     //
     // Another version of the above that is implemented using MPI All-to-All
     //
     static void doHandShakeAllToAll (const Vector<Long>& Snds, Vector<Long>& Rcvs);
 
-    bool m_local;
+    bool m_local = false;
+    int m_do_one_sided_comms = 0;
 };
 
 struct GetSendBufferOffset

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -16,6 +16,8 @@
 
 namespace amrex {
 
+class ParticleContainerBase;
+
 struct NeighborUnpackPolicy
 {
     template <class PTile>
@@ -268,7 +270,7 @@ struct ParticleCopyPlan
         m_superparticle_size += num_real_comm_comp * sizeof(typename PC::ParticleType::RealType)
                               + num_int_comm_comp  * sizeof(int);
 
-        buildMPIStart(pc.BufferMap(), m_superparticle_size);
+        buildMPIStart(pc, pc.BufferMap(), m_superparticle_size);
     }
 
     void clear ();
@@ -277,14 +279,14 @@ struct ParticleCopyPlan
 
 private:
 
-    void buildMPIStart (const ParticleBufferMap& map, Long psize);
+    void buildMPIStart (const ParticleContainerBase& pc, const ParticleBufferMap& map, Long psize);
 
     //
     // Snds - a Vector with the number of bytes that is process will send to each proc.
     // Rcvs - a Vector that, after calling this method, will contain the
     //        number of bytes this process will receive from each proc.
     //
-    void doHandShake (const Vector<Long>& Snds, Vector<Long>& Rcvs) const;
+    void doHandShake (const ParticleContainerBase& pc, const Vector<Long>& Snds, Vector<Long>& Rcvs) const;
 
     //
     // In the local version of this method, each proc knows which other
@@ -303,7 +305,8 @@ private:
     // Another version of the global handshake implemented with MPI-3
     // one-sided communication.
     //
-    static void doHandShakeOneSided (const Vector<Long>& Snds, Vector<Long>& Rcvs);
+    static void doHandShakeOneSided (const ParticleContainerBase& pc,
+                                     const Vector<Long>& Snds, Vector<Long>& Rcvs);
 
     //
     // Another version of the above that is implemented using MPI All-to-All

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -272,6 +272,7 @@ void ParticleCopyPlan::doHandShake (const ParticleContainerBase& pc,
 #if defined(BL_USE_MPI3)
         doHandShakeOneSided(pc, Snds, Rcvs);
 #else
+        amrex::ignore_unused(pc);
         amrex::Abort("ParticleCopyPlan::doHandShake: particles.do_one_sided_comms=1 requires MPI-3");
 #endif
     }

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -1,4 +1,5 @@
 #include <AMReX_ParticleCommunication.H>
+#include <AMReX_ParticleContainerBase.H>
 #include <AMReX_ParallelDescriptor.H>
 
 namespace amrex {
@@ -45,7 +46,9 @@ void ParticleCopyPlan::clear ()
     m_rcv_box_levs.clear();
 }
 
-void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize) // NOLINT(readability-convert-member-functions-to-static)
+void ParticleCopyPlan::buildMPIStart (const ParticleContainerBase& pc,
+                                      const ParticleBufferMap& map,
+                                      Long psize) // NOLINT(readability-convert-member-functions-to-static)
 {
     BL_PROFILE("ParticleCopyPlan::buildMPIStart");
 
@@ -94,7 +97,7 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize) 
         m_NumSnds += nbytes;
     }
 
-    doHandShake(m_Snds, m_Rcvs);
+    doHandShake(pc, m_Snds, m_Rcvs);
 
     const int SeqNum = ParallelDescriptor::SeqNum();
     Long tot_snds_this_proc = 0;
@@ -206,7 +209,7 @@ void ParticleCopyPlan::buildMPIStart (const ParticleBufferMap& map, Long psize) 
     snd_stats.resize(snd_reqs.size());
     ParallelDescriptor::Waitall(snd_reqs, snd_stats);
 #else
-    amrex::ignore_unused(map,psize);
+    amrex::ignore_unused(pc,map,psize);
 #endif
 }
 
@@ -259,13 +262,15 @@ void ParticleCopyPlan::buildMPIFinish (const ParticleBufferMap& map) // NOLINT(r
 #endif // MPI
 }
 
-void ParticleCopyPlan::doHandShake (const Vector<Long>& Snds, Vector<Long>& Rcvs) const // NOLINT(readability-convert-member-functions-to-static)
+void ParticleCopyPlan::doHandShake (const ParticleContainerBase& pc,
+                                    const Vector<Long>& Snds,
+                                    Vector<Long>& Rcvs) const // NOLINT(readability-convert-member-functions-to-static)
 {
     BL_PROFILE("ParticleCopyPlan::doHandShake");
     if (m_local) { doHandShakeLocal(Snds, Rcvs); }
     else if (m_do_one_sided_comms) {
 #if defined(BL_USE_MPI3)
-        doHandShakeOneSided(Snds, Rcvs);
+        doHandShakeOneSided(pc, Snds, Rcvs);
 #else
         amrex::Abort("ParticleCopyPlan::doHandShake: particles.do_one_sided_comms=1 requires MPI-3");
 #endif
@@ -388,7 +393,9 @@ void ParticleCopyPlan::doHandShakeReduceScatter (const Vector<Long>& Snds, Vecto
 #endif
 }
 
-void ParticleCopyPlan::doHandShakeOneSided (const Vector<Long>& Snds, Vector<Long>& Rcvs)
+void ParticleCopyPlan::doHandShakeOneSided (const ParticleContainerBase& pc,
+                                            const Vector<Long>& Snds,
+                                            Vector<Long>& Rcvs)
 {
 #if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
     const int MyProc = ParallelContext::MyProcSub();
@@ -397,16 +404,12 @@ void ParticleCopyPlan::doHandShakeOneSided (const Vector<Long>& Snds, Vector<Lon
     AMREX_ALWAYS_ASSERT(static_cast<int>(Snds.size()) == NProcs);
     AMREX_ALWAYS_ASSERT(static_cast<int>(Rcvs.size()) == NProcs);
 
-    std::fill(Rcvs.begin(), Rcvs.end(), 0);
+    pc.ensureParticleHandshakeWindow();
+    auto* handshake_buffer = pc.particleHandshakeBuffer();
+    AMREX_ALWAYS_ASSERT(handshake_buffer != nullptr);
+    std::fill_n(handshake_buffer, NProcs, Long(0));
 
-    MPI_Win win;
-    BL_MPI_REQUIRE(MPI_Win_create(Rcvs.dataPtr(),
-                                  static_cast<MPI_Aint>(NProcs*sizeof(Long)),
-                                  sizeof(Long),
-                                  MPI_INFO_NULL,
-                                  ParallelContext::CommunicatorSub(),
-                                  &win));
-
+    MPI_Win win = pc.particleHandshakeWindow();
     BL_MPI_REQUIRE(MPI_Win_fence(0, win));
 
     for (int i = 0; i < NProcs; ++i)
@@ -424,11 +427,11 @@ void ParticleCopyPlan::doHandShakeOneSided (const Vector<Long>& Snds, Vector<Lon
     }
 
     BL_MPI_REQUIRE(MPI_Win_fence(0, win));
-    BL_MPI_REQUIRE(MPI_Win_free(&win));
+    std::copy_n(handshake_buffer, NProcs, Rcvs.begin());
 
     AMREX_ASSERT(Rcvs[MyProc] == 0);
 #else
-    amrex::ignore_unused(Snds,Rcvs);
+    amrex::ignore_unused(pc,Snds,Rcvs);
 #endif
 }
 

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -267,14 +267,11 @@ void ParticleCopyPlan::doHandShake (const ParticleContainerBase& pc,
     BL_PROFILE("ParticleCopyPlan::doHandShake");
     if (m_local) { doHandShakeLocal(Snds, Rcvs); }
     else if (m_do_one_sided_comms) {
-#if defined(BL_USE_MPI3)
         doHandShakeOneSided(pc, Snds, Rcvs);
-#else
-        amrex::ignore_unused(pc);
-        amrex::Abort("ParticleCopyPlan::doHandShake: particles.do_one_sided_comms=1 requires MPI-3");
-#endif
     }
-    else         { doHandShakeReduceScatter(Snds, Rcvs); }
+    else {
+        doHandShakeReduceScatter(Snds, Rcvs);
+    }
 }
 
 void ParticleCopyPlan::doHandShakeLocal (const Vector<Long>& Snds, Vector<Long>& Rcvs) const // NOLINT(readability-convert-member-functions-to-static)
@@ -396,7 +393,7 @@ void ParticleCopyPlan::doHandShakeOneSided (const ParticleContainerBase& pc,
                                             const Vector<Long>& Snds,
                                             Vector<Long>& Rcvs)
 {
-#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+#if defined(AMREX_USE_MPI)
     const int MyProc = ParallelContext::MyProcSub();
     const int NProcs = ParallelContext::NProcsSub();
 

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -46,9 +46,7 @@ void ParticleCopyPlan::clear ()
     m_rcv_box_levs.clear();
 }
 
-void ParticleCopyPlan::buildMPIStart (const ParticleContainerBase& pc,
-                                      const ParticleBufferMap& map,
-                                      Long psize) // NOLINT(readability-convert-member-functions-to-static)
+void ParticleCopyPlan::buildMPIStart (const ParticleContainerBase& pc, const ParticleBufferMap& map, Long psize) // NOLINT(readability-convert-member-functions-to-static)
 {
     BL_PROFILE("ParticleCopyPlan::buildMPIStart");
 

--- a/Src/Particle/AMReX_ParticleCommunication.cpp
+++ b/Src/Particle/AMReX_ParticleCommunication.cpp
@@ -263,7 +263,14 @@ void ParticleCopyPlan::doHandShake (const Vector<Long>& Snds, Vector<Long>& Rcvs
 {
     BL_PROFILE("ParticleCopyPlan::doHandShake");
     if (m_local) { doHandShakeLocal(Snds, Rcvs); }
-    else         { doHandShakeGlobal(Snds, Rcvs); }
+    else if (m_do_one_sided_comms) {
+#if defined(BL_USE_MPI3)
+        doHandShakeOneSided(Snds, Rcvs);
+#else
+        amrex::Abort("ParticleCopyPlan::doHandShake: particles.do_one_sided_comms=1 requires MPI-3");
+#endif
+    }
+    else         { doHandShakeReduceScatter(Snds, Rcvs); }
 }
 
 void ParticleCopyPlan::doHandShakeLocal (const Vector<Long>& Snds, Vector<Long>& Rcvs) const // NOLINT(readability-convert-member-functions-to-static)
@@ -333,7 +340,7 @@ void ParticleCopyPlan::doHandShakeAllToAll (const Vector<Long>& Snds, Vector<Lon
 #endif
 }
 
-void ParticleCopyPlan::doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>& Rcvs)
+void ParticleCopyPlan::doHandShakeReduceScatter (const Vector<Long>& Snds, Vector<Long>& Rcvs)
 {
 #ifdef AMREX_USE_MPI
     const int SeqNum = ParallelDescriptor::SeqNum();
@@ -376,6 +383,50 @@ void ParticleCopyPlan::doHandShakeGlobal (const Vector<Long>& Snds, Vector<Long>
         const auto Who = rstats[i].MPI_SOURCE;
         Rcvs[Who] = num_bytes_rcv[i];
     }
+#else
+    amrex::ignore_unused(Snds,Rcvs);
+#endif
+}
+
+void ParticleCopyPlan::doHandShakeOneSided (const Vector<Long>& Snds, Vector<Long>& Rcvs)
+{
+#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+    const int MyProc = ParallelContext::MyProcSub();
+    const int NProcs = ParallelContext::NProcsSub();
+
+    AMREX_ALWAYS_ASSERT(static_cast<int>(Snds.size()) == NProcs);
+    AMREX_ALWAYS_ASSERT(static_cast<int>(Rcvs.size()) == NProcs);
+
+    std::fill(Rcvs.begin(), Rcvs.end(), 0);
+
+    MPI_Win win;
+    BL_MPI_REQUIRE(MPI_Win_create(Rcvs.dataPtr(),
+                                  static_cast<MPI_Aint>(NProcs*sizeof(Long)),
+                                  sizeof(Long),
+                                  MPI_INFO_NULL,
+                                  ParallelContext::CommunicatorSub(),
+                                  &win));
+
+    BL_MPI_REQUIRE(MPI_Win_fence(0, win));
+
+    for (int i = 0; i < NProcs; ++i)
+    {
+        if (i == MyProc || Snds[i] == 0) { continue; }
+
+        BL_MPI_REQUIRE(MPI_Put(&Snds[i],
+                               1,
+                               ParallelDescriptor::Mpi_typemap<Long>::type(),
+                               i,
+                               MyProc,
+                               1,
+                               ParallelDescriptor::Mpi_typemap<Long>::type(),
+                               win));
+    }
+
+    BL_MPI_REQUIRE(MPI_Win_fence(0, win));
+    BL_MPI_REQUIRE(MPI_Win_free(&win));
+
+    AMREX_ASSERT(Rcvs[MyProc] == 0);
 #else
     amrex::ignore_unused(Snds,Rcvs);
 #endif

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -12,6 +12,7 @@
 #include <AMReX_Vector.H>
 #include <AMReX_ParticleUtil.H>
 #include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
 #include <AMReX_ParticleLocator.H>
 #include <AMReX_DenseBins.H>
 
@@ -72,13 +73,13 @@ public:
     {
     }
 
-    virtual ~ParticleContainerBase () = default;
+    virtual ~ParticleContainerBase ();
 
     ParticleContainerBase ( const ParticleContainerBase &) = delete;
     ParticleContainerBase& operator= ( const ParticleContainerBase & ) = delete;
 
-    ParticleContainerBase ( ParticleContainerBase && ) = default;
-    ParticleContainerBase& operator= ( ParticleContainerBase && ) = default;
+    ParticleContainerBase ( ParticleContainerBase && other ) noexcept;
+    ParticleContainerBase& operator= ( ParticleContainerBase && other ) noexcept;
 
     void Define (ParGDBBase* gdb) { m_gdb = gdb;}
 
@@ -237,6 +238,13 @@ public:
 
     const ParticleBufferMap& BufferMap () const {return m_buffer_map;}
 
+#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+    void ensureParticleHandshakeWindow () const;
+    void releaseParticleHandshakeWindow ();
+    [[nodiscard]] Long* particleHandshakeBuffer () const { return m_particle_handshake_ptr; }
+    [[nodiscard]] MPI_Win particleHandshakeWindow () const { return m_particle_handshake_win; }
+#endif
+
     Vector<int> NeighborProcs(int ngrow) const
     {
         return computeNeighborProcs(this->GetParGDB(), ngrow);
@@ -283,6 +291,13 @@ protected:
     mutable int redistribute_mask_nghost = std::numeric_limits<int>::min();
     mutable amrex::Vector<int> neighbor_procs;
     mutable ParticleBufferMap m_buffer_map;
+
+#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+    mutable MPI_Win m_particle_handshake_win = MPI_WIN_NULL;
+    mutable Long* m_particle_handshake_ptr = nullptr;
+    mutable int m_particle_handshake_nprocs = 0;
+    mutable MPI_Comm m_particle_handshake_comm = MPI_COMM_NULL;
+#endif
 
 };
 

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -20,6 +20,25 @@
 
 namespace amrex {
 
+#if defined(AMREX_USE_MPI)
+struct ParticleHandshakeWindow
+{
+    ParticleHandshakeWindow () = default;
+
+    ParticleHandshakeWindow (const ParticleHandshakeWindow&) = delete;
+    ParticleHandshakeWindow& operator= (const ParticleHandshakeWindow&) = delete;
+    ParticleHandshakeWindow (ParticleHandshakeWindow&&) = delete;
+    ParticleHandshakeWindow& operator= (ParticleHandshakeWindow&&) = delete;
+
+    ~ParticleHandshakeWindow ();
+
+    MPI_Win win = MPI_WIN_NULL;
+    Long* ptr = nullptr;
+    int nprocs = 0;
+    MPI_Comm comm = MPI_COMM_NULL;
+};
+#endif
+
 class ParticleContainerBase
 {
 public:
@@ -73,13 +92,13 @@ public:
     {
     }
 
-    virtual ~ParticleContainerBase ();
+    virtual ~ParticleContainerBase () = default;
 
     ParticleContainerBase ( const ParticleContainerBase &) = delete;
     ParticleContainerBase& operator= ( const ParticleContainerBase & ) = delete;
 
-    ParticleContainerBase ( ParticleContainerBase && other ) noexcept;
-    ParticleContainerBase& operator= ( ParticleContainerBase && other ) noexcept;
+    ParticleContainerBase ( ParticleContainerBase && ) noexcept = default;
+    ParticleContainerBase& operator= ( ParticleContainerBase && ) noexcept = default;
 
     void Define (ParGDBBase* gdb) { m_gdb = gdb;}
 
@@ -240,9 +259,10 @@ public:
 
 #if defined(AMREX_USE_MPI)
     void ensureParticleHandshakeWindow () const;
-    void releaseParticleHandshakeWindow ();
-    [[nodiscard]] Long* particleHandshakeBuffer () const { return m_particle_handshake_ptr; }
-    [[nodiscard]] MPI_Win particleHandshakeWindow () const { return m_particle_handshake_win; }
+    [[nodiscard]] Long* particleHandshakeBuffer () const
+        { return m_particle_handshake_window ? m_particle_handshake_window->ptr : nullptr; }
+    [[nodiscard]] MPI_Win particleHandshakeWindow () const
+        { return m_particle_handshake_window ? m_particle_handshake_window->win : MPI_WIN_NULL; }
 #endif
 
     Vector<int> NeighborProcs(int ngrow) const
@@ -293,10 +313,7 @@ protected:
     mutable ParticleBufferMap m_buffer_map;
 
 #if defined(AMREX_USE_MPI)
-    mutable MPI_Win m_particle_handshake_win = MPI_WIN_NULL;
-    mutable Long* m_particle_handshake_ptr = nullptr;
-    mutable int m_particle_handshake_nprocs = 0;
-    mutable MPI_Comm m_particle_handshake_comm = MPI_COMM_NULL;
+    mutable std::unique_ptr<ParticleHandshakeWindow> m_particle_handshake_window;
 #endif
 
 };

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -238,7 +238,7 @@ public:
 
     const ParticleBufferMap& BufferMap () const {return m_buffer_map;}
 
-#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+#if defined(AMREX_USE_MPI)
     void ensureParticleHandshakeWindow () const;
     void releaseParticleHandshakeWindow ();
     [[nodiscard]] Long* particleHandshakeBuffer () const { return m_particle_handshake_ptr; }
@@ -292,7 +292,7 @@ protected:
     mutable amrex::Vector<int> neighbor_procs;
     mutable ParticleBufferMap m_buffer_map;
 
-#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+#if defined(AMREX_USE_MPI)
     mutable MPI_Win m_particle_handshake_win = MPI_WIN_NULL;
     mutable Long* m_particle_handshake_ptr = nullptr;
     mutable int m_particle_handshake_nprocs = 0;

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -12,78 +12,6 @@ IntVect ParticleContainerBase::tile_size { AMREX_D_DECL(1024000,8,8) };
 bool    ParticleContainerBase::memEfficientSort = true;
 bool    ParticleContainerBase::use_comms_arena = false;
 
-ParticleContainerBase::~ParticleContainerBase ()
-{
-#if defined(AMREX_USE_MPI)
-    releaseParticleHandshakeWindow();
-#endif
-}
-
-ParticleContainerBase::ParticleContainerBase (ParticleContainerBase&& other) noexcept
-    : m_particle_locator(std::move(other.m_particle_locator)),
-      m_verbose(other.m_verbose),
-      m_stable_redistribute(other.m_stable_redistribute),
-      m_gdb_object(std::move(other.m_gdb_object)),
-      m_gdb(other.m_gdb),
-      m_dummy_mf(std::move(other.m_dummy_mf)),
-      m_arena(other.m_arena),
-      redistribute_mask_ptr(std::move(other.redistribute_mask_ptr)),
-      redistribute_mask_nghost(other.redistribute_mask_nghost),
-      neighbor_procs(std::move(other.neighbor_procs)),
-      m_buffer_map(std::move(other.m_buffer_map))
-#if defined(AMREX_USE_MPI)
-    , m_particle_handshake_win(other.m_particle_handshake_win),
-      m_particle_handshake_ptr(other.m_particle_handshake_ptr),
-      m_particle_handshake_nprocs(other.m_particle_handshake_nprocs),
-      m_particle_handshake_comm(other.m_particle_handshake_comm)
-#endif
-{
-    other.m_gdb = nullptr;
-#if defined(AMREX_USE_MPI)
-    other.m_particle_handshake_win = MPI_WIN_NULL;
-    other.m_particle_handshake_ptr = nullptr;
-    other.m_particle_handshake_nprocs = 0;
-    other.m_particle_handshake_comm = MPI_COMM_NULL;
-#endif
-}
-
-ParticleContainerBase&
-ParticleContainerBase::operator= (ParticleContainerBase&& other) noexcept
-{
-    if (this != &other)
-    {
-#if defined(AMREX_USE_MPI)
-        releaseParticleHandshakeWindow();
-#endif
-
-        m_particle_locator = std::move(other.m_particle_locator);
-        m_verbose = other.m_verbose;
-        m_stable_redistribute = other.m_stable_redistribute;
-        m_gdb_object = std::move(other.m_gdb_object);
-        m_gdb = other.m_gdb;
-        m_dummy_mf = std::move(other.m_dummy_mf);
-        m_arena = other.m_arena;
-        redistribute_mask_ptr = std::move(other.redistribute_mask_ptr);
-        redistribute_mask_nghost = other.redistribute_mask_nghost;
-        neighbor_procs = std::move(other.neighbor_procs);
-        m_buffer_map = std::move(other.m_buffer_map);
-#if defined(AMREX_USE_MPI)
-        m_particle_handshake_win = other.m_particle_handshake_win;
-        m_particle_handshake_ptr = other.m_particle_handshake_ptr;
-        m_particle_handshake_nprocs = other.m_particle_handshake_nprocs;
-        m_particle_handshake_comm = other.m_particle_handshake_comm;
-
-        other.m_particle_handshake_win = MPI_WIN_NULL;
-        other.m_particle_handshake_ptr = nullptr;
-        other.m_particle_handshake_nprocs = 0;
-        other.m_particle_handshake_comm = MPI_COMM_NULL;
-#endif
-        other.m_gdb = nullptr;
-    }
-
-    return *this;
-}
-
 void ParticleContainerBase::Define (const Geometry            & geom,
                                     const DistributionMapping & dmap,
                                     const BoxArray            & ba)
@@ -153,16 +81,16 @@ ParticleContainerBase::defineBufferMap () const
 }
 
 #if defined(AMREX_USE_MPI)
-void ParticleContainerBase::releaseParticleHandshakeWindow ()
+ParticleHandshakeWindow::~ParticleHandshakeWindow ()
 {
-    if (m_particle_handshake_win != MPI_WIN_NULL) {
-        BL_MPI_REQUIRE(MPI_Win_free(&m_particle_handshake_win));
+    if (win != MPI_WIN_NULL) {
+        BL_MPI_REQUIRE(MPI_Win_free(&win));
     }
-    if (m_particle_handshake_comm != MPI_COMM_NULL) {
-        BL_MPI_REQUIRE(MPI_Comm_free(&m_particle_handshake_comm));
+    if (comm != MPI_COMM_NULL) {
+        BL_MPI_REQUIRE(MPI_Comm_free(&comm));
     }
-    m_particle_handshake_ptr = nullptr;
-    m_particle_handshake_nprocs = 0;
+    ptr = nullptr;
+    nprocs = 0;
 }
 
 void ParticleContainerBase::ensureParticleHandshakeWindow () const
@@ -170,21 +98,21 @@ void ParticleContainerBase::ensureParticleHandshakeWindow () const
     const int nprocs = ParallelContext::NProcsSub();
     MPI_Comm comm = ParallelContext::CommunicatorSub();
 
-    bool needs_rebuild = (m_particle_handshake_win == MPI_WIN_NULL)
-        || (m_particle_handshake_nprocs != nprocs)
-        || (m_particle_handshake_comm == MPI_COMM_NULL);
+    auto const* handshake_window = m_particle_handshake_window.get();
+    bool needs_rebuild = (handshake_window == nullptr)
+        || (handshake_window->win == MPI_WIN_NULL)
+        || (handshake_window->nprocs != nprocs)
+        || (handshake_window->comm == MPI_COMM_NULL);
 
     if (!needs_rebuild)
     {
         int cmp = MPI_UNEQUAL;
-        BL_MPI_REQUIRE(MPI_Comm_compare(comm, m_particle_handshake_comm, &cmp));
+        BL_MPI_REQUIRE(MPI_Comm_compare(comm, handshake_window->comm, &cmp));
         needs_rebuild = (cmp != MPI_IDENT && cmp != MPI_CONGRUENT);
     }
 
     if (needs_rebuild)
     {
-        const_cast<ParticleContainerBase*>(this)->releaseParticleHandshakeWindow();
-
         Long* baseptr = nullptr;
         MPI_Win win = MPI_WIN_NULL;
         BL_MPI_REQUIRE(MPI_Win_allocate(static_cast<MPI_Aint>(nprocs*sizeof(Long)),
@@ -197,10 +125,11 @@ void ParticleContainerBase::ensureParticleHandshakeWindow () const
         MPI_Comm dup_comm = MPI_COMM_NULL;
         BL_MPI_REQUIRE(MPI_Comm_dup(comm, &dup_comm));
 
-        m_particle_handshake_ptr = baseptr;
-        m_particle_handshake_win = win;
-        m_particle_handshake_nprocs = nprocs;
-        m_particle_handshake_comm = dup_comm;
+        m_particle_handshake_window = std::make_unique<ParticleHandshakeWindow>();
+        m_particle_handshake_window->ptr = baseptr;
+        m_particle_handshake_window->win = win;
+        m_particle_handshake_window->nprocs = nprocs;
+        m_particle_handshake_window->comm = dup_comm;
     }
 }
 #endif

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -14,7 +14,7 @@ bool    ParticleContainerBase::use_comms_arena = false;
 
 ParticleContainerBase::~ParticleContainerBase ()
 {
-#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+#if defined(AMREX_USE_MPI)
     releaseParticleHandshakeWindow();
 #endif
 }
@@ -31,7 +31,7 @@ ParticleContainerBase::ParticleContainerBase (ParticleContainerBase&& other) noe
       redistribute_mask_nghost(other.redistribute_mask_nghost),
       neighbor_procs(std::move(other.neighbor_procs)),
       m_buffer_map(std::move(other.m_buffer_map))
-#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+#if defined(AMREX_USE_MPI)
     , m_particle_handshake_win(other.m_particle_handshake_win),
       m_particle_handshake_ptr(other.m_particle_handshake_ptr),
       m_particle_handshake_nprocs(other.m_particle_handshake_nprocs),
@@ -39,7 +39,7 @@ ParticleContainerBase::ParticleContainerBase (ParticleContainerBase&& other) noe
 #endif
 {
     other.m_gdb = nullptr;
-#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+#if defined(AMREX_USE_MPI)
     other.m_particle_handshake_win = MPI_WIN_NULL;
     other.m_particle_handshake_ptr = nullptr;
     other.m_particle_handshake_nprocs = 0;
@@ -52,7 +52,7 @@ ParticleContainerBase::operator= (ParticleContainerBase&& other) noexcept
 {
     if (this != &other)
     {
-#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+#if defined(AMREX_USE_MPI)
         releaseParticleHandshakeWindow();
 #endif
 
@@ -67,7 +67,7 @@ ParticleContainerBase::operator= (ParticleContainerBase&& other) noexcept
         redistribute_mask_nghost = other.redistribute_mask_nghost;
         neighbor_procs = std::move(other.neighbor_procs);
         m_buffer_map = std::move(other.m_buffer_map);
-#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+#if defined(AMREX_USE_MPI)
         m_particle_handshake_win = other.m_particle_handshake_win;
         m_particle_handshake_ptr = other.m_particle_handshake_ptr;
         m_particle_handshake_nprocs = other.m_particle_handshake_nprocs;
@@ -152,7 +152,7 @@ ParticleContainerBase::defineBufferMap () const
     }
 }
 
-#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+#if defined(AMREX_USE_MPI)
 void ParticleContainerBase::releaseParticleHandshakeWindow ()
 {
     if (m_particle_handshake_win != MPI_WIN_NULL) {

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -12,6 +12,78 @@ IntVect ParticleContainerBase::tile_size { AMREX_D_DECL(1024000,8,8) };
 bool    ParticleContainerBase::memEfficientSort = true;
 bool    ParticleContainerBase::use_comms_arena = false;
 
+ParticleContainerBase::~ParticleContainerBase ()
+{
+#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+    releaseParticleHandshakeWindow();
+#endif
+}
+
+ParticleContainerBase::ParticleContainerBase (ParticleContainerBase&& other) noexcept
+    : m_particle_locator(std::move(other.m_particle_locator)),
+      m_verbose(other.m_verbose),
+      m_stable_redistribute(other.m_stable_redistribute),
+      m_gdb_object(std::move(other.m_gdb_object)),
+      m_gdb(other.m_gdb),
+      m_dummy_mf(std::move(other.m_dummy_mf)),
+      m_arena(other.m_arena),
+      redistribute_mask_ptr(std::move(other.redistribute_mask_ptr)),
+      redistribute_mask_nghost(other.redistribute_mask_nghost),
+      neighbor_procs(std::move(other.neighbor_procs)),
+      m_buffer_map(std::move(other.m_buffer_map))
+#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+    , m_particle_handshake_win(other.m_particle_handshake_win),
+      m_particle_handshake_ptr(other.m_particle_handshake_ptr),
+      m_particle_handshake_nprocs(other.m_particle_handshake_nprocs),
+      m_particle_handshake_comm(other.m_particle_handshake_comm)
+#endif
+{
+    other.m_gdb = nullptr;
+#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+    other.m_particle_handshake_win = MPI_WIN_NULL;
+    other.m_particle_handshake_ptr = nullptr;
+    other.m_particle_handshake_nprocs = 0;
+    other.m_particle_handshake_comm = MPI_COMM_NULL;
+#endif
+}
+
+ParticleContainerBase&
+ParticleContainerBase::operator= (ParticleContainerBase&& other) noexcept
+{
+    if (this != &other)
+    {
+#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+        releaseParticleHandshakeWindow();
+#endif
+
+        m_particle_locator = std::move(other.m_particle_locator);
+        m_verbose = other.m_verbose;
+        m_stable_redistribute = other.m_stable_redistribute;
+        m_gdb_object = std::move(other.m_gdb_object);
+        m_gdb = other.m_gdb;
+        m_dummy_mf = std::move(other.m_dummy_mf);
+        m_arena = other.m_arena;
+        redistribute_mask_ptr = std::move(other.redistribute_mask_ptr);
+        redistribute_mask_nghost = other.redistribute_mask_nghost;
+        neighbor_procs = std::move(other.neighbor_procs);
+        m_buffer_map = std::move(other.m_buffer_map);
+#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+        m_particle_handshake_win = other.m_particle_handshake_win;
+        m_particle_handshake_ptr = other.m_particle_handshake_ptr;
+        m_particle_handshake_nprocs = other.m_particle_handshake_nprocs;
+        m_particle_handshake_comm = other.m_particle_handshake_comm;
+
+        other.m_particle_handshake_win = MPI_WIN_NULL;
+        other.m_particle_handshake_ptr = nullptr;
+        other.m_particle_handshake_nprocs = 0;
+        other.m_particle_handshake_comm = MPI_COMM_NULL;
+#endif
+        other.m_gdb = nullptr;
+    }
+
+    return *this;
+}
+
 void ParticleContainerBase::Define (const Geometry            & geom,
                                     const DistributionMapping & dmap,
                                     const BoxArray            & ba)
@@ -79,6 +151,59 @@ ParticleContainerBase::defineBufferMap () const
         m_buffer_map.define(GetParGDB());
     }
 }
+
+#if defined(AMREX_USE_MPI) && defined(BL_USE_MPI3)
+void ParticleContainerBase::releaseParticleHandshakeWindow ()
+{
+    if (m_particle_handshake_win != MPI_WIN_NULL) {
+        BL_MPI_REQUIRE(MPI_Win_free(&m_particle_handshake_win));
+    }
+    if (m_particle_handshake_comm != MPI_COMM_NULL) {
+        BL_MPI_REQUIRE(MPI_Comm_free(&m_particle_handshake_comm));
+    }
+    m_particle_handshake_ptr = nullptr;
+    m_particle_handshake_nprocs = 0;
+}
+
+void ParticleContainerBase::ensureParticleHandshakeWindow () const
+{
+    const int nprocs = ParallelContext::NProcsSub();
+    MPI_Comm comm = ParallelContext::CommunicatorSub();
+
+    bool needs_rebuild = (m_particle_handshake_win == MPI_WIN_NULL)
+        || (m_particle_handshake_nprocs != nprocs)
+        || (m_particle_handshake_comm == MPI_COMM_NULL);
+
+    if (!needs_rebuild)
+    {
+        int cmp = MPI_UNEQUAL;
+        BL_MPI_REQUIRE(MPI_Comm_compare(comm, m_particle_handshake_comm, &cmp));
+        needs_rebuild = (cmp != MPI_IDENT && cmp != MPI_CONGRUENT);
+    }
+
+    if (needs_rebuild)
+    {
+        const_cast<ParticleContainerBase*>(this)->releaseParticleHandshakeWindow();
+
+        Long* baseptr = nullptr;
+        MPI_Win win = MPI_WIN_NULL;
+        BL_MPI_REQUIRE(MPI_Win_allocate(static_cast<MPI_Aint>(nprocs*sizeof(Long)),
+                                        sizeof(Long),
+                                        MPI_INFO_NULL,
+                                        comm,
+                                        &baseptr,
+                                        &win));
+
+        MPI_Comm dup_comm = MPI_COMM_NULL;
+        BL_MPI_REQUIRE(MPI_Comm_dup(comm, &dup_comm));
+
+        m_particle_handshake_ptr = baseptr;
+        m_particle_handshake_win = win;
+        m_particle_handshake_nprocs = nprocs;
+        m_particle_handshake_comm = dup_comm;
+    }
+}
+#endif
 
 void ParticleContainerBase::SetParGDB (const Geometry            & geom,
                                        const DistributionMapping & dmap,

--- a/Tests/Particles/RedistributeGlobal/CMakeLists.txt
+++ b/Tests/Particles/RedistributeGlobal/CMakeLists.txt
@@ -1,0 +1,13 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources     main.cpp)
+    if (NOT AMReX_GPU_BACKEND STREQUAL NONE)
+      set(_input_files inputs.rt.cuda)
+    else ()
+      set(_input_files inputs.rt)
+    endif ()
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Particles/RedistributeGlobal/GNUmakefile
+++ b/Tests/Particles/RedistributeGlobal/GNUmakefile
@@ -1,0 +1,22 @@
+AMREX_HOME = ../../../
+
+DEBUG = FALSE
+
+DIM = 3
+
+COMP = gcc
+
+USE_MPI = TRUE
+USE_OMP = FALSE
+USE_CUDA = FALSE
+
+TINY_PROFILE = TRUE
+USE_PARTICLES = TRUE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Particles/RedistributeGlobal/Make.package
+++ b/Tests/Particles/RedistributeGlobal/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Particles/RedistributeGlobal/inputs
+++ b/Tests/Particles/RedistributeGlobal/inputs
@@ -1,0 +1,13 @@
+redistribute_global.size = (64, 64, 64)
+redistribute_global.max_grid_size = 32
+redistribute_global.is_periodic = 1
+redistribute_global.num_ppc = 2
+redistribute_global.nsteps = 200
+redistribute_global.nlevs = 1
+
+redistribute_global.num_runtime_real = 0
+redistribute_global.num_runtime_int = 0
+
+redistribute_global.sort = 0
+
+amrex.use_gpu_aware_mpi = 0

--- a/Tests/Particles/RedistributeGlobal/inputs.rt
+++ b/Tests/Particles/RedistributeGlobal/inputs.rt
@@ -1,0 +1,13 @@
+redistribute_global.size = (64, 64, 64)
+redistribute_global.max_grid_size = 32
+redistribute_global.is_periodic = 1
+redistribute_global.num_ppc = 1
+redistribute_global.nsteps = 200
+redistribute_global.nlevs = 1
+
+redistribute_global.num_runtime_real = 0
+redistribute_global.num_runtime_int = 0
+
+redistribute_global.sort = 0
+
+amrex.use_gpu_aware_mpi = 0

--- a/Tests/Particles/RedistributeGlobal/inputs.rt.cuda
+++ b/Tests/Particles/RedistributeGlobal/inputs.rt.cuda
@@ -1,0 +1,13 @@
+redistribute_global.size = (64, 64, 64)
+redistribute_global.max_grid_size = 32
+redistribute_global.is_periodic = 1
+redistribute_global.num_ppc = 1
+redistribute_global.nsteps = 200
+redistribute_global.nlevs = 1
+
+redistribute_global.num_runtime_real = 0
+redistribute_global.num_runtime_int = 0
+
+redistribute_global.sort = 0
+
+amrex.use_gpu_aware_mpi = 0

--- a/Tests/Particles/RedistributeGlobal/main.cpp
+++ b/Tests/Particles/RedistributeGlobal/main.cpp
@@ -1,0 +1,383 @@
+#include <AMReX.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Particles.H>
+
+using namespace amrex;
+
+static constexpr int NSR = 6;
+static constexpr int NSI = 1;
+static constexpr int NAR = 1;
+static constexpr int NAI = 1;
+
+int num_runtime_real = 0;
+int num_runtime_int = 0;
+
+void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
+{
+    int nx = nppc[0];
+#if AMREX_SPACEDIM > 1
+    int ny = nppc[1];
+#else
+    int ny = 1;
+#endif
+#if AMREX_SPACEDIM > 2
+    int nz = nppc[2];
+#else
+    int nz = 1;
+#endif
+
+    int ix_part = i_part/(ny * nz);
+    int iy_part = (i_part % (ny * nz)) % ny;
+    int iz_part = (i_part % (ny * nz)) / ny;
+
+    r[0] = (0.5+ix_part)/nx;
+    r[1] = (0.5+iy_part)/ny;
+    r[2] = (0.5+iz_part)/nz;
+}
+
+class TestParticleContainer
+    : public amrex::ParticleContainer<NSR, NSI, NAR, NAI>
+{
+public:
+
+    TestParticleContainer (const Vector<amrex::Geometry>& a_geom,
+                           const Vector<amrex::DistributionMapping>& a_dmap,
+                           const Vector<amrex::BoxArray>& a_ba,
+                           const Vector<amrex::IntVect>& a_rr)
+        : amrex::ParticleContainer<NSR, NSI, NAR, NAI>(a_geom, a_dmap, a_ba, a_rr)
+    {
+        for (int i = 0; i < num_runtime_real; ++i)
+        {
+            AddRealComp(true);
+        }
+        for (int i = 0; i < num_runtime_int; ++i)
+        {
+            AddIntComp(true);
+        }
+    }
+
+    void RedistributeGlobal ()
+    {
+        const int lev_min = 0;
+        const int lev_max = finestLevel();
+        const int nGrow = 0;
+        const int local = 0;
+        Redistribute(lev_min, lev_max, nGrow, local);
+    }
+
+    void InitParticles (const amrex::IntVect& a_num_particles_per_cell)
+    {
+        BL_PROFILE("InitParticles");
+
+        const int lev = 0;
+        const Real* dx = Geom(lev).CellSize();
+        const Real* plo = Geom(lev).ProbLo();
+
+        const int num_ppc = AMREX_D_TERM( a_num_particles_per_cell[0],
+                                         *a_num_particles_per_cell[1],
+                                         *a_num_particles_per_cell[2]);
+
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            const Box& tile_box = mfi.tilebox();
+
+            Gpu::HostVector<ParticleType> host_particles;
+            std::array<Gpu::HostVector<ParticleReal>, NAR> host_real;
+            std::array<Gpu::HostVector<int>, NAI> host_int;
+
+            std::vector<Gpu::HostVector<ParticleReal> > host_runtime_real(NumRuntimeRealComps());
+            std::vector<Gpu::HostVector<int> > host_runtime_int(NumRuntimeIntComps());
+
+            for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd(); tile_box.next(iv))
+            {
+                for (int i_part = 0; i_part < num_ppc; ++i_part)
+                {
+                    Real r[3];
+                    get_position_unit_cell(r, a_num_particles_per_cell, i_part);
+
+                    ParticleType p;
+                    p.id() = ParticleType::NextID();
+                    p.cpu() = ParallelDescriptor::MyProc();
+                    p.pos(0) = static_cast<ParticleReal>(plo[0] + (iv[0] + r[0])*dx[0]);
+#if AMREX_SPACEDIM > 1
+                    p.pos(1) = static_cast<ParticleReal>(plo[1] + (iv[1] + r[1])*dx[1]);
+#endif
+#if AMREX_SPACEDIM > 2
+                    p.pos(2) = static_cast<ParticleReal>(plo[2] + (iv[2] + r[2])*dx[2]);
+#endif
+
+                    for (int i = 0; i < NSR; ++i) { p.rdata(i) = ParticleReal(p.id()); }
+                    for (int i = 0; i < NSI; ++i) { p.idata(i) = int(p.id()); }
+
+                    host_particles.push_back(p);
+                    for (int i = 0; i < NAR; ++i) {
+                        host_real[i].push_back(ParticleReal(p.id()));
+                    }
+                    for (int i = 0; i < NAI; ++i) {
+                        host_int[i].push_back(int(p.id()));
+                    }
+                    for (int i = 0; i < NumRuntimeRealComps(); ++i) {
+                        host_runtime_real[i].push_back(ParticleReal(p.id()));
+                    }
+                    for (int i = 0; i < NumRuntimeIntComps(); ++i) {
+                        host_runtime_int[i].push_back(int(p.id()));
+                    }
+                }
+            }
+
+            auto& particle_tile = DefineAndReturnParticleTile(lev, mfi.index(), mfi.LocalTileIndex());
+            auto old_size = particle_tile.GetArrayOfStructs().size();
+            auto new_size = old_size + host_particles.size();
+            particle_tile.resize(new_size);
+
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_particles.begin(),
+                           host_particles.end(),
+                           particle_tile.GetArrayOfStructs().begin() + old_size);
+
+            auto& soa = particle_tile.GetStructOfArrays();
+            for (int i = 0; i < NAR; ++i)
+            {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_real[i].begin(),
+                               host_real[i].end(),
+                               soa.GetRealData(i).begin() + old_size);
+            }
+
+            for (int i = 0; i < NAI; ++i)
+            {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_int[i].begin(),
+                               host_int[i].end(),
+                               soa.GetIntData(i).begin() + old_size);
+            }
+
+            for (int i = 0; i < NumRuntimeRealComps(); ++i)
+            {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_real[i].begin(),
+                               host_runtime_real[i].end(),
+                               soa.GetRealData(NAR+i).begin() + old_size);
+            }
+
+            for (int i = 0; i < NumRuntimeIntComps(); ++i)
+            {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_int[i].begin(),
+                               host_runtime_int[i].end(),
+                               soa.GetIntData(NAI+i).begin() + old_size);
+            }
+
+            Gpu::streamSynchronize();
+        }
+
+        RedistributeGlobal();
+    }
+
+    void moveParticles ()
+    {
+        BL_PROFILE("TestParticleContainer::moveParticles");
+
+        for (int lev = 0; lev <= finestLevel(); ++lev)
+        {
+            const auto plo = Geom(lev).ProbLoArray();
+            const auto phi = Geom(lev).ProbHiArray();
+            auto& plev = GetParticles(lev);
+
+            for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+            {
+                int gid = mfi.index();
+                int tid = mfi.LocalTileIndex();
+                auto& ptile = plev[std::make_pair(gid, tid)];
+                auto& aos = ptile.GetArrayOfStructs();
+                ParticleType* pstruct = aos.data();
+                const size_t np = aos.numParticles();
+
+                amrex::ParallelForRNG(np,
+                [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
+                {
+                    ParticleType& p = pstruct[i];
+                    p.pos(0) = static_cast<ParticleReal>(plo[0] + (phi[0] - plo[0])*amrex::Random(engine));
+#if AMREX_SPACEDIM > 1
+                    p.pos(1) = static_cast<ParticleReal>(plo[1] + (phi[1] - plo[1])*amrex::Random(engine));
+#endif
+#if AMREX_SPACEDIM > 2
+                    p.pos(2) = static_cast<ParticleReal>(plo[2] + (phi[2] - plo[2])*amrex::Random(engine));
+#endif
+                });
+            }
+        }
+    }
+
+    void checkAnswer () const
+    {
+        BL_PROFILE("TestParticleContainer::checkAnswer");
+
+        AMREX_ALWAYS_ASSERT(OK());
+
+        int num_rr = NumRuntimeRealComps();
+        int num_ii = NumRuntimeIntComps();
+
+        for (int lev = 0; lev <= finestLevel(); ++lev)
+        {
+            const auto& plev = GetParticles(lev);
+            for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+            {
+                int gid = mfi.index();
+                int tid = mfi.LocalTileIndex();
+                const auto& ptile = plev.at(std::make_pair(gid, tid));
+                const auto& ptd = ptile.getConstParticleTileData();
+                const size_t np = ptile.numParticles();
+
+                AMREX_FOR_1D(np, i,
+                {
+                    for (int j = 0; j < NSR; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ptd.m_aos[i].id());
+                    }
+                    for (int j = 0; j < NSI; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].idata(j) == ptd.m_aos[i].id());
+                    }
+                    if constexpr (NAR > 0) {
+                        for (int j = 0; j < NAR; ++j)
+                        {
+                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ptd.m_aos[i].id());
+                        }
+                    }
+                    if constexpr (NAI > 0) {
+                        for (int j = 0; j < NAI; ++j)
+                        {
+                            AMREX_ALWAYS_ASSERT(ptd.m_idata[j][i] == ptd.m_aos[i].id());
+                        }
+                    }
+                    for (int j = 0; j < num_rr; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ptd.m_aos[i].id());
+                    }
+                    for (int j = 0; j < num_ii; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_idata[j][i] == ptd.m_aos[i].id());
+                    }
+                });
+            }
+        }
+    }
+};
+
+struct TestParams
+{
+    IntVect size;
+    int max_grid_size;
+    int num_ppc;
+    int is_periodic;
+    int nsteps;
+    int nlevs;
+    int sort;
+    int stable_redistribute = 0;
+};
+
+void testRedistributeGlobal ();
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc,argv);
+
+    amrex::Print() << "Running global redistribute test\n";
+    testRedistributeGlobal();
+
+    amrex::Finalize();
+}
+
+void get_test_params (TestParams& params, const std::string& prefix)
+{
+    ParmParse pp(prefix);
+    pp.get("size", params.size);
+    pp.get("max_grid_size", params.max_grid_size);
+    pp.get("num_ppc", params.num_ppc);
+    pp.get("is_periodic", params.is_periodic);
+    pp.get("nsteps", params.nsteps);
+    pp.get("nlevs", params.nlevs);
+    pp.query("num_runtime_real", num_runtime_real);
+    pp.query("num_runtime_int", num_runtime_int);
+    pp.query("stable_redistribute", params.stable_redistribute);
+
+    params.sort = 0;
+    pp.query("sort", params.sort);
+}
+
+void testRedistributeGlobal ()
+{
+    BL_PROFILE("testRedistributeGlobal");
+    TestParams params;
+    get_test_params(params, "redistribute_global");
+
+    int is_per[] = {AMREX_D_DECL(params.is_periodic,
+                                 params.is_periodic,
+                                 params.is_periodic)};
+
+    Vector<IntVect> rr(params.nlevs-1);
+    for (int lev = 1; lev < params.nlevs; ++lev) {
+        rr[lev-1] = IntVect(AMREX_D_DECL(2,2,2));
+    }
+
+    RealBox real_box;
+    for (int n = 0; n < BL_SPACEDIM; ++n)
+    {
+        real_box.setLo(n, 0.0);
+        real_box.setHi(n, params.size[n]);
+    }
+
+    IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
+    IntVect domain_hi(AMREX_D_DECL(params.size[0]-1,params.size[1]-1,params.size[2]-1));
+    const Box base_domain(domain_lo, domain_hi);
+
+    Vector<Geometry> geom(params.nlevs);
+    geom[0].define(base_domain, &real_box, CoordSys::cartesian, is_per);
+    for (int lev = 1; lev < params.nlevs; ++lev) {
+        geom[lev].define(amrex::refine(geom[lev-1].Domain(), rr[lev-1]),
+                         &real_box, CoordSys::cartesian, is_per);
+    }
+
+    Vector<BoxArray> ba(params.nlevs);
+    Vector<DistributionMapping> dm(params.nlevs);
+    IntVect lo(0);
+    IntVect size = params.size;
+    for (int lev = 0; lev < params.nlevs; ++lev)
+    {
+        ba[lev].define(Box(lo, lo+params.size-1));
+        ba[lev].maxSize(params.max_grid_size);
+        dm[lev].define(ba[lev]);
+        lo += size/2;
+        size *= 2;
+    }
+
+    TestParticleContainer pc(geom, dm, ba, rr);
+    pc.setStableRedistribute(params.stable_redistribute);
+
+    IntVect nppc(params.num_ppc);
+
+    amrex::Print() << "About to initialize particles\n";
+
+    pc.InitParticles(nppc);
+    pc.checkAnswer();
+
+    auto np_old = pc.TotalNumberOfParticles();
+
+    if (params.sort) { pc.SortParticlesByCell(); }
+
+    for (int i = 0; i < params.nsteps; ++i)
+    {
+        pc.moveParticles();
+        pc.RedistributeGlobal();
+        if (params.sort) { pc.SortParticlesByCell(); }
+        pc.checkAnswer();
+    }
+
+    if (geom[0].isAllPeriodic()) {
+        AMREX_ALWAYS_ASSERT(np_old == pc.TotalNumberOfParticles());
+    }
+
+    amrex::Print() << "pass\n";
+}

--- a/Tests/Particles/RedistributeGlobalDM/CMakeLists.txt
+++ b/Tests/Particles/RedistributeGlobalDM/CMakeLists.txt
@@ -1,0 +1,13 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources     main.cpp)
+    if (NOT AMReX_GPU_BACKEND STREQUAL NONE)
+      set(_input_files inputs.rt.cuda)
+    else ()
+      set(_input_files inputs.rt)
+    endif ()
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Particles/RedistributeGlobalDM/GNUmakefile
+++ b/Tests/Particles/RedistributeGlobalDM/GNUmakefile
@@ -1,0 +1,22 @@
+AMREX_HOME = ../../../
+
+DEBUG = FALSE
+
+DIM = 3
+
+COMP = gcc
+
+USE_MPI = TRUE
+USE_OMP = FALSE
+USE_CUDA = FALSE
+
+TINY_PROFILE = TRUE
+USE_PARTICLES = TRUE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Particles/RedistributeGlobalDM/Make.package
+++ b/Tests/Particles/RedistributeGlobalDM/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Particles/RedistributeGlobalDM/inputs
+++ b/Tests/Particles/RedistributeGlobalDM/inputs
@@ -1,0 +1,15 @@
+redistribute_global_dm.size = (64, 64, 64)
+redistribute_global_dm.max_grid_size = 8
+redistribute_global_dm.is_periodic = 1
+redistribute_global_dm.num_ppc = 2
+redistribute_global_dm.nsteps = 50
+redistribute_global_dm.nlevs = 1
+redistribute_global_dm.random_seed = 8675309
+redistribute_global_dm.check_answer_each_step = 1
+
+redistribute_global_dm.num_runtime_real = 0
+redistribute_global_dm.num_runtime_int = 0
+
+redistribute_global_dm.sort = 0
+
+amrex.use_gpu_aware_mpi = 0

--- a/Tests/Particles/RedistributeGlobalDM/inputs.rt
+++ b/Tests/Particles/RedistributeGlobalDM/inputs.rt
@@ -1,0 +1,15 @@
+redistribute_global_dm.size = (64, 64, 64)
+redistribute_global_dm.max_grid_size = 8
+redistribute_global_dm.is_periodic = 1
+redistribute_global_dm.num_ppc = 1
+redistribute_global_dm.nsteps = 25
+redistribute_global_dm.nlevs = 1
+redistribute_global_dm.random_seed = 8675309
+redistribute_global_dm.check_answer_each_step = 1
+
+redistribute_global_dm.num_runtime_real = 0
+redistribute_global_dm.num_runtime_int = 0
+
+redistribute_global_dm.sort = 0
+
+amrex.use_gpu_aware_mpi = 0

--- a/Tests/Particles/RedistributeGlobalDM/inputs.rt.cuda
+++ b/Tests/Particles/RedistributeGlobalDM/inputs.rt.cuda
@@ -1,0 +1,15 @@
+redistribute_global_dm.size = (64, 64, 64)
+redistribute_global_dm.max_grid_size = 8
+redistribute_global_dm.is_periodic = 1
+redistribute_global_dm.num_ppc = 1
+redistribute_global_dm.nsteps = 25
+redistribute_global_dm.nlevs = 1
+redistribute_global_dm.random_seed = 8675309
+redistribute_global_dm.check_answer_each_step = 1
+
+redistribute_global_dm.num_runtime_real = 0
+redistribute_global_dm.num_runtime_int = 0
+
+redistribute_global_dm.sort = 0
+
+amrex.use_gpu_aware_mpi = 0

--- a/Tests/Particles/RedistributeGlobalDM/main.cpp
+++ b/Tests/Particles/RedistributeGlobalDM/main.cpp
@@ -366,7 +366,7 @@ void testRedistributeGlobalDM ()
         const auto dm_start = amrex::second();
         for (int lev = 0; lev < params.nlevs; ++lev)
         {
-            auto pmap = makeRandomPMap(ba[lev].size(), nprocs,
+            auto pmap = makeRandomPMap(static_cast<int>(ba[lev].size()), nprocs,
                                        static_cast<std::uint32_t>(params.random_seed + 7919*i + 101*lev));
             DistributionMapping new_dm;
             new_dm.define(pmap);

--- a/Tests/Particles/RedistributeGlobalDM/main.cpp
+++ b/Tests/Particles/RedistributeGlobalDM/main.cpp
@@ -1,0 +1,402 @@
+#include <AMReX.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Particles.H>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <random>
+
+using namespace amrex;
+
+static constexpr int NSR = 6;
+static constexpr int NSI = 1;
+static constexpr int NAR = 1;
+static constexpr int NAI = 1;
+
+int num_runtime_real = 0;
+int num_runtime_int = 0;
+
+void get_position_unit_cell (Real* r, const IntVect& nppc, int i_part)
+{
+    int nx = nppc[0];
+#if AMREX_SPACEDIM > 1
+    int ny = nppc[1];
+#else
+    int ny = 1;
+#endif
+#if AMREX_SPACEDIM > 2
+    int nz = nppc[2];
+#else
+    int nz = 1;
+#endif
+
+    int ix_part = i_part/(ny * nz);
+    int iy_part = (i_part % (ny * nz)) % ny;
+    int iz_part = (i_part % (ny * nz)) / ny;
+
+    r[0] = (0.5+ix_part)/nx;
+    r[1] = (0.5+iy_part)/ny;
+    r[2] = (0.5+iz_part)/nz;
+}
+
+class TestParticleContainer
+    : public amrex::ParticleContainer<NSR, NSI, NAR, NAI>
+{
+public:
+
+    TestParticleContainer (const Vector<amrex::Geometry>& a_geom,
+                           const Vector<amrex::DistributionMapping>& a_dmap,
+                           const Vector<amrex::BoxArray>& a_ba,
+                           const Vector<amrex::IntVect>& a_rr)
+        : amrex::ParticleContainer<NSR, NSI, NAR, NAI>(a_geom, a_dmap, a_ba, a_rr)
+    {
+        for (int i = 0; i < num_runtime_real; ++i)
+        {
+            AddRealComp(true);
+        }
+        for (int i = 0; i < num_runtime_int; ++i)
+        {
+            AddIntComp(true);
+        }
+    }
+
+    void RedistributeGlobal ()
+    {
+        const int lev_min = 0;
+        const int lev_max = finestLevel();
+        const int nGrow = 0;
+        const int local = 0;
+        Redistribute(lev_min, lev_max, nGrow, local);
+    }
+
+    void InitParticles (const amrex::IntVect& a_num_particles_per_cell)
+    {
+        BL_PROFILE("InitParticles");
+
+        const int lev = 0;
+        const Real* dx = Geom(lev).CellSize();
+        const Real* plo = Geom(lev).ProbLo();
+
+        const int num_ppc = AMREX_D_TERM(a_num_particles_per_cell[0],
+                                         * a_num_particles_per_cell[1],
+                                         * a_num_particles_per_cell[2]);
+
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            const Box& tile_box = mfi.tilebox();
+
+            Gpu::HostVector<ParticleType> host_particles;
+            std::array<Gpu::HostVector<ParticleReal>, NAR> host_real;
+            std::array<Gpu::HostVector<int>, NAI> host_int;
+
+            std::vector<Gpu::HostVector<ParticleReal> > host_runtime_real(NumRuntimeRealComps());
+            std::vector<Gpu::HostVector<int> > host_runtime_int(NumRuntimeIntComps());
+
+            for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd(); tile_box.next(iv))
+            {
+                for (int i_part = 0; i_part < num_ppc; ++i_part)
+                {
+                    Real r[3];
+                    get_position_unit_cell(r, a_num_particles_per_cell, i_part);
+
+                    ParticleType p;
+                    p.id() = ParticleType::NextID();
+                    p.cpu() = ParallelDescriptor::MyProc();
+                    p.pos(0) = static_cast<ParticleReal>(plo[0] + (iv[0] + r[0])*dx[0]);
+#if AMREX_SPACEDIM > 1
+                    p.pos(1) = static_cast<ParticleReal>(plo[1] + (iv[1] + r[1])*dx[1]);
+#endif
+#if AMREX_SPACEDIM > 2
+                    p.pos(2) = static_cast<ParticleReal>(plo[2] + (iv[2] + r[2])*dx[2]);
+#endif
+
+                    for (int i = 0; i < NSR; ++i) { p.rdata(i) = ParticleReal(p.id()); }
+                    for (int i = 0; i < NSI; ++i) { p.idata(i) = int(p.id()); }
+
+                    host_particles.push_back(p);
+                    for (int i = 0; i < NAR; ++i) {
+                        host_real[i].push_back(ParticleReal(p.id()));
+                    }
+                    for (int i = 0; i < NAI; ++i) {
+                        host_int[i].push_back(int(p.id()));
+                    }
+                    for (int i = 0; i < NumRuntimeRealComps(); ++i) {
+                        host_runtime_real[i].push_back(ParticleReal(p.id()));
+                    }
+                    for (int i = 0; i < NumRuntimeIntComps(); ++i) {
+                        host_runtime_int[i].push_back(int(p.id()));
+                    }
+                }
+            }
+
+            auto& particle_tile = DefineAndReturnParticleTile(lev, mfi.index(), mfi.LocalTileIndex());
+            auto old_size = particle_tile.GetArrayOfStructs().size();
+            auto new_size = old_size + host_particles.size();
+            particle_tile.resize(new_size);
+
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_particles.begin(),
+                           host_particles.end(),
+                           particle_tile.GetArrayOfStructs().begin() + old_size);
+
+            auto& soa = particle_tile.GetStructOfArrays();
+            for (int i = 0; i < NAR; ++i)
+            {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_real[i].begin(),
+                               host_real[i].end(),
+                               soa.GetRealData(i).begin() + old_size);
+            }
+
+            for (int i = 0; i < NAI; ++i)
+            {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_int[i].begin(),
+                               host_int[i].end(),
+                               soa.GetIntData(i).begin() + old_size);
+            }
+
+            for (int i = 0; i < NumRuntimeRealComps(); ++i)
+            {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_real[i].begin(),
+                               host_runtime_real[i].end(),
+                               soa.GetRealData(NAR+i).begin() + old_size);
+            }
+
+            for (int i = 0; i < NumRuntimeIntComps(); ++i)
+            {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_runtime_int[i].begin(),
+                               host_runtime_int[i].end(),
+                               soa.GetIntData(NAI+i).begin() + old_size);
+            }
+
+            Gpu::streamSynchronize();
+        }
+
+        RedistributeGlobal();
+    }
+
+    void checkAnswer () const
+    {
+        BL_PROFILE("TestParticleContainer::checkAnswer");
+
+        AMREX_ALWAYS_ASSERT(OK());
+
+        int num_rr = NumRuntimeRealComps();
+        int num_ii = NumRuntimeIntComps();
+
+        for (int lev = 0; lev <= finestLevel(); ++lev)
+        {
+            const auto& plev = GetParticles(lev);
+            for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+            {
+                int gid = mfi.index();
+                int tid = mfi.LocalTileIndex();
+                const auto& ptile = plev.at(std::make_pair(gid, tid));
+                const auto& ptd = ptile.getConstParticleTileData();
+                const size_t np = ptile.numParticles();
+
+                AMREX_FOR_1D(np, i,
+                {
+                    for (int j = 0; j < NSR; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ptd.m_aos[i].id());
+                    }
+                    for (int j = 0; j < NSI; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].idata(j) == ptd.m_aos[i].id());
+                    }
+                    if constexpr (NAR > 0) {
+                        for (int j = 0; j < NAR; ++j)
+                        {
+                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ptd.m_aos[i].id());
+                        }
+                    }
+                    if constexpr (NAI > 0) {
+                        for (int j = 0; j < NAI; ++j)
+                        {
+                            AMREX_ALWAYS_ASSERT(ptd.m_idata[j][i] == ptd.m_aos[i].id());
+                        }
+                    }
+                    for (int j = 0; j < num_rr; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ptd.m_aos[i].id());
+                    }
+                    for (int j = 0; j < num_ii; ++j)
+                    {
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_idata[j][i] == ptd.m_aos[i].id());
+                    }
+                });
+            }
+        }
+    }
+};
+
+struct TestParams
+{
+    IntVect size;
+    int max_grid_size;
+    int num_ppc;
+    int is_periodic;
+    int nsteps;
+    int nlevs;
+    int sort;
+    int stable_redistribute = 0;
+    int random_seed = 8675309;
+    int check_answer_each_step = 1;
+};
+
+auto makeRandomPMap (int nboxes, int nprocs, std::uint32_t seed) -> Vector<int>
+{
+    Vector<int> pmap(nboxes);
+    for (int i = 0; i < nboxes; ++i) {
+        pmap[i] = i % nprocs;
+    }
+
+    std::mt19937 gen(seed);
+    std::shuffle(pmap.begin(), pmap.end(), gen);
+
+    return pmap;
+}
+
+void testRedistributeGlobalDM ();
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc,argv);
+
+    amrex::Print() << "Running global redistribute DistributionMap shuffle test\n";
+    testRedistributeGlobalDM();
+
+    amrex::Finalize();
+}
+
+void get_test_params (TestParams& params, const std::string& prefix)
+{
+    ParmParse pp(prefix);
+    pp.get("size", params.size);
+    pp.get("max_grid_size", params.max_grid_size);
+    pp.get("num_ppc", params.num_ppc);
+    pp.get("is_periodic", params.is_periodic);
+    pp.get("nsteps", params.nsteps);
+    pp.get("nlevs", params.nlevs);
+    pp.query("num_runtime_real", num_runtime_real);
+    pp.query("num_runtime_int", num_runtime_int);
+    pp.query("stable_redistribute", params.stable_redistribute);
+    pp.query("random_seed", params.random_seed);
+    pp.query("check_answer_each_step", params.check_answer_each_step);
+
+    params.sort = 0;
+    pp.query("sort", params.sort);
+}
+
+void testRedistributeGlobalDM ()
+{
+    BL_PROFILE("testRedistributeGlobalDM");
+    TestParams params;
+    get_test_params(params, "redistribute_global_dm");
+
+    int is_per[] = {AMREX_D_DECL(params.is_periodic,
+                                 params.is_periodic,
+                                 params.is_periodic)};
+
+    Vector<IntVect> rr(params.nlevs-1);
+    for (int lev = 1; lev < params.nlevs; ++lev) {
+        rr[lev-1] = IntVect(AMREX_D_DECL(2,2,2));
+    }
+
+    RealBox real_box;
+    for (int n = 0; n < BL_SPACEDIM; ++n)
+    {
+        real_box.setLo(n, 0.0);
+        real_box.setHi(n, params.size[n]);
+    }
+
+    IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
+    IntVect domain_hi(AMREX_D_DECL(params.size[0]-1,params.size[1]-1,params.size[2]-1));
+    const Box base_domain(domain_lo, domain_hi);
+
+    Vector<Geometry> geom(params.nlevs);
+    geom[0].define(base_domain, &real_box, CoordSys::cartesian, is_per);
+    for (int lev = 1; lev < params.nlevs; ++lev) {
+        geom[lev].define(amrex::refine(geom[lev-1].Domain(), rr[lev-1]),
+                         &real_box, CoordSys::cartesian, is_per);
+    }
+
+    Vector<BoxArray> ba(params.nlevs);
+    Vector<DistributionMapping> dm(params.nlevs);
+    IntVect lo(0);
+    IntVect size = params.size;
+    for (int lev = 0; lev < params.nlevs; ++lev)
+    {
+        ba[lev].define(Box(lo, lo+params.size-1));
+        ba[lev].maxSize(params.max_grid_size);
+        dm[lev].define(ba[lev]);
+        lo += size/2;
+        size *= 2;
+    }
+
+    TestParticleContainer pc(geom, dm, ba, rr);
+    pc.setStableRedistribute(params.stable_redistribute);
+
+    IntVect nppc(params.num_ppc);
+
+    amrex::Print() << "About to initialize particles\n";
+
+    pc.InitParticles(nppc);
+    pc.checkAnswer();
+
+    auto np_old = pc.TotalNumberOfParticles();
+    const int nprocs = ParallelDescriptor::NProcs();
+
+    amrex::Print() << "Benchmark setup: " << ba[0].size() << " boxes on level 0 across "
+                   << nprocs << " MPI ranks\n";
+
+    if (params.sort) { pc.SortParticlesByCell(); }
+
+    Real total_dm_time = Real(0.0);
+    Real total_redistribute_time = Real(0.0);
+
+    for (int i = 0; i < params.nsteps; ++i)
+    {
+        const auto dm_start = amrex::second();
+        for (int lev = 0; lev < params.nlevs; ++lev)
+        {
+            auto pmap = makeRandomPMap(ba[lev].size(), nprocs,
+                                       static_cast<std::uint32_t>(params.random_seed + 7919*i + 101*lev));
+            DistributionMapping new_dm;
+            new_dm.define(pmap);
+            pc.SetParticleDistributionMap(lev, new_dm);
+        }
+        total_dm_time += amrex::second() - dm_start;
+
+        ParallelDescriptor::Barrier();
+        const auto redistribute_start = amrex::second();
+        pc.RedistributeGlobal();
+        total_redistribute_time += amrex::second() - redistribute_start;
+
+        if (params.sort) { pc.SortParticlesByCell(); }
+        if (params.check_answer_each_step) { pc.checkAnswer(); }
+    }
+
+    if (!params.check_answer_each_step) {
+        pc.checkAnswer();
+    }
+
+    if (geom[0].isAllPeriodic()) {
+        AMREX_ALWAYS_ASSERT(np_old == pc.TotalNumberOfParticles());
+    }
+
+    ParallelDescriptor::ReduceRealMax(total_dm_time, ParallelDescriptor::IOProcessorNumber());
+    ParallelDescriptor::ReduceRealMax(total_redistribute_time, ParallelDescriptor::IOProcessorNumber());
+
+    amrex::Print() << "Max DM shuffle time over all ranks: " << total_dm_time << " s\n";
+    amrex::Print() << "Max redistribute time over all ranks: " << total_redistribute_time << " s\n";
+    amrex::Print() << "Average redistribute time per step: "
+                   << total_redistribute_time/static_cast<Real>(params.nsteps) << " s\n";
+    amrex::Print() << "pass\n";
+}

--- a/Tests/Particles/RedistributeSOA/inputs.rt.cuda
+++ b/Tests/Particles/RedistributeSOA/inputs.rt.cuda
@@ -10,3 +10,5 @@ redistribute.do_regrid = 1
 
 redistribute.num_runtime_real = 2
 redistribute.num_runtime_int = 3
+
+particles.do_one_sided_comms = 1


### PR DESCRIPTION
This is one of the possible optimizations raised in Issue #4179. 

This passes all tests locally and on Perlmutter. However, the one-sided version of doHandShake doesn't seem to be a performance win in the tests I ran.

The new handshake is only needed for the global redistribution path. To trigger this path, as a first test I made a particle redistribution benchmark where 1% of the particles jump to a random location in the domain. For this communication pattern, the one-sided handshake is basically the same as reduce/scatter on up to 128 nodes, then slower after that.
   
<img width="1635" height="742" alt="scaling_comparison_global" src="https://github.com/user-attachments/assets/4f50912e-e4bb-4efb-b023-42674992bcc6" />

Then I thought, the above communication pattern has each rank on average sending some particles to every other rank, basically an all-to-all, which is a bad case for the one-sided version. So I did another test modeled on what we do in load balancing in WarpX. Here, there are 2 boxes per GPU, so on 1024 ranks there would be 2048 boxes. Instead of moving the particles, each step I change the distribution map randomly, so that on average each rank will send particles to 2 other ranks and receive from 2. This kind of sparse distribution pattern should be a good case for the one-sided version. However, even in this case the performance is basically the same in both cases. 

<img width="1635" height="742" alt="scaling_comparison_regrid" src="https://github.com/user-attachments/assets/2e1d62ce-28b6-4231-ac39-c58b36c2e9c1" />

None of these runs included the fix in PR #5260, which would improve the overall redistribute scaling but not effect the handshake time.

Overall I think the regime in which on-sided would be expected to win is relatively small. It would need to trigger the global redistribution path but with a sparse comm pattern. And even in the case I didn't see a win on the test I did.

However, since the one-sided method is off by default I think we should merge this as an option, since the timings are dependent on how good the RMA support is for specific MPI implementations and maybe this will work better on other systems. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
