### PR TITLE
Call HYPRE_DeviceInitialize after HYPRE_Init if using GPUs

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -754,6 +754,7 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         hypre_HandleDefaultExecPolicy(hypre_handle()) = HYPRE_EXEC_DEVICE;
         hypre_HandleSpgemmUseCusparse(hypre_handle()) = 0;
 #endif
+        HYPRE_DeviceInitialize();
 #endif
 
         if (system::verbose > 0) {

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -754,7 +754,10 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
         hypre_HandleDefaultExecPolicy(hypre_handle()) = HYPRE_EXEC_DEVICE;
         hypre_HandleSpgemmUseCusparse(hypre_handle()) = 0;
 #endif
+#if (HYPRE_RELEASE_NUMBER >= 23100)
+        // Discussion in https://github.com/AMReX-Codes/amrex/pull/5336
         HYPRE_DeviceInitialize();
+#endif
 #endif
 
         if (system::verbose > 0) {


### PR DESCRIPTION
## Summary

Without this, I was experiencing errors during init on a machine where MPI ranks can see multiple GPUs:
```
CUDA ERROR (code = 1, invalid argument) at /whatever/hypre/src/utilities/memory.c:136
```

Setting `export CUDA_VISIBLE_DEVICES=0` was able to avoid the error, but the actual fix seems to be to include the call to `HYPRE_DeviceInitialize()` after `HYPRE_Init()` when using GPUs.

I can verify this solves the error I was seeing when using hypre with AMReX in AMR-Wind.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
