### PR TITLE
Fix out-of-bounds access in amrex::bisect

### DIFF
--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -206,7 +206,7 @@ namespace amrex
               std::enable_if_t<std::is_integral_v<I>,int> = 0>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     I bisect (T const* d, I lo, I hi, T const& v) {
-        while (lo < hi - 1) {
+        while (hi - lo > 1) {
             I mid = lo + (hi - lo) / 2;
             if (v < d[mid]) {
                 hi = mid;

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -187,10 +187,12 @@ namespace amrex
      * \brief Find the index of the interval containing a value in a sorted
      * array.
      *
-     * Find index `i` in the range [lo,hi) that d[i] <= v < d[i+1].  It is
-     * assumed that the input data are sorted and d[lo] <= v < d[hi].  Note
-     * that this is different from std::lower_bound that searches for the
-     * first element which is not less than `v`.
+     * Find index `i` in the range [lo,hi) that d[i] <= v < d[i+1]. It is
+     * assumed that the input data is sorted.
+     * The elements d[lo] and d[hi] are never acessed.
+     * If v < d[lo+1], lo is returned, and if v >= d[hi-1], hi-1 is returned.
+     * Note that this is different from std::lower_bound that searches
+     * for the first element which is not less than `v`.
      *
      * \tparam T value type.
      * \tparam I integral index type.
@@ -198,23 +200,21 @@ namespace amrex
      * \param lo inclusive lower bound of the search range.
      * \param hi exclusive upper bound of the search range.
      * \param v value to be located.
-     * \return an index `i` such that `d[i] <= v < d[i+1]`.
+     * \return an index `i` such that `d[i] <= v < d[i+1]`, with `lo <= i < hi`.
      */
     template <typename T, typename I,
               std::enable_if_t<std::is_integral_v<I>,int> = 0>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     I bisect (T const* d, I lo, I hi, T const& v) {
-        while (lo <= hi) {
-            int mid = lo + (hi-lo)/2;
-            if (v >= d[mid] && v < d[mid+1]) {
-                return mid;
-            } else if (v < d[mid]) {
-                hi = mid-1;
+        while (lo < hi - 1) {
+            I mid = lo + (hi - lo) / 2;
+            if (v < d[mid]) {
+                hi = mid;
             } else {
-                lo = mid+1;
+                lo = mid;
             }
         };
-        return hi;
+        return lo;
     }
 
     /**

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -190,7 +190,8 @@ namespace amrex
      * Find index `i` in the range [lo,hi) that d[i] <= v < d[i+1]. It is
      * assumed that the input data is sorted.
      * The elements d[lo] and d[hi] are never accessed.
-     * If v < d[lo+1], lo is returned, and if v >= d[hi-1], hi-1 is returned.
+     * It is not checked whether elements are out-of-bounds.
+     * For such elements, if v < d[lo], lo is returned, and if v >= d[hi], hi-1 is returned.
      * Note that this is different from std::lower_bound that searches
      * for the first element which is not less than `v`.
      *

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -189,9 +189,10 @@ namespace amrex
      *
      * Find index `i` in the range [lo,hi) that d[i] <= v < d[i+1]. It is
      * assumed that the input data is sorted.
-     * The elements d[lo] and d[hi] are never accessed.
-     * It is not checked whether elements are out-of-bounds.
-     * For such elements, if v < d[lo], lo is returned, and if v >= d[hi], hi-1 is returned.
+     * The elements d[lo] and d[hi] are never accessed,
+     * so that d only needs to be valid in the exclusive range (lo,hi).
+     * It is not checked whether the value v is out-of-bounds.
+     * In that case, if v < d[lo], lo is returned, and if v >= d[hi], hi-1 is returned.
      * Note that this is different from std::lower_bound that searches
      * for the first element which is not less than `v`.
      *

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -189,7 +189,7 @@ namespace amrex
      *
      * Find index `i` in the range [lo,hi) that d[i] <= v < d[i+1]. It is
      * assumed that the input data is sorted.
-     * The elements d[lo] and d[hi] are never acessed.
+     * The elements d[lo] and d[hi] are never accessed.
      * If v < d[lo+1], lo is returned, and if v >= d[hi-1], hi-1 is returned.
      * Note that this is different from std::lower_bound that searches
      * for the first element which is not less than `v`.


### PR DESCRIPTION
## Summary

Despite the documentation claiming that hi is an exclusive upper bound
```
Find index `i` in the range [lo,hi) that d[i] <= v < d[i+1].
```
The previous version would still read from the array at `d[hi]` and, if `v >= d[hi]`, return `hi` which is outside `[lo,hi)`.
Additionally, the `d[mid+1]` access would read the value at `d[hi+1]`. This is outside the bounds of arrays typically used with bisect that have size `hi - lo + 1`.
Interestingly, if one treats hi as an inclusive index by calling `bisect(d, lo, hi-1, v)`, the correct value is returned, independent of `d[hi]`. However, `d[hi]` is still accessed by `d[mid+1]`.

This PR makes hi a proper exclusive upper bound and ensures that the return value is always in `[lo, hi)`. It is implicitly assumed, but never checked, that ` d[lo] <= v < d[hi]`. This results in `d[lo]` and `d[hi]` never being accessed.

Code that I have seen that currently uses bisect gives it an array of size `hi - lo + 1` and sets `d[hi]` to be larger than any v. With this PR that code should still function correctly, however, now it will be sufficient to have an array of size `hi - lo`.

Test: https://godbolt.org/z/ca3TKxnET

## Additional background

The type of `mid` is changed from `int` to `I`.

While I have not tested the performance, the new version should be faster due to using fewer array accesses on average. With the old version in `v >= d[mid] && v < d[mid+1]`  the `d[mid+1]` access was dependent on the result of the first access due to boolean short-circuiting. If it were truly independent and the two accesses were done concurrently, then reading two values instead of one might have been an interesting performance optimization.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
