### PR TITLE
MFIter Tiling: Set a default tile size in MFItInfo::SetTiling(bool)

### DIFF
--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -35,6 +35,9 @@ struct MFItInfo
     }
     MFItInfo& SetTiling (bool f) noexcept {
         do_tiling = f;
+        if (do_tiling && tilesize == 0) {
+            tilesize = FabArrayBase::mfiter_tile_size;
+        }
         return *this;
     }
     MFItInfo& SetDynamic (bool f) noexcept {


### PR DESCRIPTION
Otherwise, it might be surprising that calling SetTiling(true) alone does not turn on tiling.
