### PR TITLE
EdgeFluxRegister: add plus() member function

### DIFF
--- a/Src/Boundary/AMReX_EdgeFluxRegister.H
+++ b/Src/Boundary/AMReX_EdgeFluxRegister.H
@@ -87,6 +87,12 @@ public:
     //! Reset accumulated state at the start of a coarse step.
     void reset ();
 
+    //! Accumulate another register with identical layout into this one.
+    EdgeFluxRegister& operator+= (EdgeFluxRegister const& rhs);
+
+    //! Convenience alias for operator+=.
+    EdgeFluxRegister& plus (EdgeFluxRegister const& rhs);
+
 #if (AMREX_SPACEDIM == 3)
 
     /**

--- a/Src/Boundary/AMReX_EdgeFluxRegister.H
+++ b/Src/Boundary/AMReX_EdgeFluxRegister.H
@@ -88,9 +88,6 @@ public:
     void reset ();
 
     //! Accumulate another register with identical layout into this one.
-    EdgeFluxRegister& operator+= (EdgeFluxRegister const& rhs);
-
-    //! Convenience alias for operator+=.
     EdgeFluxRegister& plus (EdgeFluxRegister const& rhs);
 
 #if (AMREX_SPACEDIM == 3)

--- a/Src/Boundary/AMReX_EdgeFluxRegister.cpp
+++ b/Src/Boundary/AMReX_EdgeFluxRegister.cpp
@@ -183,7 +183,7 @@ void EdgeFluxRegister::reset ()
 }
 
 EdgeFluxRegister&
-EdgeFluxRegister::operator+= (EdgeFluxRegister const& rhs)
+EdgeFluxRegister::plus (EdgeFluxRegister const& rhs)
 {
     AMREX_ALWAYS_ASSERT(m_ratio == rhs.m_ratio);
     AMREX_ALWAYS_ASSERT(m_ncomp == rhs.m_ncomp);
@@ -205,12 +205,6 @@ EdgeFluxRegister::operator+= (EdgeFluxRegister const& rhs)
 #endif
 
     return *this;
-}
-
-EdgeFluxRegister&
-EdgeFluxRegister::plus (EdgeFluxRegister const& rhs)
-{
-    return operator+=(rhs);
 }
 
 #if (AMREX_SPACEDIM == 3)

--- a/Src/Boundary/AMReX_EdgeFluxRegister.cpp
+++ b/Src/Boundary/AMReX_EdgeFluxRegister.cpp
@@ -182,6 +182,37 @@ void EdgeFluxRegister::reset ()
     Gpu::synchronize();
 }
 
+EdgeFluxRegister&
+EdgeFluxRegister::operator+= (EdgeFluxRegister const& rhs)
+{
+    AMREX_ALWAYS_ASSERT(m_ratio == rhs.m_ratio);
+    AMREX_ALWAYS_ASSERT(m_ncomp == rhs.m_ncomp);
+
+#if (AMREX_SPACEDIM == 3)
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        MultiFab::Add(m_E_crse[idim], rhs.m_E_crse[idim], 0, 0, m_ncomp, 0);
+    }
+    for (int iface = 0; iface < AMREX_SPACEDIM*2; ++iface) {
+        for (int icomp = 0; icomp < 2; ++icomp) {
+            MultiFab::Add(m_E_fine[iface][icomp], rhs.m_E_fine[iface][icomp], 0, 0, m_ncomp, 0);
+        }
+    }
+#else
+    MultiFab::Add(m_E_crse, rhs.m_E_crse, 0, 0, m_ncomp, 0);
+    for (int iface = 0; iface < AMREX_SPACEDIM*2; ++iface) {
+        MultiFab::Add(m_E_fine[iface], rhs.m_E_fine[iface], 0, 0, m_ncomp, 0);
+    }
+#endif
+
+    return *this;
+}
+
+EdgeFluxRegister&
+EdgeFluxRegister::plus (EdgeFluxRegister const& rhs)
+{
+    return operator+=(rhs);
+}
+
 #if (AMREX_SPACEDIM == 3)
 
 void EdgeFluxRegister::CrseAdd (MFIter const& mfi, const Array<FArrayBox const*,3>& E_crse,


### PR DESCRIPTION
## Summary
Adds `plus(rhs)` to `EdgeFluxRegister`. (`FluxRegister` already has this operator.)

## Additional background
This allows the user to add a temporary EdgeFluxRegister (say, for a given hydro step) to a simulation-wide EdgeFluxRegister. Then, for example, if a hydro step is rejected, the temporary EdgeFluxRegister (which may have been incremented during each stage for a multi-stage integrator) for that step can simply be discarded and implicitly deallocated.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
