### PR TITLE
Regression test for MLEBABecLap when dx =/= dy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,11 @@ BLProfParser.lex.yy.cpp
 BLProfParser.tab.H
 BLProfParser.tab.cpp
 BLProfParserNC.y
+
+# Regtests
+ChangeLog.AMReX
+git.AMReX.HEAD
+git.AMReX.out
+fboxinfo.make.out
+fcompare.make.out
+fsnapshot.make.out

--- a/Tests/LinearSolvers/CellEB2/MyTest.H
+++ b/Tests/LinearSolvers/CellEB2/MyTest.H
@@ -28,6 +28,9 @@ private:
     int max_level = 0;
     int ref_ratio = 2;
     int n_cell = 128;
+    int n_cell_x = 128;
+    int n_cell_y = 128;
+    int n_cell_z = 128;
     int max_grid_size = 64;
 
     int prob_type = 2;

--- a/Tests/LinearSolvers/CellEB2/MyTest.cpp
+++ b/Tests/LinearSolvers/CellEB2/MyTest.cpp
@@ -170,7 +170,7 @@ MyTest::solve ()
             MultiFab::Multiply(mf, vfrc, 0, 0, 1, 0);
 
             Real norminf = mf.norm0();
-            Real norm1 = mf.norm1()*AMREX_D_TERM((1.0/n_cell), *(1.0/n_cell), *(1.0/n_cell));
+            Real norm1 = mf.norm1()*AMREX_D_TERM((1.0/n_cell_x), *(1.0/n_cell_y), *(1.0/n_cell_z));
             amrex::Print() << "Level " << ilev << ": weighted max and 1 norms " << norminf << ", " << norm1 << '\n';
         }
     }
@@ -285,7 +285,7 @@ MyTest::initGrids ()
     RealBox rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,1.,1.)});
     std::array<int,AMREX_SPACEDIM> isperiodic{AMREX_D_DECL(0,0,0)};
     Geometry::Setup(&rb, 0, isperiodic.data());
-    Box domain0(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell-1,n_cell-1,n_cell-1)});
+    Box domain0(IntVect{AMREX_D_DECL(0,0,0)}, IntVect{AMREX_D_DECL(n_cell_x-1,n_cell_y-1,n_cell_z-1)});
     Box domain = domain0;
     for (int ilev = 0; ilev < nlevels; ++ilev)
     {

--- a/Tests/LinearSolvers/CellEB2/MyTest.cpp
+++ b/Tests/LinearSolvers/CellEB2/MyTest.cpp
@@ -231,6 +231,15 @@ MyTest::readParameters ()
     ParmParse pp;
     pp.query("max_level", max_level);
     pp.query("n_cell", n_cell);
+    if (!pp.query("n_cell_x", n_cell_x)) {
+        n_cell_x = n_cell;
+    }
+    if (!pp.query("n_cell_y", n_cell_y)) {
+        n_cell_y = n_cell;
+    }
+    if (!pp.query("n_cell_z", n_cell_z)) {
+        n_cell_z = n_cell;
+    }
     pp.query("max_grid_size", max_grid_size);
     pp.query("prob_type", prob_type);
 

--- a/Tests/LinearSolvers/CellEB2/inputs.rt.2d.aniso
+++ b/Tests/LinearSolvers/CellEB2/inputs.rt.2d.aniso
@@ -1,0 +1,34 @@
+amrex.fpe_trap_invalid = 1
+
+composite_solve = 0
+
+#max_coarsening_level = 0
+reltol = 1.e-12
+
+prob_type = 1
+
+max_level = 1
+
+n_cell_x = 96
+n_cell_y = 176
+
+max_grid_size = 64
+eb2.max_grid_size = 32
+eb2.num_coarsen_opt = 3
+
+eb2.geom_type = sphere
+eb2.sphere_center = 0.5  0.5  0.5
+eb2.sphere_radius = 0.4
+eb2.sphere_has_fluid_inside = 1
+
+eb2.geom_type = box
+eb2.box_lo = 0.2  0.2  0.2
+eb2.box_hi = 0.8  0.8  0.8
+eb2.box_has_fluid_inside = 1
+
+eb2.geom_type = flower
+
+eb2.geom_type = rotated_box
+
+# choose geom_type
+eb2.geom_type = flower

--- a/Tests/LinearSolvers/CellEB2/inputs.rt.3d.aniso
+++ b/Tests/LinearSolvers/CellEB2/inputs.rt.3d.aniso
@@ -1,0 +1,35 @@
+amrex.fpe_trap_invalid = 1
+
+composite_solve = 1
+
+#max_coarsening_level = 0
+reltol = 1.e-12
+
+prob_type = 2
+
+max_level = 1
+
+n_cell_x = 96
+n_cell_y = 176
+n_cell_z = 128
+
+max_grid_size = 64
+eb2.max_grid_size = 32
+eb2.num_coarsen_opt = 3
+
+eb2.geom_type = sphere
+eb2.sphere_center = 0.5  0.5  0.5
+eb2.sphere_radius = 0.4
+eb2.sphere_has_fluid_inside = 1
+
+eb2.geom_type = box
+eb2.box_lo = 0.2  0.2  0.2
+eb2.box_hi = 0.8  0.8  0.8
+eb2.box_has_fluid_inside = 1
+
+eb2.geom_type = flower
+
+eb2.geom_type = rotated_box
+
+# choose geom_type
+eb2.geom_type = flower

--- a/Tools/RegressionTesting/AMReX-cuda-tests.ini
+++ b/Tools/RegressionTesting/AMReX-cuda-tests.ini
@@ -143,12 +143,46 @@ doVis = 0
 outputFile = plot
 testSrcTree = C_Src
 
+[EB_Cell_Dir_2D_Aniso]
+addToCompileString = USE_CUDA=TRUE
+tolerance = 6.e-11
+runtime_params = gpu_regtest=1
+buildDir = Tests/LinearSolvers/CellEB2
+inputFile = inputs.rt.2d.aniso
+dim = 2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+outputFile = plot
+testSrcTree = C_Src
+
 [EB_Cell_Dir_3D]
 addToCompileString = USE_CUDA=TRUE
 tolerance = 1.e-13
 runtime_params = eb2.geom_type=rotated_box gpu_regtest=1
 buildDir = Tests/LinearSolvers/CellEB2
 inputFile = inputs.rt.3d
+dim = 3
+restartTest = 0
+useMPI = 1
+numprocs = 4
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+outputFile = plot
+testSrcTree = C_Src
+
+[EB_Cell_Dir_3D_Aniso]
+addToCompileString = USE_CUDA=TRUE
+tolerance = 1.e-13
+runtime_params = eb2.geom_type=rotated_box gpu_regtest=1
+buildDir = Tests/LinearSolvers/CellEB2
+inputFile = inputs.rt.3d.aniso
 dim = 3
 restartTest = 0
 useMPI = 1

--- a/Tools/RegressionTesting/AMReX-hip-tests.ini
+++ b/Tools/RegressionTesting/AMReX-hip-tests.ini
@@ -141,12 +141,46 @@ doVis = 0
 outputFile = plot
 testSrcTree = C_Src
 
+[EB_Cell_Dir_2D_Aniso]
+addToCompileString = USE_CUDA=FALSE USE_HIP=TRUE
+tolerance = 3.e-8
+runtime_params = gpu_regtest=1
+buildDir = Tests/LinearSolvers/CellEB2
+inputFile = inputs.rt.2d.aniso
+dim = 2
+restartTest = 0
+useMPI = 0
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+outputFile = plot
+testSrcTree = C_Src
+
 [EB_Cell_Dir_3D]
 addToCompileString = USE_CUDA=FALSE USE_HIP=TRUE
 tolerance = 3.e-13
 runtime_params = eb2.geom_type=rotated_box gpu_regtest=1
 buildDir = Tests/LinearSolvers/CellEB2
 inputFile = inputs.rt.3d
+dim = 3
+restartTest = 0
+useMPI = 0
+numprocs = 4
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+outputFile = plot
+testSrcTree = C_Src
+
+[EB_Cell_Dir_3D_Aniso]
+addToCompileString = USE_CUDA=FALSE USE_HIP=TRUE
+tolerance = 3.e-13
+runtime_params = eb2.geom_type=rotated_box gpu_regtest=1
+buildDir = Tests/LinearSolvers/CellEB2
+inputFile = inputs.rt.3d.aniso
 dim = 3
 restartTest = 0
 useMPI = 0

--- a/Tools/RegressionTesting/AMReX-sycl-tests.ini
+++ b/Tools/RegressionTesting/AMReX-sycl-tests.ini
@@ -90,12 +90,46 @@ doVis = 0
 outputFile = plot
 testSrcTree = C_Src
 
+[EB_Cell_Dir_2D_Aniso]
+addToCompileString = USE_CUDA=FALSE USE_HIP=FALSE USE_SYCL=TRUE
+tolerance = 2.e-12
+runtime_params = gpu_regtest=1
+buildDir = Tests/LinearSolvers/CellEB2
+inputFile = inputs.rt.2d.aniso
+dim = 2
+restartTest = 0
+useMPI = 0
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+outputFile = plot
+testSrcTree = C_Src
+
 [EB_Cell_Dir_3D]
 addToCompileString = USE_CUDA=FALSE USE_SYCL=TRUE
 tolerance = 2.e-11
 runtime_params = eb2.geom_type=rotated_box gpu_regtest=1
 buildDir = Tests/LinearSolvers/CellEB2
 inputFile = inputs.rt.3d
+dim = 3
+restartTest = 0
+useMPI = 0
+numprocs = 4
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+outputFile = plot
+testSrcTree = C_Src
+
+[EB_Cell_Dir_3D_Aniso]
+addToCompileString = USE_CUDA=FALSE USE_SYCL=TRUE
+tolerance = 2.e-11
+runtime_params = eb2.geom_type=rotated_box gpu_regtest=1
+buildDir = Tests/LinearSolvers/CellEB2
+inputFile = inputs.rt.3d.aniso
 dim = 3
 restartTest = 0
 useMPI = 0

--- a/Tools/RegressionTesting/AMReX-tests.ini
+++ b/Tools/RegressionTesting/AMReX-tests.ini
@@ -290,11 +290,11 @@ testSrcTree = C_Src
 [EB_Cell_Dir_3D_Aniso]
 buildDir = Tests/LinearSolvers/CellEB2
 inputFile = inputs.rt.3d.aniso
-dim = 2
+dim = 3
 restartTest = 0
 useMPI = 1
 numprocs = 2
-useOMP = 0
+useOMP = 1
 numthreads = 2
 compileTest = 0
 doVis = 0

--- a/Tools/RegressionTesting/AMReX-tests.ini
+++ b/Tools/RegressionTesting/AMReX-tests.ini
@@ -259,6 +259,20 @@ doVis = 0
 outputFile = plot
 testSrcTree = C_Src
 
+[EB_Cell_Dir_2D_Aniso]
+buildDir = Tests/LinearSolvers/CellEB2
+inputFile = inputs.rt.2d.aniso
+dim = 2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
+numthreads = 2
+compileTest = 0
+doVis = 0
+outputFile = plot
+testSrcTree = C_Src
+
 [EB_Cell_Dir_3D]
 buildDir = Tests/LinearSolvers/CellEB2
 inputFile = inputs.rt.3d
@@ -267,6 +281,20 @@ restartTest = 0
 useMPI = 1
 numprocs = 2
 useOMP = 1
+numthreads = 2
+compileTest = 0
+doVis = 0
+outputFile = plot
+testSrcTree = C_Src
+
+[EB_Cell_Dir_3D_Aniso]
+buildDir = Tests/LinearSolvers/CellEB2
+inputFile = inputs.rt.3d.aniso
+dim = 2
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 0
 numthreads = 2
 compileTest = 0
 doVis = 0


### PR DESCRIPTION
## Summary
This tests the linear solver MLEBABecLap in the case where dx =/= dy. The test currently converges for the 2D case, but not the 3D case.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
