### PR TITLE
Fix insufficient buffer when projecting grids during regrid

### DIFF
--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -654,17 +654,18 @@ AmrMesh::MakeNewGrids (int lbase, Real time, int& new_finest, Vector<BoxArray>& 
         if (levf < new_finest)
         {
             ba_proj = new_grids[levf+1].simplified();
-            ba_proj.coarsen(ref_ratio[levf]);
-            ba_proj.growcoarsen(n_proper, ref_ratio[levc]);
-
+            ba_proj.coarsengrow(Array<IntVect,2>{ref_ratio[levf]         , ref_ratio[levc]},
+                                Array<IntVect,2>{   bf_lev[levf]*n_proper,    bf_lev[levc]*n_proper});
             BoxArray levcBA = grids[levc].simplified();
             int ngrow = 0;
             while (!levcBA.contains(ba_proj))
             {
-                levcBA.grow(1);
+                levcBA.grow(bf_lev[levc]);
                 ++ngrow;
             }
-            ngt.max(IntVect(ngrow));
+            if (ngrow > 0) {
+                ngt.max(bf_lev[levc]*(ngrow-1)+IntVect(1));
+            }
         }
         TagBoxArray tags(grids[levc],dmap[levc],ngt);
 

--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -679,6 +679,16 @@ public:
     BoxArray& growcoarsen (int n, const IntVect& iv);
     BoxArray& growcoarsen (IntVect const& ngrow, const IntVect& iv);
 
+    /**
+     * \brief Apply a sequence of coarsen/grow stages to every box.
+     *
+     * Each entry in \p coarsen_ratio is applied first, followed by the
+     * corresponding grow in \p grow_vect.
+     */
+    template <std::size_t N>
+    BoxArray& coarsengrow (const Array<IntVect,N>& coarsen_ratio,
+                           const Array<IntVect,N>& grow_vect);
+
     //! Grow each Box in the BoxArray by the specified amount.
     BoxArray& grow (int n);
 
@@ -898,6 +908,30 @@ private:
 std::ostream& operator<< (std::ostream& os, const BoxArray& ba);
 
 std::ostream& operator<< (std::ostream& os, const BoxArray::RefID& id);
+
+template <std::size_t N>
+inline BoxArray&
+BoxArray::coarsengrow (const Array<IntVect,N>& coarsen_ratio,
+                       const Array<IntVect,N>& grow_vect)
+{
+    static_assert(N > 0, "BoxArray::coarsengrow needs at least one stage");
+
+    uniqify();
+
+    const int nboxes = static_cast<int>(m_ref->m_abox.size());
+#ifdef AMREX_USE_OMP
+#pragma omp parallel for
+#endif
+    for (int i = 0; i < nboxes; ++i) {
+        Box& bx = m_ref->m_abox[i];
+        for (std::size_t n = 0; n < N; ++n) {
+            bx.coarsen(coarsen_ratio[n]);
+            bx.grow(grow_vect[n]);
+        }
+    }
+
+    return *this;
+}
 
 }
 


### PR DESCRIPTION
AmrMesh::MakeNewGrids now grows TagBoxes enough to keep intermediate levels properly nested after projecting fine grids downward, preventing the under-tagging that previously led to improperly nested grids.
