### PR TITLE
CMake: Always Register Export Set

### DIFF
--- a/Tools/CMake/AMReXInstallHelpers.cmake
+++ b/Tools/CMake/AMReXInstallHelpers.cmake
@@ -39,27 +39,30 @@ function (install_amrex_targets)
        ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXConfigVersion.cmake
        COMPATIBILITY AnyNewerVersion )
 
+   #
+   # Export install-tree
+   #   Always register targets in the export set so that superbuilds
+   #   (e.g., pyAMReX, WarpX, ImpactX) can reference them in their own
+   #   install(EXPORT).
+   #
+   install(
+      TARGETS       ${_targets}
+      EXPORT        AMReXTargets
+      ARCHIVE       DESTINATION lib
+      LIBRARY       DESTINATION lib
+      INCLUDES      DESTINATION include # Adds proper directory to INTERFACE_INCLUDE_DIRECTORIES
+      PUBLIC_HEADER DESTINATION include
+      RUNTIME       DESTINATION bin
+      )
+
+   install( EXPORT AMReXTargets
+      NAMESPACE AMReX::
+      DESTINATION ${CMAKE_FILES_DIR} )
+
    if(AMReX_INSTALL)
        install( FILES
           ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXConfig.cmake
           ${PROJECT_BINARY_DIR}/${CMAKE_FILES_DIR}/AMReXConfigVersion.cmake
-          DESTINATION ${CMAKE_FILES_DIR} )
-
-       #
-       # Export install-tree
-       #
-       install(
-          TARGETS       ${_targets}
-          EXPORT        AMReXTargets
-          ARCHIVE       DESTINATION lib
-          LIBRARY       DESTINATION lib
-          INCLUDES      DESTINATION include # Adds proper directory to INTERFACE_INCLUDE_DIRECTORIES
-          PUBLIC_HEADER DESTINATION include
-          RUNTIME       DESTINATION bin
-          )
-
-       install( EXPORT AMReXTargets
-          NAMESPACE AMReX::
           DESTINATION ${CMAKE_FILES_DIR} )
 
        #


### PR DESCRIPTION
## Summary

Always register AMReX targets in CMake install export set. Before, they were only set with `AMReX_INSTALL`, which causes errors in superbuilds (e.g., pyAMReX, WarpX, ImpactX) w/ static libs.

## Additional background

Seen with ImpactX build with `-DAMReX_BUILD_SHARED_LIBS=OFF`.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
