### PR TITLE
Create symbolic link during install

### DIFF
--- a/Tools/CMake/AMReXInstallHelpers.cmake
+++ b/Tools/CMake/AMReXInstallHelpers.cmake
@@ -71,11 +71,13 @@ function (install_amrex_targets)
 
        # legacy symlink for: libamrex.[so|a] / amrex.[dll.lib]
        #   escape spaces for generated cmake_install.cmake file
-       file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}/lib" ABS_INSTALL_LIB_DIR)
-       install(CODE "file(CREATE_LINK
-           $<TARGET_FILE_NAME:amrex_${AMReX_SPACEDIM_LAST}d>
-           \"${ABS_INSTALL_LIB_DIR}/$<TARGET_FILE_PREFIX:amrex_${AMReX_SPACEDIM_LAST}d>amrex$<TARGET_FILE_SUFFIX:amrex_${AMReX_SPACEDIM_LAST}d>\"
-           COPY_ON_ERROR SYMBOLIC)"
+       install(CODE "
+           file(TO_CMAKE_PATH \"\${CMAKE_INSTALL_PREFIX}/lib\" ABS_INSTALL_LIB_DIR)
+
+           file(CREATE_LINK
+                $<TARGET_FILE_NAME:amrex_${AMReX_SPACEDIM_LAST}d>
+                \"\${ABS_INSTALL_LIB_DIR}/$<TARGET_FILE_PREFIX:amrex_${AMReX_SPACEDIM_LAST}d>amrex$<TARGET_FILE_SUFFIX:amrex_${AMReX_SPACEDIM_LAST}d>\"
+                COPY_ON_ERROR SYMBOLIC)"
        )
 
        # Install fortran modules if Fortran is enabled

--- a/Tools/CMake/AMReXInstallHelpers.cmake
+++ b/Tools/CMake/AMReXInstallHelpers.cmake
@@ -72,12 +72,17 @@ function (install_amrex_targets)
        # legacy symlink for: libamrex.[so|a] / amrex.[dll.lib]
        #   escape spaces for generated cmake_install.cmake file
        install(CODE "
-           file(TO_CMAKE_PATH \"\${CMAKE_INSTALL_PREFIX}/lib\" ABS_INSTALL_LIB_DIR)
+           file(TO_CMAKE_PATH \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib\" ABS_INSTALL_LIB_DIR)
+           set(symlink_name
+               \"\${ABS_INSTALL_LIB_DIR}/$<TARGET_FILE_PREFIX:amrex_${AMReX_SPACEDIM_LAST}d>amrex$<TARGET_FILE_SUFFIX:amrex_${AMReX_SPACEDIM_LAST}d>\")
+           set(symlink_manifest_name
+               \"\${CMAKE_INSTALL_PREFIX}/lib/$<TARGET_FILE_PREFIX:amrex_${AMReX_SPACEDIM_LAST}d>amrex$<TARGET_FILE_SUFFIX:amrex_${AMReX_SPACEDIM_LAST}d>\")
 
            file(CREATE_LINK
                 $<TARGET_FILE_NAME:amrex_${AMReX_SPACEDIM_LAST}d>
-                \"\${ABS_INSTALL_LIB_DIR}/$<TARGET_FILE_PREFIX:amrex_${AMReX_SPACEDIM_LAST}d>amrex$<TARGET_FILE_SUFFIX:amrex_${AMReX_SPACEDIM_LAST}d>\"
-                COPY_ON_ERROR SYMBOLIC)"
+                \"\${symlink_name}\"
+                COPY_ON_ERROR SYMBOLIC)
+           list(APPEND CMAKE_INSTALL_MANIFEST_FILES \"\${symlink_manifest_name}\")"
        )
 
        # Install fortran modules if Fortran is enabled


### PR DESCRIPTION
## Summary
Setting the install directory in the CMake install step gives an error in the creation of the symlink for `libamrex.a`.
The proposed fix creates the path for the symlink during the install step, allowing to change `CMAKE_INSTALL_PREFIX` in the install step.

Basically the fix moves the creation of the path-variable into `cmake_install.cmake`.
The previous version created the path in CMake configure step and the link during the CMake install step.

## Reproducer
```
git clone https://github.com/AMReX-Codes/amrex.git
cmake -S . -B build
cmake --build build
cmake --install build --prefix install
```
Gives the error
```
CMake Error at build/cmake_install.cmake:420 (file):                                                                                                                                                                                                         
  file Copy failed: No such file or directory     
```