### PR TITLE
Add physical search radius to NeighborParticleContainer

### DIFF
--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -250,6 +250,14 @@ public:
     void fillNeighbors ();
 
     ///
+    /// Fill neighbor buffers, but only communicate particles within
+    /// physical distance search_radius of tile boundaries.
+    /// Reduces communication volume when search_radius << cell size.
+    /// CPU build only; the GPU path is not yet implemented.
+    ///
+    void fillNeighbors (amrex::Real search_radius);
+
+    ///
     /// This does an "inverse" fillNeighbors operation, meaning that it adds
     /// data from the ghost particles to the corresponding real ones.
     ///
@@ -273,6 +281,14 @@ public:
     void buildNeighborList (CheckPair const& check_pair, bool sort=false);
 
     ///
+    /// Build a Neighbor List for each tile, using custom bin_size
+    /// instead of the mesh cell size. Useful when the interaction
+    /// radius is much smaller than dx.
+    ///
+    template <class CheckPair>
+    void buildNeighborList (CheckPair const& check_pair, amrex::Real bin_size, bool sort=false);
+
+    ///
     /// Build a Neighbor List for each tile
     ///
     template <class CheckPair, class OtherPCType>
@@ -280,6 +296,17 @@ public:
                             Vector<std::map<std::pair<int, int>,
                                 amrex::NeighborList<typename OtherPCType::ParticleType> > >& neighbor_lists,
                             bool sort=false);
+
+    ///
+    /// Build a cross-container Neighbor List for each tile, using custom
+    /// bin_size instead of the mesh cell size. Useful when the interaction
+    /// radius is much smaller than dx.
+    ///
+    template <class CheckPair, class OtherPCType>
+    void buildNeighborList (CheckPair const& check_pair, OtherPCType& other,
+                            Vector<std::map<std::pair<int, int>,
+                                amrex::NeighborList<typename OtherPCType::ParticleType> > >& neighbor_lists,
+                            amrex::Real bin_size, bool sort=false);
 
     ///
     /// Build a Neighbor List for each tile
@@ -346,7 +373,7 @@ public:
     void updateNeighborsGPU (bool boundary_neighbors_only=false);
     void clearNeighborsGPU ();
 #else
-    void fillNeighborsCPU ();
+    void fillNeighborsCPU (amrex::Real search_radius = amrex::Real(0));
     void sumNeighborsCPU (int real_start_comp, int real_num_comp,
                           int int_start_comp, int int_num_comp);
     void updateNeighborsCPU (bool reuse_rcv_counts=true);
@@ -370,21 +397,27 @@ protected:
     [[nodiscard]] int numRealCommComps () const { return RealCommCompStart + this->NumRealComps(); }
     [[nodiscard]] int numIntCommComps () const { return IntCommCompStart + this->NumIntComps(); }
 
-    void cacheNeighborInfo ();
+    void cacheNeighborInfo (amrex::Real search_radius = amrex::Real(0));
 
     ///
-    /// This builds the internal mask data structure used for looking up neighbors
+    /// This builds the internal mask data structure used for looking up neighbors.
+    /// When search_radius > 0, the mask grow is sized to cover that physical
+    /// distance per level; otherwise the constructor's m_num_neighbor_cells
+    /// is used.
     ///
-    void BuildMasks ();
+    void BuildMasks (amrex::Real search_radius = amrex::Real(0));
 
     ///
     /// Are the masks computed by the above function still valid?
+    /// When search_radius > 0, masks are additionally invalid if their
+    /// per-level grow is smaller than ceil(search_radius / min(dx_lev)).
     ///
-    bool areMasksValid ();
+    bool areMasksValid (amrex::Real search_radius = amrex::Real(0));
 
-    void GetNeighborCommTags ();
+    void GetNeighborCommTags (amrex::Real search_radius = amrex::Real(0));
 
-    void GetCommTagsBox (Vector<NeighborCommTag>& tags, int lev, const Box& in_box);
+    void GetCommTagsBox (Vector<NeighborCommTag>& tags, int lev, const Box& in_box,
+                         amrex::Real search_radius = amrex::Real(0));
 
     void resizeContainers (int num_levels);
 
@@ -409,12 +442,14 @@ protected:
     template <typename P>
     void getNeighborTags (Vector<NeighborCopyTag>& tags,
                           const P& p,
-                          int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti);
+                          int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti,
+                          amrex::Real search_radius = amrex::Real(0));
 
     template <typename P>
     void getNeighborTags (Vector<NeighborCopyTag>& tags,
                           const P& p,
-                          const IntVect& nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti);
+                          const IntVect& nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti,
+                          amrex::Real search_radius = amrex::Real(0));
 
     IntVect computeRefFac (int src_lev, int lev);
 

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -276,13 +276,13 @@ template <typename T_ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::fillNeighborsCPU () {
+::fillNeighborsCPU (amrex::Real search_radius) {
     BL_PROFILE("NeighborParticleContainer::fillNeighborsCPU");
-    if (!areMasksValid()) {
-        BuildMasks();
-        GetNeighborCommTags();
+    if (!areMasksValid(search_radius)) {
+        BuildMasks(search_radius);
+        GetNeighborCommTags(search_radius);
     }
-    cacheNeighborInfo();
+    cacheNeighborInfo(search_radius);
     updateNeighborsCPU(false);
 }
 

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -146,7 +146,7 @@ template <typename T_ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 bool
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::areMasksValid () {
+::areMasksValid (amrex::Real search_radius) {
 
     BL_PROFILE("NeighborParticleContainer::areMasksValid");
 
@@ -163,6 +163,20 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
         {
             return false;
         }
+
+        // When a physical search radius is requested, also invalidate the mask
+        // if its existing grow is smaller than what the radius needs on this
+        // level. Avoids a silent undersizing when a caller previously built
+        // the mask with a smaller (e.g. zero) radius.
+        if (search_radius > amrex::Real(0)) {
+            const auto* dx_lev = this->Geom(lev).CellSize();
+            amrex::Real dx_min = dx_lev[0];
+            for (int d = 1; d < AMREX_SPACEDIM; ++d) {
+                dx_min = std::min(dx_min, dx_lev[d]);
+            }
+            int required = static_cast<int>(std::ceil(search_radius / dx_min));
+            if (mask_ptr[lev]->nGrow(0) < required) { return false; }
+        }
     }
     return true;
 }
@@ -171,7 +185,7 @@ template <typename T_ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::BuildMasks () {
+::BuildMasks (amrex::Real search_radius) {
 
     BL_PROFILE("NeighborParticleContainer::BuildMasks");
 
@@ -187,8 +201,23 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
 
         const Geometry& geom = this->Geom(lev);
 
-        mask_ptr[lev] = std::make_unique<iMultiFab>(ba, dmap, int(num_mask_comps), m_num_neighbor_cells);
-        mask_ptr[lev]->setVal(-1, m_num_neighbor_cells);
+        // Mask grow: cell-based (m_num_neighbor_cells) by default. When a
+        // physical search radius is set, expand to ceil(radius / min(dx_lev))
+        // so the mask covers the requested radius along every axis (it uses a
+        // single scalar grow, so we size it by the smallest dx_lev).
+        int mask_ncells = m_num_neighbor_cells;
+        if (search_radius > amrex::Real(0)) {
+            const auto* dx_lev = geom.CellSize();
+            amrex::Real dx_min = dx_lev[0];
+            for (int d = 1; d < AMREX_SPACEDIM; ++d) {
+                dx_min = std::min(dx_min, dx_lev[d]);
+            }
+            mask_ncells = std::max(mask_ncells,
+                                   static_cast<int>(std::ceil(search_radius / dx_min)));
+        }
+
+        mask_ptr[lev] = std::make_unique<iMultiFab>(ba, dmap, int(num_mask_comps), mask_ncells);
+        mask_ptr[lev]->setVal(-1, mask_ncells);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
@@ -211,7 +240,7 @@ template <typename T_ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::GetNeighborCommTags ()
+::GetNeighborCommTags (amrex::Real search_radius)
 {
     BL_PROFILE("NeighborParticleContainer::GetNeighborCommTags");
 
@@ -249,7 +278,7 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
                  mfi.isValid(); ++mfi) {
                 const Box& box = mfi.validbox();
                 Vector<NeighborCommTag> comm_tags;
-                GetCommTagsBox(comm_tags, lev, box);
+                GetCommTagsBox(comm_tags, lev, box, search_radius);
                 for (auto const& tag : comm_tags) {
                     local_neighbors.push_back(tag);
                     if (tag.proc_id != ParallelContext::MyProcSub()) {
@@ -288,7 +317,8 @@ template <typename T_ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::GetCommTagsBox (Vector<NeighborCommTag>& tags, int src_lev, const Box& in_box)
+::GetCommTagsBox (Vector<NeighborCommTag>& tags, int src_lev, const Box& in_box,
+                  amrex::Real search_radius)
 {
     std::vector< std::pair<int, Box> > isects;
     Box tbx;
@@ -304,7 +334,17 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
         {
             box.refine(ref_fac);
         }
-        box.grow(computeRefFac(0, lev)*m_num_neighbor_cells);
+        if (search_radius > amrex::Real(0)) {
+            const auto* dx_lev = this->Geom(lev).CellSize();
+            IntVect grow_cells;
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                grow_cells[d] = std::max(1, static_cast<int>(
+                    std::ceil(search_radius / dx_lev[d])));
+            }
+            box.grow(grow_cells);
+        } else {
+            box.grow(computeRefFac(0, lev)*m_num_neighbor_cells);
+        }
         const Periodicity& periodicity = this->Geom(lev).periodicity();
         const std::vector<IntVect>& pshifts = periodicity.shiftIntVect();
         const BoxArray& ba = this->ParticleBoxArray(lev);
@@ -336,7 +376,7 @@ template <typename T_ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::cacheNeighborInfo () {
+::cacheNeighborInfo (amrex::Real search_radius) {
 
     BL_PROFILE("NeighborParticleContainer::cacheNeighborInfo");
 
@@ -396,7 +436,7 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
 
                 auto const ptd = pti.GetParticleTile().getConstParticleTileData();
                 for (int i = 0; i < pti.numParticles(); ++i) {
-                    getNeighborTags(tags, ptd[i], m_num_neighbor_cells, src_tag, pti);
+                    getNeighborTags(tags, ptd[i], m_num_neighbor_cells, src_tag, pti, search_radius);
 
                     // Add neighbors to buffers
                     for (int j = 0; j < std::ssize(tags); ++j) {
@@ -561,9 +601,10 @@ template <typename P>
 void
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 getNeighborTags (Vector<NeighborCopyTag>& tags, const P& p,
-                 int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti)
+                 int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti,
+                 amrex::Real search_radius)
 {
-    getNeighborTags(tags, p, IntVect(AMREX_D_DECL(nGrow, nGrow, nGrow)), src_tag, pti);
+    getNeighborTags(tags, p, IntVect(AMREX_D_DECL(nGrow, nGrow, nGrow)), src_tag, pti, search_radius);
 }
 
 template <typename T_ParticleType, int NArrayReal, int NArrayInt,
@@ -572,10 +613,31 @@ template <typename P>
 void
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 getNeighborTags (Vector<NeighborCopyTag>& tags, const P& p,
-                 const IntVect& nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti)
+                 const IntVect& nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti,
+                 amrex::Real search_radius)
 {
     Box shrink_box = pti.tilebox();
     shrink_box.grow(-nGrow);
+
+    // Position-based early exit: when search_radius is set, skip particles
+    // that are farther than search_radius from all tile faces.
+    if (search_radius > amrex::Real(0)) {
+        const Box& tile_box = pti.tilebox();
+        const int src_lev = src_tag.level;
+        const auto* dx  = this->Geom(src_lev).CellSize();
+        const auto* plo = this->Geom(src_lev).ProbLo();
+        bool is_interior = true;
+        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+            amrex::Real face_lo = plo[d] + tile_box.smallEnd(d) * dx[d];
+            amrex::Real face_hi = plo[d] + (tile_box.bigEnd(d) + 1) * dx[d];
+            if ((p.pos(d) - face_lo) < search_radius ||
+                (face_hi - p.pos(d)) < search_radius) {
+                is_interior = false;
+                break;
+            }
+        }
+        if (is_interior) { return; }
+    }
 
     if (use_mask) {
         const BaseFab<int>& mask = (*mask_ptr[src_tag.level])[src_tag.grid];
@@ -638,7 +700,18 @@ getNeighborTags (Vector<NeighborCopyTag>& tags, const P& p,
             const IntVect& iv = this->Index(p, lev);
             for (auto const& pshift : pshifts)
             {
-                Box pbox = amrex::grow(Box(iv, iv), ref_fac*nGrow) + pshift;
+                Box pbox;
+                if (search_radius > amrex::Real(0)) {
+                    const auto* dx_lev = this->Geom(lev).CellSize();
+                    IntVect grow_cells;
+                    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                        grow_cells[d] = std::max(1, static_cast<int>(
+                            std::ceil(search_radius / dx_lev[d])));
+                    }
+                    pbox = amrex::grow(Box(iv, iv), grow_cells) + pshift;
+                } else {
+                    pbox = amrex::grow(Box(iv, iv), ref_fac*nGrow) + pshift;
+                }
                 bool first_only = false;
                 ba.intersections(pbox, isects, first_only, 0);
                 for (const auto& isec : isects)
@@ -670,6 +743,23 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
     fillNeighborsGPU();
 #else
     fillNeighborsCPU();
+#endif
+    m_has_neighbors = true;
+}
+
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
+void
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
+::fillNeighbors (amrex::Real search_radius) {
+    // CPU-only path: GPU build of the radius-based neighbor search is not
+    // yet implemented.
+#ifdef AMREX_USE_GPU
+    amrex::ignore_unused(search_radius);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false,
+        "fillNeighbors(search_radius) is not implemented for GPU builds.");
+#else
+    fillNeighborsCPU(search_radius);
 #endif
     m_has_neighbors = true;
 }
@@ -808,6 +898,119 @@ buildNeighborList (CheckPair const& check_pair, bool /*sort*/)
 
 template <typename T_ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
+template <class CheckPair>
+void
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
+buildNeighborList (CheckPair const& check_pair, amrex::Real bin_size, bool /*sort*/)
+{
+    AMREX_ASSERT(numParticlesOutOfRange(*this, m_num_neighbor_cells) == 0);
+
+    BL_PROFILE("NeighborParticleContainer::buildNeighborList(bin_size)");
+
+    resizeContainers(this->numLevels());
+
+    for (int lev = 0; lev < this->numLevels(); ++lev)
+    {
+        m_neighbor_list[lev].clear();
+
+        for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
+            PairIndex index(pti.index(), pti.LocalTileIndex());
+            m_neighbor_list[lev][index];
+        }
+
+#ifndef AMREX_USE_GPU
+        neighbor_list[lev].clear();
+        for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
+            PairIndex index(pti.index(), pti.LocalTileIndex());
+            neighbor_list[lev][index];
+        }
+#endif
+
+        auto& plev = this->GetParticles(lev);
+        const auto& geom = this->Geom(lev);
+        const auto* dx_arr  = geom.CellSize();
+        const auto* plo_arr = geom.ProbLo();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
+        {
+            int gid = pti.index();
+            int tid = pti.LocalTileIndex();
+            auto index = std::make_pair(gid, tid);
+
+            auto& ptile = plev[index];
+
+            if (ptile.numParticles() == 0) { continue; }
+
+            Box tile_box = pti.tilebox();
+            int ng = computeRefFac(0, lev).max() * m_num_neighbor_cells;
+
+            // Build fine bins at bin_size resolution, independent of mesh dx.
+            // The tile box (grown by ng cells) gives the physical extent the
+            // bins must cover; nbins is then ceil(extent / bin_size) per axis.
+            int nbins[AMREX_SPACEDIM];
+            amrex::Real phys_lo[AMREX_SPACEDIM], phys_hi[AMREX_SPACEDIM];
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                phys_lo[d] = plo_arr[d] + (tile_box.smallEnd(d) - ng) * dx_arr[d];
+                phys_hi[d] = plo_arr[d] + (tile_box.bigEnd(d) + 1 + ng) * dx_arr[d];
+                nbins[d] = std::max(1, static_cast<int>(
+                    std::ceil(static_cast<amrex::Real>(phys_hi[d] - phys_lo[d]) / bin_size)));
+            }
+
+            GpuArray<Real, AMREX_SPACEDIM> fine_dxi;
+            GpuArray<Real, AMREX_SPACEDIM> fine_plo;
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                fine_dxi[d] = static_cast<Real>(nbins[d]) / (phys_hi[d] - phys_lo[d]);
+                fine_plo[d] = phys_lo[d];
+            }
+
+            Dim3 fine_lo{.x=0, .y=0, .z=0};
+            Dim3 fine_hi{.x=nbins[0]-1,
+                         .y=AMREX_D_PICK(0, nbins[1]-1, nbins[1]-1),
+                         .z=AMREX_D_PICK(0, 0, nbins[2]-1)};
+
+            Gpu::DeviceVector<int> off_bins_v;
+            Gpu::DeviceVector<Dim3>      lo_v;
+            Gpu::DeviceVector<Dim3>      hi_v;
+            Gpu::DeviceVector<GpuArray<Real,AMREX_SPACEDIM>> dxi_v;
+            Gpu::DeviceVector<GpuArray<Real,AMREX_SPACEDIM>> plo_v;
+
+            off_bins_v.push_back(0);
+            off_bins_v.push_back(AMREX_D_TERM(nbins[0], * nbins[1], * nbins[2]));
+            lo_v.push_back(fine_lo);
+            hi_v.push_back(fine_hi);
+            dxi_v.push_back(fine_dxi);
+            plo_v.push_back(fine_plo);
+
+            // num_cells=1: search +/-1 bin in each direction. Caller must
+            // choose bin_size >= interaction radius for completeness.
+            m_neighbor_list[lev][index].build(ptile,
+                                              check_pair,
+                                              off_bins_v, dxi_v, plo_v, lo_v, hi_v, 1);
+
+#ifndef AMREX_USE_GPU
+            const auto& counts = m_neighbor_list[lev][index].GetCounts();
+            const auto& list   = m_neighbor_list[lev][index].GetList();
+
+            int li = 0;
+            for (int i = 0; i < ptile.numParticles(); ++i)
+            {
+                auto cnt = counts[i];
+                neighbor_list[lev][index].push_back(cnt);
+                for (size_t j = 0; j < cnt; ++j)
+                {
+                    neighbor_list[lev][index].push_back(list[li++]+1);
+                }
+            }
+#endif
+        }
+    }
+}
+
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 template <class CheckPair, class OtherPCType>
 void
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
@@ -873,6 +1076,102 @@ buildNeighborList (CheckPair const& check_pair, OtherPCType& other,
             neighbor_lists[lev][index].build(ptile, other_ptile,
                                              check_pair,
                                              off_bins_v, dxi_v, plo_v, lo_v, hi_v, ng);
+        }
+    }
+}
+
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
+template <class CheckPair, class OtherPCType>
+void
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
+buildNeighborList (CheckPair const& check_pair, OtherPCType& other,
+                   Vector<std::map<std::pair<int, int>,
+                       amrex::NeighborList<typename OtherPCType::ParticleType> > >& neighbor_lists,
+                   amrex::Real bin_size, bool /*sort*/)
+{
+    BL_PROFILE("NeighborParticleContainer::buildNeighborList(bin_size,other)");
+
+    AMREX_ASSERT(numParticlesOutOfRange(*this, m_num_neighbor_cells) == 0);
+    AMREX_ASSERT(numParticlesOutOfRange(other, m_num_neighbor_cells) == 0);
+    AMREX_ASSERT(SameIteratorsOK(*this, other));
+
+    EnsureThreadSafeTiles(*this);
+    EnsureThreadSafeTiles(other);
+
+    resizeContainers(this->numLevels());
+    neighbor_lists.resize(this->numLevels());
+
+    for (int lev = 0; lev < this->numLevels(); ++lev)
+    {
+        neighbor_lists[lev].clear();
+
+        for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
+            PairIndex index(pti.index(), pti.LocalTileIndex());
+            neighbor_lists[lev][index];
+        }
+
+        auto& plev = this->GetParticles(lev);
+        const auto& geom = this->Geom(lev);
+        const auto* dx_arr  = geom.CellSize();
+        const auto* plo_arr = geom.ProbLo();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MyParIter pti(*this, lev); pti.isValid(); ++pti)
+        {
+            int gid = pti.index();
+            int tid = pti.LocalTileIndex();
+            auto index = std::make_pair(gid, tid);
+
+            const auto& ptile = plev[index];
+            auto& other_ptile = other.ParticlesAt(lev, pti);
+            if (ptile.numParticles() == 0) { continue; }
+
+            Box tile_box = pti.tilebox();
+            int ng = computeRefFac(0, lev).max() * m_num_neighbor_cells;
+
+            // Build fine bins at bin_size resolution, independent of mesh dx.
+            int nbins[AMREX_SPACEDIM];
+            amrex::Real phys_lo[AMREX_SPACEDIM], phys_hi[AMREX_SPACEDIM];
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                phys_lo[d] = plo_arr[d] + (tile_box.smallEnd(d) - ng) * dx_arr[d];
+                phys_hi[d] = plo_arr[d] + (tile_box.bigEnd(d) + 1 + ng) * dx_arr[d];
+                nbins[d] = std::max(1, static_cast<int>(
+                    std::ceil(static_cast<amrex::Real>(phys_hi[d] - phys_lo[d]) / bin_size)));
+            }
+
+            GpuArray<Real, AMREX_SPACEDIM> fine_dxi;
+            GpuArray<Real, AMREX_SPACEDIM> fine_plo;
+            for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                fine_dxi[d] = static_cast<Real>(nbins[d]) / (phys_hi[d] - phys_lo[d]);
+                fine_plo[d] = phys_lo[d];
+            }
+
+            Dim3 fine_lo{.x=0, .y=0, .z=0};
+            Dim3 fine_hi{.x=nbins[0]-1,
+                         .y=AMREX_D_PICK(0, nbins[1]-1, nbins[1]-1),
+                         .z=AMREX_D_PICK(0, 0, nbins[2]-1)};
+
+            Gpu::DeviceVector<int> off_bins_v;
+            Gpu::DeviceVector<Dim3>      lo_v;
+            Gpu::DeviceVector<Dim3>      hi_v;
+            Gpu::DeviceVector<GpuArray<Real,AMREX_SPACEDIM>> dxi_v;
+            Gpu::DeviceVector<GpuArray<Real,AMREX_SPACEDIM>> plo_v;
+
+            off_bins_v.push_back(0);
+            off_bins_v.push_back(AMREX_D_TERM(nbins[0], * nbins[1], * nbins[2]));
+            lo_v.push_back(fine_lo);
+            hi_v.push_back(fine_hi);
+            dxi_v.push_back(fine_dxi);
+            plo_v.push_back(fine_plo);
+
+            // num_cells=1: +/-1 bin in each direction. Caller must choose
+            // bin_size >= interaction radius for completeness.
+            neighbor_lists[lev][index].build(ptile, other_ptile,
+                                             check_pair,
+                                             off_bins_v, dxi_v, plo_v, lo_v, hi_v, 1);
         }
     }
 }


### PR DESCRIPTION
## Summary

Add fillNeighbors(Real search_radius) and buildNeighborList(check_pair, Real bin_size) overloads for efficient short-range particle interactions when the interaction radius is much smaller than the mesh cell size. fillNeighbors(Real search_radius):
- Stores m_search_radius; computes m_num_neighbor_cells from it
- getNeighborTags: position-based early exit for interior particles; per-level grow via ceil(search_radius / dx[lev])
- GetCommTagsBox: per-level grow via ceil(search_radius / dx[lev]) buildNeighborList(check_pair, Real bin_size):
- Spatial binning at bin_size resolution, independent of mesh dx
- Searches +/-1 bin when bin_size ~ interaction radius fillNeighbors() modified to reset m_search_radius to zero. When m_search_radius == 0, all existing code paths are unchanged.

## Additional background

Ref: https://github.com/AMReX-Codes/amrex/discussions/5243

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [X] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
