### PR TITLE
CMake: Smoke Test w/ Prefix & Stage

### DIFF
--- a/Tests/CMakeTestInstall/VerifyInstall.cmake
+++ b/Tests/CMakeTestInstall/VerifyInstall.cmake
@@ -40,34 +40,38 @@ run_checked(${_install_cmd})
 set(_legacy_lib "${AMREX_TEST_INSTALL_PREFIX}/lib/${AMREX_TEST_INSTALL_LEGACY_LIB_NAME}")
 assert_exists("${_legacy_lib}")
 
-set(_stage_install_cmd
-    "${CMAKE_COMMAND}" "-E" "env" "DESTDIR=${AMREX_TEST_INSTALL_STAGE_ROOT}"
-    "${CMAKE_COMMAND}" "--install" "${AMREX_TEST_INSTALL_BUILD_DIR}"
-    "--prefix" "${AMREX_TEST_INSTALL_STAGE_PREFIX}")
-if(AMREX_TEST_INSTALL_CONFIG)
-    list(APPEND _stage_install_cmd "--config" "${AMREX_TEST_INSTALL_CONFIG}")
-endif()
-run_checked(${_stage_install_cmd})
+if(CMAKE_HOST_WIN32)
+    message(STATUS "Skipping DESTDIR staged install check on Windows.")
+else()
+    set(_stage_install_cmd
+        "${CMAKE_COMMAND}" "-E" "env" "DESTDIR=${AMREX_TEST_INSTALL_STAGE_ROOT}"
+        "${CMAKE_COMMAND}" "--install" "${AMREX_TEST_INSTALL_BUILD_DIR}"
+        "--prefix" "${AMREX_TEST_INSTALL_STAGE_PREFIX}")
+    if(AMREX_TEST_INSTALL_CONFIG)
+        list(APPEND _stage_install_cmd "--config" "${AMREX_TEST_INSTALL_CONFIG}")
+    endif()
+    run_checked(${_stage_install_cmd})
 
-set(_staged_legacy_lib
-    "${AMREX_TEST_INSTALL_STAGE_ROOT}${AMREX_TEST_INSTALL_STAGE_PREFIX}/lib/${AMREX_TEST_INSTALL_LEGACY_LIB_NAME}")
-assert_exists("${_staged_legacy_lib}")
+    set(_staged_legacy_lib
+        "${AMREX_TEST_INSTALL_STAGE_ROOT}${AMREX_TEST_INSTALL_STAGE_PREFIX}/lib/${AMREX_TEST_INSTALL_LEGACY_LIB_NAME}")
+    assert_exists("${_staged_legacy_lib}")
 
-file(READ "${AMREX_TEST_INSTALL_BUILD_DIR}/install_manifest.txt" _manifest)
-set(_manifest_legacy_lib
-    "${AMREX_TEST_INSTALL_STAGE_PREFIX}/lib/${AMREX_TEST_INSTALL_LEGACY_LIB_NAME}")
-string(FIND "${_manifest}" "${_manifest_legacy_lib}" _manifest_legacy_lib_pos)
-if(_manifest_legacy_lib_pos EQUAL -1)
-    message(FATAL_ERROR
-        "Install manifest is missing the legacy library entry: ${_manifest_legacy_lib}")
-endif()
+    file(READ "${AMREX_TEST_INSTALL_BUILD_DIR}/install_manifest.txt" _manifest)
+    set(_manifest_legacy_lib
+        "${AMREX_TEST_INSTALL_STAGE_PREFIX}/lib/${AMREX_TEST_INSTALL_LEGACY_LIB_NAME}")
+    string(FIND "${_manifest}" "${_manifest_legacy_lib}" _manifest_legacy_lib_pos)
+    if(_manifest_legacy_lib_pos EQUAL -1)
+        message(FATAL_ERROR
+            "Install manifest is missing the legacy library entry: ${_manifest_legacy_lib}")
+    endif()
 
-set(_staged_manifest_legacy_lib
-    "${AMREX_TEST_INSTALL_STAGE_ROOT}${_manifest_legacy_lib}")
-string(FIND "${_manifest}" "${_staged_manifest_legacy_lib}" _staged_manifest_legacy_lib_pos)
-if(NOT _staged_manifest_legacy_lib_pos EQUAL -1)
-    message(FATAL_ERROR
-        "Install manifest should not record DESTDIR paths: ${_staged_manifest_legacy_lib}")
+    set(_staged_manifest_legacy_lib
+        "${AMREX_TEST_INSTALL_STAGE_ROOT}${_manifest_legacy_lib}")
+    string(FIND "${_manifest}" "${_staged_manifest_legacy_lib}" _staged_manifest_legacy_lib_pos)
+    if(NOT _staged_manifest_legacy_lib_pos EQUAL -1)
+        message(FATAL_ERROR
+            "Install manifest should not record DESTDIR paths: ${_staged_manifest_legacy_lib}")
+    endif()
 endif()
 
 set(_configure_cmd

--- a/Tests/CMakeTestInstall/VerifyInstall.cmake
+++ b/Tests/CMakeTestInstall/VerifyInstall.cmake
@@ -1,0 +1,96 @@
+function(run_checked)
+    execute_process(
+        COMMAND ${ARGN}
+        RESULT_VARIABLE _result
+        OUTPUT_VARIABLE _stdout
+        ERROR_VARIABLE _stderr
+    )
+
+    if(NOT _result EQUAL 0)
+        string(JOIN " " _command ${ARGN})
+        message(FATAL_ERROR
+            "Command failed (${_result}): ${_command}\n"
+            "stdout:\n${_stdout}\n"
+            "stderr:\n${_stderr}")
+    endif()
+endfunction()
+
+function(assert_exists _path)
+    if(NOT EXISTS "${_path}" AND NOT IS_SYMLINK "${_path}")
+        message(FATAL_ERROR "Expected installed file is missing: ${_path}")
+    endif()
+endfunction()
+
+file(REMOVE_RECURSE
+    "${AMREX_TEST_INSTALL_PREFIX}"
+    "${AMREX_TEST_INSTALL_STAGE_ROOT}"
+    "${AMREX_TEST_INSTALL_TEST_BUILD_DIR}")
+file(MAKE_DIRECTORY
+    "${AMREX_TEST_INSTALL_PREFIX}"
+    "${AMREX_TEST_INSTALL_STAGE_ROOT}")
+
+set(_install_cmd
+    "${CMAKE_COMMAND}" "--install" "${AMREX_TEST_INSTALL_BUILD_DIR}"
+    "--prefix" "${AMREX_TEST_INSTALL_PREFIX}")
+if(AMREX_TEST_INSTALL_CONFIG)
+    list(APPEND _install_cmd "--config" "${AMREX_TEST_INSTALL_CONFIG}")
+endif()
+run_checked(${_install_cmd})
+
+set(_legacy_lib "${AMREX_TEST_INSTALL_PREFIX}/lib/${AMREX_TEST_INSTALL_LEGACY_LIB_NAME}")
+assert_exists("${_legacy_lib}")
+
+set(_stage_install_cmd
+    "${CMAKE_COMMAND}" "-E" "env" "DESTDIR=${AMREX_TEST_INSTALL_STAGE_ROOT}"
+    "${CMAKE_COMMAND}" "--install" "${AMREX_TEST_INSTALL_BUILD_DIR}"
+    "--prefix" "${AMREX_TEST_INSTALL_STAGE_PREFIX}")
+if(AMREX_TEST_INSTALL_CONFIG)
+    list(APPEND _stage_install_cmd "--config" "${AMREX_TEST_INSTALL_CONFIG}")
+endif()
+run_checked(${_stage_install_cmd})
+
+set(_staged_legacy_lib
+    "${AMREX_TEST_INSTALL_STAGE_ROOT}${AMREX_TEST_INSTALL_STAGE_PREFIX}/lib/${AMREX_TEST_INSTALL_LEGACY_LIB_NAME}")
+assert_exists("${_staged_legacy_lib}")
+
+file(READ "${AMREX_TEST_INSTALL_BUILD_DIR}/install_manifest.txt" _manifest)
+set(_manifest_legacy_lib
+    "${AMREX_TEST_INSTALL_STAGE_PREFIX}/lib/${AMREX_TEST_INSTALL_LEGACY_LIB_NAME}")
+string(FIND "${_manifest}" "${_manifest_legacy_lib}" _manifest_legacy_lib_pos)
+if(_manifest_legacy_lib_pos EQUAL -1)
+    message(FATAL_ERROR
+        "Install manifest is missing the legacy library entry: ${_manifest_legacy_lib}")
+endif()
+
+set(_staged_manifest_legacy_lib
+    "${AMREX_TEST_INSTALL_STAGE_ROOT}${_manifest_legacy_lib}")
+string(FIND "${_manifest}" "${_staged_manifest_legacy_lib}" _staged_manifest_legacy_lib_pos)
+if(NOT _staged_manifest_legacy_lib_pos EQUAL -1)
+    message(FATAL_ERROR
+        "Install manifest should not record DESTDIR paths: ${_staged_manifest_legacy_lib}")
+endif()
+
+set(_configure_cmd
+    "${CMAKE_COMMAND}"
+    "-S" "${AMREX_TEST_INSTALL_TEST_PROJECT_DIR}"
+    "-B" "${AMREX_TEST_INSTALL_TEST_BUILD_DIR}"
+    "-DAMReX_ROOT=${AMREX_TEST_INSTALL_PREFIX}"
+    "-DCMAKE_CXX_COMPILER=${AMREX_TEST_INSTALL_CXX_COMPILER}")
+if(AMREX_TEST_INSTALL_FORTRAN_COMPILER)
+    list(APPEND _configure_cmd
+        "-DCMAKE_Fortran_COMPILER=${AMREX_TEST_INSTALL_FORTRAN_COMPILER}")
+endif()
+if(NOT AMREX_TEST_INSTALL_IS_MULTI_CONFIG AND AMREX_TEST_INSTALL_CONFIG)
+    list(APPEND _configure_cmd
+        "-DCMAKE_BUILD_TYPE=${AMREX_TEST_INSTALL_CONFIG}")
+endif()
+run_checked(${_configure_cmd})
+
+set(_build_cmd
+    "${CMAKE_COMMAND}" "--build" "${AMREX_TEST_INSTALL_TEST_BUILD_DIR}")
+if(AMREX_TEST_INSTALL_CONFIG)
+    list(APPEND _build_cmd "--config" "${AMREX_TEST_INSTALL_CONFIG}")
+endif()
+run_checked(${_build_cmd})
+
+file(REMOVE_RECURSE "${AMREX_TEST_INSTALL_TEST_BUILD_DIR}")

--- a/Tools/CMake/AMReXInstallHelpers.cmake
+++ b/Tools/CMake/AMReXInstallHelpers.cmake
@@ -139,21 +139,24 @@ macro( add_test_install_target _dir _amrex_root )
    # select the build type at build time. Others (GNUmake, Ninja, ...) select
    # the build type at configure time.
    get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-   set(_select_config)
-   set(_select_bldtype)
-   if(isMultiConfig)
-      set(_select_config "--config $<CONFIG>")
-   else()
-      set(_select_bldtype "-DCMAKE_BUILD_TYPE=$<CONFIG>")
-   endif()
+   set(_test_config "$<CONFIG>")
 
    # Fortran compiler used?
    get_filename_component( _dirname ${_dir} NAME )
    set(_builddir  ${CMAKE_CURRENT_BINARY_DIR}/${_dirname})
    set(_enable_fortran)
    if(AMReX_FORTRAN)
-      set(_enable_fortran -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER})
+      set(_enable_fortran ${CMAKE_Fortran_COMPILER})
    endif()
+
+   list(LENGTH AMReX_SPACEDIM list_len)
+   math(EXPR list_last "${list_len} - 1")
+   list(GET AMReX_SPACEDIM ${list_last} AMReX_SPACEDIM_LAST)
+
+   set(_install_prefix ${CMAKE_CURRENT_BINARY_DIR}/test_install_prefix)
+   set(_stage_root ${CMAKE_CURRENT_BINARY_DIR}/test_install_stage_root)
+   set(_stage_prefix ${CMAKE_CURRENT_BINARY_DIR}/test_install_stage_prefix)
+   set(_verify_install_script ${_dir}/VerifyInstall.cmake)
 
    # Configure and Build
    # A registered POST_BUILD target in Tests/CMakeTestInstall will then also run the test.
@@ -163,11 +166,19 @@ macro( add_test_install_target _dir _amrex_root )
       COMMAND ${CMAKE_COMMAND} -E echo "     Testing AMReX installation     "
       COMMAND ${CMAKE_COMMAND} -E echo "------------------------------------"
       COMMAND ${CMAKE_COMMAND} -E echo ""
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${_builddir}
-      COMMAND ${CMAKE_COMMAND} -E echo "Configuring test project"
-      COMMAND ${CMAKE_COMMAND} -S ${_dir} -B ${_builddir} ${_select_bldtype} -DAMReX_ROOT=${_amrex_root} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ${_enable_fortran}
-      COMMAND ${CMAKE_COMMAND} -E echo "Building test project"
-      COMMAND ${CMAKE_COMMAND} --build ${_builddir} ${_select_config}
+      COMMAND ${CMAKE_COMMAND}
+         -DAMREX_TEST_INSTALL_BUILD_DIR=${PROJECT_BINARY_DIR}
+         -DAMREX_TEST_INSTALL_TEST_PROJECT_DIR=${_dir}
+         -DAMREX_TEST_INSTALL_TEST_BUILD_DIR=${_builddir}
+         -DAMREX_TEST_INSTALL_PREFIX=${_install_prefix}
+         -DAMREX_TEST_INSTALL_STAGE_ROOT=${_stage_root}
+         -DAMREX_TEST_INSTALL_STAGE_PREFIX=${_stage_prefix}
+         -DAMREX_TEST_INSTALL_CONFIG=${_test_config}
+         -DAMREX_TEST_INSTALL_IS_MULTI_CONFIG=${isMultiConfig}
+         -DAMREX_TEST_INSTALL_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+         -DAMREX_TEST_INSTALL_FORTRAN_COMPILER=${_enable_fortran}
+         -DAMREX_TEST_INSTALL_LEGACY_LIB_NAME=$<TARGET_FILE_PREFIX:amrex_${AMReX_SPACEDIM_LAST}d>amrex$<TARGET_FILE_SUFFIX:amrex_${AMReX_SPACEDIM_LAST}d>
+         -P ${_verify_install_script}
       COMMAND ${CMAKE_COMMAND} -E echo ""
       COMMAND ${CMAKE_COMMAND} -E echo "------------------------------------"
       COMMAND ${CMAKE_COMMAND} -E echo "   AMReX is installed correctly"


### PR DESCRIPTION
## Summary

Cover `--prefix` and `DESTDIR` stage in the CMake install smoke test.

## Additional background

Was also reported in #4775

- [x] merge `development` after the fix in #5277 was merged

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
