### PR TITLE
TrackedVector

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -770,8 +770,8 @@ under **Gpu Vectors** above (``The_Managed_Arena()``).  Like :cpp:`Gpu::Buffer`
 it can only be used while AMReX is initialized / a GPU device context exists.
 
 :cpp:`Gpu::TrackedVector` exposes a host ``std::vector`` via ``host()`` /
-``host_const()`` and a device :cpp:`Gpu::DeviceVector` via ``device()`` /
-``device_const()`` (GPU builds only).  Every accessor **automatically
+``host_const()`` and a device :cpp:`Gpu::NonManagedDeviceVector` via
+``device()`` / ``device_const()`` (GPU builds only).  Every accessor **automatically
 synchronizes** the other side when needed: if the host was modified and you
 call ``device()`` or ``device_const()``, a synchronous host-to-device copy
 runs first (and vice versa).  Writable accessors (``host()``, ``device()``)
@@ -802,7 +802,7 @@ dirty state unnecessarily.
      - Only between ``amrex::Initialize/Finalize()``
      - Anytime and cross-session, GPU part only between ``amrex::Initialize/Finalize()``
    * - **Usage**
-     - ``operator[]`` etc.   , explicit ``copyToDeviceAsync`` /
+     - ``operator[]`` etc., explicit ``copyToDeviceAsync`` /
        ``copyToHost``
      - Single ``data()`` like :cpp:`amrex::Vector`
      - Separate ``host()`` / ``device()`` (and ``*_const``)
@@ -855,7 +855,7 @@ A minimal :cpp:`Gpu::Buffer` pattern (host fill, async upload, kernel pointer):
     // mv[i] now accessible on host with updated values
 
 :cpp:`Gpu::TrackedVector` example:
-On GPU builds, you can create this type at any time, even before `amrex::Initialize()`.
+On GPU builds, you can create this type at any time, even before ``amrex::Initialize()``.
 ``amrex::Finalize()`` releases device storage for the vector but
 keeps the host ``std::vector``, so a later ``Initialize()`` session
 can access ``device_const()`` or ``device()`` and the host data is

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -753,6 +753,144 @@ constructed inside of an MFIter loop with GPU kernels and great care should
 be used when accessing :cpp:`Gpu::ManagedVector` data on GPUs to avoid race
 conditions.
 
+.. _sec:gpu:buffer_managed_tracked:
+
+Gpu::Buffer, Gpu::ManagedVector, and Gpu::TrackedVector
+-------------------------------------------------------
+
+:cpp:`Gpu::Buffer` (``AMReX_GpuBuffer.H``) and :cpp:`Gpu::TrackedVector`
+(``AMReX_TrackedVector.H``) pair a host allocation with a device mirror.
+
+:cpp:`Gpu::Buffer` uses :cpp:`Gpu::PinnedVector` on the host and
+``copyToDeviceAsync()`` / ``copyToHost()`` for transfers.  Use it for
+**frequent, performance-oriented** async copies during a normal GPU run.
+
+:cpp:`Gpu::ManagedVector` is the arena-backed unified-memory vector introduced
+under **Gpu Vectors** above (``The_Managed_Arena()``).  Like :cpp:`Gpu::Buffer`
+it can only be used while AMReX is initialized / a GPU device context exists.
+
+:cpp:`Gpu::TrackedVector` exposes a host ``std::vector`` via ``host()`` /
+``host_const()`` and a device :cpp:`Gpu::DeviceVector` via ``device()`` /
+``device_const()`` (GPU builds only).  Writable accessors mark the mirror
+out-of-date; ``to_device()``/``to_host()`` perform **synchronous** copies when
+needed.  You may populate the host **before** :cpp:`amrex::Initialize()`. Device
+memory is only valid while AMReX is initialized.  On :cpp:`amrex::Finalize()`,
+AMReX clears device storage via ``release_gpu()`` and leaves the host copy for
+reuse, which supports **Python / pyAMReX** and other workflows
+that cross multiple AMReX initialize/finalize cycles.  Use read-only
+``host_const()`` / ``device_const()`` when you are not writing, so the object
+does not flip to a dirty state unnecessarily.
+
+.. _tab:gpu:buffer_managed_tracked:
+
+.. list-table::
+   :widths: 12 28 28 28
+   :header-rows: 1
+
+   * -
+     - :cpp:`Gpu::Buffer`
+     - :cpp:`Gpu::ManagedVector`
+     - :cpp:`Gpu::TrackedVector`
+   * - **Lifetime**
+     - Only between ``amrex::Initialize/Finalize()``
+     - Only between ``amrex::Initialize/Finalize()``
+     - Anytime and cross-session, GPU part only between ``amrex::Initialize/Finalize()``
+   * - **Usage**
+     - ``operator[]`` etc.   , explicit ``copyToDeviceAsync`` /
+       ``copyToHost``
+     - Single ``data()`` like :cpp:`amrex::Vector`
+     - Separate ``host()`` / ``device()`` (and ``*_const``)
+   * - **Synchronization**
+     - explicit
+     - implicit
+     - explicit, but tracks status
+   * - **Performance**
+     - Best: pinned host enables asynchronous transfers
+     - Implicit memory migration can add latency
+     - Synchronous copy adds latency
+   * - **Best for**
+     - hot copy loops inside a run
+     - maximum simplicity
+     - interactive and cross-AMReX session usage, e.g., in pyAMReX for user inputs that do not change often
+
+
+A minimal :cpp:`Gpu::Buffer` pattern (host fill, async upload, kernel pointer):
+
+.. highlight:: c++
+
+::
+
+    amrex::Initialize(argc, argv);
+
+    Gpu::Buffer<int> buf(n);
+    for (int i = 0; i < n; ++i) { buf[i] = i; }
+
+    int* dp = buf.copyToDeviceAsync();
+    // launch kernels using dp, then optionally:
+    buf.copyToHost();
+
+:cpp:`Gpu::ManagedVector` example (unified memory, accessible from both host and device):
+
+.. highlight:: c++
+
+::
+
+    amrex::Initialize(argc, argv);
+
+    Gpu::ManagedVector<int> mv(n);
+    for (int i = 0; i < n; ++i) { mv[i] = i; }
+
+    int* dp = mv.data();
+    amrex::ParallelFor(n, [=] AMREX_GPU_DEVICE (int i) {
+        dp[i] *= 2;  // access on device
+    });
+
+    Gpu::streamSynchronize();
+    // mv[i] now accessible on host with updated values
+
+:cpp:`Gpu::TrackedVector` example:
+On GPU builds, you can create this type at any time, even before `amrex::Initialize()`.
+``amrex::Finalize()`` releases device storage for the vector but
+keeps the host ``std::vector``, so a later ``Initialize()`` can call
+``to_device()`` again to rebuild the device copy.
+
+.. highlight:: c++
+
+::
+
+    // Host data before AMReX init; GPU available after Initialize().
+    amrex::Gpu::TrackedVector<int> cross_session;
+    cross_session.host() = {7, 8, 9};
+
+    // ... a lot of other interactive user code, e.g., to set up
+    // complex input data, optimization libraries or ML frameworks
+    // in multi-simulation workflows ...
+
+    amrex::Initialize(argc, argv);
+    {
+        cross_session.to_device();
+        // Host and device match; use host_const() / device_const() for reads.
+    }
+    amrex::Finalize();
+
+    // cross_session.device() is not available now and will throw,
+    // but you can keep using cross_session.host() / .host_const()
+
+    amrex::Initialize(argc, argv);
+    {
+        cross_session.to_device();
+        // Device buffer is re-created; kernels may read via
+        // device_const().data() or write via device().data()
+    }
+    amrex::Finalize();
+
+Optional: Call ``release_gpu()`` when you need to free device memory while
+keeping the host ``std::vector`` for later (unless already released,
+``amrex::Finalize()`` clears device storage registered for the object).
+
+Generally, after device kernels, call :cpp:`Gpu::streamSynchronize()`
+(or equivalent ordering) before relying on host data, as for any other device work.
+
 MultiFab Reductions
 -------------------
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -771,15 +771,21 @@ it can only be used while AMReX is initialized / a GPU device context exists.
 
 :cpp:`Gpu::TrackedVector` exposes a host ``std::vector`` via ``host()`` /
 ``host_const()`` and a device :cpp:`Gpu::DeviceVector` via ``device()`` /
-``device_const()`` (GPU builds only).  Writable accessors mark the mirror
-out-of-date; ``to_device()``/``to_host()`` perform **synchronous** copies when
-needed.  You may populate the host **before** :cpp:`amrex::Initialize()`. Device
-memory is only valid while AMReX is initialized.  On :cpp:`amrex::Finalize()`,
-AMReX clears device storage via ``release_gpu()`` and leaves the host copy for
-reuse, which supports **Python / pyAMReX** and other workflows
-that cross multiple AMReX initialize/finalize cycles.  Use read-only
-``host_const()`` / ``device_const()`` when you are not writing, so the object
-does not flip to a dirty state unnecessarily.
+``device_const()`` (GPU builds only).  Every accessor **automatically
+synchronizes** the other side when needed: if the host was modified and you
+call ``device()`` or ``device_const()``, a synchronous host-to-device copy
+runs first (and vice versa).  Writable accessors (``host()``, ``device()``)
+additionally mark the returned side as dirty so that the next access to the
+opposite side triggers a copy back.  Read-only accessors
+(``host_const()``, ``device_const()``) leave the status as ``up_to_date``
+after syncing.  You may populate the host **before**
+:cpp:`amrex::Initialize()`. Device memory is only valid while AMReX is
+initialized.  On :cpp:`amrex::Finalize()`, AMReX clears device storage via
+``release_gpu()`` and leaves the host copy for reuse, which supports
+**Python / pyAMReX** and other workflows that cross multiple AMReX
+initialize/finalize cycles.  Use read-only ``host_const()`` /
+``device_const()`` when you are not writing, so the object does not flip to a
+dirty state unnecessarily.
 
 .. _tab:gpu:buffer_managed_tracked:
 
@@ -803,7 +809,7 @@ does not flip to a dirty state unnecessarily.
    * - **Synchronization**
      - explicit
      - implicit
-     - explicit, but tracks status
+     - automatic on access, tracks status
    * - **Performance**
      - Best: pinned host enables asynchronous transfers
      - Implicit memory migration can add latency
@@ -851,8 +857,9 @@ A minimal :cpp:`Gpu::Buffer` pattern (host fill, async upload, kernel pointer):
 :cpp:`Gpu::TrackedVector` example:
 On GPU builds, you can create this type at any time, even before `amrex::Initialize()`.
 ``amrex::Finalize()`` releases device storage for the vector but
-keeps the host ``std::vector``, so a later ``Initialize()`` can call
-``to_device()`` again to rebuild the device copy.
+keeps the host ``std::vector``, so a later ``Initialize()`` session
+can access ``device_const()`` or ``device()`` and the host data is
+automatically copied to the device.
 
 .. highlight:: c++
 
@@ -868,8 +875,9 @@ keeps the host ``std::vector``, so a later ``Initialize()`` can call
 
     amrex::Initialize(argc, argv);
     {
-        cross_session.to_device();
-        // Host and device match; use host_const() / device_const() for reads.
+        // device access auto-syncs host data to device.
+        int const* dp = cross_session.device_const().data();
+        // use dp in kernels ...
     }
     amrex::Finalize();
 
@@ -878,9 +886,10 @@ keeps the host ``std::vector``, so a later ``Initialize()`` can call
 
     amrex::Initialize(argc, argv);
     {
-        cross_session.to_device();
-        // Device buffer is re-created; kernels may read via
-        // device_const().data() or write via device().data()
+        // Device buffer is re-created automatically on access.
+        int const* dp = cross_session.device_const().data();
+        // kernels may read via device_const().data()
+        // or write via device().data()
     }
     amrex::Finalize();
 

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -41,106 +41,74 @@ namespace amrex::Gpu
         using value_type      = T;
         using size_type       = std::size_t;
 
-    private:
-        void register_finalize () {
-#ifdef AMREX_USE_GPU
-            if (*m_finalize_registered) { return; }
-            *m_finalize_registered = true;
-
-            std::weak_ptr<std::vector<T>> weak_host = m_host;
-            std::weak_ptr<amrex::Gpu::DeviceVector<T>> weak_device = m_device;
-            std::weak_ptr<Status> weak_status = m_status;
-            std::weak_ptr<bool> weak_registered = m_finalize_registered;
-
-            amrex::ExecOnFinalize([weak_host, weak_device, weak_status, weak_registered]() {
-                // see: release_gpu()
-                auto host   = weak_host.lock();
-                auto device = weak_device.lock();
-                auto status = weak_status.lock();
-                if (host && device && status
-                    && *status == Status::device_dirty
-                    && !device->empty())
-                {
-                    // see: to_host()
-                    host->resize(device->size());
-                    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
-                        device->begin(), device->end(), host->begin());
-                }
-                if (device) {
-                    device->clear();
-                    device->shrink_to_fit();
-                }
-                if (status) {
-                    *status = Status::host_dirty;
-                }
-                if (auto reg = weak_registered.lock()) {
-                    *reg = false;
-                }
-            });
-#endif
-        }
-    public:
+        enum class Status {
+            up_to_date,    //!< host and device data are in sync
+            device_dirty,  //!< host data needs an update
+            host_dirty     //!< device data needs an update
+        };
 
         TrackedVector () = default;
 
         explicit TrackedVector (size_type a_size)
-            : m_host(std::make_shared<std::vector<T>>(a_size))
         {
+            m_data->host.resize(a_size);
 #ifdef AMREX_USE_GPU
-            *m_status = Status::host_dirty;
+            m_data->status = Status::host_dirty;
 #endif
         }
 
         TrackedVector (size_type a_size, value_type const & a_value)
-            : m_host(std::make_shared<std::vector<T>>(a_size, a_value))
         {
+            m_data->host.assign(a_size, a_value);
 #ifdef AMREX_USE_GPU
-            *m_status = Status::host_dirty;
+            m_data->status = Status::host_dirty;
 #endif
         }
 
         TrackedVector (std::initializer_list<T> a_initializer_list)
-            : m_host(std::make_shared<std::vector<T>>(a_initializer_list))
         {
+            m_data->host = a_initializer_list;
 #ifdef AMREX_USE_GPU
-            *m_status = Status::host_dirty;
+            m_data->status = Status::host_dirty;
 #endif
         }
 
         TrackedVector (std::vector<T> a_vector)
-            : m_host(std::make_shared<std::vector<T>>(std::move(a_vector)))
         {
+            m_data->host = std::move(a_vector);
 #ifdef AMREX_USE_GPU
-            *m_status = Status::host_dirty;
+            m_data->status = Status::host_dirty;
 #endif
         }
 
         TrackedVector (TrackedVector const & a_vector)
-            : m_host(std::make_shared<std::vector<T>>(*a_vector.m_host))
+            : m_data(std::make_shared<Data>())
         {
-            *m_status = *a_vector.m_status;
+            m_data->status = a_vector.m_data->status;
+            m_data->host = a_vector.m_data->host;
 #ifdef AMREX_USE_GPU
-            *m_device = *a_vector.m_device;
+            m_data->device = a_vector.m_data->device;
+            if (amrex::Initialized()) {
+                register_finalize();
+            }
 #endif
         }
 
         /** Swap data of this and a_vector */
         TrackedVector (TrackedVector && a_vector) noexcept
         {
-            std::swap(m_status, a_vector.m_status);
-            std::swap(m_host, a_vector.m_host);
-#ifdef AMREX_USE_GPU
-            std::swap(m_device, a_vector.m_device);
-            std::swap(m_finalize_registered, a_vector.m_finalize_registered);
-#endif
+            std::swap(m_data, a_vector.m_data);
         }
 
         TrackedVector& operator= (TrackedVector const & a_vector) {
             if (this != &a_vector) {
-                *m_status = *a_vector.m_status;
-                *m_host = *a_vector.m_host;
+                m_data->status = a_vector.m_data->status;
+                m_data->host = a_vector.m_data->host;
 #ifdef AMREX_USE_GPU
-                *m_device = *a_vector.m_device;
+                m_data->device = a_vector.m_data->device;
+                if (amrex::Initialized()) {
+                    register_finalize();
+                }
 #endif
             }
             return *this;
@@ -149,25 +117,14 @@ namespace amrex::Gpu
         /** Swap the data of this and a_vector */
         TrackedVector& operator= (TrackedVector && a_vector) noexcept {
             if (this != &a_vector) {
-                std::swap(m_host, a_vector.m_host);
-                std::swap(m_status, a_vector.m_status);
-#ifdef AMREX_USE_GPU
-                std::swap(m_device, a_vector.m_device);
-                std::swap(m_finalize_registered, a_vector.m_finalize_registered);
-#endif
+                std::swap(m_data, a_vector.m_data);
             }
             return *this;
         }
 
         ~TrackedVector () = default;
 
-        enum class Status {
-            up_to_date,    //!< host and device data are in sync
-            device_dirty,  //!< host data needs an update
-            host_dirty     //!< device data needs an update
-        };
-
-        [[nodiscard]] Status status () const { return *m_status; }
+        [[nodiscard]] Status status () const { return m_data->status; }
 
         /** Return writable host data
          *
@@ -177,12 +134,12 @@ namespace amrex::Gpu
         [[nodiscard]] std::vector<T> &
         host () {
 #ifdef AMREX_USE_GPU
-            if (*m_status == Status::device_dirty) {
+            if (m_data->status == Status::device_dirty) {
                 to_host();
             }
-            *m_status = Status::host_dirty;
+            m_data->status = Status::host_dirty;
 #endif
-            return *m_host;
+            return m_data->host;
         }
 
         /** Return read-only host data
@@ -192,11 +149,11 @@ namespace amrex::Gpu
         [[nodiscard]] std::vector<T> const &
         host_const () const {
 #ifdef AMREX_USE_GPU
-            if (*m_status == Status::device_dirty) {
+            if (m_data->status == Status::device_dirty) {
                 to_host();
             }
 #endif
-            return *m_host;
+            return m_data->host;
         }
 
 #ifdef AMREX_USE_GPU
@@ -211,11 +168,11 @@ namespace amrex::Gpu
                 throw std::runtime_error("TrackedVector::device() called before AMReX initialize/after AMReX finalize");
             }
             register_finalize();
-            if (*m_status == Status::host_dirty) {
+            if (m_data->status == Status::host_dirty) {
                 to_device();
             }
-            *m_status = Status::device_dirty;
-            return *m_device;
+            m_data->status = Status::device_dirty;
+            return m_data->device;
         }
 
         /** Return read-only device data
@@ -227,20 +184,20 @@ namespace amrex::Gpu
             if (!amrex::Initialized()) {
                 throw std::runtime_error("TrackedVector::device_const() called before AMReX initialize/after AMReX finalize");
             }
-            const_cast<TrackedVector*>(this)->register_finalize();
-            if (*m_status == Status::host_dirty) {
+            register_finalize();
+            if (m_data->status == Status::host_dirty) {
                 to_device();
             }
-            return *m_device;
+            return m_data->device;
         }
 #else
         /** Return writable device (==host) data, up to date by definition */
         [[nodiscard]] std::vector<T> &
-        device () { return *m_host; }
+        device () { return m_data->host; }
 
         /** Return read-only device (==host) data */
         [[nodiscard]] std::vector<T> const &
-        device_const () const { return *m_host; }
+        device_const () const { return m_data->host; }
 #endif
 
         /** Release GPU memory
@@ -253,16 +210,25 @@ namespace amrex::Gpu
         void release_gpu ()
         {
 #ifdef AMREX_USE_GPU
-            if (*m_status == Status::device_dirty) {
+            if (m_data->status == Status::device_dirty) {
                 to_host();
             }
-            m_device->clear();
-            m_device->shrink_to_fit();
-            *m_status = Status::host_dirty;
+            m_data->device.clear();
+            m_data->device.shrink_to_fit();
+            m_data->status = Status::host_dirty;
 #endif
         }
 
     private:
+
+        struct Data {
+            Status status = Status::up_to_date;
+            std::vector<T> host;
+#ifdef AMREX_USE_GPU
+            amrex::Gpu::DeviceVector<T> device;
+            bool finalize_registered = false;
+#endif
+        };
 
         /** Synchronize host data to device */
         void to_device () const {
@@ -270,15 +236,15 @@ namespace amrex::Gpu
             if (!amrex::Initialized()) {
                 throw std::runtime_error("TrackedVector::to_device() called outside of AMReX initialize/finalize");
             }
-            auto const size = m_host->size();
+            auto const size = m_data->host.size();
             if (size > 0U) {
-                m_device->resize(size);
+                m_data->device.resize(size);
                 amrex::Gpu::copy(amrex::Gpu::hostToDevice,
-                    m_host->begin(), m_host->end(), m_device->begin());
+                    m_data->host.begin(), m_data->host.end(), m_data->device.begin());
             } else {
-                m_device->clear();
+                m_data->device.clear();
             }
-            *m_status = Status::up_to_date;
+            m_data->status = Status::up_to_date;
 #endif
         }
 
@@ -288,19 +254,44 @@ namespace amrex::Gpu
             if (!amrex::Initialized()) {
                 throw std::runtime_error("TrackedVector::to_host() called outside of AMReX initialize/finalize");
             }
-            m_host->resize(m_device->size());
+            m_data->host.resize(m_data->device.size());
             amrex::Gpu::copy(amrex::Gpu::deviceToHost,
-                m_device->begin(), m_device->end(), m_host->begin());
-            *m_status = Status::up_to_date;
+                m_data->device.begin(), m_data->device.end(), m_data->host.begin());
+            m_data->status = Status::up_to_date;
 #endif
         }
 
-        mutable std::shared_ptr<Status> m_status = std::make_shared<Status>();
-        mutable std::shared_ptr<std::vector<T>> m_host = std::make_shared<std::vector<T>>();
+        void register_finalize () const {
 #ifdef AMREX_USE_GPU
-        mutable std::shared_ptr<amrex::Gpu::DeviceVector<T>> m_device = std::make_shared<amrex::Gpu::DeviceVector<T>>();
-        mutable std::shared_ptr<bool> m_finalize_registered = std::make_shared<bool>(false);
+            if (!amrex::Initialized()) {
+                throw std::runtime_error("TrackedVector::register_finalize() called outside of AMReX initialize/finalize");
+            }
+
+            if (m_data->finalize_registered) { return; }
+            m_data->finalize_registered = true;
+
+            std::weak_ptr<Data> weak_data = m_data;
+
+            amrex::ExecOnFinalize([weak_data]() {
+                auto data = weak_data.lock();
+                if (!data) { return; }
+
+                if (data->status == Status::device_dirty
+                    && !data->device.empty())
+                {
+                    data->host.resize(data->device.size());
+                    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                        data->device.begin(), data->device.end(), data->host.begin());
+                }
+                data->device.clear();
+                data->device.shrink_to_fit();
+                data->status = Status::host_dirty;
+                data->finalize_registered = false;
+            });
 #endif
+        }
+
+        mutable std::shared_ptr<Data> m_data = std::make_shared<Data>();
     };
 
 }

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -208,11 +208,15 @@ namespace amrex::Gpu
              *
              * Leaves with the host side marked dirty, so a .device/.device_const
              * call in a future AMReX session resyncs to device.
+             *
+             * Assumes the GPU context is still alive (called from ExecOnFinalize,
+             * which runs before GPU device teardown in amrex::Finalize).
              */
             static void drain_device (Data& d) {
                 if (d.status == Status::device_dirty
                     && !d.device.empty())
                 {
+                    amrex::Gpu::streamSynchronize();
                     d.host.resize(d.device.size());
                     amrex::Gpu::copy(amrex::Gpu::deviceToHost,
                         d.device.begin(), d.device.end(), d.host.begin());
@@ -236,6 +240,17 @@ namespace amrex::Gpu
         /** Helper to copy Data and register conditionally */
         void copy_from (TrackedVector const & a_vector) {
 #ifdef AMREX_USE_GPU
+            // Outside an AMReX session, host data is the only
+            // usable copy.  A device_dirty source has stale host
+            // data and no accessible device, so the copy would
+            // silently lose updates.
+            if (!amrex::Initialized()
+                && a_vector.m_data->status == Status::device_dirty)
+            {
+                throw std::runtime_error(
+                    "TrackedVector::copy_from: source is device_dirty "
+                    "outside an AMReX session (host data is stale)");
+            }
             bool const was_finalize_registered = m_data->finalize_registered;
 #endif
             *m_data = *a_vector.m_data;
@@ -275,6 +290,7 @@ namespace amrex::Gpu
         void to_host () const {
 #ifdef AMREX_USE_GPU
             require_amrex("to_host");
+            amrex::Gpu::streamSynchronize();
             m_data->host.resize(m_data->device.size());
             amrex::Gpu::copy(amrex::Gpu::deviceToHost,
                 m_data->device.begin(), m_data->device.end(), m_data->host.begin());

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -245,35 +245,79 @@ namespace amrex::Gpu
             }
         }
 
-        /** Helper to copy Data and register conditionally */
-        void copy_from (TrackedVector const & a_vector) {
 #ifdef AMREX_USE_GPU
-            // Outside an AMReX session, host data is the only
-            // usable copy.  A device_dirty source has stale host
-            // data and no accessible device, so the copy would
-            // silently lose updates.
-            if (!amrex::Initialized()
-                && a_vector.m_data->status == Status::device_dirty)
-            {
+        /** Validate that a copy is safe without a live AMReX session.
+         *
+         * Outside Initialize/Finalize, only host-authoritative states are copyable.
+         */
+        static void require_copyable_without_amrex (Data const& src, Data const& dst)
+        {
+            if (amrex::Initialized()) {
+                return;
+            }
+            if (src.status == Status::device_dirty) {
                 throw std::runtime_error(
                     "TrackedVector::copy_from: source is device_dirty "
                     "outside an AMReX session (host data is stale)");
             }
-            bool const was_finalize_registered = m_data->finalize_registered;
+            if (!src.device.empty()) {
+                throw std::runtime_error(
+                    "TrackedVector::copy_from: source retains device storage "
+                    "outside an AMReX session");
+            }
+            if (!dst.device.empty()) {
+                throw std::runtime_error(
+                    "TrackedVector::copy_from: destination retains device storage "
+                    "outside an AMReX session");
+            }
+            if (src.finalize_registered) {
+                throw std::runtime_error(
+                    "TrackedVector::copy_from: source finalize callback still registered "
+                    "outside an AMReX session");
+            }
+            if (dst.finalize_registered) {
+                throw std::runtime_error(
+                    "TrackedVector::copy_from: destination finalize callback still registered "
+                    "outside an AMReX session");
+            }
+        }
 #endif
-            *m_data = *a_vector.m_data;
+
+        /** Helper to copy Data and register conditionally */
+        void copy_from (TrackedVector const & a_vector) {
 #ifdef AMREX_USE_GPU
-            m_data->finalize_registered = was_finalize_registered;
+            Data const& src = *a_vector.m_data;
+            require_copyable_without_amrex(src, *m_data);
+
+            // Copy status & host data
+            m_data->status = src.status;
+            m_data->host = src.host;
+
+            // Device data & finalize registration:
+            // Device copy only makes sense inside a live AMReX session where
+            // the device arena is available.  Outside a session both sides
+            // must already be empty (drained by Finalize / never allocated).
             if (amrex::Initialized()) {
-                // Don't copy stale device data — it will be resynced on next access.
-                if (m_data->status == Status::host_dirty) {
+                if (src.status == Status::host_dirty) {
+                    // host_dirty means the device mirror is stale —
+                    // avoid a wasteful D->D copy; it will resync on demand.
                     m_data->device.clear();
                     m_data->device.shrink_to_fit();
+                } else {
+                    // Ensure pending kernels that dirtied src.device
+                    // have completed before the D->D copy reads it.
+                    if (src.status == Status::device_dirty) {
+                        amrex::Gpu::streamSynchronize();
+                    }
+                    m_data->device = src.device;
                 }
-                if (!was_finalize_registered) {
+
+                if (!m_data->finalize_registered) {
                     register_finalize();
                 }
             }
+#else
+            *m_data = *a_vector.m_data;
 #endif
         }
 

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -48,6 +48,12 @@ namespace amrex::Gpu
         using value_type      = T;
         using size_type       = std::size_t;
 
+#ifdef AMREX_USE_GPU
+        using device_vector_type = amrex::Gpu::NonManagedDeviceVector<T>;
+#else
+        using device_vector_type = std::vector<T>;
+#endif
+
         enum class Status {
             up_to_date,    //!< host and device data are in sync
             device_dirty,  //!< host data needs an update
@@ -135,7 +141,7 @@ namespace amrex::Gpu
          * If host data is newer, syncs host-to-device first.
          * Marks device as dirty so the next host access will sync back.
          */
-        [[nodiscard]] amrex::Gpu::NonManagedDeviceVector<T> &
+        [[nodiscard]] device_vector_type &
         device () {
             require_amrex("device");
             register_finalize();
@@ -150,7 +156,7 @@ namespace amrex::Gpu
          *
          * If host data is newer, syncs host-to-device first.
          */
-        [[nodiscard]] amrex::Gpu::NonManagedDeviceVector<T> const &
+        [[nodiscard]] device_vector_type const &
         device_const () const {
             require_amrex("device_const");
             register_finalize();
@@ -161,11 +167,11 @@ namespace amrex::Gpu
         }
 #else
         /** Return writable device (==host) data, up to date by definition */
-        [[nodiscard]] std::vector<T> &
+        [[nodiscard]] device_vector_type &
         device () { return m_data->host; }
 
         /** Return read-only device (==host) data */
-        [[nodiscard]] std::vector<T> const &
+        [[nodiscard]] device_vector_type const &
         device_const () const { return m_data->host; }
 #endif
 
@@ -189,7 +195,7 @@ namespace amrex::Gpu
             Status status = Status::up_to_date;
             std::vector<T> host;
 #ifdef AMREX_USE_GPU
-            amrex::Gpu::NonManagedDeviceVector<T> device;
+            device_vector_type device;
             bool finalize_registered = false;
 #endif
             Data () = default;

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -60,7 +60,7 @@ namespace amrex::Gpu
         }
     public:
 
-        constexpr TrackedVector () {
+        TrackedVector () {
             register_finalize();
         }
 
@@ -154,7 +154,7 @@ namespace amrex::Gpu
         ~TrackedVector () = default;
 
         enum class Status {
-            up_to_date,    //<! host and device data are in sync
+            up_to_date,    //!< host and device data are in sync
             device_dirty,  //!< host data needs an update
             host_dirty     //!< device data needs an update
         };

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -208,18 +208,20 @@ namespace amrex::Gpu
              *
              * Leaves with the host side marked dirty, so a .device/.device_const
              * call in a future AMReX session resyncs to device.
+             * A dirty marked device side remains authoritative even when it was
+             * shrunk to size zero through the mutable device vector returned by device().
              *
              * Assumes the GPU context is still alive (called from ExecOnFinalize,
              * which runs before GPU device teardown in amrex::Finalize).
              */
             static void drain_device (Data& d) {
-                if (d.status == Status::device_dirty
-                    && !d.device.empty())
-                {
+                if (d.status == Status::device_dirty) {
                     amrex::Gpu::streamSynchronize();
                     d.host.resize(d.device.size());
-                    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
-                        d.device.begin(), d.device.end(), d.host.begin());
+                    if (!d.device.empty()) {
+                        amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                            d.device.begin(), d.device.end(), d.host.begin());
+                    }
                 }
                 d.device.clear();
                 d.device.shrink_to_fit();
@@ -292,8 +294,10 @@ namespace amrex::Gpu
             require_amrex("to_host");
             amrex::Gpu::streamSynchronize();
             m_data->host.resize(m_data->device.size());
-            amrex::Gpu::copy(amrex::Gpu::deviceToHost,
-                m_data->device.begin(), m_data->device.end(), m_data->host.begin());
+            if (!m_data->device.empty()) {
+                amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                    m_data->device.begin(), m_data->device.end(), m_data->host.begin());
+            }
             m_data->status = Status::up_to_date;
 #endif
         }

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -135,7 +135,7 @@ namespace amrex::Gpu
          * If host data is newer, syncs host-to-device first.
          * Marks device as dirty so the next host access will sync back.
          */
-        [[nodiscard]] amrex::Gpu::DeviceVector<T> &
+        [[nodiscard]] amrex::Gpu::NonManagedDeviceVector<T> &
         device () {
             require_amrex("device");
             register_finalize();
@@ -150,7 +150,7 @@ namespace amrex::Gpu
          *
          * If host data is newer, syncs host-to-device first.
          */
-        [[nodiscard]] amrex::Gpu::DeviceVector<T> const &
+        [[nodiscard]] amrex::Gpu::NonManagedDeviceVector<T> const &
         device_const () const {
             require_amrex("device_const");
             register_finalize();
@@ -189,7 +189,7 @@ namespace amrex::Gpu
             Status status = Status::up_to_date;
             std::vector<T> host;
 #ifdef AMREX_USE_GPU
-            amrex::Gpu::DeviceVector<T> device;
+            amrex::Gpu::NonManagedDeviceVector<T> device;
             bool finalize_registered = false;
 #endif
             Data () = default;

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -85,6 +85,13 @@ namespace amrex::Gpu
             host_dirty();
         }
 
+        TrackedVector (std::vector<T> a_vector)
+            : m_host(std::move(a_vector))
+        {
+            register_finalize();
+            host_dirty();
+        }
+
         TrackedVector (TrackedVector const & a_vector)
             : m_host(a_vector.m_host)
         {

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -44,16 +44,29 @@ namespace amrex::Gpu
     private:
         void register_finalize () {
 #ifdef AMREX_USE_GPU
+            std::weak_ptr<std::vector<T>> weak_host = m_host;
             std::weak_ptr<amrex::Gpu::DeviceVector<T>> weak_device = m_device;
             std::weak_ptr<Status> weak_status = m_status;
-            amrex::ExecOnFinalize([weak_device, weak_status]() {
+            amrex::ExecOnFinalize([weak_host, weak_device, weak_status]() {
                 // see: release_gpu()
-                if (auto self = weak_device.lock()) {
-                    self->clear();
-                    self->shrink_to_fit();
+                auto host   = weak_host.lock();
+                auto device = weak_device.lock();
+                auto status = weak_status.lock();
+                if (host && device && status
+                    && *status == Status::device_dirty
+                    && !device->empty())
+                {
+                    // see: to_host()
+                    host->resize(device->size());
+                    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                        device->begin(), device->end(), host->begin());
                 }
-                if (auto self = weak_status.lock()) {
-                    *self = Status::host_dirty;
+                if (device) {
+                    device->clear();
+                    device->shrink_to_fit();
+                }
+                if (status) {
+                    *status = Status::host_dirty;
                 }
             });
 #endif
@@ -65,7 +78,7 @@ namespace amrex::Gpu
         }
 
         explicit TrackedVector (size_type a_size)
-            : m_host(a_size)
+            : m_host(std::make_shared<std::vector<T>>(a_size))
         {
             register_finalize();
 #ifdef AMREX_USE_GPU
@@ -74,7 +87,7 @@ namespace amrex::Gpu
         }
 
         TrackedVector (size_type a_size, value_type const & a_value)
-            : m_host(a_size, a_value)
+            : m_host(std::make_shared<std::vector<T>>(a_size, a_value))
         {
             register_finalize();
 #ifdef AMREX_USE_GPU
@@ -83,7 +96,7 @@ namespace amrex::Gpu
         }
 
         TrackedVector (std::initializer_list<T> a_initializer_list)
-            : m_host(a_initializer_list)
+            : m_host(std::make_shared<std::vector<T>>(a_initializer_list))
         {
             register_finalize();
 #ifdef AMREX_USE_GPU
@@ -92,7 +105,7 @@ namespace amrex::Gpu
         }
 
         TrackedVector (std::vector<T> a_vector)
-            : m_host(std::move(a_vector))
+            : m_host(std::make_shared<std::vector<T>>(std::move(a_vector)))
         {
             register_finalize();
 #ifdef AMREX_USE_GPU
@@ -101,7 +114,7 @@ namespace amrex::Gpu
         }
 
         TrackedVector (TrackedVector const & a_vector)
-            : m_host(a_vector.m_host)
+            : m_host(std::make_shared<std::vector<T>>(*a_vector.m_host))
         {
             *m_status = *a_vector.m_status;
 #ifdef AMREX_USE_GPU
@@ -131,7 +144,7 @@ namespace amrex::Gpu
         TrackedVector& operator= (TrackedVector const & a_vector) {
             if (this != &a_vector) {
                 *m_status = *a_vector.m_status;
-                m_host = a_vector.m_host;
+                *m_host = *a_vector.m_host;
 #ifdef AMREX_USE_GPU
                 *m_device = *a_vector.m_device;
 #endif
@@ -174,7 +187,7 @@ namespace amrex::Gpu
             }
             *m_status = Status::host_dirty;
 #endif
-            return m_host;
+            return *m_host;
         }
 
         /** Return read-only host data
@@ -188,7 +201,7 @@ namespace amrex::Gpu
                 to_host();
             }
 #endif
-            return m_host;
+            return *m_host;
         }
 
 #ifdef AMREX_USE_GPU
@@ -226,21 +239,26 @@ namespace amrex::Gpu
 #else
         /** Return writable device (==host) data, up to date by definition */
         [[nodiscard]] std::vector<T> &
-        device () { return m_host; }
+        device () { return *m_host; }
 
         /** Return read-only device (==host) data */
         [[nodiscard]] std::vector<T> const &
-        device_const () const { return m_host; }
+        device_const () const { return *m_host; }
 #endif
 
         /** Release GPU memory
          *
+         * If the device side was modified (device_dirty), syncs device data
+         * back to the host first so no updates are lost.
          * Host data preserved for reuse until destructor.
          * This enables use outside of and across AMReX init/finalize cycles.
          */
         void release_gpu ()
         {
 #ifdef AMREX_USE_GPU
+            if (*m_status == Status::device_dirty) {
+                to_host();
+            }
             m_device->clear();
             m_device->shrink_to_fit();
             *m_status = Status::host_dirty;
@@ -255,11 +273,11 @@ namespace amrex::Gpu
             if (!amrex::Initialized()) {
                 throw std::runtime_error("TrackedVector::to_device() called outside of AMReX initialize/finalize");
             }
-            auto const size = m_host.size();
+            auto const size = m_host->size();
             if (size > 0U) {
                 m_device->resize(size);
                 amrex::Gpu::copy(amrex::Gpu::hostToDevice,
-                    m_host.begin(), m_host.end(), m_device->begin());
+                    m_host->begin(), m_host->end(), m_device->begin());
             } else {
                 m_device->clear();
             }
@@ -273,15 +291,15 @@ namespace amrex::Gpu
             if (!amrex::Initialized()) {
                 throw std::runtime_error("TrackedVector::to_host() called outside of AMReX initialize/finalize");
             }
-            m_host.resize(m_device->size());
+            m_host->resize(m_device->size());
             amrex::Gpu::copy(amrex::Gpu::deviceToHost,
-                m_device->begin(), m_device->end(), m_host.begin());
+                m_device->begin(), m_device->end(), m_host->begin());
             *m_status = Status::up_to_date;
 #endif
         }
 
         mutable std::shared_ptr<Status> m_status = std::make_shared<Status>();
-        mutable std::vector<T> m_host;
+        mutable std::shared_ptr<std::vector<T>> m_host = std::make_shared<std::vector<T>>();
 #ifdef AMREX_USE_GPU
         mutable std::shared_ptr<amrex::Gpu::DeviceVector<T>> m_device = std::make_shared<amrex::Gpu::DeviceVector<T>>();
 #endif

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -68,28 +68,36 @@ namespace amrex::Gpu
             : m_host(a_size)
         {
             register_finalize();
-            host_dirty();
+#ifdef AMREX_USE_GPU
+            *m_status = Status::host_dirty;
+#endif
         }
 
         TrackedVector (size_type a_size, value_type const & a_value)
             : m_host(a_size, a_value)
         {
             register_finalize();
-            host_dirty();
+#ifdef AMREX_USE_GPU
+            *m_status = Status::host_dirty;
+#endif
         }
 
         TrackedVector (std::initializer_list<T> a_initializer_list)
             : m_host(a_initializer_list)
         {
             register_finalize();
-            host_dirty();
+#ifdef AMREX_USE_GPU
+            *m_status = Status::host_dirty;
+#endif
         }
 
         TrackedVector (std::vector<T> a_vector)
             : m_host(std::move(a_vector))
         {
             register_finalize();
-            host_dirty();
+#ifdef AMREX_USE_GPU
+            *m_status = Status::host_dirty;
+#endif
         }
 
         TrackedVector (TrackedVector const & a_vector)
@@ -153,33 +161,65 @@ namespace amrex::Gpu
 
         [[nodiscard]] Status status () const { return *m_status; }
 
-        /** Return writable host data, mark host as dirty */
+        /** Return writable host data
+         *
+         * If device data is newer, syncs device-to-host first (GPU builds).
+         * Marks host as dirty so the next device access will sync back.
+         */
         [[nodiscard]] std::vector<T> &
         host () {
-            host_dirty();
+#ifdef AMREX_USE_GPU
+            if (*m_status == Status::device_dirty) {
+                to_host();
+            }
+            *m_status = Status::host_dirty;
+#endif
             return m_host;
         }
 
-        /** Return read-only host data */
+        /** Return read-only host data
+         *
+         * If device data is newer, syncs device-to-host first (GPU builds).
+         */
         [[nodiscard]] std::vector<T> const &
-        host_const () const { return m_host; }
+        host_const () const {
+#ifdef AMREX_USE_GPU
+            if (*m_status == Status::device_dirty) {
+                to_host();
+            }
+#endif
+            return m_host;
+        }
 
 #ifdef AMREX_USE_GPU
-        /** Return writable device data, mark device as dirty */
+        /** Return writable device data
+         *
+         * If host data is newer, syncs host-to-device first.
+         * Marks device as dirty so the next host access will sync back.
+         */
         [[nodiscard]] amrex::Gpu::DeviceVector<T> &
         device () {
             if (!amrex::Initialized()) {
                 throw std::runtime_error("TrackedVector::device() called before AMReX initialize/after AMReX finalize");
             }
-            device_dirty();
+            if (*m_status == Status::host_dirty) {
+                to_device();
+            }
+            *m_status = Status::device_dirty;
             return *m_device;
         }
 
-        /** Return read-only device data */
+        /** Return read-only device data
+         *
+         * If host data is newer, syncs host-to-device first.
+         */
         [[nodiscard]] amrex::Gpu::DeviceVector<T> const &
         device_const () const {
             if (!amrex::Initialized()) {
-                throw std::runtime_error("TrackedVector::device() called before AMReX initialize/after AMReX finalize");
+                throw std::runtime_error("TrackedVector::device_const() called before AMReX initialize/after AMReX finalize");
+            }
+            if (*m_status == Status::host_dirty) {
+                to_device();
             }
             return *m_device;
         }
@@ -201,98 +241,49 @@ namespace amrex::Gpu
         void release_gpu ()
         {
 #ifdef AMREX_USE_GPU
-            device().clear();
-            device().shrink_to_fit();
+            m_device->clear();
+            m_device->shrink_to_fit();
             *m_status = Status::host_dirty;
-#endif
-        }
-
-        /** Mark host data as modified; next sync will copy to GPU. */
-        void host_dirty () {
-#ifdef AMREX_USE_GPU
-            *m_status = Status::host_dirty;
-#endif
-        }
-
-        /** Mark device data as modified; next sync will copy to CPU. */
-        void device_dirty () {
-#ifdef AMREX_USE_GPU
-            *m_status = Status::device_dirty;
-#endif
-        }
-
-        /** Conditionally synchronize host data to device
-         *
-         * If either the host or device side are dirty, this will
-         * copy the host data over the device data.
-         *
-         * @param[in] force  If true, force a copy even if the status is up to date.
-         */
-        void to_device (bool force=false) {
-#ifdef AMREX_USE_GPU
-            if (status() != Status::up_to_date || force) {
-                if (!amrex::Initialized()) {
-                    throw std::runtime_error("TrackedVector::to_device() called outside of AMReX initialize/finalize");
-                }
-                auto const size = m_host.size();
-                if (size > 0U) {
-                    m_device->resize(size);
-                    amrex::Gpu::copy(amrex::Gpu::hostToDevice,
-                        m_host.begin(), m_host.end(), m_device->begin());
-                } else {
-                    m_device->clear();
-                }
-            }
-            *m_status = Status::up_to_date;
-#else
-            amrex::ignore_unused(force);
-#endif
-        }
-
-        /** Conditionally synchronize device data to host
-         *
-         * If either the host or device side are dirty, this will
-         * copy the device data over the host data.
-         *
-         * @param[in] force  If true, force a copy even if the status is up to date.
-         */
-        void to_host (bool force=false) {
-#ifdef AMREX_USE_GPU
-            if (status() != Status::up_to_date || force) {
-                if (!amrex::Initialized()) {
-                    throw std::runtime_error("TrackedVector::to_host() called outside of AMReX initialize/finalize");
-                }
-                m_host.resize(m_device->size());
-                amrex::Gpu::copy(amrex::Gpu::deviceToHost,
-                    m_device->begin(), m_device->end(), m_host.begin());
-            }
-            *m_status = Status::up_to_date;
-#else
-            amrex::ignore_unused(force);
-#endif
-        }
-
-        /** Ensure equivalent host-device data (sync copy)
-         *
-         * This performs a conditional synchronous copy from whatever
-         * host()/device() side was accessed last.
-         */
-        void ensure_same ()
-        {
-#ifdef AMREX_USE_GPU
-            if (status() == Status::host_dirty) {
-                to_device(false);
-            } else if (status() == Status::device_dirty) {
-                to_host(false);
-            }
 #endif
         }
 
     private:
-        std::shared_ptr<Status> m_status = std::make_shared<Status>();
-        std::vector<T> m_host;
+
+        /** Synchronize host data to device */
+        void to_device () const {
 #ifdef AMREX_USE_GPU
-        std::shared_ptr<amrex::Gpu::DeviceVector<T>> m_device = std::make_shared<amrex::Gpu::DeviceVector<T>>();
+            if (!amrex::Initialized()) {
+                throw std::runtime_error("TrackedVector::to_device() called outside of AMReX initialize/finalize");
+            }
+            auto const size = m_host.size();
+            if (size > 0U) {
+                m_device->resize(size);
+                amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                    m_host.begin(), m_host.end(), m_device->begin());
+            } else {
+                m_device->clear();
+            }
+            *m_status = Status::up_to_date;
+#endif
+        }
+
+        /** Synchronize device data to host */
+        void to_host () const {
+#ifdef AMREX_USE_GPU
+            if (!amrex::Initialized()) {
+                throw std::runtime_error("TrackedVector::to_host() called outside of AMReX initialize/finalize");
+            }
+            m_host.resize(m_device->size());
+            amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                m_device->begin(), m_device->end(), m_host.begin());
+            *m_status = Status::up_to_date;
+#endif
+        }
+
+        mutable std::shared_ptr<Status> m_status = std::make_shared<Status>();
+        mutable std::vector<T> m_host;
+#ifdef AMREX_USE_GPU
+        mutable std::shared_ptr<amrex::Gpu::DeviceVector<T>> m_device = std::make_shared<amrex::Gpu::DeviceVector<T>>();
 #endif
     };
 

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -1,0 +1,294 @@
+#ifndef AMREX_TRACKED_VECTOR_H
+#define AMREX_TRACKED_VECTOR_H
+
+#include <AMReX_Config.H>
+
+#include <AMReX.H>
+#include <AMReX_GpuContainers.H>
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+
+namespace amrex::Gpu
+{
+    /** Base for element data with dynamic host vectors mirrored lazily to GPU.
+     *
+     * Provides lifetimes independent of AMReX initialize/finalize cycles,
+     * synchronization tracking, and data release APIs.
+     *
+     * This object is primarily for input handling, allowing to initialize
+     * data even before AMReX was initialized and enabling workflows crossing
+     * AMReX init/finalize cycles. GPU memory will always be bound to an
+     * AMReX session, but CPU memory can be allocated and live arbitrarily long.
+     *
+     * For AMReX CPU builds, the host and device members point to the *same* memory
+     * and the status will always be up to date.
+     *
+     * Usage contract:
+     *   - Device data can only be allocated after AMReX initialize and before finalize.
+     *   - You can call `release_gpu()` anytime, but we will call it during AMReX finalize
+     *     to invalidate device().
+     *   - Always access data via host/device[_const](). Do not cache references/pointers to
+     *     host/device memory managed by this object, or you run the risk of stale memory access.
+     */
+    template <class T>
+    struct TrackedVector
+    {
+        static_assert(std::is_trivially_copyable<T>(), "TrackedVector can only hold trivially copyable types");
+        using value_type      = T;
+        using size_type       = std::size_t;
+
+    private:
+        void register_finalize () {
+#ifdef AMREX_USE_GPU
+            std::weak_ptr<amrex::Gpu::DeviceVector<T>> weak_device = m_device;
+            std::weak_ptr<Status> weak_status = m_status;
+            amrex::ExecOnFinalize([weak_device, weak_status]() {
+                // see: release_gpu()
+                if (auto self = weak_device.lock()) {
+                    self->clear();
+                    self->shrink_to_fit();
+                }
+                if (auto self = weak_status.lock()) {
+                    *self = Status::host_dirty;
+                }
+            });
+#endif
+        }
+    public:
+
+        constexpr TrackedVector () {
+            register_finalize();
+        }
+
+        explicit TrackedVector (size_type a_size)
+            : m_host(a_size)
+        {
+            register_finalize();
+            host_dirty();
+        }
+
+        TrackedVector (size_type a_size, value_type const & a_value)
+            : m_host(a_size, a_value)
+        {
+            register_finalize();
+            host_dirty();
+        }
+
+        TrackedVector (std::initializer_list<T> a_initializer_list)
+            : m_host(a_initializer_list)
+        {
+            register_finalize();
+            host_dirty();
+        }
+
+        TrackedVector (TrackedVector const & a_vector)
+            : m_host(a_vector.m_host)
+        {
+            *m_status = *a_vector.m_status;
+#ifdef AMREX_USE_GPU
+            *m_device = *a_vector.m_device;
+#endif
+
+            register_finalize();
+        }
+
+        /** Swap the empty data of this and a_vector */
+        TrackedVector (TrackedVector && a_vector) noexcept
+        {
+            std::swap(m_status, a_vector.m_status);
+            std::swap(m_host, a_vector.m_host);
+#ifdef AMREX_USE_GPU
+            std::swap(m_device, a_vector.m_device);
+#endif
+
+            // We inherit a_vector's original registration.
+            // But we need to register a_vector's new data now:
+            //   the shared ptrs that we owned briefly up to here.
+            // That way, a_vector can be either reused/assigned values
+            // or safely destructed.
+            a_vector.register_finalize();
+        }
+
+        TrackedVector& operator= (TrackedVector const & a_vector) {
+            if (this != &a_vector) {
+                *m_status = *a_vector.m_status;
+                m_host = a_vector.m_host;
+#ifdef AMREX_USE_GPU
+                *m_device = *a_vector.m_device;
+#endif
+            }
+            return *this;
+        }
+
+        /** Swap the data of this and a_vector */
+        TrackedVector& operator= (TrackedVector && a_vector) noexcept {
+            if (this != &a_vector) {
+                std::swap(m_host, a_vector.m_host);
+                std::swap(m_status, a_vector.m_status);
+#ifdef AMREX_USE_GPU
+                std::swap(m_device, a_vector.m_device);
+#endif
+            }
+            return *this;
+        }
+
+        ~TrackedVector () = default;
+
+        enum class Status {
+            up_to_date,    //<! host and device data are in sync
+            device_dirty,  //!< host data needs an update
+            host_dirty     //!< device data needs an update
+        };
+
+        [[nodiscard]] Status status () const { return *m_status; }
+
+        /** Return writable host data, mark host as dirty */
+        [[nodiscard]] std::vector<T> &
+        host () {
+            host_dirty();
+            return m_host;
+        }
+
+        /** Return read-only host data */
+        [[nodiscard]] std::vector<T> const &
+        host_const () const { return m_host; }
+
+#ifdef AMREX_USE_GPU
+        /** Return writable device data, mark device as dirty */
+        [[nodiscard]] amrex::Gpu::DeviceVector<T> &
+        device () {
+            if (!amrex::Initialized()) {
+                throw std::runtime_error("TrackedVector::device() called before AMReX initialize/after AMReX finalize");
+            }
+            device_dirty();
+            return *m_device;
+        }
+
+        /** Return read-only device data */
+        [[nodiscard]] amrex::Gpu::DeviceVector<T> const &
+        device_const () const {
+            if (!amrex::Initialized()) {
+                throw std::runtime_error("TrackedVector::device() called before AMReX initialize/after AMReX finalize");
+            }
+            return *m_device;
+        }
+#else
+        /** Return writable device (==host) data, up to date by definition */
+        [[nodiscard]] std::vector<T> &
+        device () { return m_host; }
+
+        /** Return read-only device (==host) data */
+        [[nodiscard]] std::vector<T> const &
+        device_const () const { return m_host; }
+#endif
+
+        /** Release GPU memory
+         *
+         * Host data preserved for reuse until destructor.
+         * This enables use outside of and across AMReX init/finalize cycles.
+         */
+        void release_gpu ()
+        {
+#ifdef AMREX_USE_GPU
+            device().clear();
+            device().shrink_to_fit();
+            *m_status = Status::host_dirty;
+#endif
+        }
+
+        /** Mark host data as modified; next sync will copy to GPU. */
+        void host_dirty () {
+#ifdef AMREX_USE_GPU
+            *m_status = Status::host_dirty;
+#endif
+        }
+
+        /** Mark device data as modified; next sync will copy to CPU. */
+        void device_dirty () {
+#ifdef AMREX_USE_GPU
+            *m_status = Status::device_dirty;
+#endif
+        }
+
+        /** Conditionally synchronize host data to device
+         *
+         * If either the host or device side are dirty, this will
+         * copy the host data over the device data.
+         *
+         * @param[in] force  If true, force a copy even if the status is up to date.
+         */
+        void to_device (bool force=false) {
+#ifdef AMREX_USE_GPU
+            if (status() != Status::up_to_date || force) {
+                if (!amrex::Initialized()) {
+                    throw std::runtime_error("TrackedVector::to_device() called outside of AMReX initialize/finalize");
+                }
+                auto const size = m_host.size();
+                if (size > 0U) {
+                    m_device->resize(size);
+                    amrex::Gpu::copy(amrex::Gpu::hostToDevice,
+                        m_host.begin(), m_host.end(), m_device->begin());
+                } else {
+                    m_device->clear();
+                }
+            }
+            *m_status = Status::up_to_date;
+#else
+            amrex::ignore_unused(force);
+#endif
+        }
+
+        /** Conditionally synchronize device data to host
+         *
+         * If either the host or device side are dirty, this will
+         * copy the device data over the host data.
+         *
+         * @param[in] force  If true, force a copy even if the status is up to date.
+         */
+        void to_host (bool force=false) {
+#ifdef AMREX_USE_GPU
+            if (status() != Status::up_to_date || force) {
+                if (!amrex::Initialized()) {
+                    throw std::runtime_error("TrackedVector::to_host() called outside of AMReX initialize/finalize");
+                }
+                m_host.resize(m_device->size());
+                amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                    m_device->begin(), m_device->end(), m_host.begin());
+            }
+            *m_status = Status::up_to_date;
+#else
+            amrex::ignore_unused(force);
+#endif
+        }
+
+        /** Ensure equivalent host-device data (sync copy)
+         *
+         * This performs a conditional synchronous copy from whatever
+         * host()/device() side was accessed last.
+         */
+        void ensure_same ()
+        {
+#ifdef AMREX_USE_GPU
+            if (status() == Status::host_dirty) {
+                to_device(false);
+            } else if (status() == Status::device_dirty) {
+                to_host(false);
+            }
+#endif
+        }
+
+    private:
+        std::shared_ptr<Status> m_status = std::make_shared<Status>();
+        std::vector<T> m_host;
+#ifdef AMREX_USE_GPU
+        std::shared_ptr<amrex::Gpu::DeviceVector<T>> m_device = std::make_shared<amrex::Gpu::DeviceVector<T>>();
+#endif
+    };
+
+}
+
+#endif

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -7,6 +7,8 @@
 #include <AMReX_GpuContainers.H>
 
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -33,6 +35,11 @@ namespace amrex::Gpu
      *     to invalidate device().
      *   - Always access data via host/device[_const](). Do not cache references/pointers to
      *     host/device memory managed by this object, or you run the risk of stale memory access.
+     *   - Read-only accessors (`host_const`, `device_const`) may trigger a synchronous
+     *     copy when the opposite side is dirty. They are logically const but not
+     *     side-effect-free.
+     *   - This class is **not** thread-safe. All accesses (including `_const` variants)
+     *     must be externally synchronized if used from multiple threads.
      */
     template <class T>
     struct TrackedVector
@@ -50,48 +57,20 @@ namespace amrex::Gpu
         TrackedVector () = default;
 
         explicit TrackedVector (size_type a_size)
-        {
-            m_data->host.resize(a_size);
-#ifdef AMREX_USE_GPU
-            m_data->status = Status::host_dirty;
-#endif
-        }
+            : m_data(std::make_shared<Data>(std::vector<T>(a_size))) {}
 
         TrackedVector (size_type a_size, value_type const & a_value)
-        {
-            m_data->host.assign(a_size, a_value);
-#ifdef AMREX_USE_GPU
-            m_data->status = Status::host_dirty;
-#endif
-        }
+            : m_data(std::make_shared<Data>(std::vector<T>(a_size, a_value))) {}
 
         TrackedVector (std::initializer_list<T> a_initializer_list)
-        {
-            m_data->host = a_initializer_list;
-#ifdef AMREX_USE_GPU
-            m_data->status = Status::host_dirty;
-#endif
-        }
+            : m_data(std::make_shared<Data>(std::vector<T>(a_initializer_list))) {}
 
         TrackedVector (std::vector<T> a_vector)
-        {
-            m_data->host = std::move(a_vector);
-#ifdef AMREX_USE_GPU
-            m_data->status = Status::host_dirty;
-#endif
-        }
+            : m_data(std::make_shared<Data>(std::move(a_vector))) {}
 
         TrackedVector (TrackedVector const & a_vector)
-            : m_data(std::make_shared<Data>())
         {
-            m_data->status = a_vector.m_data->status;
-            m_data->host = a_vector.m_data->host;
-#ifdef AMREX_USE_GPU
-            m_data->device = a_vector.m_data->device;
-            if (amrex::Initialized()) {
-                register_finalize();
-            }
-#endif
+            copy_from(a_vector);
         }
 
         /** Swap data of this and a_vector */
@@ -100,16 +79,10 @@ namespace amrex::Gpu
             std::swap(m_data, a_vector.m_data);
         }
 
+        /** Copy data from a_vector */
         TrackedVector& operator= (TrackedVector const & a_vector) {
             if (this != &a_vector) {
-                m_data->status = a_vector.m_data->status;
-                m_data->host = a_vector.m_data->host;
-#ifdef AMREX_USE_GPU
-                m_data->device = a_vector.m_data->device;
-                if (amrex::Initialized()) {
-                    register_finalize();
-                }
-#endif
+                copy_from(a_vector);
             }
             return *this;
         }
@@ -164,9 +137,7 @@ namespace amrex::Gpu
          */
         [[nodiscard]] amrex::Gpu::DeviceVector<T> &
         device () {
-            if (!amrex::Initialized()) {
-                throw std::runtime_error("TrackedVector::device() called before AMReX initialize/after AMReX finalize");
-            }
+            require_amrex("device");
             register_finalize();
             if (m_data->status == Status::host_dirty) {
                 to_device();
@@ -181,9 +152,7 @@ namespace amrex::Gpu
          */
         [[nodiscard]] amrex::Gpu::DeviceVector<T> const &
         device_const () const {
-            if (!amrex::Initialized()) {
-                throw std::runtime_error("TrackedVector::device_const() called before AMReX initialize/after AMReX finalize");
-            }
+            require_amrex("device_const");
             register_finalize();
             if (m_data->status == Status::host_dirty) {
                 to_device();
@@ -210,12 +179,7 @@ namespace amrex::Gpu
         void release_gpu ()
         {
 #ifdef AMREX_USE_GPU
-            if (m_data->status == Status::device_dirty) {
-                to_host();
-            }
-            m_data->device.clear();
-            m_data->device.shrink_to_fit();
-            m_data->status = Status::host_dirty;
+            Data::drain_device(*m_data);
 #endif
         }
 
@@ -228,14 +192,72 @@ namespace amrex::Gpu
             amrex::Gpu::DeviceVector<T> device;
             bool finalize_registered = false;
 #endif
+            Data () = default;
+
+            /** Host owns authoritative data */
+            explicit Data (std::vector<T> h)
+                : host(std::move(h))
+            {
+#ifdef AMREX_USE_GPU
+                status = Status::host_dirty;
+#endif
+            }
+
+#ifdef AMREX_USE_GPU
+            /** Sync device data back to host if dirty, then free device memory
+             *
+             * Leaves with the host side marked dirty, so a .device/.device_const
+             * call in a future AMReX session resyncs to device.
+             */
+            static void drain_device (Data& d) {
+                if (d.status == Status::device_dirty
+                    && !d.device.empty())
+                {
+                    d.host.resize(d.device.size());
+                    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                        d.device.begin(), d.device.end(), d.host.begin());
+                }
+                d.device.clear();
+                d.device.shrink_to_fit();
+                d.status = Status::host_dirty;
+            }
+#endif
         };
+
+        /** Check amrex::Initialized or throw */
+        static void require_amrex (char const * func) {
+            if (!amrex::Initialized()) {
+                throw std::runtime_error(
+                    std::string("TrackedVector::") + func +
+                    " called outside of AMReX initialize/finalize");
+            }
+        }
+
+        /** Helper to copy Data and register conditionally */
+        void copy_from (TrackedVector const & a_vector) {
+#ifdef AMREX_USE_GPU
+            bool const was_finalize_registered = m_data->finalize_registered;
+#endif
+            *m_data = *a_vector.m_data;
+#ifdef AMREX_USE_GPU
+            m_data->finalize_registered = was_finalize_registered;
+            if (amrex::Initialized()) {
+                // Don't copy stale device data — it will be resynced on next access.
+                if (m_data->status == Status::host_dirty) {
+                    m_data->device.clear();
+                    m_data->device.shrink_to_fit();
+                }
+                if (!was_finalize_registered) {
+                    register_finalize();
+                }
+            }
+#endif
+        }
 
         /** Synchronize host data to device */
         void to_device () const {
 #ifdef AMREX_USE_GPU
-            if (!amrex::Initialized()) {
-                throw std::runtime_error("TrackedVector::to_device() called outside of AMReX initialize/finalize");
-            }
+            require_amrex("to_device");
             auto const size = m_data->host.size();
             if (size > 0U) {
                 m_data->device.resize(size);
@@ -243,6 +265,7 @@ namespace amrex::Gpu
                     m_data->host.begin(), m_data->host.end(), m_data->device.begin());
             } else {
                 m_data->device.clear();
+                m_data->device.shrink_to_fit();
             }
             m_data->status = Status::up_to_date;
 #endif
@@ -251,9 +274,7 @@ namespace amrex::Gpu
         /** Synchronize device data to host */
         void to_host () const {
 #ifdef AMREX_USE_GPU
-            if (!amrex::Initialized()) {
-                throw std::runtime_error("TrackedVector::to_host() called outside of AMReX initialize/finalize");
-            }
+            require_amrex("to_host");
             m_data->host.resize(m_data->device.size());
             amrex::Gpu::copy(amrex::Gpu::deviceToHost,
                 m_data->device.begin(), m_data->device.end(), m_data->host.begin());
@@ -261,12 +282,14 @@ namespace amrex::Gpu
 #endif
         }
 
+        /** Register with AMReX to free device memory on Finalize()
+         *
+         * This function is idempotent and drains device memory to
+         * host first if dirty.
+         */
         void register_finalize () const {
 #ifdef AMREX_USE_GPU
-            if (!amrex::Initialized()) {
-                throw std::runtime_error("TrackedVector::register_finalize() called outside of AMReX initialize/finalize");
-            }
-
+            require_amrex("register_finalize");
             if (m_data->finalize_registered) { return; }
             m_data->finalize_registered = true;
 
@@ -275,22 +298,15 @@ namespace amrex::Gpu
             amrex::ExecOnFinalize([weak_data]() {
                 auto data = weak_data.lock();
                 if (!data) { return; }
-
-                if (data->status == Status::device_dirty
-                    && !data->device.empty())
-                {
-                    data->host.resize(data->device.size());
-                    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
-                        data->device.begin(), data->device.end(), data->host.begin());
-                }
-                data->device.clear();
-                data->device.shrink_to_fit();
-                data->status = Status::host_dirty;
+                Data::drain_device(*data);
                 data->finalize_registered = false;
             });
 #endif
         }
 
+        // mutable: lazy-sync accessors (host_const, device_const) need to
+        // update status and trigger copies through the shared_ptr even on
+        // const TrackedVector references.
         mutable std::shared_ptr<Data> m_data = std::make_shared<Data>();
     };
 

--- a/Src/Base/AMReX_TrackedVector.H
+++ b/Src/Base/AMReX_TrackedVector.H
@@ -44,10 +44,15 @@ namespace amrex::Gpu
     private:
         void register_finalize () {
 #ifdef AMREX_USE_GPU
+            if (*m_finalize_registered) { return; }
+            *m_finalize_registered = true;
+
             std::weak_ptr<std::vector<T>> weak_host = m_host;
             std::weak_ptr<amrex::Gpu::DeviceVector<T>> weak_device = m_device;
             std::weak_ptr<Status> weak_status = m_status;
-            amrex::ExecOnFinalize([weak_host, weak_device, weak_status]() {
+            std::weak_ptr<bool> weak_registered = m_finalize_registered;
+
+            amrex::ExecOnFinalize([weak_host, weak_device, weak_status, weak_registered]() {
                 // see: release_gpu()
                 auto host   = weak_host.lock();
                 auto device = weak_device.lock();
@@ -68,19 +73,19 @@ namespace amrex::Gpu
                 if (status) {
                     *status = Status::host_dirty;
                 }
+                if (auto reg = weak_registered.lock()) {
+                    *reg = false;
+                }
             });
 #endif
         }
     public:
 
-        TrackedVector () {
-            register_finalize();
-        }
+        TrackedVector () = default;
 
         explicit TrackedVector (size_type a_size)
             : m_host(std::make_shared<std::vector<T>>(a_size))
         {
-            register_finalize();
 #ifdef AMREX_USE_GPU
             *m_status = Status::host_dirty;
 #endif
@@ -89,7 +94,6 @@ namespace amrex::Gpu
         TrackedVector (size_type a_size, value_type const & a_value)
             : m_host(std::make_shared<std::vector<T>>(a_size, a_value))
         {
-            register_finalize();
 #ifdef AMREX_USE_GPU
             *m_status = Status::host_dirty;
 #endif
@@ -98,7 +102,6 @@ namespace amrex::Gpu
         TrackedVector (std::initializer_list<T> a_initializer_list)
             : m_host(std::make_shared<std::vector<T>>(a_initializer_list))
         {
-            register_finalize();
 #ifdef AMREX_USE_GPU
             *m_status = Status::host_dirty;
 #endif
@@ -107,7 +110,6 @@ namespace amrex::Gpu
         TrackedVector (std::vector<T> a_vector)
             : m_host(std::make_shared<std::vector<T>>(std::move(a_vector)))
         {
-            register_finalize();
 #ifdef AMREX_USE_GPU
             *m_status = Status::host_dirty;
 #endif
@@ -120,25 +122,17 @@ namespace amrex::Gpu
 #ifdef AMREX_USE_GPU
             *m_device = *a_vector.m_device;
 #endif
-
-            register_finalize();
         }
 
-        /** Swap the empty data of this and a_vector */
+        /** Swap data of this and a_vector */
         TrackedVector (TrackedVector && a_vector) noexcept
         {
             std::swap(m_status, a_vector.m_status);
             std::swap(m_host, a_vector.m_host);
 #ifdef AMREX_USE_GPU
             std::swap(m_device, a_vector.m_device);
+            std::swap(m_finalize_registered, a_vector.m_finalize_registered);
 #endif
-
-            // We inherit a_vector's original registration.
-            // But we need to register a_vector's new data now:
-            //   the shared ptrs that we owned briefly up to here.
-            // That way, a_vector can be either reused/assigned values
-            // or safely destructed.
-            a_vector.register_finalize();
         }
 
         TrackedVector& operator= (TrackedVector const & a_vector) {
@@ -159,6 +153,7 @@ namespace amrex::Gpu
                 std::swap(m_status, a_vector.m_status);
 #ifdef AMREX_USE_GPU
                 std::swap(m_device, a_vector.m_device);
+                std::swap(m_finalize_registered, a_vector.m_finalize_registered);
 #endif
             }
             return *this;
@@ -215,6 +210,7 @@ namespace amrex::Gpu
             if (!amrex::Initialized()) {
                 throw std::runtime_error("TrackedVector::device() called before AMReX initialize/after AMReX finalize");
             }
+            register_finalize();
             if (*m_status == Status::host_dirty) {
                 to_device();
             }
@@ -231,6 +227,7 @@ namespace amrex::Gpu
             if (!amrex::Initialized()) {
                 throw std::runtime_error("TrackedVector::device_const() called before AMReX initialize/after AMReX finalize");
             }
+            const_cast<TrackedVector*>(this)->register_finalize();
             if (*m_status == Status::host_dirty) {
                 to_device();
             }
@@ -302,6 +299,7 @@ namespace amrex::Gpu
         mutable std::shared_ptr<std::vector<T>> m_host = std::make_shared<std::vector<T>>();
 #ifdef AMREX_USE_GPU
         mutable std::shared_ptr<amrex::Gpu::DeviceVector<T>> m_device = std::make_shared<amrex::Gpu::DeviceVector<T>>();
+        mutable std::shared_ptr<bool> m_finalize_registered = std::make_shared<bool>(false);
 #endif
     };
 

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -241,6 +241,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_GpuReduce.H
        AMReX_GpuAllocators.H
        AMReX_GpuContainers.H
+       AMReX_TrackedVector.H
        AMReX_MFParallelFor.H
        AMReX_MFParallelForC.H
        AMReX_MFParallelForG.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -107,7 +107,9 @@ C$(AMREX_BASE)_sources += AMReX_GpuElixir.cpp
 
 C$(AMREX_BASE)_headers += AMReX_GpuReduce.H
 
-C$(AMREX_BASE)_headers += AMReX_CudaGraph.H AMReX_GpuContainers.H
+C$(AMREX_BASE)_headers += AMReX_CudaGraph.H
+C$(AMREX_BASE)_headers += AMReX_GpuContainers.H
+C$(AMREX_BASE)_headers += AMReX_TrackedVector.H
 
 C$(AMREX_BASE)_headers += AMReX_GpuAllocators.H
 

--- a/Tests/Base/TrackedVector/CMakeLists.txt
+++ b/Tests/Base/TrackedVector/CMakeLists.txt
@@ -1,0 +1,9 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources     main.cpp)
+    set(_input_files)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Base/TrackedVector/GNUmakefile
+++ b/Tests/Base/TrackedVector/GNUmakefile
@@ -1,0 +1,24 @@
+AMREX_HOME ?= ../../..
+
+DEBUG	= TRUE
+
+DIM	= 3
+
+COMP    = gcc
+
+USE_MPI   = FALSE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+USE_HIP   = FALSE
+USE_SYCL  = FALSE
+
+BL_NO_FORT = TRUE
+
+TINY_PROFILE = FALSE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Base/TrackedVector/Make.package
+++ b/Tests/Base/TrackedVector/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -91,6 +91,34 @@ void test_release_gpu ()
     verify_host_device_match(v);
 }
 
+void test_release_gpu_device_dirty ()
+{
+    // Device is modified, then release_gpu() must sync D->H before freeing.
+    TVec v;
+    v.host().assign({0, 0, 0});
+
+    // Write on device: {100, 101, 102}
+    fill_device_linear(v, 100);
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::device_dirty);
+#endif
+
+    // release_gpu() should sync device->host, then free device memory
+    v.release_gpu();
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::host_dirty);
+#endif
+
+    // Host must have the device-written values
+    AMREX_ALWAYS_ASSERT(v.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(v.host_const()[0] == 100);
+    AMREX_ALWAYS_ASSERT(v.host_const()[1] == 101);
+    AMREX_ALWAYS_ASSERT(v.host_const()[2] == 102);
+
+    // Can round-trip back to device
+    verify_host_device_match(v);
+}
+
 void test_d2h ()
 {
     TVec v;
@@ -258,6 +286,7 @@ void run_tests_before_finalize ()
 {
     test_dirty_semantics();
     test_release_gpu();
+    test_release_gpu_device_dirty();
     test_d2h();
     test_empty();
     test_aggregate();
@@ -274,6 +303,11 @@ int main (int argc, char* argv[])
     TVec cross_session;
     cross_session.host() = {7, 8, 9};
 
+    // This vector will be device-dirty when Finalize runs.
+    // ExecOnFinalize must sync D->H so the data survives.
+    TVec dirty_on_finalize;
+    dirty_on_finalize.host().assign({0, 0, 0});
+
 #ifdef AMREX_USE_MPI
     MPI_Init(&argc, &argv);
 #endif
@@ -285,12 +319,25 @@ int main (int argc, char* argv[])
         // device_const() auto-syncs host->device
         verify_host_device_match(cross_session);
         AMREX_ALWAYS_ASSERT(cross_session.host_const()[0] == 7);
+
+        // Write on device, leave device_dirty for Finalize to handle
+        fill_device_linear(dirty_on_finalize, 200);
+#ifdef AMREX_USE_GPU
+        AMREX_ALWAYS_ASSERT(dirty_on_finalize.status() == Status::device_dirty);
+#endif
     }
-    amrex::Finalize();  // calls implicitly: cross_session.release_gpu();
+    amrex::Finalize();  // calls implicitly: release_gpu() with D->H sync
 
 #ifdef AMREX_USE_GPU
     AMREX_ALWAYS_ASSERT(cross_session.status() == Status::host_dirty);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.status() == Status::host_dirty);
 #endif
+
+    // ExecOnFinalize must have synced device data to host
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[0] == 200);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[1] == 201);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[2] == 202);
 
     amrex::Initialize(argc, argv);
     {
@@ -301,6 +348,10 @@ int main (int argc, char* argv[])
         // Device was released on Finalize, device access will re-sync.
         // auto-syncs host->device in new AMReX session
         verify_host_device_match(cross_session);
+
+        // dirty_on_finalize also round-trips into the new session
+        verify_host_device_match(dirty_on_finalize);
+        AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[0] == 200);
     }
     amrex::Finalize();
 

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -339,6 +339,7 @@ int main (int argc, char* argv[])
     AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[1] == 201);
     AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[2] == 202);
 
+    // --- Session 2 ---
     amrex::Initialize(argc, argv);
     {
         AMREX_ALWAYS_ASSERT(cross_session.host_const().size() == 3U);
@@ -352,6 +353,50 @@ int main (int argc, char* argv[])
         // dirty_on_finalize also round-trips into the new session
         verify_host_device_match(dirty_on_finalize);
         AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[0] == 200);
+
+        // Write new device values for the session-3 finalize test.
+        // This re-arms the finalize hook via to_device().
+        fill_device_linear(dirty_on_finalize, 300);
+#ifdef AMREX_USE_GPU
+        AMREX_ALWAYS_ASSERT(dirty_on_finalize.status() == Status::device_dirty);
+#endif
+    }
+    amrex::Finalize();
+
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.status() == Status::host_dirty);
+#endif
+
+    // Re-armed finalize hook must have synced {300,301,302} back to host
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[0] == 300);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[1] == 301);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[2] == 302);
+
+    // --- Session 3 ---
+    amrex::Initialize(argc, argv);
+    {
+        // Verify data round-trips into a 3rd session
+        verify_host_device_match(cross_session);
+        verify_host_device_match(dirty_on_finalize);
+        AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[0] == 300);
+
+        // Write yet again — exercises re-arming a second time
+        fill_device_linear(dirty_on_finalize, 400);
+    }
+    amrex::Finalize();
+
+    // Finalize hook fired a 3rd time
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[0] == 400);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[1] == 401);
+    AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[2] == 402);
+
+    // --- Session 4: read-only device access after 3 finalizations ---
+    amrex::Initialize(argc, argv);
+    {
+        verify_host_device_match(cross_session);
+        verify_host_device_match(dirty_on_finalize);
     }
     amrex::Finalize();
 

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -25,6 +25,29 @@ void verify_host_device_match (TVec const & v)
     }
 }
 
+void verify_host_values (TVec const & v, std::vector<int> const & expected)
+{
+    auto const & host = v.host_const();
+    AMREX_ALWAYS_ASSERT(host.size() == expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        AMREX_ALWAYS_ASSERT(host[i] == expected[i]);
+    }
+}
+
+void test_copy_without_amrex_session (TVec const & src, std::vector<int> const & expected)
+{
+    TVec copy_ctor(src);
+
+    TVec copy_assign;
+    copy_assign.host().assign({-1});
+    copy_assign = src;
+
+    verify_host_values(copy_ctor, expected);
+    verify_host_values(copy_assign, expected);
+    AMREX_ALWAYS_ASSERT(copy_ctor.status() == src.status());
+    AMREX_ALWAYS_ASSERT(copy_assign.status() == src.status());
+}
+
 void fill_device_linear (TVec& v, int base)
 {
     const int n = static_cast<int>(v.device().size());
@@ -300,6 +323,10 @@ void run_tests_before_finalize ()
 
 int main (int argc, char* argv[])
 {
+    TVec pre_init_copy_source;
+    pre_init_copy_source.host() = {21, 22, 23};
+    test_copy_without_amrex_session(pre_init_copy_source, {21, 22, 23});
+
     TVec cross_session;
     cross_session.host() = {7, 8, 9};
 
@@ -347,6 +374,9 @@ int main (int argc, char* argv[])
     AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[0] == 200);
     AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[1] == 201);
     AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[2] == 202);
+
+    test_copy_without_amrex_session(cross_session, {7, 8, 9});
+    test_copy_without_amrex_session(dirty_on_finalize, {200, 201, 202});
 
     // --- Session 2 ---
     amrex::Initialize(argc, argv);

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -308,6 +308,15 @@ int main (int argc, char* argv[])
     TVec dirty_on_finalize;
     dirty_on_finalize.host().assign({0, 0, 0});
 
+    // Cross-session copy/move tests (review point 2):
+    // Copies must register their own finalize handler so the device mirror
+    // is drained and released even when the copy's device() is never called.
+    TVec copy_assign_cross;
+    TVec move_assign_cross;
+    TVec copy_assign_dirty_cross;
+    std::unique_ptr<TVec> copy_ctor_cross;
+    std::unique_ptr<TVec> move_ctor_cross;
+
 #ifdef AMREX_USE_MPI
     MPI_Init(&argc, &argv);
 #endif
@@ -397,6 +406,102 @@ int main (int argc, char* argv[])
     {
         verify_host_device_match(cross_session);
         verify_host_device_match(dirty_on_finalize);
+    }
+    amrex::Finalize();
+
+    // --- Session 5: cross-session copy and move ---
+    // Exercises all four code paths: copy ctor, copy assignment,
+    // move ctor, move assignment — each must arm finalize so the
+    // device mirror is drained even when device() is never called
+    // on the target before Finalize.
+    amrex::Initialize(argc, argv);
+    {
+        // Source with up_to_date status (both sides synced)
+        TVec src_synced;
+        src_synced.host() = {60, 61, 62};
+        verify_host_device_match(src_synced);
+
+        // Copy assignment
+        copy_assign_cross = src_synced;
+
+        // Copy constructor
+        copy_ctor_cross = std::make_unique<TVec>(src_synced);
+
+        // Move assignment
+        TVec move_assign_src;
+        move_assign_src.host() = {70, 71, 72};
+        verify_host_device_match(move_assign_src);
+        move_assign_cross = std::move(move_assign_src);
+
+        // Move constructor
+        TVec move_ctor_src;
+        move_ctor_src.host() = {80, 81, 82};
+        verify_host_device_match(move_ctor_src);
+        move_ctor_cross = std::make_unique<TVec>(std::move(move_ctor_src));
+
+        // Copy assignment from a device-dirty source
+        TVec src_dirty;
+        src_dirty.host().assign({0, 0, 0});
+        fill_device_linear(src_dirty, 90);
+#ifdef AMREX_USE_GPU
+        AMREX_ALWAYS_ASSERT(src_dirty.status() == Status::device_dirty);
+#endif
+        copy_assign_dirty_cross = src_dirty;
+#ifdef AMREX_USE_GPU
+        AMREX_ALWAYS_ASSERT(copy_assign_dirty_cross.status() == Status::device_dirty);
+#endif
+
+        // Intentionally do NOT call device() on any target before Finalize
+    }
+    amrex::Finalize();
+
+    // All five must have host_dirty status after finalize (GPU builds)
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(copy_assign_cross.status() == Status::host_dirty);
+    AMREX_ALWAYS_ASSERT(copy_ctor_cross->status() == Status::host_dirty);
+    AMREX_ALWAYS_ASSERT(move_assign_cross.status() == Status::host_dirty);
+    AMREX_ALWAYS_ASSERT(move_ctor_cross->status() == Status::host_dirty);
+    AMREX_ALWAYS_ASSERT(copy_assign_dirty_cross.status() == Status::host_dirty);
+#endif
+
+    // Copy assignment: host data intact
+    AMREX_ALWAYS_ASSERT(copy_assign_cross.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(copy_assign_cross.host_const()[0] == 60);
+    AMREX_ALWAYS_ASSERT(copy_assign_cross.host_const()[1] == 61);
+    AMREX_ALWAYS_ASSERT(copy_assign_cross.host_const()[2] == 62);
+
+    // Copy constructor: host data intact
+    AMREX_ALWAYS_ASSERT(copy_ctor_cross->host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(copy_ctor_cross->host_const()[0] == 60);
+    AMREX_ALWAYS_ASSERT(copy_ctor_cross->host_const()[1] == 61);
+    AMREX_ALWAYS_ASSERT(copy_ctor_cross->host_const()[2] == 62);
+
+    // Move assignment: host data intact
+    AMREX_ALWAYS_ASSERT(move_assign_cross.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(move_assign_cross.host_const()[0] == 70);
+    AMREX_ALWAYS_ASSERT(move_assign_cross.host_const()[1] == 71);
+    AMREX_ALWAYS_ASSERT(move_assign_cross.host_const()[2] == 72);
+
+    // Move constructor: host data intact
+    AMREX_ALWAYS_ASSERT(move_ctor_cross->host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(move_ctor_cross->host_const()[0] == 80);
+    AMREX_ALWAYS_ASSERT(move_ctor_cross->host_const()[1] == 81);
+    AMREX_ALWAYS_ASSERT(move_ctor_cross->host_const()[2] == 82);
+
+    // Copy assignment (device-dirty): finalize synced D->H
+    AMREX_ALWAYS_ASSERT(copy_assign_dirty_cross.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(copy_assign_dirty_cross.host_const()[0] == 90);
+    AMREX_ALWAYS_ASSERT(copy_assign_dirty_cross.host_const()[1] == 91);
+    AMREX_ALWAYS_ASSERT(copy_assign_dirty_cross.host_const()[2] == 92);
+
+    // --- Session 6: verify all five round-trip into a new session ---
+    amrex::Initialize(argc, argv);
+    {
+        verify_host_device_match(copy_assign_cross);
+        verify_host_device_match(*copy_ctor_cross);
+        verify_host_device_match(move_assign_cross);
+        verify_host_device_match(*move_ctor_cross);
+        verify_host_device_match(copy_assign_dirty_cross);
     }
     amrex::Finalize();
 

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -13,8 +13,7 @@ namespace {
 
 void verify_host_device_match (TVec const & v)
 {
-    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
-
+    // Calling host_const() and device_const() auto-syncs both sides
     const auto n = v.host_const().size();
     AMREX_ALWAYS_ASSERT(v.device_const().size() == n);
     if (n == 0) { return; }
@@ -41,20 +40,6 @@ void test_dirty_semantics ()
     TVec v;
     AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
 
-    v.host_dirty();
-#ifdef AMREX_USE_GPU
-    AMREX_ALWAYS_ASSERT(v.status() == Status::host_dirty);
-#else
-    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
-#endif
-
-    v.device_dirty();
-#ifdef AMREX_USE_GPU
-    AMREX_ALWAYS_ASSERT(v.status() == Status::device_dirty);
-#else
-    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
-#endif
-
     // potential write (host): must mark dirty
     v.host().resize(3);
     v.host().at(2) = 42;
@@ -65,7 +50,8 @@ void test_dirty_semantics ()
 #endif
     AMREX_ALWAYS_ASSERT(v.host_const().size() == 3);
 
-    v.to_device();
+    // read-only device access syncs host->device, status becomes up_to_date
+    [[maybe_unused]] auto dsize = v.device_const().size();
     AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
 
     // potential write (device): must mark dirty
@@ -76,10 +62,7 @@ void test_dirty_semantics ()
     AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
 #endif
 
-    v.ensure_same();
-    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
-
-    // read-only (host): must not mark dirty
+    // read-only host access syncs device->host, status becomes up_to_date
     auto first = v.host_const().at(2);
     AMREX_ALWAYS_ASSERT(first == 42);
     AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
@@ -93,20 +76,17 @@ void test_release_gpu ()
 {
     TVec v;
     v.host().assign({1, 2, 3});
-    v.ensure_same();
     verify_host_device_match(v);
 
     v.release_gpu();
 #ifdef AMREX_USE_GPU
-    AMREX_ALWAYS_ASSERT(v.device_const().empty());
     AMREX_ALWAYS_ASSERT(v.status() == Status::host_dirty);
 #else
-    AMREX_ALWAYS_ASSERT(v.device_const().size() == 3U);
     AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
 #endif
     AMREX_ALWAYS_ASSERT(v.host_const().size() == 3U);
 
-    v.ensure_same();
+    // device_const() auto-syncs from host
     verify_host_device_match(v);
 }
 
@@ -114,11 +94,11 @@ void test_d2h ()
 {
     TVec v;
     v.host().assign({0, 0, 0});
-    v.ensure_same();
 
+    // device() auto-syncs host->device, then fill_device_linear writes on device
     fill_device_linear(v, 100);
-    v.ensure_same();
 
+    // host_const() auto-syncs device->host
     AMREX_ALWAYS_ASSERT(v.host_const()[0] == 100 && v.host_const()[1] == 101 && v.host_const()[2] == 102);
     verify_host_device_match(v);
 }
@@ -127,14 +107,14 @@ void test_empty ()
 {
     TVec v;
     AMREX_ALWAYS_ASSERT(v.device_const().empty());
-
-    v.ensure_same();
-    AMREX_ALWAYS_ASSERT(v.device_const().empty());
     AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
 
+    // device() on empty gives empty device vec, marks device_dirty
+    // then host_const() syncs back (empty)
     fill_device_linear(v, 100);
-    v.host_dirty();  // ignore that device had newer data
-    v.ensure_same();
+
+    // Overwrite host (discards any device data)
+    v.host().clear();
     AMREX_ALWAYS_ASSERT(v.device_const().empty());
     AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
 }
@@ -156,7 +136,8 @@ void test_copy_constructor ()
 {
     TVec a;
     a.host().assign({1, 2, 3});
-    a.ensure_same();
+    // Sync to device via read-only access
+    verify_host_device_match(a);
 
     TVec b(a);  // copy construct
 
@@ -175,7 +156,8 @@ void test_move_constructor ()
 {
     TVec a;
     a.host().assign({4, 5, 6});
-    a.ensure_same();
+    // Sync to device via read-only access
+    [[maybe_unused]] auto ds = a.device_const().size();
 
     TVec b(std::move(a));  // move construct
 
@@ -195,13 +177,13 @@ void test_move_constructor ()
     auto a_status_before = a.status();
     auto a_device_size_before = a.device_const().size();
     b.host()[0] = 99;
-    b.ensure_same();
+    // device_const() on b auto-syncs
+    [[maybe_unused]] auto bds = b.device_const().size();
     AMREX_ALWAYS_ASSERT(a.status() == a_status_before);
     AMREX_ALWAYS_ASSERT(a.device_const().size() == a_device_size_before);
 
     // a can be reused
     a.host().assign({10, 20});
-    a.ensure_same();
     verify_host_device_match(a);
     AMREX_ALWAYS_ASSERT(a.host_const()[0] == 10);
     // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
@@ -211,11 +193,12 @@ void test_copy_assignment ()
 {
     TVec a;
     a.host().assign({7, 8, 9});
-    a.ensure_same();
+    // Sync via read-only access
+    [[maybe_unused]] auto ds = a.device_const().size();
 
     TVec b;
     b.host().assign({0});
-    b.ensure_same();
+    [[maybe_unused]] auto ds2 = b.device_const().size();
 
     b = a;  // copy assign
 
@@ -233,11 +216,12 @@ void test_move_assignment ()
 {
     TVec a;
     a.host().assign({11, 12, 13});
-    a.ensure_same();
+    // Sync via read-only access
+    [[maybe_unused]] auto ds = a.device_const().size();
 
     TVec b;
     b.host().assign({0});
-    b.ensure_same();
+    [[maybe_unused]] auto ds2 = b.device_const().size();
 
     b = std::move(a);  // move assign
 
@@ -258,14 +242,13 @@ void test_move_assignment ()
     auto a_status_before = a.status();
     auto a_device_size_before = a.device_const().size();
     b.host()[0] = 99;
-    b.ensure_same();
+    [[maybe_unused]] auto bds = b.device_const().size();
     AMREX_ALWAYS_ASSERT(a.status() == a_status_before);
     AMREX_ALWAYS_ASSERT(a.device_const().size() == a_device_size_before);
     AMREX_ALWAYS_ASSERT(a.host_const()[0] == 0);  // a's data unchanged
 
     // a can be reused
     a.host().assign({30, 40});
-    a.ensure_same();
     verify_host_device_match(a);
     // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 }
@@ -298,7 +281,7 @@ int main (int argc, char* argv[])
     {
         run_tests_before_finalize();
 
-        cross_session.to_device();
+        // device_const() auto-syncs host->device
         verify_host_device_match(cross_session);
         AMREX_ALWAYS_ASSERT(cross_session.host_const()[0] == 7);
     }
@@ -313,16 +296,10 @@ int main (int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(cross_session.host_const().size() == 3U);
         AMREX_ALWAYS_ASSERT(cross_session.host_const()[0] == 7 && cross_session.host_const()[1] == 8 &&
                             cross_session.host_const()[2] == 9);
-#ifdef AMREX_USE_GPU
-        AMREX_ALWAYS_ASSERT(cross_session.device_const().empty());
-#else
-        AMREX_ALWAYS_ASSERT(cross_session.device_const().size() == 3U);
-#endif
-
-        cross_session.host()[1] = 99;
-        cross_session.to_device();  // re-init device data in new AMReX session
+        // GPU builds:
+        // Device was released on Finalize, device access will re-sync.
+        // auto-syncs host->device in new AMReX session
         verify_host_device_match(cross_session);
-        AMREX_ALWAYS_ASSERT(cross_session.host_const()[1] == 99);
     }
     amrex::Finalize();
 

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -1,6 +1,7 @@
 #include <AMReX.H>
 #include <AMReX_TrackedVector.H>
 
+#include <iostream>
 #include <memory>
 #include <vector>
 
@@ -307,6 +308,6 @@ int main (int argc, char* argv[])
     MPI_Finalize();
 #endif
 
-    amrex::Print() << "TrackedVector tests passed.\n";
+    std::cout << "TrackedVector tests passed.\n";
     return 0;
 }

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -58,6 +58,21 @@ void fill_device_linear (TVec& v, int base)
     });
 }
 
+void clear_device_vector (TVec& v)
+{
+    v.device().clear();
+}
+
+void resize_device_vector_zero (TVec& v)
+{
+    v.device().resize(0);
+}
+
+void resize_device_vector (TVec& v, TVec::size_type size)
+{
+    v.device().resize(size);
+}
+
 void test_dirty_semantics ()
 {
     TVec v;
@@ -138,6 +153,58 @@ void test_release_gpu_device_dirty ()
     AMREX_ALWAYS_ASSERT(v.host_const()[2] == 102);
 
     // Can round-trip back to device
+    verify_host_device_match(v);
+}
+
+void test_release_gpu_device_cleared ()
+{
+    // Device is authoritatively shrunk to zero, then release_gpu() must
+    // preserve that state on the host before freeing device storage.
+    TVec v;
+    v.host().assign({5, 6, 7});
+    verify_host_device_match(v);
+
+    clear_device_vector(v);
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::device_dirty);
+#endif
+
+    v.release_gpu();
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::host_dirty);
+#else
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+#endif
+    AMREX_ALWAYS_ASSERT(v.host_const().empty());
+
+    // An empty authoritative device state must still round-trip cleanly.
+    verify_host_device_match(v);
+}
+
+void test_release_gpu_device_resized_smaller ()
+{
+    // Device is authoritatively resized from 3 elements to 2 elements, then
+    // release_gpu() must preserve the smaller device state on the host.
+    TVec v;
+    v.host().assign({0, 0, 0});
+    fill_device_linear(v, 100);
+
+    resize_device_vector(v, 2);
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::device_dirty);
+#endif
+
+    v.release_gpu();
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::host_dirty);
+#else
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+#endif
+
+    AMREX_ALWAYS_ASSERT(v.host_const().size() == 2U);
+    AMREX_ALWAYS_ASSERT(v.host_const()[0] == 100);
+    AMREX_ALWAYS_ASSERT(v.host_const()[1] == 101);
+
     verify_host_device_match(v);
 }
 
@@ -309,6 +376,8 @@ void run_tests_before_finalize ()
     test_dirty_semantics();
     test_release_gpu();
     test_release_gpu_device_dirty();
+    test_release_gpu_device_cleared();
+    test_release_gpu_device_resized_smaller();
     test_d2h();
     test_empty();
     test_aggregate();
@@ -333,6 +402,11 @@ int main (int argc, char* argv[])
     // ExecOnFinalize must sync D->H so the data survives.
     TVec dirty_on_finalize;
     dirty_on_finalize.host().assign({0, 0, 0});
+
+    // This vector is shrunk to zero on the device before Finalize.
+    // ExecOnFinalize must preserve the empty authoritative state on the host.
+    TVec cleared_on_finalize;
+    cleared_on_finalize.host().assign({10, 11, 12});
 
     // Cross-session copy/move tests (review point 2):
     // Copies must register their own finalize handler so the device mirror
@@ -360,12 +434,19 @@ int main (int argc, char* argv[])
 #ifdef AMREX_USE_GPU
         AMREX_ALWAYS_ASSERT(dirty_on_finalize.status() == Status::device_dirty);
 #endif
+
+        verify_host_device_match(cleared_on_finalize);
+        resize_device_vector_zero(cleared_on_finalize);
+#ifdef AMREX_USE_GPU
+        AMREX_ALWAYS_ASSERT(cleared_on_finalize.status() == Status::device_dirty);
+#endif
     }
     amrex::Finalize();  // calls implicitly: release_gpu() with D->H sync
 
 #ifdef AMREX_USE_GPU
     AMREX_ALWAYS_ASSERT(cross_session.status() == Status::host_dirty);
     AMREX_ALWAYS_ASSERT(dirty_on_finalize.status() == Status::host_dirty);
+    AMREX_ALWAYS_ASSERT(cleared_on_finalize.status() == Status::host_dirty);
 #endif
 
     // ExecOnFinalize must have synced device data to host
@@ -373,9 +454,11 @@ int main (int argc, char* argv[])
     AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[0] == 200);
     AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[1] == 201);
     AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[2] == 202);
+    AMREX_ALWAYS_ASSERT(cleared_on_finalize.host_const().empty());
 
     test_copy_without_amrex_session(cross_session, {7, 8, 9});
     test_copy_without_amrex_session(dirty_on_finalize, {200, 201, 202});
+    test_copy_without_amrex_session(cleared_on_finalize, {});
 
     // --- Session 2 ---
     amrex::Initialize(argc, argv);
@@ -391,6 +474,10 @@ int main (int argc, char* argv[])
         // dirty_on_finalize also round-trips into the new session
         verify_host_device_match(dirty_on_finalize);
         AMREX_ALWAYS_ASSERT(dirty_on_finalize.host_const()[0] == 200);
+
+        // An empty device-side state must persist across sessions too.
+        verify_host_device_match(cleared_on_finalize);
+        AMREX_ALWAYS_ASSERT(cleared_on_finalize.host_const().empty());
 
         // Write new device values for the session-3 finalize test.
         // This re-arms the finalize hook via to_device().

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -1,0 +1,320 @@
+#include <AMReX.H>
+#include <AMReX_TrackedVector.H>
+
+#include <vector>
+
+using namespace amrex;
+
+using TVec = Gpu::TrackedVector<int>;
+using Status = TVec::Status;
+
+namespace {
+
+void verify_host_device_match (TVec const & v)
+{
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+
+    const auto n = v.host_const().size();
+    AMREX_ALWAYS_ASSERT(v.device_const().size() == n);
+    if (n == 0) { return; }
+    std::vector<int> tmp(n);
+    Gpu::copy(Gpu::deviceToHost, v.device_const().begin(), v.device_const().end(), tmp.begin());
+    for (std::size_t i = 0; i < n; ++i) {
+        AMREX_ALWAYS_ASSERT(tmp[i] == v.host_const()[i]);
+    }
+}
+
+void fill_device_linear (TVec& v, int base)
+{
+    const int n = static_cast<int>(v.device().size());
+    if (n == 0) { return; }
+    int* dp = v.device().data();
+    ParallelFor(n, [=] AMREX_GPU_DEVICE (int i) noexcept {
+        dp[i] = base + i;
+    });
+    Gpu::streamSynchronize();
+}
+
+void test_dirty_semantics ()
+{
+    TVec v;
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+
+    v.host_dirty();
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::host_dirty);
+#else
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+#endif
+
+    v.device_dirty();
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::device_dirty);
+#else
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+#endif
+
+    // potential write (host): must mark dirty
+    v.host().resize(3);
+    v.host().at(2) = 42;
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::host_dirty);
+#else
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+#endif
+    AMREX_ALWAYS_ASSERT(v.host_const().size() == 3);
+
+    v.to_device();
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+
+    // potential write (device): must mark dirty
+    [[maybe_unused]] auto* dp = v.device().data();
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.status() == Status::device_dirty);
+#else
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+#endif
+
+    v.ensure_same();
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+
+    // read-only (host): must not mark dirty
+    auto first = v.host_const().at(2);
+    AMREX_ALWAYS_ASSERT(first == 42);
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+
+    // read-only (device): must not mark dirty
+    [[maybe_unused]] auto const* dcp = v.device_const().data();
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+}
+
+void test_release_gpu ()
+{
+    TVec v;
+    v.host().assign({1, 2, 3});
+    v.ensure_same();
+    verify_host_device_match(v);
+
+    v.release_gpu();
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(v.device_const().empty());
+    AMREX_ALWAYS_ASSERT(v.status() == Status::host_dirty);
+#else
+    AMREX_ALWAYS_ASSERT(v.device_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+#endif
+    AMREX_ALWAYS_ASSERT(v.host_const().size() == 3U);
+
+    v.ensure_same();
+    verify_host_device_match(v);
+}
+
+void test_d2h ()
+{
+    TVec v;
+    v.host().assign({0, 0, 0});
+    v.ensure_same();
+
+    fill_device_linear(v, 100);
+    v.ensure_same();
+
+    AMREX_ALWAYS_ASSERT(v.host_const()[0] == 100 && v.host_const()[1] == 101 && v.host_const()[2] == 102);
+    verify_host_device_match(v);
+}
+
+void test_empty ()
+{
+    TVec v;
+    AMREX_ALWAYS_ASSERT(v.device_const().empty());
+
+    v.ensure_same();
+    AMREX_ALWAYS_ASSERT(v.device_const().empty());
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+
+    fill_device_linear(v, 100);
+    v.host_dirty();  // ignore that device had newer data
+    v.ensure_same();
+    AMREX_ALWAYS_ASSERT(v.device_const().empty());
+    AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
+}
+
+void test_copy_constructor ()
+{
+    TVec a;
+    a.host().assign({1, 2, 3});
+    a.ensure_same();
+
+    TVec b(a);  // copy construct
+
+    // Both have same data
+    AMREX_ALWAYS_ASSERT(b.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(b.host_const()[0] == 1 && b.host_const()[1] == 2 && b.host_const()[2] == 3);
+    AMREX_ALWAYS_ASSERT(b.status() == a.status());
+    verify_host_device_match(b);
+
+    // Modifying b doesn't affect a
+    b.host()[0] = 99;
+    AMREX_ALWAYS_ASSERT(a.host_const()[0] == 1);
+}
+
+void test_move_constructor ()
+{
+    TVec a;
+    a.host().assign({4, 5, 6});
+    a.ensure_same();
+
+    TVec b(std::move(a));  // move construct
+
+    // b has the data
+    AMREX_ALWAYS_ASSERT(b.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(b.host_const()[0] == 4 && b.host_const()[1] == 5 && b.host_const()[2] == 6);
+    AMREX_ALWAYS_ASSERT(b.status() == Status::up_to_date);
+    verify_host_device_match(b);
+
+    // a is valid but empty (got fresh shared_ptrs via swap)
+    // NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+    AMREX_ALWAYS_ASSERT(a.host_const().empty());
+    AMREX_ALWAYS_ASSERT(a.status() == Status::up_to_date);
+    AMREX_ALWAYS_ASSERT(a.device_const().empty());
+
+    // Modifying b must not affect a's status or device
+    auto a_status_before = a.status();
+    auto a_device_size_before = a.device_const().size();
+    b.host()[0] = 99;
+    b.ensure_same();
+    AMREX_ALWAYS_ASSERT(a.status() == a_status_before);
+    AMREX_ALWAYS_ASSERT(a.device_const().size() == a_device_size_before);
+
+    // a can be reused
+    a.host().assign({10, 20});
+    a.ensure_same();
+    verify_host_device_match(a);
+    AMREX_ALWAYS_ASSERT(a.host_const()[0] == 10);
+    // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+}
+
+void test_copy_assignment ()
+{
+    TVec a;
+    a.host().assign({7, 8, 9});
+    a.ensure_same();
+
+    TVec b;
+    b.host().assign({0});
+    b.ensure_same();
+
+    b = a;  // copy assign
+
+    AMREX_ALWAYS_ASSERT(b.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(b.host_const()[0] == 7 && b.host_const()[1] == 8 && b.host_const()[2] == 9);
+    AMREX_ALWAYS_ASSERT(b.status() == a.status());
+    verify_host_device_match(b);
+
+    // Modifying b doesn't affect a
+    b.host()[0] = 99;
+    AMREX_ALWAYS_ASSERT(a.host_const()[0] == 7);
+}
+
+void test_move_assignment ()
+{
+    TVec a;
+    a.host().assign({11, 12, 13});
+    a.ensure_same();
+
+    TVec b;
+    b.host().assign({0});
+    b.ensure_same();
+
+    b = std::move(a);  // move assign
+
+    // b has a's original data
+    AMREX_ALWAYS_ASSERT(b.host_const().size() == 3U);
+    AMREX_ALWAYS_ASSERT(b.host_const()[0] == 11 && b.host_const()[1] == 12 && b.host_const()[2] == 13);
+    AMREX_ALWAYS_ASSERT(b.status() == Status::up_to_date);
+    verify_host_device_match(b);
+
+    // a is valid (has b's old data via swap)
+    // NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+    AMREX_ALWAYS_ASSERT(a.host_const().size() == 1U);
+    AMREX_ALWAYS_ASSERT(a.host_const()[0] == 0);
+    AMREX_ALWAYS_ASSERT(a.status() == Status::up_to_date);
+    verify_host_device_match(a);
+
+    // Modifying b must not affect a's status or device
+    auto a_status_before = a.status();
+    auto a_device_size_before = a.device_const().size();
+    b.host()[0] = 99;
+    b.ensure_same();
+    AMREX_ALWAYS_ASSERT(a.status() == a_status_before);
+    AMREX_ALWAYS_ASSERT(a.device_const().size() == a_device_size_before);
+    AMREX_ALWAYS_ASSERT(a.host_const()[0] == 0);  // a's data unchanged
+
+    // a can be reused
+    a.host().assign({30, 40});
+    a.ensure_same();
+    verify_host_device_match(a);
+    // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
+}
+
+void run_tests_before_finalize ()
+{
+    test_dirty_semantics();
+    test_release_gpu();
+    test_d2h();
+    test_empty();
+    test_copy_constructor();
+    test_move_constructor();
+    test_copy_assignment();
+    test_move_assignment();
+}
+
+} // namespace
+
+int main (int argc, char* argv[])
+{
+    TVec cross_session;
+    cross_session.host() = {7, 8, 9};
+
+#ifdef AMREX_USE_MPI
+    MPI_Init(&argc, &argv);
+#endif
+
+    amrex::Initialize(argc, argv);
+    {
+        run_tests_before_finalize();
+
+        cross_session.to_device();
+        verify_host_device_match(cross_session);
+        AMREX_ALWAYS_ASSERT(cross_session.host_const()[0] == 7);
+    }
+    amrex::Finalize();  // calls implicitly: cross_session.release_gpu();
+
+#ifdef AMREX_USE_GPU
+    AMREX_ALWAYS_ASSERT(cross_session.status() == Status::host_dirty);
+#endif
+
+    amrex::Initialize(argc, argv);
+    {
+        AMREX_ALWAYS_ASSERT(cross_session.host_const().size() == 3U);
+        AMREX_ALWAYS_ASSERT(cross_session.host_const()[0] == 7 && cross_session.host_const()[1] == 8 &&
+                            cross_session.host_const()[2] == 9);
+#ifdef AMREX_USE_GPU
+        AMREX_ALWAYS_ASSERT(cross_session.device_const().empty());
+#else
+        AMREX_ALWAYS_ASSERT(cross_session.device_const().size() == 3U);
+#endif
+
+        cross_session.host()[1] = 99;
+        cross_session.to_device();  // re-init device data in new AMReX session
+        verify_host_device_match(cross_session);
+        AMREX_ALWAYS_ASSERT(cross_session.host_const()[1] == 99);
+    }
+    amrex::Finalize();
+
+#ifdef AMREX_USE_MPI
+    MPI_Finalize();
+#endif
+
+    amrex::Print() << "TrackedVector tests passed.\n";
+    return 0;
+}

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -36,7 +36,7 @@ void verify_host_values (TVec const & v, std::vector<int> const & expected)
 
 void test_copy_without_amrex_session (TVec const & src, std::vector<int> const & expected)
 {
-    TVec copy_ctor(src);
+    TVec copy_ctor(src); // NOLINT(performance-unnecessary-copy-initialization)
 
     TVec copy_assign;
     copy_assign.host().assign({-1});
@@ -56,7 +56,6 @@ void fill_device_linear (TVec& v, int base)
     ParallelFor(n, [=] AMREX_GPU_DEVICE (int i) noexcept {
         dp[i] = base + i;
     });
-    Gpu::streamSynchronize();
 }
 
 void test_dirty_semantics ()

--- a/Tests/Base/TrackedVector/main.cpp
+++ b/Tests/Base/TrackedVector/main.cpp
@@ -1,6 +1,7 @@
 #include <AMReX.H>
 #include <AMReX_TrackedVector.H>
 
+#include <memory>
 #include <vector>
 
 using namespace amrex;
@@ -138,6 +139,19 @@ void test_empty ()
     AMREX_ALWAYS_ASSERT(v.status() == Status::up_to_date);
 }
 
+void test_aggregate ()
+{
+    struct S {
+        double x;
+        TVec a, b;
+    };
+
+    std::vector<int> i = {1, 2, 3};
+    std::vector<int> j = {4, 5, 6};
+
+    [[maybe_unused]] auto ptr1 = std::shared_ptr<S>(new S{42.0, i, j});  // NOLINT(modernize-make-shared)
+}
+
 void test_copy_constructor ()
 {
     TVec a;
@@ -262,6 +276,7 @@ void run_tests_before_finalize ()
     test_release_gpu();
     test_d2h();
     test_empty();
+    test_aggregate();
     test_copy_constructor();
     test_move_constructor();
     test_copy_assignment();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -99,6 +99,8 @@ endfunction ()
 
 if (AMReX_TEST_TYPE STREQUAL "Small")
 
+   add_subdirectory("Base/TrackedVector")
+
    add_subdirectory("Amr/Advection_AmrCore")
 
    if (AMReX_OMP)
@@ -125,7 +127,7 @@ else()
    #
    # List of subdirectories to search for CMakeLists.
    #
-   set( AMREX_TESTS_SUBDIRS Amr ArrayND AsyncOut CallNoinline CLZ CommType CTOParFor DeviceGlobal
+   set( AMREX_TESTS_SUBDIRS Amr ArrayND AsyncOut Base CallNoinline CLZ CommType CTOParFor DeviceGlobal
                             Enum HeatEquation MultiBlock MultiPeriod ParmParse Parser Parser2
                             ParserUserFn Reducer ReduceToPlanePatchy Reinit RoundoffDomain SIMD
                             SmallMatrix SumBoundary TOML)


### PR DESCRIPTION
## Summary

This adds a helper class for synchronizing a pair of host & device vectors (w/o using managed memory).

In BLAST codes, I find this to cause significant boilerplate in physics-focused parts of the code and this little helper class cuts down on lines and mental book-keeping.

Additionally, especially in interactive pyAMReX and ImpactX workflows, this construct is a building block for enabling user-friendly and even multi-simulation-spanning user data (e.g., ImpactX element data) by enabling users to define their inputs even before AMReX was initialized and being able to reuse their input classes across many thousands of simulations, e.g., in optimization loops, even with AMReX device arenas being shut down/recreated in between.

## Additional background

The unit test shows the most common usage patterns & needs.

https://github.com/BLAST-ImpactX/impactx/pull/1368

## Checklist

The proposed changes:
- [x] add new capabilities to AMReX
- [x] CPU build: write the optimized fallback path
- [x] GPU build: use AMReX-session agnostic pinned memory for host OR do synchronous copies
- [x] include documentation in the code and/or rst files, if appropriate
- [x] is covered by unit tests