### PR TITLE
AmrMesh: Recompute roundoff domain for fine Geometry objects

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -64,6 +64,7 @@ AmrMesh::AmrMesh (Geometry const& level_0_geom, AmrInfo const& amr_info)
     geom.push_back(level_0_geom);
     for (int lev = 1; lev <= max_level; ++lev) {
         geom.push_back(amrex::refine(geom[lev-1], ref_ratio[lev-1]));
+        geom.back().computeRoundoffDomain();
     }
 
     finest_level = -1;

--- a/Src/Base/AMReX_Geometry.H
+++ b/Src/Base/AMReX_Geometry.H
@@ -433,10 +433,7 @@ public:
     */
     [[nodiscard]] bool insideRoundoffDomain (AMREX_D_DECL(ParticleReal x, ParticleReal y, ParticleReal z)) const;
 
-    /**
-    * \brief Compute the roundoff domain. Public because it contains an
-    *        extended host / device lambda.
-    */
+    //! Compute the roundoff domain.
     void computeRoundoffDomain ();
 
     //! Returns roundoff domain's lower end


### PR DESCRIPTION
The roundoff domain depends on the cell size and the number of cells. So we must recompute them after refinement.
