### PR TITLE
Remove un-needed streamSynchronize from unpackRemotes

### DIFF
--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -666,8 +666,6 @@ void unpackRemotes (PC& pc, const ParticleCopyPlan& plan, Buffer& rcv_buffer, Un
                 ptd.unpackParticleData(p_rcv_buffer, src_offset, dst_index,
                                        p_comm_real, p_comm_int);
               });
-
-            Gpu::streamSynchronize();
         }
     }
 #else


### PR DESCRIPTION
This is not needed because we have already resized all destination tiles and done a sync after that on line 638 of `AMReX_ParticleCommunication.H`. This sync effectively serialized unpacking remote messages. 

Results on 1-8 Perlmutter nodeson  a redistribution benchmark that I changed to have a lot of global communication: 

```
No sync:

run_1.out:amrex::unpackRemotes       201    0.02891    0.02918    0.02936   2.60%
run_2.out:amrex::unpackRemotes       201    0.03514    0.03534    0.03562   2.89%
run_4.out:amrex::unpackRemotes       201    0.04276    0.04295    0.04313   3.18%
run_8.out:amrex::unpackRemotes       201    0.05578    0.05628    0.05682   3.46%

Sync:

run_1.out:amrex::unpackRemotes       201    0.06974    0.07011    0.07035   6.17%
run_2.out:amrex::unpackRemotes       201     0.1301     0.1306     0.1316  10.56%
run_4.out:amrex::unpackRemotes       201     0.2456     0.2465     0.2486  17.78%
run_8.out:amrex::unpackRemotes       201     0.4721      0.476     0.4804  28.24%
```

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
