### PR TITLE
GNU Make: Update ifx options

### DIFF
--- a/Tools/GNUMake/comps/intel-llvm.mak
+++ b/Tools/GNUMake/comps/intel-llvm.mak
@@ -27,8 +27,8 @@ ifeq ($(DEBUG),TRUE)
 
   CXXFLAGS += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
   CFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ftrapv
-  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ftrapuv -check bounds,pointers,uninit -traceback
-  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -ftrapuv -check bounds,pointers,uninit -traceback
+  FFLAGS   += -g -O$(DEBUG_OPT_LEVEL) -ftrapuv -check bounds,pointers -traceback
+  F90FLAGS += -g -O$(DEBUG_OPT_LEVEL) -ftrapuv -check bounds,pointers -traceback
 
 else
 
@@ -97,6 +97,11 @@ CXXFLAGS += $(GENERIC_COMP_FLAGS) -pthread
 CFLAGS   += $(GENERIC_COMP_FLAGS)
 FFLAGS   += $(GENERIC_COMP_FLAGS)
 F90FLAGS += $(GENERIC_COMP_FLAGS)
+
+ifneq ($(USE_F_INTERFACES),TRUE)
+  F90FLAGS += -nofor-main
+  FFLAGS   += -nofor-main
+endif
 
 ########################################################################
 


### PR DESCRIPTION
- Remove `-check=uninit` because it requries LLVM MSAN
- Add `-nofor-main` so that linking with Fortran compiler works.
