### PR TITLE
Reduce memory usage in ReduceToPlaneMF2Patchy

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -1498,7 +1498,7 @@ ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf, F const&
     }
 
     BoxList bl_unique = ba_patch2d.boxList();
-    bl_unique.simplify();
+    //bl_unique.simplify();
     BoxArray ba2d(std::move(bl_unique));
     ba2d.removeOverlap();
     DistributionMapping dm2d(ba2d);

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -1504,8 +1504,10 @@ ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf,
         }
     }
 
-    BoxArray ba2d(ba_patch2d);
-    ba2d.removeOverlap(/*simplify=*/true);
+    BoxList bl_unique = ba_patch2d.boxList();
+    bl_unique.simplify(); // reduces work for .removeOverlap()
+    BoxArray ba2d(std::move(bl_unique));
+    ba2d.removeOverlap();
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(plane_max_grid_size.allGE(1),
         "ReduceToPlaneMF2Patchy: plane_max_grid_size must be >= 1 in every direction.");

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -1498,7 +1498,6 @@ ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf, F const&
     }
 
     BoxList bl_unique = ba_patch2d.boxList();
-    //bl_unique.simplify();
     BoxArray ba2d(std::move(bl_unique));
     ba2d.removeOverlap();
     DistributionMapping dm2d(ba2d);

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -481,6 +481,9 @@ namespace amrex
      * \param domain    domain Box. For patchy inputs this must cover the full
      *                  extent of mf.boxArray() (subdomains are not supported).
      * \param mf        a FabArray/MultiFab object specifying the iteration space
+     * \param plane_max_grid_size
+     *                  the desired max_grid_size of the unique projected 2D
+     *                  BoxArray. The collapsed direction is forced to 1.
      * \param f         a callable object returning data for reduction. It takes
      *                  four ints, where the first int is the local box index and
      *                  the others are spatial indices for x, y, and z-directions.
@@ -495,7 +498,8 @@ namespace amrex
 #endif
                                , int> FOO = 0>
     std::pair<FA,FA>
-    ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf, F const& f);
+    ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf,
+                            IntVect const& plane_max_grid_size, F const& f);
 
     /**
      * \brief Sum MultiFab data to line
@@ -1400,6 +1404,7 @@ FA reduce_to_plane (int direction, Box const& domain, FA const& mf, F const& f)
 
     return tmpfa;
 }
+
 }
 /// \endcond
 
@@ -1468,9 +1473,11 @@ template <typename Op, typename FA, typename F,
 #endif
                            , int> FOO>
 std::pair<FA,FA>
-ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf, F const& f)
+ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf,
+                        IntVect const& plane_max_grid_size, F const& f)
 {
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(mf.is_cell_centered(), "ReduceToPlaneMF2Patchy: only cell-centered data is supported.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(mf.is_cell_centered(),
+        "ReduceToPlaneMF2Patchy: only cell-centered data is supported.");
 
     Box const ndomain = amrex::convert(domain, mf.ixType());
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ndomain.contains(mf.boxArray().minimalBox()),
@@ -1497,9 +1504,15 @@ ReduceToPlaneMF2Patchy (int direction, Box const& domain, FA const& mf, F const&
         }
     }
 
-    BoxList bl_unique = ba_patch2d.boxList();
-    BoxArray ba2d(std::move(bl_unique));
-    ba2d.removeOverlap();
+    BoxArray ba2d(ba_patch2d);
+    ba2d.removeOverlap(/*simplify=*/true);
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(plane_max_grid_size.allGE(1),
+        "ReduceToPlaneMF2Patchy: plane_max_grid_size must be >= 1 in every direction.");
+    IntVect mgs2d = plane_max_grid_size;
+    mgs2d[direction] = 1;
+    ba2d.maxSize(mgs2d);
+
     DistributionMapping dm2d(ba2d);
 
     FA mf2d(ba2d, dm2d, 1, 0);

--- a/Tests/ReduceToPlanePatchy/main.cpp
+++ b/Tests/ReduceToPlanePatchy/main.cpp
@@ -64,7 +64,11 @@ int main (int argc, char* argv[])
 #endif
         }
 
-        auto [plane_patch, plane_unique] = ReduceToPlaneMF2Patchy<ReduceOpSum>(dir, domain, mf,
+        IntVect plane_max_grid_size(4);
+        plane_max_grid_size[dir] = 1;
+
+        auto [plane_patch, plane_unique] = ReduceToPlaneMF2Patchy<ReduceOpSum>(
+            dir, domain, mf, plane_max_grid_size,
             [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) -> Real
             {
                 return ma[box_no](i,j,k);


### PR DESCRIPTION
## Summary
Avoid calling `simplify()` on the BoxList. This avoids making boxes that are too big for any given MPI rank, and avoids out of memory situations with very large runs.

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
