### PR TITLE
Guard flag-dependent tests in CTest setup

### DIFF
--- a/Tests/Amr/Advection_AmrLevel/CMakeLists.txt
+++ b/Tests/Amr/Advection_AmrLevel/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (NOT AMReX_AMRLEVEL)
+    return()
+endif ()
+
 foreach(D IN LISTS AMReX_SPACEDIM)
     if (D EQUAL 1)
        continue()

--- a/Tests/EB/CNS/CMakeLists.txt
+++ b/Tests/EB/CNS/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (NOT AMReX_AMRLEVEL)
+   return()
+endif ()
+
 if (NOT (3 IN_LIST AMReX_SPACEDIM) OR NOT CMAKE_Fortran_COMPILER_LOADED)
    return()
 endif ()

--- a/Tests/EB_CNS/CMakeLists.txt
+++ b/Tests/EB_CNS/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (NOT AMReX_AMRLEVEL)
+    return()
+endif ()
+
 foreach(D IN LISTS AMReX_SPACEDIM)
     set(_sources main.cpp CNS_advance.cpp CNS_advance_box.cpp CNS_advance_box_eb.cpp CNS_bcfill.cpp
        CNSBld.cpp CNS.cpp CNS.H CNS_derive.cpp CNS_derive.H CNS_index_macros.H CNS_init_eb2.cpp CNS_io.cpp

--- a/Tests/GPU/CNS/CMakeLists.txt
+++ b/Tests/GPU/CNS/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (NOT AMReX_AMRLEVEL)
+   return()
+endif ()
+
 if (NOT 3 IN_LIST AMReX_SPACEDIM)
    return()
 endif ()

--- a/Tests/LinearSolvers/CurlCurl/CMakeLists.txt
+++ b/Tests/LinearSolvers/CurlCurl/CMakeLists.txt
@@ -1,6 +1,10 @@
+if (NOT AMReX_LINEAR_SOLVERS_EM)
+    return()
+endif ()
+
 foreach(D IN LISTS AMReX_SPACEDIM)
-    if (D EQUAL 1 OR NOT AMReX_LINEAR_SOLVERS_EM)
-       return()
+    if (D EQUAL 1)
+       continue()
     endif ()
 
     set(_sources

--- a/Tests/LinearSolvers/NodalPoisson/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodalPoisson/CMakeLists.txt
@@ -1,7 +1,11 @@
+if (NOT AMReX_LINEAR_SOLVERS_INCFLO)
+    return()
+endif ()
+
 foreach(D IN LISTS AMReX_SPACEDIM)
-    if(D EQUAL 1 OR NOT AMReX_LINEAR_SOLVERS_INCFLO)
+    if (D EQUAL 1)
        continue()
-    endif()
+    endif ()
 
     set(_sources main.cpp MyTest.cpp MyTest.H MyTestPlotfile.cpp)
 

--- a/Tests/LinearSolvers/NodeTensorLap/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodeTensorLap/CMakeLists.txt
@@ -1,8 +1,12 @@
+if (NOT AMReX_LINEAR_SOLVERS_EM)
+    return()
+endif ()
+
 if (AMReX_GPU_BACKEND STREQUAL NONE)
     foreach(D IN LISTS AMReX_SPACEDIM)
-        if(D EQUAL 1 OR NOT AMReX_LINEAR_SOLVERS_EM)
+        if (D EQUAL 1)
             continue()
-        endif()
+        endif ()
 
         set(_sources main.cpp MyTest.cpp MyTest.H MyTestPlotfile.cpp)
         set(_input_files)


### PR DESCRIPTION
Add explicit AMReX_AMRLEVEL checks to every AmrLevel-driven test suite so they short-circuit when the class is disabled.

Guard linear-solver samples with AMReX_LINEAR_SOLVERS_INCFLO and AMReX_LINEAR_SOLVERS_EM at the file level rather than per-dimension checks.
