### PR TITLE
Robustify AMREX_ASSUME

### DIFF
--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -238,7 +238,8 @@
 #   elif defined(_MSC_VER)
 #       define AMREX_ASSUME(ASSUMPTION) __assume(ASSUMPTION)
 #   elif defined(__GNUC__)
-#       define AMREX_ASSUME(ASSUMPTION) if (ASSUMPTION) {} else { __builtin_unreachable(); }
+#       define AMREX_ASSUME(ASSUMPTION) \
+            do { if (!(ASSUMPTION)) { __builtin_unreachable(); } } while (0)
 #   else
 #       define AMREX_ASSUME(ASSUMPTION)
 #   endif


### PR DESCRIPTION
The issue is the implementation based on if-else is not a single statement. So code like below does not work.
```
    if (foo)
        AMREX_ASSUME(bar);
    else
        std::cout << "else\n";
```

The new implementation based on do-while(0) fixes this issue.
