### PR TITLE
Linear Solver Tests: Loosen convergence tolerance for single precision

### DIFF
--- a/Tests/LinearSolvers/ABecLaplacian_C/CMakeLists.txt
+++ b/Tests/LinearSolvers/ABecLaplacian_C/CMakeLists.txt
@@ -1,6 +1,6 @@
 foreach(D IN LISTS AMReX_SPACEDIM)
     if (D EQUAL 1)
-       return()
+       continue()
     endif ()
 
     set(_sources

--- a/Tests/LinearSolvers/ABecLaplacian_C/MyTest.cpp
+++ b/Tests/LinearSolvers/ABecLaplacian_C/MyTest.cpp
@@ -56,7 +56,12 @@ MyTest::solvePoisson ()
     info.setDeterministic(deterministic);
     info.setMaxCoarseningLevel(max_coarsening_level);
 
-    const auto tol_rel = Real(1.e-10);
+    Real tol_rel;
+    if constexpr (std::is_same_v<double,Real>) {
+        tol_rel = Real(1.0e-10);
+    } else {
+        tol_rel = Real(1.0e-4);
+    }
     const auto tol_abs = Real(0.0);
 
     const auto nlevels = static_cast<int>(geom.size());
@@ -157,7 +162,12 @@ MyTest::solveABecLaplacian ()
     info.setMaxCoarseningLevel(max_coarsening_level);
     info.setMaxSemicoarseningLevel(max_semicoarsening_level);
 
-    const auto tol_rel = Real(1.e-10);
+    Real tol_rel;
+    if constexpr (std::is_same_v<double,Real>) {
+        tol_rel = Real(1.0e-10);
+    } else {
+        tol_rel = Real(1.0e-4);
+    }
     const auto tol_abs = Real(0.0);
 
     const auto nlevels = static_cast<int>(geom.size());

--- a/Tests/LinearSolvers/CurlCurl/MyTest.cpp
+++ b/Tests/LinearSolvers/CurlCurl/MyTest.cpp
@@ -57,7 +57,12 @@ MyTest::solve ()
         mf.setVal(Real(0));
     }
 
-    auto tol_rel = Real(1.0e-10);
+    Real tol_rel;
+    if constexpr (std::is_same_v<double,Real>) {
+        tol_rel = Real(1.0e-10);
+    } else {
+        tol_rel = Real(1.0e-4);
+    }
     auto tol_abs = Real(0.0);
 
     if (use_gmres)


### PR DESCRIPTION
This should solve the HPSF GitLab CI failures.

The tests started to fail after #5305, not because that PR introduced a bug, but because that PR fixed a CMake bug that prevented the tests from running.

A similar CMake bug is also fixed in this PR.
