### PR TITLE
PlotFileData: Add refRatioVect

### DIFF
--- a/Src/Base/AMReX_PlotFileDataImpl.H
+++ b/Src/Base/AMReX_PlotFileDataImpl.H
@@ -19,31 +19,43 @@ public:
 
     [[nodiscard]] int finestLevel () const noexcept { return m_finest_level; }
 
-    [[nodiscard]] int refRatio (int level) const noexcept { return m_ref_ratio[level]; }
+    [[nodiscard]] int refRatio (int level) const { return m_ref_ratio[level]; }
 
-    [[nodiscard]] int levelStep (int level) const noexcept { return m_level_steps[level]; }
+    [[nodiscard]] IntVect refRatioVect (int level) const {
+        if (level >= 0 && level < m_finest_level) {
+            auto flen = probDomain(level+1).length();
+            auto clen = probDomain(level  ).length();
+            auto ratio = flen / clen;
+            AMREX_ASSERT(ratio*clen == flen);
+            return ratio;
+        } else {
+            return IntVect(0);
+        }
+    }
 
-    [[nodiscard]] const BoxArray& boxArray (int level) const noexcept { return m_ba[level]; }
+    [[nodiscard]] int levelStep (int level) const { return m_level_steps[level]; }
 
-    [[nodiscard]] const DistributionMapping& DistributionMap (int level) const noexcept { return m_dmap[level]; }
+    [[nodiscard]] const BoxArray& boxArray (int level) const { return m_ba[level]; }
 
-    void syncDistributionMap (PlotFileDataImpl const& src) noexcept;
+    [[nodiscard]] const DistributionMapping& DistributionMap (int level) const { return m_dmap[level]; }
 
-    void syncDistributionMap (int level, PlotFileDataImpl const& src) noexcept;
+    void syncDistributionMap (PlotFileDataImpl const& src);
+
+    void syncDistributionMap (int level, PlotFileDataImpl const& src);
 
     [[nodiscard]] int coordSys () const noexcept { return m_coordsys; }
 
-    [[nodiscard]] Box probDomain (int level) const noexcept { return m_prob_domain[level]; }
+    [[nodiscard]] Box probDomain (int level) const { return m_prob_domain[level]; }
 
     [[nodiscard]] Array<Real,AMREX_SPACEDIM> probSize () const noexcept { return m_prob_size; }
     [[nodiscard]] Array<Real,AMREX_SPACEDIM> probLo () const noexcept { return m_prob_lo; }
     [[nodiscard]] Array<Real,AMREX_SPACEDIM> probHi () const noexcept { return m_prob_hi; }
-    [[nodiscard]] Array<Real,AMREX_SPACEDIM> cellSize (int level) const noexcept { return m_cell_size[level]; }
+    [[nodiscard]] Array<Real,AMREX_SPACEDIM> cellSize (int level) const { return m_cell_size[level]; }
 
     [[nodiscard]] const Vector<std::string>& varNames () const noexcept { return m_var_names; }
 
     [[nodiscard]] int nComp () const noexcept { return m_ncomp; }
-    [[nodiscard]] IntVect nGrowVect (int level) const noexcept { return m_ngrow[level]; }
+    [[nodiscard]] IntVect nGrowVect (int level) const { return m_ngrow[level]; }
 
     MultiFab get (int level);
     MultiFab get (int level, std::string const& varname);

--- a/Src/Base/AMReX_PlotFileDataImpl.cpp
+++ b/Src/Base/AMReX_PlotFileDataImpl.cpp
@@ -104,7 +104,7 @@ PlotFileDataImpl::PlotFileDataImpl (std::string const& plotfile_name)
 }
 
 void
-PlotFileDataImpl::syncDistributionMap (PlotFileDataImpl const& src) noexcept
+PlotFileDataImpl::syncDistributionMap (PlotFileDataImpl const& src)
 {
     int nlevs_min = std::min(m_nlevels, src.m_nlevels);
     for (int ilev = 0; ilev < nlevs_min; ++ilev) {
@@ -113,7 +113,7 @@ PlotFileDataImpl::syncDistributionMap (PlotFileDataImpl const& src) noexcept
 }
 
 void
-PlotFileDataImpl::syncDistributionMap (int level, PlotFileDataImpl const& src) noexcept
+PlotFileDataImpl::syncDistributionMap (int level, PlotFileDataImpl const& src)
 {
     if (level <= src.finestLevel() && m_dmap[level].size() == src.DistributionMap(level).size()) {
         m_dmap[level] = src.DistributionMap(level);

--- a/Src/Base/AMReX_PlotFileUtil.H
+++ b/Src/Base/AMReX_PlotFileUtil.H
@@ -165,31 +165,38 @@ namespace amrex
 
         [[nodiscard]] int finestLevel () const noexcept { return m_impl->finestLevel(); }
 
-        [[nodiscard]] int refRatio (int level) const noexcept { return m_impl->refRatio(level); }
+        //! Note that the refinement ratio stored in plotfiles are integers,
+        //! not IntVects, for backward compatibility. If you have
+        //! non-uniform refinement ratio, you could compute it by using
+        //! `probDomain(int level)`.
+        [[nodiscard]] int refRatio (int level) const { return m_impl->refRatio(level); }
 
-        [[nodiscard]] int levelStep (int level) const noexcept { return m_impl->levelStep(level); }
+        //! Return the per-direction refinement ratio vector for the requested level.
+        [[nodiscard]] IntVect refRatioVect (int level) const { return m_impl->refRatioVect(level); }
 
-        [[nodiscard]] const BoxArray& boxArray (int level) const noexcept { return m_impl->boxArray(level); }
+        [[nodiscard]] int levelStep (int level) const { return m_impl->levelStep(level); }
 
-        [[nodiscard]] const DistributionMapping& DistributionMap (int level) const noexcept { return m_impl->DistributionMap(level); }
+        [[nodiscard]] const BoxArray& boxArray (int level) const { return m_impl->boxArray(level); }
 
-        void syncDistributionMap (PlotFileData const& src) noexcept { m_impl->syncDistributionMap(*src.m_impl); }
+        [[nodiscard]] const DistributionMapping& DistributionMap (int level) const { return m_impl->DistributionMap(level); }
 
-        void syncDistributionMap (int level, PlotFileData const& src) noexcept { m_impl->syncDistributionMap(level, *src.m_impl); }
+        void syncDistributionMap (PlotFileData const& src) { m_impl->syncDistributionMap(*src.m_impl); }
+
+        void syncDistributionMap (int level, PlotFileData const& src) { m_impl->syncDistributionMap(level, *src.m_impl); }
 
         [[nodiscard]] int coordSys () const noexcept { return m_impl->coordSys(); }
 
-        [[nodiscard]] Box probDomain (int level) const noexcept { return m_impl->probDomain(level); }
+        [[nodiscard]] Box probDomain (int level) const { return m_impl->probDomain(level); }
 
         [[nodiscard]] Array<Real,AMREX_SPACEDIM> probSize () const noexcept { return m_impl->probSize(); }
         [[nodiscard]] Array<Real,AMREX_SPACEDIM> probLo () const noexcept { return m_impl->probLo(); }
         [[nodiscard]] Array<Real,AMREX_SPACEDIM> probHi () const noexcept { return m_impl->probHi(); }
-        [[nodiscard]] Array<Real,AMREX_SPACEDIM> cellSize (int level) const noexcept { return m_impl->cellSize(level); }
+        [[nodiscard]] Array<Real,AMREX_SPACEDIM> cellSize (int level) const { return m_impl->cellSize(level); }
 
         [[nodiscard]] const Vector<std::string>& varNames () const noexcept { return m_impl->varNames(); }
 
         [[nodiscard]] int nComp () const noexcept { return m_impl->nComp(); }
-        [[nodiscard]] IntVect nGrowVect (int level) const noexcept { return m_impl->nGrowVect(level); }
+        [[nodiscard]] IntVect nGrowVect (int level) const { return m_impl->nGrowVect(level); }
 
         MultiFab get (int level) { return m_impl->get(level); }
         MultiFab get (int level, std::string const& varname) { return m_impl->get(level, varname); }

--- a/Src/Base/AMReX_PlotFileUtil.cpp
+++ b/Src/Base/AMReX_PlotFileUtil.cpp
@@ -114,7 +114,7 @@ WriteGenericPlotfileHeader (std::ostream &HeaderFile,
         }
         HeaderFile << '\n';
         for (int i = 0; i < finest_level; ++i) {
-            HeaderFile << ref_ratio[i][0] << ' ';
+            HeaderFile << ref_ratio[i][0] << ' '; // For backward compatibility, ref_ratio is saved as a scalar.
         }
         HeaderFile << '\n';
         for (int i = 0; i <= finest_level; ++i) {


### PR DESCRIPTION
Add a new function `PlotFileData::refRatioVect`. Note that for backward compatibility, the refinement ratio in a plotfile header is int, not IntVect. So we compute refinement ratio IntVect from domain Boxes.

Remove `noexcept` from a number of functions that could throw exceptions.
