### PR TITLE
Clang-Tidy: modernize-use-ranges

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -58,6 +58,7 @@ Checks: >
        -readability-magic-numbers,
        -readability-math-missing-parentheses,
        -readability-named-parameter,
+       -readability-qualified-auto,
        -readability-redundant-casting,
        -readability-redundant-member-init,
        -readability-static-accessed-through-instance,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -73,6 +73,10 @@ HeaderFilterRegex: '([^n].....|[^o]....|[^l]...|[^i]..|[^n].|[^t])\.H$'
 # Only available in clang-tidy >= 17
 HeaderFileExtensions: ['', "H", 'h', 'hh', 'hpp', 'hxx']
 
-# modernize-use-constraints and modernize-use-ranges are disabled.
+# modernize-use-constraints is not a required check:
 # C++20 concepts/constraints have too many compiler-specific issues
 # (MSVC, NVHPC, CUDA-on-Windows, etc.) to be used in AMReX.
+
+# modernize-use-ranges is not a required check:
+# (1) Clang <= 15 has bugs with std::ranges.
+# (2) std::ranges::sort requires std::sortable, which is stricter than operator<.

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -207,7 +207,7 @@ jobs:
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
-        export CCACHE_MAXSIZE=220M
+        export CCACHE_MAXSIZE=300M
         ccache -z
 
         source /etc/profile.d/modules.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,8 @@ parenthesis of the parameter list (but not when simply calling the function). Fo
   * C++20 concepts and constraints are discouraged on class templates and their member functions.
     Compiler support for these features is still inconsistent across AMReX's target platforms
     (e.g., MSVC, NVHPC, older Clang).
+  * Avoid `std::ranges::find_if` and `std::ranges::unique` — Clang ≤ 15
+    has bugs when compiling them with libstdc++. Use `std::find_if` and `std::unique` instead.
 
 These guidelines should be adhered to in new contributions to AMReX, but
 please refrain from making stylistic changes to unrelated sections of code in your PRs.

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -607,14 +607,14 @@ Amr::finalizeInSitu()
 bool
 Amr::isStatePlotVar (const std::string& name)
 {
-    auto it = std::find(state_plot_vars.begin(), state_plot_vars.end(), name);
+    auto it = std::ranges::find(state_plot_vars, name);
     return (it != state_plot_vars.end());
 }
 
 bool
 Amr::isStateSmallPlotVar (const std::string& name)
 {
-    auto it = std::find(state_small_plot_vars.begin(), state_small_plot_vars.end(), name);
+    auto it = std::ranges::find(state_small_plot_vars, name);
     return (it != state_small_plot_vars.end());
 }
 
@@ -685,14 +685,14 @@ Amr::deleteStatePlotVar (const std::string& name)
 bool
 Amr::isDerivePlotVar (const std::string& name) noexcept
 {
-    auto it = std::find(derive_plot_vars.begin(), derive_plot_vars.end(), name);
+    auto it = std::ranges::find(derive_plot_vars, name);
     return (it != derive_plot_vars.end());
 }
 
 bool
 Amr::isDeriveSmallPlotVar (const std::string& name) noexcept
 {
-    auto it = std::find(derive_small_plot_vars.begin(), derive_small_plot_vars.end(), name);
+    auto it = std::ranges::find(derive_small_plot_vars, name);
     return (it != derive_small_plot_vars.end());
 }
 

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -485,7 +485,7 @@ AmrMesh::ChopGrids (int lev, BoxArray& ba, int target_size) const
             chunk_dir{AMREX_D_DECL(std::make_pair(chunk[0],int(0)),
                                    std::make_pair(chunk[1],int(1)),
                                    std::make_pair(chunk[2],int(2)))};
-        std::sort(chunk_dir.begin(), chunk_dir.end());
+        std::ranges::sort(chunk_dir);
 
         for (int idx = AMREX_SPACEDIM-1; idx >= 0; idx--) {
             int idim = chunk_dir[idx].second;

--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -661,8 +661,8 @@ TagBoxArray::collate (Gpu::PinnedVector<IntVect>& TheGlobalCollateSpace) const
     auto countvec_int = std::vector<int>(countvec.size());
     auto offset_int = std::vector<int>(offset.size());
     const auto mul_funct = [](const auto el){return el*AMREX_SPACEDIM;};
-    std::transform(countvec.begin(), countvec.end(), countvec_int.begin(), mul_funct);
-    std::transform(offset.begin(), offset.end(), offset_int.begin(), mul_funct);
+    std::ranges::transform(countvec, countvec_int.begin(), mul_funct);
+    std::ranges::transform(offset, offset_int.begin(), mul_funct);
     ParallelDescriptor::Gatherv(
         psend_int, count_int, precv_int, countvec_int, offset_int, IOProcNumber);
 #endif

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -1943,7 +1943,7 @@ bool match (const BoxArray& x, const BoxArray& y)
 BoxArray decompose (Box const& domain, int nboxes,
                     Array<bool,AMREX_SPACEDIM> const& decomp, bool no_overlap)
 {
-    auto ndecomp = std::count(decomp.begin(), decomp.end(), true);
+    auto ndecomp = std::ranges::count(decomp, true);
 
     if (nboxes <= 1 || ndecomp == 0) {
         return BoxArray(domain);
@@ -2017,7 +2017,7 @@ BoxArray decompose (Box const& domain, int nboxes,
 
         int nprocs_tot = 1;
         while (!factors.empty()) {
-            std::sort(procdim.begin(), procdim.end(), comp);
+            std::ranges::sort(procdim, comp);
             auto f = factors.back();
             factors.pop_back();
             procdim.back().nproc *= f;
@@ -2031,7 +2031,7 @@ BoxArray decompose (Box const& domain, int nboxes,
         // swap to see if the decomposition can be improved.
         while (true)
         {
-            std::sort(procdim.begin(), procdim.end(), comp);
+            std::ranges::sort(procdim, comp);
             auto fit = std::find_if(procdim.begin(),procdim.end(),
                                     [] (ProcDim const& x) { return x.nproc > 1; });
             if (fit == procdim.end()) { break; } // This should not actually happen.

--- a/Src/Base/AMReX_BoxDomain.cpp
+++ b/Src/Base/AMReX_BoxDomain.cpp
@@ -138,9 +138,7 @@ BoxDomain::add (const Box& b)
                 cbx = Box();
             }
         }
-        check.erase(std::remove_if(check.begin(), check.end(),
-                                   [](const Box& x) { return x.isEmpty(); }),
-                    check.end());
+        std::erase_if(check, [](const Box& x) { return x.isEmpty(); });
         check.insert(std::end(check), std::begin(tmp), std::end(tmp));
     }
     join(check);

--- a/Src/Base/AMReX_BoxList.cpp
+++ b/Src/Base/AMReX_BoxList.cpp
@@ -92,9 +92,7 @@ BoxList::catenate (BoxList& blist)
 BoxList&
 BoxList::removeEmpty()
 {
-    m_lbox.erase(std::remove_if(m_lbox.begin(), m_lbox.end(),
-                                [](const Box& x) { return x.isEmpty(); }),
-                 m_lbox.end());
+    std::erase_if(m_lbox, [](const Box& x) { return x.isEmpty(); });
     return *this;
 }
 
@@ -236,8 +234,8 @@ BoxList::BoxList (const Box& bx, int nboxes, Direction dir)
 bool
 BoxList::ok () const noexcept
 {
-    return std::all_of(this->cbegin(), this->cend(),
-                       [] (Box const& b) { return b.ok(); });
+    return std::ranges::all_of(*this,
+                               [] (Box const& b) { return b.ok(); });
 }
 
 bool
@@ -259,8 +257,8 @@ BoxList::contains (const BoxList& bl) const
 
     BoxArray ba(*this);
 
-    return std::all_of(bl.cbegin(), bl.cend(),
-                       [&ba] (Box const& b) { return ba.contains(b); });
+    return std::ranges::all_of(bl,
+                               [&ba] (Box const& b) { return ba.contains(b); });
 }
 
 BoxList&
@@ -653,7 +651,7 @@ boxDiff (BoxList& bl_diff, const Box& b1in, const Box& b2)
 int
 BoxList::simplify (bool best)
 {
-    std::sort(m_lbox.begin(), m_lbox.end(), [](const Box& l, const Box& r) {
+    std::ranges::sort(m_lbox, [](const Box& l, const Box& r) {
             return l.smallEnd() < r.smallEnd(); });
 
     //

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -408,24 +408,21 @@ CArena::freeUnused_protected ()
 {
     std::size_t nbytes = 0;
     std::vector<std::pair<void*, std::size_t>> to_free{};
-    m_alloc.erase(std::remove_if(m_alloc.begin(), m_alloc.end(),
-                                 [&nbytes,&to_free,this] (std::pair<void*,std::size_t> a)
-                                 {
-                                     // We cannot simply use std::set::erase because
-                                     // Node::operator== only compares the starting address.
-                                     auto it = m_freelist.find(Node(a.first,nullptr,0));
-                                     if (it != m_freelist.end() &&
-                                         it->owner() == a.first &&
-                                         it->size()  == a.second)
-                                     {
-                                         it = m_freelist.erase(it);
-                                         nbytes += a.second;
-                                         to_free.emplace_back(a.first, a.second);
-                                         return true;
-                                     }
-                                     return false;
-                                 }),
-                  m_alloc.end());
+    std::erase_if(m_alloc, [&nbytes,&to_free,this] (std::pair<void*,std::size_t> a) {
+        // We cannot simply use std::set::erase because
+        // Node::operator== only compares the starting address.
+        auto it = m_freelist.find(Node(a.first,nullptr,0));
+        if (it != m_freelist.end() &&
+            it->owner() == a.first &&
+            it->size()  == a.second)
+        {
+            it = m_freelist.erase(it);
+            nbytes += a.second;
+            to_free.emplace_back(a.first, a.second);
+            return true;
+        }
+        return false;
+    });
     m_used -= nbytes;
 
     // deallocate_system can call cudafree which may perform implicit synchronization

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -182,10 +182,10 @@ DistributionMapping::Sort (std::vector<LIpair>& vec,
     if (std::ssize(vec) > 1)
     {
         if (reverse) {
-            std::stable_sort(vec.begin(), vec.end(), LIpairGT());
+            std::ranges::stable_sort(vec, LIpairGT());
         }
         else {
-            std::stable_sort(vec.begin(), vec.end(), LIpairLT());
+            std::ranges::stable_sort(vec, LIpairLT());
         }
     }
 }
@@ -1057,8 +1057,8 @@ DistributionMapping::KnapSackProcessorMap (const DistributionMapping& olddm,
                 }
             }
 
-            AMREX_ASSERT(std::none_of(m_ref->m_pmap.cbegin(), m_ref->m_pmap.cend(),
-                                      [] (int i) { return i < 0; }));
+            AMREX_ASSERT(std::ranges::none_of(m_ref->m_pmap,
+                                              [] (int i) { return i < 0; }));
         }
     }
 }
@@ -1324,7 +1324,7 @@ DistributionMapping::SFCProcessorMapDoIt (const BoxArray&          boxes,
     //
     // Put'm in Morton space filling curve order.
     //
-    std::sort(tokens.begin(), tokens.end(), SFCToken::Compare());
+    std::ranges::sort(tokens, SFCToken::Compare());
     //
     // Split'm up as equitably as possible per team.
     //
@@ -1569,7 +1569,7 @@ DistributionMapping::RRSFCDoIt (const BoxArray&          boxes,
     //
     // Put'm in Morton space filling curve order.
     //
-    std::sort(tokens.begin(), tokens.end(), SFCToken::Compare());
+    std::ranges::sort(tokens, SFCToken::Compare());
 
     Vector<int> ord;
 
@@ -1600,7 +1600,7 @@ DistributionMapping::ConvertCostRealToLong (const Vector<Real>& rcost)
 
     if (rcost.empty()) { return cost; }
 
-    Real wmax = *std::max_element(rcost.begin(), rcost.end());
+    Real wmax = *std::ranges::max_element(rcost);
     Real scale = (wmax == 0) ? 1.e9_rt : 1.e9_rt/wmax;
 
     for (Long i = 0; i < rcost.size(); ++i) {
@@ -1897,7 +1897,7 @@ DistributionMapping::makeSFC (const BoxArray& ba, bool use_box_vol, int nprocs)
     //
     // Put'm in Morton space filling curve order.
     //
-    std::sort(tokens.begin(), tokens.end(), SFCToken::Compare());
+    std::ranges::sort(tokens, SFCToken::Compare());
 
     Real volper = static_cast<Real>(vol_sum) / static_cast<Real>(nprocs);
 

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -117,8 +117,7 @@ public:
 
     //! Return local index in the vector of FABs.
     [[nodiscard]] int localindex (int K) const noexcept {
-        auto low
-            = std::lower_bound(indexArray.begin(), indexArray.end(), K);
+        auto low = std::ranges::lower_bound(indexArray, K);
         if (low != indexArray.end() && *low == K) {
             return static_cast<int>(low - indexArray.begin());
         }

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -2404,9 +2404,9 @@ FabArrayBase::buildTileArray (const IntVect& tileSize, TileArray& ta) const
         const int nworkers = ParallelDescriptor::TeamSize();
         if (nworkers > 1) {
             // reorder it so that each worker will be more likely to work on their own fabs
-            std::stable_sort(local_idxs.begin(), local_idxs.end(), [this](int i, int j)
-                             { return  this->distributionMap[this->indexArray[i]]
-                                     < this->distributionMap[this->indexArray[j]]; });
+            std::ranges::stable_sort(local_idxs, [this](int i, int j)
+                                     { return  this->distributionMap[this->indexArray[i]]
+                                             < this->distributionMap[this->indexArray[j]]; });
         }
 #endif
 

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -242,7 +242,7 @@ FabArray<FAB>::FillBoundary_finish ()
             }
         }
 
-        int actual_n_rcvs = N_rcvs - std::count(fbd->recv_data.begin(), fbd->recv_data.end(), nullptr);
+        int actual_n_rcvs = N_rcvs - std::ranges::count(fbd->recv_data, nullptr);
 
         if (actual_n_rcvs > 0) {
             ParallelDescriptor::Waitall(fbd->recv_reqs, fbd->recv_stat);
@@ -599,7 +599,7 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
         if (N_rcvs > 0) {
             PostRcvs(*thecpc.m_RcvTags, pcd->the_recv_data,
                      pcd->recv_data, pcd->recv_size, pcd->recv_from, pcd->recv_reqs, NC, pcd->tag);
-            pcd->actual_n_rcvs = N_rcvs - std::count(pcd->recv_size.begin(), pcd->recv_size.end(), 0);
+            pcd->actual_n_rcvs = N_rcvs - std::ranges::count(pcd->recv_size, 0);
         }
 
         //

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -634,7 +634,7 @@ Device::initialize_gpu (bool minimal)
             }
 #endif
         }
-        auto found = std::find(sgss.begin(), sgss.end(), static_cast<decltype(sgss)::value_type>(warp_size));
+        auto found = std::ranges::find(sgss, static_cast<decltype(sgss)::value_type>(warp_size));
         if (found == sgss.end()) { amrex::Abort("Incorrect subgroup size"); }
     }
 #endif

--- a/Src/Base/AMReX_MPMD.cpp
+++ b/Src/Base/AMReX_MPMD.cpp
@@ -25,7 +25,7 @@ namespace {
 template <typename T>
 int num_unique_elements (std::vector<T>& v)
 {
-    std::sort(v.begin(), v.end());
+    std::ranges::sort(v);
     auto last = std::unique(v.begin(), v.end());
     return last - v.begin();
 }

--- a/Src/Base/AMReX_MemProfiler.cpp
+++ b/Src/Base/AMReX_MemProfiler.cpp
@@ -25,7 +25,7 @@ void
 MemProfiler::add (const std::string& name, std::function<MemInfo()>&& f)
 {
     MemProfiler& mprofiler = getInstance();
-    auto it = std::find(mprofiler.the_names.begin(), mprofiler.the_names.end(), name);
+    auto it = std::ranges::find(mprofiler.the_names, name);
     if (it != mprofiler.the_names.end()) {
         std::string s = "MemProfiler::add (MemInfo) failed because " + name + " already existed";
         amrex::Abort(s.c_str());
@@ -38,7 +38,7 @@ void
 MemProfiler::add (const std::string& name, std::function<NBuildsInfo()>&& f)
 {
     MemProfiler& mprofiler = getInstance();
-    auto it = std::find(mprofiler.the_names_builds.begin(), mprofiler.the_names_builds.end(), name);
+    auto it = std::ranges::find(mprofiler.the_names_builds, name);
     if (it != mprofiler.the_names_builds.end()) {
         std::string s = "MemProfiler::add (NBuildsInfo) failed because " + name + " already existed";
         amrex::Abort(s.c_str());
@@ -249,8 +249,8 @@ MemProfiler::report_ (const std::string& prefix, const std::string& memory_log_n
 
         std::vector<int> idxs(the_names.size());
         std::iota(idxs.begin(), idxs.end(), 0);
-        std::sort(idxs.begin(), idxs.end(), [&](int i, int j)
-                  { return hwm_max[i] > hwm_max[j]; });
+        std::ranges::sort(idxs, [&](int i, int j)
+                          { return hwm_max[i] > hwm_max[j]; });
 
         for (int ii = 0; ii < idxs.size(); ++ii) {
             int i = idxs[ii];

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -173,9 +173,9 @@ namespace amrex::ParallelDescriptor {
       std::vector<unsigned short> PMI_y_meshcoord(all_y_meshcoords, all_y_meshcoords + ParallelDescriptor::NProcs());
       std::vector<unsigned short> PMI_z_meshcoord(all_z_meshcoords, all_z_meshcoords + ParallelDescriptor::NProcs());
 
-      std::sort(PMI_x_meshcoord.begin(), PMI_x_meshcoord.end());
-      std::sort(PMI_y_meshcoord.begin(), PMI_y_meshcoord.end());
-      std::sort(PMI_z_meshcoord.begin(), PMI_z_meshcoord.end());
+      std::ranges::sort(PMI_x_meshcoord);
+      std::ranges::sort(PMI_y_meshcoord);
+      std::ranges::sort(PMI_z_meshcoord);
 
       auto last = std::unique(PMI_x_meshcoord.begin(), PMI_x_meshcoord.end());
       amrex::Print() << "# of unique groups: " << std::distance(PMI_x_meshcoord.begin(), last) << '\n';

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1496,10 +1496,9 @@ public:
         int exist = this->query(name, s, ival);
         if (exist) {
             try {
-                s.erase(std::remove_if(s.begin(), s.end(),
-                                       [&] (auto const& c) {
-                                           return ignores.find(c) != std::string_view::npos; }),
-                        s.end());
+                std::erase_if(s, [&] (auto const& c) {
+                    return ignores.find(c) != std::string_view::npos;
+                });
                 ref = amrex::getEnumCaseInsensitive<T>(s);
             } catch (...) {
                 if (amrex::Verbose() > 0) {

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -705,8 +705,7 @@ read_file (const char* fname, ParmParse::Table& tab)
                 continue;
             }
 
-            if (std::find(std::begin(valid_region), std::end(valid_region), false)
-                != std::end(valid_region)) {
+            if (std::ranges::find(valid_region, false) != std::end(valid_region)) {
                 continue;
             }
 
@@ -1457,10 +1456,10 @@ ppinit (int argc, char** argv, const char* parfile, ParmParse::Table& table)
         for (auto& [name, arg_entry] : arg_table) {
             auto& src = arg_entry.m_vals;
             auto& dst = table[name].m_vals;
-            std::move(std::begin(src), std::end(src), std::back_inserter(dst));
+            std::ranges::move(src, std::back_inserter(dst));
             auto& src_quotes = arg_entry.m_quotes;
             auto& dst_quotes = table[name].m_quotes;
-            std::move(std::begin(src_quotes), std::end(src_quotes), std::back_inserter(dst_quotes));
+            std::ranges::move(src_quotes, std::back_inserter(dst_quotes));
         }
     }
     initialized = true;
@@ -1470,13 +1469,13 @@ bool unused_table_entries_q (const ParmParse::Table& table,
                              const std::string& prefix = std::string())
 {
     if (prefix.empty()) {
-        return std::any_of(table.begin(), table.end(),
-                           [] (auto const& x) -> bool {
-                               return x.second.m_count == 0;
-                           });
+        return std::ranges::any_of(table,
+                                   [] (auto const& x) -> bool {
+                                       return x.second.m_count == 0;
+                                   });
     } else {
         auto s = prefix + '.';
-        return std::any_of(table.begin(), table.end(),
+        return std::ranges::any_of(table,
                            [&] (auto const& x) -> bool {
                                return x.second.m_count == 0
                                    && x.first.starts_with(s);
@@ -1493,7 +1492,7 @@ void pp_print_unused (const std::string& pfx, const ParmParse::Table& table)
             sorted_names.push_back(name);
         }
     }
-    std::sort(sorted_names.begin(), sorted_names.end());
+    std::ranges::sort(sorted_names);
 
     for (auto const& name : sorted_names) {
         auto const& entry = table.at(name);
@@ -1698,7 +1697,7 @@ ParmParse::getUnusedInputs (const std::string& prefix)
             sorted_names.push_back(name);
         }
     }
-    std::sort(sorted_names.begin(), sorted_names.end());
+    std::ranges::sort(sorted_names);
 
     std::vector<std::string> r;
     for (auto const& name : sorted_names) {
@@ -1791,7 +1790,7 @@ ParmParse::dumpTable (std::ostream& os, bool prettyPrint)
     for (auto const& [name, entry] : g_table) {
         sorted_names.push_back(name);
     }
-    std::sort(sorted_names.begin(), sorted_names.end());
+    std::ranges::sort(sorted_names);
 
     for (auto const& name : sorted_names) {
         auto const& entry = g_table[name];
@@ -1830,7 +1829,7 @@ void pretty_print_table (std::ostream& os, PPFlag pp_flag)
         }
         if (to_print) { sorted_names.push_back(name); }
     }
-    std::sort(sorted_names.begin(), sorted_names.end());
+    std::ranges::sort(sorted_names);
 
     for (auto const& name : sorted_names) {
         auto const& entry = g_table[name];

--- a/Src/Base/AMReX_PlotFileDataImpl.cpp
+++ b/Src/Base/AMReX_PlotFileDataImpl.cpp
@@ -132,7 +132,7 @@ MultiFab
 PlotFileDataImpl::get (int level, std::string const& varname)
 {
     MultiFab mf(m_ba[level], m_dmap[level], 1, m_ngrow[level]);
-    auto r = std::find(std::begin(m_var_names), std::end(m_var_names), varname);
+    auto r = std::ranges::find(m_var_names, varname);
     if (r == std::end(m_var_names)) {
         amrex::Abort("PlotFileDataImpl::get: varname not found "+varname);
     } else {

--- a/Src/Base/AMReX_String.cpp
+++ b/Src/Base/AMReX_String.cpp
@@ -11,15 +11,15 @@ namespace amrex {
 
 std::string toLower (std::string s)
 {
-    std::transform(s.begin(), s.end(), s.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
+    std::ranges::transform(s, s.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
     return s;
 }
 
 std::string toUpper (std::string s)
 {
-    std::transform(s.begin(), s.end(), s.begin(),
-                   [](unsigned char c) { return std::toupper(c); });
+    std::ranges::transform(s, s.begin(),
+                           [](unsigned char c) { return std::toupper(c); });
     return s;
 }
 

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -954,7 +954,7 @@ TinyProfiler::StartRegion (std::string regname) noexcept
     if (!enabled) { return; }
 
     bool pushed = false;
-    if (std::find(regionstack.begin(), regionstack.end(), regname) == regionstack.end()) {
+    if (std::ranges::find(regionstack, regname) == regionstack.end()) {
         regionstack.emplace_back(regname);
         pushed = true;
     }

--- a/Src/Base/AMReX_Vector.H
+++ b/Src/Base/AMReX_Vector.H
@@ -195,13 +195,13 @@ namespace amrex
     template <class T>
     void FillNull (Vector<T*>& a)
     {
-        std::for_each(a.begin(), a.end(), [](T*& p) { p = nullptr; });
+        std::ranges::for_each(a, [](T*& p) { p = nullptr; });
     }
 
     template <class T>
     void FillNull (Vector<std::unique_ptr<T> >& a)
     {
-        std::for_each(a.begin(), a.end(), [](std::unique_ptr<T>& p) { p.reset(); });
+        std::ranges::for_each(a, [](std::unique_ptr<T>& p) { p.reset(); });
     }
 
     /////////////////////////////////////////////////////////////

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -1679,7 +1679,7 @@ VisMF::Read (FabArray<FArrayBox> &mf,
       const std::string &fileName = frcIter->first;
       Vector<FabReadLink> &frc = frcIter->second;
       // ---- sort by offset
-      std::sort(frc.begin(), frc.end(), [] (const FabReadLink &a, const FabReadLink &b)
+      std::ranges::sort(frc, [] (const FabReadLink &a, const FabReadLink &b)
                                               { return a.fileOffset < b.fileOffset; } );
 
       Vector<int> nBoxesPerRank(nRanksPerFile[currentFileIndex]);

--- a/Src/Base/Parser/AMReX_IParser.cpp
+++ b/Src/Base/Parser/AMReX_IParser.cpp
@@ -27,10 +27,7 @@ IParser::define (std::string const& func_body)
 
     if (!func_body.empty()) {
         m_data->m_expression = func_body;
-        m_data->m_expression.erase(
-            std::remove_if(m_data->m_expression.begin(), m_data->m_expression.end(),
-                           [](char c) { return c == '\n' || c == '\r'; }),
-            m_data->m_expression.end());
+        std::erase_if(m_data->m_expression, [](char c) { return c == '\n' || c == '\r'; });
         std::string f = m_data->m_expression + "\n";
 
         std::scoped_lock iparser_lock(iparser_mutex);

--- a/Src/Base/Parser/AMReX_IParser_Y.cpp
+++ b/Src/Base/Parser/AMReX_IParser_Y.cpp
@@ -1482,7 +1482,7 @@ long long
 iparser_atoll (const char* str)
 {
     std::string s(str);
-    s.erase(std::remove(s.begin(), s.end(), '\''), s.end());
+    std::erase(s, '\'');
 
     auto pos_E = s.find('E');
     if (pos_E != std::string::npos) {

--- a/Src/Base/Parser/AMReX_Parser.cpp
+++ b/Src/Base/Parser/AMReX_Parser.cpp
@@ -27,10 +27,7 @@ Parser::define (std::string const& func_body)
 
     if (!func_body.empty()) {
         m_data->m_expression = func_body;
-        m_data->m_expression.erase(
-            std::remove_if(m_data->m_expression.begin(), m_data->m_expression.end(),
-                           [](char c) { return c == '\n' || c == '\r'; }),
-            m_data->m_expression.end());
+        std::erase_if(m_data->m_expression, [](char c) { return c == '\n' || c == '\r'; });
         std::string f = m_data->m_expression + "\n";
 
         std::scoped_lock parser_lock(parser_mutex);

--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -100,7 +100,7 @@ template <typename G>
 const Level&
 IndexSpaceImp<G>::getLevel (const Geometry& geom) const
 {
-    auto it = std::find(std::begin(m_domain), std::end(m_domain), geom.Domain());
+    auto it = std::ranges::find(m_domain, geom.Domain());
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(it != std::end(m_domain),
                                      "IndexSpaceImp::getLevel: Geometry not found");
     int i = std::distance(m_domain.begin(), it);
@@ -111,7 +111,7 @@ template <typename G>
 const Geometry&
 IndexSpaceImp<G>::getGeometry (const Box& dom) const
 {
-    auto it = std::find(std::begin(m_domain), std::end(m_domain), dom);
+    auto it = std::ranges::find(m_domain, dom);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(it != std::end(m_domain),
                                      "IndexSpaceImp::getLevel: domain not found");
     int i = std::distance(m_domain.begin(), it);

--- a/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
+++ b/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
@@ -74,7 +74,7 @@ IndexSpaceSTL::IndexSpaceSTL (const std::string& stl_file, Real stl_scale,
 const Level&
 IndexSpaceSTL::getLevel (const Geometry& geom) const
 {
-    auto it = std::find(std::begin(m_domain), std::end(m_domain), geom.Domain());
+    auto it = std::ranges::find(m_domain, geom.Domain());
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(it != std::end(m_domain),
                                      "IndexSpaceSTL::getLevel: Geometry not found");
     auto i = std::distance(m_domain.begin(), it);
@@ -84,7 +84,7 @@ IndexSpaceSTL::getLevel (const Geometry& geom) const
 const Geometry&
 IndexSpaceSTL::getGeometry (const Box& dom) const
 {
-    auto it = std::find(std::begin(m_domain), std::end(m_domain), dom);
+    auto it = std::ranges::find(m_domain, dom);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(it != std::end(m_domain),
                                      "IndexSpaceSTL::getLevel: domain not found");
     auto i = std::distance(m_domain.begin(), it);

--- a/Src/EB/AMReX_EB2_IndexSpace_chkpt_file.cpp
+++ b/Src/EB/AMReX_EB2_IndexSpace_chkpt_file.cpp
@@ -64,7 +64,7 @@ IndexSpaceChkptFile::IndexSpaceChkptFile (const ChkptFile& chkpt_file,
 const Level&
 IndexSpaceChkptFile::getLevel (const Geometry& geom) const
 {
-    auto it = std::find(std::begin(m_domain), std::end(m_domain), geom.Domain());
+    auto it = std::ranges::find(m_domain, geom.Domain());
     auto i = std::distance(m_domain.begin(), it);
     return m_chkpt_file_level[i];
 }
@@ -72,7 +72,7 @@ IndexSpaceChkptFile::getLevel (const Geometry& geom) const
 const Geometry&
 IndexSpaceChkptFile::getGeometry (const Box& dom) const
 {
-    auto it = std::find(std::begin(m_domain), std::end(m_domain), dom);
+    auto it = std::ranges::find(m_domain, dom);
     auto i = std::distance(m_domain.begin(), it);
     return m_geom[i];
 }

--- a/Src/EB/AMReX_EBToPVD.cpp
+++ b/Src/EB/AMReX_EBToPVD.cpp
@@ -348,7 +348,7 @@ void EBToPVD::calc_alpha(std::array<Real,12>& alpha,
       const Real* dx)
 {
    // default (large) value
-   std::fill(alpha.begin(), alpha.end(), 10.0);
+   std::ranges::fill(alpha, 10.0);
 
    // Ray-xAxis intersection
    if(std::abs(n0[0]) > std::numeric_limits<Real>::epsilon()) {
@@ -379,7 +379,7 @@ void EBToPVD::calc_intersects(int& int_count, std::array<bool,12>& intersects_fl
       const std::array<Real,12>& alpha)
 {
    int_count = 0;
-   std::fill(intersects_flags.begin(), intersects_flags.end(), false);
+   std::ranges::fill(intersects_flags, false);
 
    for(int lc1 = 0; lc1 < 12; ++lc1) {
       if(intersects(alpha[lc1])) {

--- a/Src/Extern/Bittree/AMReX_Bittree.cpp
+++ b/Src/Extern/Bittree/AMReX_Bittree.cpp
@@ -176,7 +176,7 @@ void btUnit::btCheckRefine (BittreeAmr* const mesh, std::vector<int>& btTags,
 
     do {
         // Clear out ref_test
-        std::fill(ref_test.begin(),ref_test.end(),0);
+        std::ranges::fill(ref_test, 0);
 
         // Check neighbors - if any adjacent child of a neighbor is either a parent
         // or marked for refinement, this block needs to be refined.

--- a/Src/Extern/ProfParser/AMReX_CommProfStats.cpp
+++ b/Src/Extern/ProfParser/AMReX_CommProfStats.cpp
@@ -204,7 +204,7 @@ void CommProfStats::AddReduction(const long rnum, const long index) {
 
 // ----------------------------------------------------------------------
 void CommProfStats::AddNameTagName(const string &name) {
-  if(std::find(nameTagNames.begin(), nameTagNames.end(), name) == nameTagNames.end()) {
+  if(std::ranges::find(nameTagNames, name) == nameTagNames.end()) {
     nameTagNames.push_back(name);
   }
 }
@@ -302,8 +302,7 @@ void CommProfStats::AddTopoCoord(const int nid, const int node,
 
 // ----------------------------------------------------------------------
 void CommProfStats::AddCommHeaderFileName(const string &hfn) {
-  if(std::find(commHeaderFileNames.begin(),
-     commHeaderFileNames.end(), hfn) == commHeaderFileNames.end())
+  if(std::ranges::find(commHeaderFileNames, hfn) == commHeaderFileNames.end())
   {
     commHeaderFileNames.push_back(hfn);
   }
@@ -781,9 +780,9 @@ void CommProfStats::ReportSyncPointDataSetup(long &nBMax, long &nRMax)
     }
   }
   //nBMin = *std::min_element(nBarriers.begin(), nBarriers.end());
-  nBMax = *std::max_element(nBarriers.begin(), nBarriers.end());
+  nBMax = *std::ranges::max_element(nBarriers);
   //nRMin = *std::min_element(nReductions.begin(), nReductions.end());
-  nRMax = *std::max_element(nReductions.begin(), nReductions.end());
+  nRMax = *std::ranges::max_element(nReductions);
 }
 
 

--- a/Src/Extern/ProfParser/AMReX_RegionsProfStats.cpp
+++ b/Src/Extern/ProfParser/AMReX_RegionsProfStats.cpp
@@ -98,8 +98,7 @@ RegionsProfStats::~RegionsProfStats() {
 
 // ----------------------------------------------------------------------
 void RegionsProfStats::AddCStatsHeaderFileName(const string &hfn) {
-  if(std::find(regHeaderFileNames.begin(),
-     regHeaderFileNames.end(), hfn) == regHeaderFileNames.end())
+  if(std::ranges::find(regHeaderFileNames, hfn) == regHeaderFileNames.end())
   {
     regHeaderFileNames.push_back(hfn);
   }

--- a/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_SUNMemory.cpp
@@ -162,9 +162,9 @@ void MemoryHelper::Initialize(int nthreads)
 {
     if (initialized.empty()) {
         initialized.resize(nthreads);
-        std::fill(initialized.begin(), initialized.end(), 0);
+        std::ranges::fill(initialized, 0);
         the_sunmemory_helper.resize(nthreads);
-        std::fill(the_sunmemory_helper.begin(), the_sunmemory_helper.end(), nullptr);
+        std::ranges::fill(the_sunmemory_helper, nullptr);
     }
     for (int i = 0; i < nthreads; i++) {
         if (initialized[i]) { continue; }

--- a/Src/Extern/SUNDIALS/AMReX_Sundials_Core.cpp
+++ b/Src/Extern/SUNDIALS/AMReX_Sundials_Core.cpp
@@ -17,9 +17,9 @@ void Initialize(int nthreads)
     // Initialize the sundials context
     if (initialized.empty()) {
         initialized.resize(nthreads);
-        std::fill(initialized.begin(), initialized.end(), 0);
+        std::ranges::fill(initialized, 0);
         the_sundials_context.resize(nthreads);
-        std::fill(the_sundials_context.begin(), the_sundials_context.end(), nullptr);
+        std::ranges::fill(the_sundials_context, nullptr);
     }
     for (int i = 0; i < nthreads; i++) {
         if (initialized[i]) { continue; }

--- a/Src/FFT/AMReX_FFT_R2C.H
+++ b/Src/FFT/AMReX_FFT_R2C.H
@@ -774,9 +774,7 @@ R2C<T,D,C>::make_layout_from_local_domain (std::array<int,AMREX_SPACEDIM> const&
             pmap.push_back(ParallelContext::local_to_global_rank(i));
         }
     }
-    allboxes.erase(std::remove_if(allboxes.begin(), allboxes.end(),
-                                  [=] (Box const& b) { return b.isEmpty(); }),
-                   allboxes.end());
+    std::erase_if(allboxes, [=] (Box const& b) { return b.isEmpty(); });
     BoxList bl(std::move(allboxes));
     return std::make_pair(BoxArray(std::move(bl)), DistributionMapping(std::move(pmap)));
 #else

--- a/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
+++ b/Src/F_Interfaces/AmrCore/AMReX_FlashFluxRegister.cpp
@@ -55,10 +55,9 @@ void FlashFluxRegister::define (const BoxArray& fba, const BoxArray& cba,
                     fndba.intersections(ndbx+shift, isects);
                     for (auto const& isect : isects) {
                         Box const& b = isect.second-shift;
-                        faces.erase(std::remove_if(faces.begin(), faces.end(),
-                                                   [&] (std::pair<Orientation,Box> const& x)
-                                                   { return x.second == b; }),
-                                    faces.end());
+                        std::erase_if(faces, [&] (std::pair<Orientation,Box> const& x) {
+                            return x.second == b;
+                        });
                     }
                 }
             }

--- a/Src/LinearSolvers/AMReX_CSR.H
+++ b/Src/LinearSolvers/AMReX_CSR.H
@@ -367,10 +367,10 @@ void CSR<T,V>::sort_on_host ()
                     perm [i] = i;
                 }
 
-                std::sort(perm.begin(), perm.end(),
-                          [&] (int i0, int i1) {
-                              return lcols[i0] < lcols[i1];
-                          });
+                std::ranges::sort(perm,
+                                  [&] (int i0, int i1) {
+                                      return lcols[i0] < lcols[i1];
+                                  });
 
                 for (int out = 0; out < len; ++out) {
                     auto const in = perm[out];

--- a/Src/LinearSolvers/AMReX_SpMatrix.H
+++ b/Src/LinearSolvers/AMReX_SpMatrix.H
@@ -1066,8 +1066,8 @@ void SpMatrix<T,Allocator>::startComm_mv (AlgVector<T,AllocT> const& x)
     this->prepare_comm_mv(x.partition());
 
     auto const mpi_tag = ParallelDescriptor::SeqNum();
-    auto const mpi_t_type = ParallelDescriptor::Mpi_typemap<T>::type(); // NOLINT(readability-qualified-auto)
-    auto const mpi_comm = ParallelContext::CommunicatorSub(); // NOLINT(readability-qualified-auto)
+    auto const mpi_t_type = ParallelDescriptor::Mpi_typemap<T>::type();
+    auto const mpi_comm = ParallelContext::CommunicatorSub();
 
     auto const nrecvs = int(m_comm_mv.recv_from.size());
     if (nrecvs > 0) {
@@ -1148,9 +1148,9 @@ void SpMatrix<T,Allocator>::startComm_tr (AlgPartition const& col_partition)
 
     int const nprocs = ParallelContext::NProcsSub();
     auto const mpi_tag = ParallelDescriptor::SeqNum();
-    auto const mpi_long = ParallelDescriptor::Mpi_typemap<Long>::type(); // NOLINT(readability-qualified-auto)
-    auto const mpi_t = ParallelDescriptor::Mpi_typemap<T>::type(); // NOLINT(readability-qualified-auto)
-    auto const mpi_comm = ParallelContext::CommunicatorSub(); // NOLINT(readability-qualified-auto)
+    auto const mpi_long = ParallelDescriptor::Mpi_typemap<Long>::type();
+    auto const mpi_t = ParallelDescriptor::Mpi_typemap<T>::type();
+    auto const mpi_comm = ParallelContext::CommunicatorSub();
 
     // transpose the off-diagonal part
     if (m_csr_remote.nnz > 0) {
@@ -1664,8 +1664,8 @@ void SpMatrix<T,Allocator>::set_num_neighbors ()
     if (m_num_neighbors >= 0) { return; }
 
     int const nprocs = ParallelContext::NProcsSub();
-    auto const mpi_int = ParallelDescriptor::Mpi_typemap<int>::type(); // NOLINT(readability-qualified-auto)
-    auto const mpi_comm = ParallelContext::CommunicatorSub(); // NOLINT(readability-qualified-auto)
+    auto const mpi_int = ParallelDescriptor::Mpi_typemap<int>::type();
+    auto const mpi_comm = ParallelContext::CommunicatorSub();
 
     amrex::Vector<int> connection(nprocs);
     for (int iproc = 0; iproc < nprocs; ++iproc) {
@@ -1689,8 +1689,8 @@ void SpMatrix<T,Allocator>::prepare_comm_mv (AlgPartition const& col_partition)
 
     int const nprocs = ParallelContext::NProcsSub();
     auto const mpi_tag = ParallelDescriptor::SeqNum();
-    auto const mpi_long = ParallelDescriptor::Mpi_typemap<Long>::type(); // NOLINT(readability-qualified-auto)
-    auto const mpi_comm = ParallelContext::CommunicatorSub(); // NOLINT(readability-qualified-auto)
+    auto const mpi_long = ParallelDescriptor::Mpi_typemap<Long>::type();
+    auto const mpi_comm = ParallelContext::CommunicatorSub();
 
     if (m_num_neighbors < 0) { set_num_neighbors(); }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -725,8 +725,8 @@ MLABecLaplacianT<MF>::update_singular_flags ()
 {
     m_is_singular.clear();
     m_is_singular.resize(this->m_num_amr_levels, false);
-    auto itlo = std::find(this->m_lobc[0].begin(), this->m_lobc[0].end(), BCType::Dirichlet);
-    auto ithi = std::find(this->m_hibc[0].begin(), this->m_hibc[0].end(), BCType::Dirichlet);
+    auto itlo = std::ranges::find(this->m_lobc[0], BCType::Dirichlet);
+    auto ithi = std::ranges::find(this->m_hibc[0], BCType::Dirichlet);
     if (itlo == this->m_lobc[0].end() && ithi == this->m_hibc[0].end())
     {  // No Dirichlet
         for (int alev = 0; alev < this->m_num_amr_levels; ++alev)

--- a/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
@@ -217,8 +217,8 @@ MLALaplacianT<MF>::updateSingularFlag ()
 {
     m_is_singular.clear();
     m_is_singular.resize(this->m_num_amr_levels, false);
-    auto itlo = std::find(this->m_lobc[0].begin(), this->m_lobc[0].end(), BCType::Dirichlet);
-    auto ithi = std::find(this->m_hibc[0].begin(), this->m_hibc[0].end(), BCType::Dirichlet);
+    auto itlo = std::ranges::find(this->m_lobc[0], BCType::Dirichlet);
+    auto ithi = std::ranges::find(this->m_hibc[0], BCType::Dirichlet);
     if (itlo == this->m_lobc[0].end() && ithi == this->m_hibc[0].end())
     {  // No Dirichlet
         for (int alev = 0; alev < this->m_num_amr_levels; ++alev)

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -704,8 +704,8 @@ MLEBABecLap::prepareForSolve ()
 
     m_is_singular.clear();
     m_is_singular.resize(m_num_amr_levels, false);
-    auto itlo = std::find(m_lobc[0].begin(), m_lobc[0].end(), BCType::Dirichlet); // NOLINT
-    auto ithi = std::find(m_hibc[0].begin(), m_hibc[0].end(), BCType::Dirichlet); // NOLINT
+    auto itlo = std::ranges::find(m_lobc[0], BCType::Dirichlet);
+    auto ithi = std::ranges::find(m_hibc[0], BCType::Dirichlet);
     if (itlo == m_lobc[0].end() && ithi == m_hibc[0].end() && !isEBDirichlet())
     {  // No Dirichlet
         for (int alev = 0; alev < m_num_amr_levels; ++alev)
@@ -1341,8 +1341,8 @@ MLEBABecLap::update ()
 
     m_is_singular.clear();
     m_is_singular.resize(m_num_amr_levels, false);
-    auto itlo = std::find(m_lobc[0].begin(), m_lobc[0].end(), BCType::Dirichlet); // NOLINT
-    auto ithi = std::find(m_hibc[0].begin(), m_hibc[0].end(), BCType::Dirichlet); // NOLINT
+    auto itlo = std::ranges::find(m_lobc[0], BCType::Dirichlet);
+    auto ithi = std::ranges::find(m_hibc[0], BCType::Dirichlet);
     if (itlo == m_lobc[0].end() && ithi == m_hibc[0].end() && !isEBDirichlet())
     {  // No Dirichlet
         for (int alev = 0; alev < m_num_amr_levels; ++alev)

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -1415,7 +1415,7 @@ MLLinOpT<MF>::makeSubCommunicator (const DistributionMapping& dm)
 #ifdef BL_USE_MPI
 
     Vector<int> newgrp_ranks = dm.ProcessorMap();
-    std::sort(newgrp_ranks.begin(), newgrp_ranks.end());
+    std::ranges::sort(newgrp_ranks);
     auto last = std::unique(newgrp_ranks.begin(), newgrp_ranks.end());
     newgrp_ranks.erase(last, newgrp_ranks.end());
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -293,8 +293,8 @@ MLNodeLinOp::buildMasks ()
     m_masks_built = true;
 
     m_is_bottom_singular = false;
-    auto itlo = std::find(m_lobc[0].begin(), m_lobc[0].end(), BCType::Dirichlet); // NOLINT
-    auto ithi = std::find(m_hibc[0].begin(), m_hibc[0].end(), BCType::Dirichlet); // NOLINT
+    auto itlo = std::ranges::find(m_lobc[0], BCType::Dirichlet);
+    auto ithi = std::ranges::find(m_hibc[0], BCType::Dirichlet);
     if (itlo == m_lobc[0].end() && ithi == m_hibc[0].end())
     {  // No Dirichlet
         m_is_bottom_singular = (m_domain_covered[0] && !m_overset_dirichlet_mask);

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -148,8 +148,8 @@ MLPoissonT<MF>::prepareForSolve ()
 
     m_is_singular.clear();
     m_is_singular.resize(this->m_num_amr_levels, false);
-    auto itlo = std::find(this->m_lobc[0].begin(), this->m_lobc[0].end(), BCType::Dirichlet);
-    auto ithi = std::find(this->m_hibc[0].begin(), this->m_hibc[0].end(), BCType::Dirichlet);
+    auto itlo = std::ranges::find(this->m_lobc[0], BCType::Dirichlet);
+    auto ithi = std::ranges::find(this->m_hibc[0], BCType::Dirichlet);
     if (itlo == this->m_lobc[0].end() && ithi == this->m_hibc[0].end())
     {  // No Dirichlet
         for (int alev = 0; alev < this->m_num_amr_levels; ++alev)

--- a/Src/Particle/AMReX_ParticleBufferMap.cpp
+++ b/Src/Particle/AMReX_ParticleBufferMap.cpp
@@ -82,7 +82,7 @@ void ParticleBufferMap::define (const ParGDBBase* a_gdb, bool a_do_tiling,
         }
     }
 
-    std::sort(box_tile_lev_proc_ids.begin(), box_tile_lev_proc_ids.end(),
+    std::ranges::sort(box_tile_lev_proc_ids,
               [](const FourIntTuple& a, const FourIntTuple& b) -> bool
               {
                   int pid_a = std::get<3>(a);

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1292,7 +1292,7 @@ public:
     void AddRealComp (std::string const & name, int communicate=1)
     {
         // names must be unique
-        auto const it = std::find(m_soa_rdata_names.begin(), m_soa_rdata_names.end(), name);
+        auto const it = std::ranges::find(m_soa_rdata_names, name);
         if (it != m_soa_rdata_names.end()) {
             throw std::runtime_error("AddRealComp: name '" + name + "' is already present in the SoA.");
         }
@@ -1325,7 +1325,7 @@ public:
     void AddIntComp (std::string const & name, int communicate=1)
     {
         // names must be unique
-        auto const it = std::find(m_soa_idata_names.begin(), m_soa_idata_names.end(), name);
+        auto const it = std::ranges::find(m_soa_idata_names, name);
         if (it != m_soa_idata_names.end()) {
             throw std::runtime_error("AddIntComp: name '" + name + "' is already present in the SoA.");
         }

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -140,7 +140,7 @@ template<
 bool
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::HasRealComp (std::string const & name)
 {
-    return std::find(m_soa_rdata_names.begin(), m_soa_rdata_names.end(), name) != std::end(m_soa_rdata_names);
+    return std::ranges::find(m_soa_rdata_names, name) != std::end(m_soa_rdata_names);
 }
 
 template <typename ParticleType, int NArrayReal, int NArrayInt,
@@ -148,7 +148,7 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
 bool
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::HasIntComp (std::string const & name)
 {
-    return std::find(m_soa_idata_names.begin(), m_soa_idata_names.end(), name) != std::end(m_soa_idata_names);
+    return std::ranges::find(m_soa_idata_names, name) != std::end(m_soa_idata_names);
 }
 
 template<
@@ -161,7 +161,7 @@ template<
 int
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::GetRealCompIndex (std::string const & name)
 {
-    const auto it = std::find(m_soa_rdata_names.begin(), m_soa_rdata_names.end(), name);
+    const auto it = std::ranges::find(m_soa_rdata_names, name);
 
     if (it == m_soa_rdata_names.end())
     {
@@ -183,7 +183,7 @@ template<
 int
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::GetIntCompIndex (std::string const & name)
 {
-    const auto it = std::find(m_soa_idata_names.begin(), m_soa_idata_names.end(), name);
+    const auto it = std::ranges::find(m_soa_idata_names, name);
 
     if (it == m_soa_idata_names.end())
     {

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -1378,19 +1378,19 @@ struct ParticleTile
                 }
             }
 
-            std::sort(pvs.begin(), pvs.end(), [] (auto const& a, auto const& b) {
+            std::ranges::sort(pvs, [] (auto const& a, auto const& b) {
                 return (a.first->size() + a.second) >
                        (b.first->size() + b.second);
             });
-            std::sort(ids.begin(), ids.end(), [] (auto const& a, auto const& b) {
+            std::ranges::sort(ids, [] (auto const& a, auto const& b) {
                 return (a.first->size() + a.second) >
                        (b.first->size() + b.second);
             });
-            std::sort(rvs.begin(), rvs.end(), [] (auto const& a, auto const& b) {
+            std::ranges::sort(rvs, [] (auto const& a, auto const& b) {
                 return (a.first->size() + a.second) >
                        (b.first->size() + b.second);
             });
-            std::sort(ivs.begin(), ivs.end(), [] (auto const& a, auto const& b) {
+            std::ranges::sort(ivs, [] (auto const& a, auto const& b) {
                 return (a.first->size() + a.second) >
                        (b.first->size() + b.second);
             });

--- a/Src/Particle/AMReX_ParticleTileRT.H
+++ b/Src/Particle/AMReX_ParticleTileRT.H
@@ -804,7 +804,7 @@ private:
 
     static int get_idx_from_str (std::string const & name, std::vector<std::string>* name_list) {
         AMREX_ALWAYS_ASSERT(name_list != nullptr);
-        auto const pos = std::find(name_list->begin(), name_list->end(), name);
+        auto const pos = std::ranges::find(*name_list, name);
         AMREX_ALWAYS_ASSERT(pos != name_list->end());
         return static_cast<int>(std::distance(name_list->begin(), pos));
     }

--- a/Src/Particle/AMReX_SparseBins.H
+++ b/Src/Particle/AMReX_SparseBins.H
@@ -147,8 +147,8 @@ public:
 
         Gpu::HostVector<index_type> host_perm(nitems);
         std::iota(host_perm.begin(), host_perm.end(), 0);
-        std::sort(host_perm.begin(), host_perm.end(),
-                  [&](int i, int j) {return host_cells[i] < host_cells[j];});
+        std::ranges::sort(host_perm,
+                          [&](int i, int j) {return host_cells[i] < host_cells[j];});
 
         Gpu::HostVector<index_type> host_bins;
         Gpu::HostVector<index_type> host_offsets = {0};

--- a/Src/Particle/AMReX_StructOfArrays.H
+++ b/Src/Particle/AMReX_StructOfArrays.H
@@ -118,7 +118,7 @@ struct StructOfArrays {
      */
     [[nodiscard]] RealVector& GetRealData (std::string const & name) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_rdata_names != nullptr, "SoA Real names were not defined.");
-        auto const pos = std::find(m_rdata_names->begin(), m_rdata_names->end(), name);
+        auto const pos = std::ranges::find(*m_rdata_names, name);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pos != m_rdata_names->end(), "Soa Real name='" + name + "' was not found components");
 
         int const index = std::distance(m_rdata_names->begin(), pos);
@@ -131,7 +131,7 @@ struct StructOfArrays {
      */
     [[nodiscard]] const RealVector& GetRealData (std::string const & name) const {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_rdata_names != nullptr, "SoA Real names were not defined.");
-        auto const pos = std::find(m_rdata_names->begin(), m_rdata_names->end(), name);
+        auto const pos = std::ranges::find(*m_rdata_names, name);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pos != m_rdata_names->end(), "Soa Real name='" + name + "' was not found components");
 
         int const index = std::distance(m_rdata_names->begin(), pos);
@@ -184,7 +184,7 @@ struct StructOfArrays {
      */
     [[nodiscard]] IntVector& GetIntData (std::string const & name) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_idata_names != nullptr, "SoA Int names were not defined.");
-        auto const pos = std::find(m_idata_names->begin(), m_idata_names->end(), name);
+        auto const pos = std::ranges::find(*m_idata_names, name);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pos != m_idata_names->end(), "Soa Int name='" + name + "' was not found components");
 
         int const index = std::distance(m_idata_names->begin(), pos);
@@ -198,7 +198,7 @@ struct StructOfArrays {
      */
     [[nodiscard]] const IntVector& GetIntData (std::string const & name) const {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_idata_names != nullptr, "SoA Int names were not defined.");
-        auto const pos = std::find(m_idata_names->begin(), m_idata_names->end(), name);
+        auto const pos = std::ranges::find(*m_idata_names, name);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pos != m_idata_names->end(), "Soa Int name='" + name + "' was not found components");
 
         int const index = std::distance(m_idata_names->begin(), pos);

--- a/Tests/SIMD/main.cpp
+++ b/Tests/SIMD/main.cpp
@@ -266,7 +266,7 @@ int main (int argc, char* argv[])
             Gpu::ManagedVector<ParticleReal> x_data(n);
             Gpu::ManagedVector<ParticleReal> y_data(n);
             std::iota(x_data.begin(), x_data.end(), ParticleReal(0));
-            std::fill(y_data.begin(), y_data.end(), ParticleReal(100));
+            std::ranges::fill(y_data, ParticleReal(100));
 
             auto* x_ptr = x_data.data();
             auto* y_ptr = y_data.data();
@@ -322,7 +322,7 @@ int main (int argc, char* argv[])
             Gpu::ManagedVector<ParticleReal> x_data(n);
             Gpu::ManagedVector<ParticleReal> y_data(n);
             std::iota(x_data.begin(), x_data.end(), ParticleReal(0));
-            std::fill(y_data.begin(), y_data.end(), ParticleReal(10));
+            std::ranges::fill(y_data, ParticleReal(10));
 
             auto* x_ptr = x_data.data();
             auto* y_ptr = y_data.data();

--- a/Tools/Plotfile/faverage.cpp
+++ b/Tools/Plotfile/faverage.cpp
@@ -81,11 +81,11 @@ int main(int argc, char* argv[])
 
         // density can be call "density" in Castro or "rho" in MAESTROeX
         int dens_comp = std::distance(var_names_pf.cbegin(),
-                                  std::find(var_names_pf.cbegin(), var_names_pf.cend(), "density"));
+                                  std::ranges::find(var_names_pf, "density"));
 
         if (dens_comp == var_names_pf.size()) {
             dens_comp = std::distance(var_names_pf.cbegin(),
-                                      std::find(var_names_pf.cbegin(), var_names_pf.cend(), "rho"));
+                                      std::ranges::find(var_names_pf, "rho"));
         }
 
         if (dens_comp == var_names_pf.size() && do_favre) {
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
         }
 
         int var_comp = std::distance(var_names_pf.cbegin(),
-                                  std::find(var_names_pf.cbegin(), var_names_pf.cend(), varname));
+                                  std::ranges::find(var_names_pf, varname));
 
         if (var_comp == var_names_pf.size()) {
             amrex::Error("variable " + varname + " not found");

--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -142,7 +142,7 @@ int main_main()
 
     Vector<int> ivar_b(ncomp_a,-1); // in case the variables are not in the same order
     for (int n_a = 0; n_a < ncomp_a; ++n_a) {
-        auto r = std::find(std::begin(names_b), std::end(names_b), names_a[n_a]);
+        auto r = std::ranges::find(names_b, names_a[n_a]);
         if (r == std::end(names_b)) {
             amrex::Print() << " WARNING: variable " << names_a[n_a] << " not found in plotfile 2\n";
             all_variables_found = false;
@@ -162,7 +162,7 @@ int main_main()
     // also print out, as a diagnostic, those variables in plotfile 1 that
     // are not in plotfile 2
     for (int n_b = 0; n_b < ncomp_b; ++n_b) {
-        auto r = std::find(std::begin(names_a),std::end(names_a),names_b[n_b]);
+        auto r = std::ranges::find(names_a, names_b[n_b]);
         if (r == std::end(names_a)) {
             amrex::Print() << " WARNING: variable " << names_b[n_b] << " not found in plotfile 1\n";
             all_variables_found = false;
@@ -332,8 +332,7 @@ int main_main()
         }
 
         global_error = std::max(global_error,
-                                *(std::max_element(aerror.begin(),
-                                                   aerror.end())));
+                                *(std::ranges::max_element(aerror)));
 
         for (int icomp_a = 0; icomp_a < ncomp_a; ++icomp_a) {
             any_nans = any_nans || has_nan_a[icomp_a] || has_nan_b[icomp_a];

--- a/Tools/Plotfile/fextract.cpp
+++ b/Tools/Plotfile/fextract.cpp
@@ -120,12 +120,9 @@ void main_main()
         std::istringstream is(varnames_arg);
         var_names.assign(std::istream_iterator<std::string>{is},
                          std::istream_iterator<std::string>{  });
-        var_names.erase(std::remove_if(var_names.begin(), var_names.end(),
-                                       [&](std::string const& x) {
-                                           return var_names_pf.end() ==
-                                               std::find(var_names_pf.begin(), var_names_pf.end(), x);
-                                       }),
-                        var_names.end());
+        std::erase_if(var_names, [&](std::string const& x) {
+            return var_names_pf.end() == std::ranges::find(var_names_pf, x);
+        });
         if (var_names.empty()) {
             amrex::Abort("ERROR: no valid variable names");
         }
@@ -334,7 +331,7 @@ void main_main()
         for (int i = 0; i < pos.size(); ++i) {
             posidx.emplace_back(pos[i],i);
         }
-        std::sort(posidx.begin(), posidx.end());
+        std::ranges::sort(posidx);
 
         const std::string dirstr = (idir == 0) ? "x" : ((idir == 1) ? "y" : "z");
 

--- a/Tools/Plotfile/fgradient.cpp
+++ b/Tools/Plotfile/fgradient.cpp
@@ -147,8 +147,7 @@ void main_main()
         Vector<std::string> args(std::istream_iterator<std::string>{is},
                                  std::istream_iterator<std::string>{  });
         for (auto const& vn : args) {
-            if (std::find(std::begin(all_names),std::end(all_names), vn)
-                != std::end(all_names)) {
+            if (std::ranges::find(all_names, vn) != std::end(all_names)) {
                 varnames.push_back(vn);
             } else {
                 amrex::Abort("fgradient: Unknown variable "+vn);

--- a/Tools/Plotfile/fsnapshot.cpp
+++ b/Tools/Plotfile/fsnapshot.cpp
@@ -142,7 +142,7 @@ void main_main()
     }
 
     const auto& var_names = pf.varNames();
-    if (std::find(var_names.begin(), var_names.end(), compname) == var_names.end()) {
+    if (std::ranges::find(var_names, compname) == var_names.end()) {
         amrex::Abort("ERROR: " + compname + " not found in pltfile " + pltfile);
     }
 


### PR DESCRIPTION
`modernize-use-ranges` is not a required check because (1) clang <= 15 have bugs with `std::ranges`; (2) `std::ranges::sort` requrires `std::sortable`, which is stricter than `operator<`.

Disable `readability-qualified-auto`. It's just not right if we have to write `auto* itlo = std::ranges::find(m_lobc[0], BCType::Dirichlet);`. It's an iterator, not really a pointer, even if it's a pointer in a particular implementation.