### PR TITLE
Fix particle dual-grid test

### DIFF
--- a/Tests/Particles/CheckpointRestartDualGridHDF5SOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartDualGridHDF5SOA/main.cpp
@@ -116,21 +116,21 @@ void verify_same (MyPC& pc_orig, MyPC& pc_new)
         ParallelDescriptor::ReduceRealSum(sm_orig);
         ParallelDescriptor::ReduceRealSum(sm_new);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            sm_orig == sm_new,
+            amrex::almostEqual(sm_orig, sm_new),
             "Real component sum mismatch after restart (comp " + std::to_string(icomp) + ")");
     }
 
     for (int icomp = 0; icomp < NInt; ++icomp) {
         auto sm_orig = amrex::ReduceSum(pc_orig,
-            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
-                return static_cast<Real>(ptd.idata(icomp)[i]);
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Long {
+                return static_cast<Long>(ptd.idata(icomp)[i]);
             });
         auto sm_new = amrex::ReduceSum(pc_new,
-            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
-                return static_cast<Real>(ptd.idata(icomp)[i]);
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Long {
+                return static_cast<Long>(ptd.idata(icomp)[i]);
             });
-        ParallelDescriptor::ReduceRealSum(sm_orig);
-        ParallelDescriptor::ReduceRealSum(sm_new);
+        ParallelDescriptor::ReduceLongSum(sm_orig);
+        ParallelDescriptor::ReduceLongSum(sm_new);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             sm_orig == sm_new,
             "Int component sum mismatch after restart (comp " + std::to_string(icomp) + ")");

--- a/Tests/Particles/CheckpointRestartDualGridSOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartDualGridSOA/main.cpp
@@ -115,21 +115,21 @@ void verify_same (MyPC& pc_orig, MyPC& pc_new)
         ParallelDescriptor::ReduceRealSum(sm_orig);
         ParallelDescriptor::ReduceRealSum(sm_new);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            sm_orig == sm_new,
+            amrex::almostEqual(sm_orig, sm_new),
             "Real component sum mismatch after restart (comp " + std::to_string(icomp) + ")");
     }
 
     for (int icomp = 0; icomp < NInt; ++icomp) {
         auto sm_orig = amrex::ReduceSum(pc_orig,
-            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
-                return static_cast<Real>(ptd.idata(icomp)[i]);
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Long {
+                return static_cast<Long>(ptd.idata(icomp)[i]);
             });
         auto sm_new = amrex::ReduceSum(pc_new,
-            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
-                return static_cast<Real>(ptd.idata(icomp)[i]);
+            [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Long {
+                return static_cast<Long>(ptd.idata(icomp)[i]);
             });
-        ParallelDescriptor::ReduceRealSum(sm_orig);
-        ParallelDescriptor::ReduceRealSum(sm_new);
+        ParallelDescriptor::ReduceLongSum(sm_orig);
+        ParallelDescriptor::ReduceLongSum(sm_new);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             sm_orig == sm_new,
             "Int component sum mismatch after restart (comp " + std::to_string(icomp) + ")");


### PR DESCRIPTION
For floating-point number comparison, use amrex::almostEqual instead of ==.

For int data, cast them to amrex::Long instead of amrex::Real (which might be float) before reduction.

Follow-up to #5204