### PR TITLE
Fix DistributionMapping::SFC_Threshold

### DIFF
--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -82,7 +82,7 @@ DistributionMapping::strategy (DistributionMapping::Strategy how)
 void
 DistributionMapping::SFC_Threshold (int n)
 {
-    sfc_threshold = std::min(n,1);
+    sfc_threshold = std::max(n,1);
 }
 
 int


### PR DESCRIPTION
The number should be >= 1. We should use max instead of min.
