### PR TITLE
Remove amrex::IsStdVector

### DIFF
--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -10,6 +10,7 @@
 #include <AMReX_IParser.H>
 #include <AMReX_Parser.H>
 #include <AMReX_TypeTraits.H>
+#include <AMReX_Vector.H>
 
 #include <array>
 #include <iosfwd>
@@ -1040,7 +1041,7 @@ public:
      * added to the ParmParse database.  The return value indicates if it
      * existed previously.
      */
-    template <typename T, std::enable_if_t<!IsStdVector<T>::value, int> = 0>
+    template <typename T>
     int queryAdd (std::string_view name, T& ref) {
         int exist = this->query(name, ref);
         if (!exist) {
@@ -1077,6 +1078,11 @@ public:
             this->addarr(name, ref);
         }
         return exist;
+    }
+
+    template <typename T>
+    int queryAdd (std::string_view name, Vector<T>& ref) {
+        return this->queryAdd(name, static_cast<std::vector<T>&>(ref));
     }
 
     /**

--- a/Src/Base/AMReX_TypeTraits.H
+++ b/Src/Base/AMReX_TypeTraits.H
@@ -301,16 +301,6 @@ namespace amrex
                                 std::is_arithmetic_v<T>
                                 && sizeof(T) <= 8 > >
         : std::true_type {};
-
-    template <class T, class Enable = void>
-    struct IsStdVector : std::false_type {};
-    //
-    template <class T>
-    struct IsStdVector<T, std::enable_if_t<std::is_base_of_v<std::vector<typename T::value_type,
-                                                                       typename T::allocator_type>,
-                                                           T>> >
-                       : std::true_type {};
-
 }
 
 #endif


### PR DESCRIPTION
The type trait was added to work around the issue of calling `queryAdd(std::string_veiw,Vector<T>&)`. We now support this by adding an overload for it directly.
