### PR TITLE
`SmallMatrix`: `Omega`

### DIFF
--- a/Src/Base/AMReX_SmallMatrix.H
+++ b/Src/Base/AMReX_SmallMatrix.H
@@ -232,24 +232,25 @@ namespace amrex {
         /** Returns the skew-symmetric matrix Omega (symplectic form)
          *
          * With 2x2 block-diagonal structure [[0,1],[-1,0]].
-         * Requires a square matrix of even dimension.
+         * Requires a square matrix of even dimension and a floating-point
+         * element type.
          *
          * @see https://en.wikipedia.org/wiki/Symplectic_matrix
          */
         template <int MM=NRows, int NN=NCols,
-                  std::enable_if_t<MM==NN && MM%2==0, int> = 0>
+                  std::enable_if_t<MM==NN && MM%2==0 && std::is_floating_point_v<T>, int> = 0>
         static constexpr
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         SmallMatrix<T,NRows,NCols,ORDER,StartIndex>
         Omega () noexcept {
             static_assert(StartIndex == 0 || StartIndex == 1);
-            SmallMatrix<T,NRows,NCols,ORDER,StartIndex> O{};
+            SmallMatrix<T,NRows,NCols,ORDER,StartIndex> omega{};
             constexpr_for<0,NRows/2>(
                 [&] (int i) {
-                    O(2*i   + StartIndex, 2*i+1 + StartIndex) =  T(1);
-                    O(2*i+1 + StartIndex, 2*i   + StartIndex) = -T(1);
+                    omega(2*i   + StartIndex, 2*i+1 + StartIndex) =  T(1);
+                    omega(2*i+1 + StartIndex, 2*i   + StartIndex) = -T(1);
                 });
-            return O;
+            return omega;
         }
 
         //! Returns a matrix initialized with zeros

--- a/Src/Base/AMReX_SmallMatrix.H
+++ b/Src/Base/AMReX_SmallMatrix.H
@@ -229,6 +229,29 @@ namespace amrex {
             return I;
         }
 
+        /** Returns the skew-symmetric matrix Omega (symplectic form)
+         *
+         * With 2x2 block-diagonal structure [[0,1],[-1,0]].
+         * Requires a square matrix of even dimension.
+         *
+         * @see https://en.wikipedia.org/wiki/Symplectic_matrix
+         */
+        template <int MM=NRows, int NN=NCols,
+                  std::enable_if_t<MM==NN && MM%2==0, int> = 0>
+        static constexpr
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        SmallMatrix<T,NRows,NCols,ORDER,StartIndex>
+        Omega () noexcept {
+            static_assert(StartIndex == 0 || StartIndex == 1);
+            SmallMatrix<T,NRows,NCols,ORDER,StartIndex> O{};
+            constexpr_for<0,NRows/2>(
+                [&] (int i) {
+                    O(2*i   + StartIndex, 2*i+1 + StartIndex) =  T(1);
+                    O(2*i+1 + StartIndex, 2*i   + StartIndex) = -T(1);
+                });
+            return O;
+        }
+
         //! Returns a matrix initialized with zeros
         static constexpr
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Tests/SmallMatrix/main.cpp
+++ b/Tests/SmallMatrix/main.cpp
@@ -4,12 +4,26 @@
 #include <AMReX_REAL.H>
 #include <AMReX_SmallMatrix.H>
 
+#include <type_traits>
+
 using namespace amrex;
+
+namespace
+{
+    template <typename Matrix, typename = void>
+    struct has_omega : std::false_type {};
+
+    template <typename Matrix>
+    struct has_omega<Matrix, std::void_t<decltype(Matrix::Omega())>> : std::true_type {};
+}
 
 int main (int argc, char* argv[])
 {
     static_assert(Order::C == Order::RowMajor &&
                   Order::F == Order::ColumnMajor);
+    static_assert(has_omega<SmallMatrix<Real,2,2>>::value);
+    static_assert(!has_omega<SmallMatrix<int,2,2>>::value);
+    static_assert(!has_omega<SmallMatrix<unsigned int,2,2>>::value);
 
     amrex::Initialize(argc, argv);
     // 0-based indexing
@@ -69,6 +83,13 @@ int main (int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(almostEqual(r[0],v3[0]) &&
                             almostEqual(r[1],v3[1]) &&
                             almostEqual(r[2],v3[2]));
+    }
+    {
+        auto omega = SmallMatrix<Real,4,4>::Omega();
+        AMREX_ALWAYS_ASSERT(omega(0,0) == 0.0_rt && omega(0,1) == 1.0_rt &&
+                            omega(1,0) ==-1.0_rt && omega(1,1) == 0.0_rt &&
+                            omega(2,2) == 0.0_rt && omega(2,3) == 1.0_rt &&
+                            omega(3,2) ==-1.0_rt && omega(3,3) == 0.0_rt);
     }
     {
         SmallMatrix<int,4,3,Order::C> A{{1, 0, 1},
@@ -214,6 +235,13 @@ int main (int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(almostEqual(r[1],v3[1]) &&
                             almostEqual(r[2],v3[2]) &&
                             almostEqual(r[3],v3[3]));
+    }
+    {
+        auto omega = SmallMatrix<Real,4,4,Order::F,1>::Omega();
+        AMREX_ALWAYS_ASSERT(omega(1,1) == 0.0_rt && omega(1,2) == 1.0_rt &&
+                            omega(2,1) ==-1.0_rt && omega(2,2) == 0.0_rt &&
+                            omega(3,3) == 0.0_rt && omega(3,4) == 1.0_rt &&
+                            omega(4,3) ==-1.0_rt && omega(4,4) == 0.0_rt);
     }
     {
         SmallMatrix<int,4,3,Order::C,1> A{{1, 0, 1},


### PR DESCRIPTION
## Summary

Add alongside the `Identity` and `Zero` matrix the skew-symmetric matrix Omega:
https://en.wikipedia.org/wiki/Symplectic_matrix#The_matrix_%CE%A9

## Additional background

Used in https://github.com/BLAST-ImpactX/impactx/pull/1396

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
