### PR TITLE
Fix HIP CI on HPSF GitLab

### DIFF
--- a/.gitlab/hpsf-gitlab-ci.yml
+++ b/.gitlab/hpsf-gitlab-ci.yml
@@ -51,7 +51,7 @@ AMD-MI300A:
   tags: [amd-mi300]
   image: rocm/dev-ubuntu-24.04:7.2-complete
   script:
-    - export ROCM_PATH=/opt/rocm-7.2
+    - export ROCM_PATH=/opt/rocm
     - export PATH=$ROCM_PATH/bin:$ROCM_PATH/llvm/bin:$PATH
     - export LD_LIBRARY_PATH=$ROCM_PATH/lib:$ROCM_PATH/lib64:$LD_LIBRARY_PATH
     - export HIP_PATH=$ROCM_PATH
@@ -68,8 +68,8 @@ AMD-MI300A:
           -DAMReX_FORTRAN=OFF                          \
           -DAMReX_GPU_BACKEND=HIP                      \
           -DAMReX_AMD_ARCH=gfx942                      \
-          -DCMAKE_C_COMPILER=$(which clang)            \
-          -DCMAKE_CXX_COMPILER=$(which clang++)        \
+          -DCMAKE_C_COMPILER=$(which amdclang)         \
+          -DCMAKE_CXX_COMPILER=$(which amdclang++)     \
           -DCMAKE_CXX_STANDARD=17
     - cmake --build build -j 16
     - export OMPI_ALLOW_RUN_AS_ROOT=1


### PR DESCRIPTION
The path to rocm installation is /opt/rocm-7.2.0, not 7.2. But using /opt/rocm also works, because it's a symbolic link to /opt/rocm-7.2.0.

Fix #5272