### PR TITLE
avoid duplicate find_package(Conduit)

### DIFF
--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -117,7 +117,7 @@ endif ()
 #
 #  Catalyst
 #
-if (AMReX_CATALYST) 
+if (AMReX_CATALYST)
     find_package(Catalyst REQUIRED PATHS "$ENV{CATALYST_IMPLEMENTATION_PATHS}")
     foreach(D IN LISTS AMReX_SPACEDIM)
         target_link_libraries(amrex_${D}d PUBLIC catalyst::catalyst)

--- a/Tools/CMake/AMReXThirdPartyLibraries.cmake
+++ b/Tools/CMake/AMReXThirdPartyLibraries.cmake
@@ -128,7 +128,9 @@ endif ()
 # Conduit
 #
 if (AMReX_CONDUIT)
-    find_package(Conduit REQUIRED)
+    if(NOT TARGET conduit::conduit)
+        find_package(Conduit REQUIRED)
+    endif()
     foreach(D IN LISTS AMReX_SPACEDIM)
         if (AMReX_MPI)
             target_link_libraries(amrex_${D}d PUBLIC conduit::conduit_mpi)


### PR DESCRIPTION
## Summary

Building MFIX-Exa with Conduit and Ascent enabled (`cmake -S . -B build -DAMReX_CONDUIT=ON -DAMReX_ASCENT=ON`) fails with:

```
CMake Error at /nfs/home/3/cwaldman/Libs/RelWithDebInfo/lib/cmake/conduit/conduit_setup_targets.cmake:65 (add_library):
  add_library cannot create imported target "conduit::conduit" because
  another target with the same name already exists.
--
CMake Error at /nfs/home/3/cwaldman/Libs/RelWithDebInfo/lib/cmake/conduit/conduit_setup_targets.cmake:101 (add_library):
  add_library cannot create imported target "conduit::conduit_mpi" because
  another target with the same name already exists.
```

This MR adds a guard against duplicate `find_package(Conduit)` calls.

The `if (NOT TARGET ...)` guard is the standard CMake idiom for this (used extensively in VTK, HDF5, etc.). If the target already exists, we use it; if not, we find it. The `target_link_libraries` calls below are unchanged either way since they just reference the same imported target name.


## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
