### PR TITLE
Support neighbor particle tiling on the GPU

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -326,9 +326,6 @@ fillNeighborsGPU ()
 
     AMREX_ASSERT(numParticlesOutOfRange(*this, 0) == 0);
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(this->do_tiling == 0,
-        "Tiling on the GPU is not supported for neighbor particles.");
-
     buildNeighborMask();
     this->defineBufferMap();
 

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -232,7 +232,6 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
         const bool do_tiling = this->do_tiling;
         const IntVect tile_size = this->tile_size;
         const int nGrow = m_num_neighbor_cells;
-        // auto p_code_offsets = m_code_offsets[gid].dataPtr();
 
         AMREX_FOR_1D ( np, i,
         {

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -7,6 +7,65 @@ namespace amrex {
 /// \cond DOXYGEN_IGNORE
 namespace detail
 {
+    template <typename F>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void forEachIntersectingTile (IntVect const& iv, int nGrow,
+                                  Box const& grid_box, IntVect const& periodic_shift,
+                                  bool do_tiling, IntVect const& tile_size, F&& f)
+    {
+        Box cell_box(iv, iv);
+        cell_box.grow(nGrow);
+        cell_box += periodic_shift;
+        cell_box &= grid_box;
+
+        if (!cell_box.ok()) { return; }
+
+        auto const& cb_lo = cell_box.smallEnd();
+        auto const& cb_hi = cell_box.bigEnd();
+
+#if (AMREX_SPACEDIM == 1)
+        for (int i = cb_lo[0]; i <= cb_hi[0]; ++i) {
+            IntVect cell(AMREX_D_DECL(i, 0, 0));
+            Box tbx;
+            int tile = getTileIndex(cell, grid_box, do_tiling, tile_size, tbx);
+            IntVect rep(AMREX_D_DECL(amrex::max(cb_lo[0], tbx.smallEnd(0)), 0, 0));
+            if (cell == rep) {
+                f(tile);
+            }
+        }
+#elif (AMREX_SPACEDIM == 2)
+        for (int j = cb_lo[1]; j <= cb_hi[1]; ++j) {
+            for (int i = cb_lo[0]; i <= cb_hi[0]; ++i) {
+                IntVect cell(AMREX_D_DECL(i, j, 0));
+                Box tbx;
+                int tile = getTileIndex(cell, grid_box, do_tiling, tile_size, tbx);
+                IntVect rep(AMREX_D_DECL(amrex::max(cb_lo[0], tbx.smallEnd(0)),
+                                         amrex::max(cb_lo[1], tbx.smallEnd(1)),
+                                         0));
+                if (cell == rep) {
+                    f(tile);
+                }
+            }
+        }
+#else
+        for (int k = cb_lo[2]; k <= cb_hi[2]; ++k) {
+            for (int j = cb_lo[1]; j <= cb_hi[1]; ++j) {
+                for (int i = cb_lo[0]; i <= cb_hi[0]; ++i) {
+                    IntVect cell(AMREX_D_DECL(i, j, k));
+                    Box tbx;
+                    int tile = getTileIndex(cell, grid_box, do_tiling, tile_size, tbx);
+                    IntVect rep(AMREX_D_DECL(amrex::max(cb_lo[0], tbx.smallEnd(0)),
+                                             amrex::max(cb_lo[1], tbx.smallEnd(1)),
+                                             amrex::max(cb_lo[2], tbx.smallEnd(2))));
+                    if (cell == rep) {
+                        f(tile);
+                    }
+                }
+            }
+        }
+#endif
+    }
+
     inline Vector<Box> getBoundaryBoxes(const Box& box, int ncells)
     {
         AMREX_ASSERT_WITH_MESSAGE(box.size() > 2*IntVect(AMREX_D_DECL(ncells, ncells, ncells)),
@@ -86,7 +145,6 @@ buildNeighborMask ()
                 {
                     int nbor_grid = isec.first;
                     const Box isec_box = isec.second - pshift;
-                    if ( (grid == nbor_grid) && (pshift == 0)) { continue; }
                     neighbor_grids.insert(NeighborTask(nbor_grid, isec_box, pshift));
                     const int global_rank = dmap[nbor_grid];
                     neighbor_procs.push_back(ParallelContext::global_to_local_rank(global_rank));
@@ -173,6 +231,7 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
         const int nisec_box = m_isec_boxes[gid].size();
         const bool do_tiling = this->do_tiling;
         const IntVect tile_size = this->tile_size;
+        const int nGrow = m_num_neighbor_cells;
         // auto p_code_offsets = m_code_offsets[gid].dataPtr();
 
         AMREX_FOR_1D ( np, i,
@@ -186,7 +245,20 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
             IntVect iv = getParticleCell(p_ptr[pid], plo, dxi, domain);
             for (int j=0; j<nisec_box; ++j) {
                 if (p_isec_boxes[j].contains(iv)) {
-                    ++p_counts[i];
+                    detail::forEachIntersectingTile(iv, nGrow,
+                                                    p_code_array[j].grid_box,
+                                                    p_code_array[j].periodic_shift,
+                                                    do_tiling, tile_size,
+                                                    [&] (int dst_tile)
+                    {
+                        bool is_self = (p_code_array[j].grid_id == gid) && (dst_tile == tid)
+                            AMREX_D_TERM( && (p_code_array[j].periodic_shift[0] == 0),
+                                          && (p_code_array[j].periodic_shift[1] == 0),
+                                          && (p_code_array[j].periodic_shift[2] == 0));
+                        if (!is_self) {
+                            ++p_counts[i];
+                        }
+                    });
                 }
             }
         });
@@ -217,14 +289,25 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
             int      k = p_offsets[i];
             for (int j=0; j<nisec_box; ++j) {
                 if (p_isec_boxes[j].contains(iv)) {
-                    p_boxes[k]          = p_code_array[j].grid_id;
-                    Box tbx;
-                    p_tiles[k]          = getTileIndex(iv, p_code_array[j].grid_box,
-                                                       do_tiling, tile_size, tbx);
-                    p_levs[k]           = 0;
-                    p_periodic_shift[k] = p_code_array[j].periodic_shift;
-                    p_src_indices[k]    = pid;
-                    ++k;
+                    detail::forEachIntersectingTile(iv, nGrow,
+                                                    p_code_array[j].grid_box,
+                                                    p_code_array[j].periodic_shift,
+                                                    do_tiling, tile_size,
+                                                    [&] (int dst_tile)
+                    {
+                        bool is_self = (p_code_array[j].grid_id == gid) && (dst_tile == tid)
+                            AMREX_D_TERM( && (p_code_array[j].periodic_shift[0] == 0),
+                                          && (p_code_array[j].periodic_shift[1] == 0),
+                                          && (p_code_array[j].periodic_shift[2] == 0));
+                        if (!is_self) {
+                            p_boxes[k]          = p_code_array[j].grid_id;
+                            p_tiles[k]          = dst_tile;
+                            p_levs[k]           = 0;
+                            p_periodic_shift[k] = p_code_array[j].periodic_shift;
+                            p_src_indices[k]    = pid;
+                            ++k;
+                        }
+                    });
                 }
             }
             AMREX_ALWAYS_ASSERT(k == p_offsets[i+1]);

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1005,8 +1005,8 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
             const auto* pstruct = aos().dataPtr();
             const auto ptile_data = this->ParticlesAt(lev, pti).getConstParticleTileData();
 
-            Box box       = pti.validbox();
-            Box grownBox  = pti.tilebox();
+            Box box       = pti.tilebox();
+            Box grownBox  = box;
             grownBox.grow(computeRefFac(0, lev).max()*m_num_neighbor_cells);
             const auto lo = lbound(grownBox);
             const auto hi = ubound(grownBox);

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.H
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.H
@@ -45,7 +45,7 @@ public:
 
     void reset_test_id ();
 
-    void checkNeighborParticles ();
+    void checkNeighborParticles (bool use_source_grid = true);
 
     void checkNeighborList ();
 

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -331,9 +331,9 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
                 ParticleReal expected_pos = src.pos[idim];
                 if (shift[idim] > 0) {
-                    expected_pos += probhi[idim] - problo[idim];
+                    expected_pos += static_cast<ParticleReal>(probhi[idim] - problo[idim]);
                 } else if (shift[idim] < 0) {
-                    expected_pos -= probhi[idim] - problo[idim];
+                    expected_pos -= static_cast<ParticleReal>(probhi[idim] - problo[idim]);
                 }
                 if (std::abs(p.pos(idim) - expected_pos) > tol) {
                     matched = false;

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -5,10 +5,47 @@
 #include "Constants.H"
 #include "CheckPair.H"
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <tuple>
+
 using namespace amrex;
 
 namespace
 {
+    using ParticleKey = std::pair<Long, int>;
+
+    struct SourceParticleData
+    {
+        ParticleKey key;
+        IntVect cell;
+        int grid_id = -1;
+        std::array<ParticleReal, AMREX_SPACEDIM> pos{};
+    };
+
+    struct TileParticleRecord
+    {
+        ParticleKey key;
+        int grid_id = -1;
+        IntVect shift = IntVect(0);
+
+        bool operator< (TileParticleRecord const& other) const
+        {
+            return std::tie(key.first, key.second, grid_id,
+                            AMREX_D_DECL(shift[0], shift[1], shift[2]))
+                < std::tie(other.key.first, other.key.second, other.grid_id,
+                           AMREX_D_DECL(other.shift[0], other.shift[1], other.shift[2]));
+        }
+
+        bool operator== (TileParticleRecord const& other) const
+        {
+            return key == other.key && grid_id == other.grid_id && shift == other.shift;
+        }
+    };
+
     void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
     {
         int nx = nppc[0];
@@ -237,55 +274,145 @@ void MDParticleContainer::writeParticles(int n)
     WriteAsciiFile(pltfile);
 }
 
-void MDParticleContainer::checkNeighborParticles()
+void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
 {
     BL_PROFILE("MDParticleContainer::checkNeighborParticles");
 
     const int lev = 0;
+    auto const& geom = Geom(lev);
+    auto const plo = geom.ProbLoArray();
+    auto const dxi = geom.InvCellSizeArray();
+    auto const domain = geom.Domain();
+    auto const problo = geom.ProbLoArray();
+    auto const probhi = geom.ProbHiArray();
+    const auto& pshifts = geom.periodicity().shiftIntVect();
     auto& plev  = GetParticles(lev);
 
     auto ngrids = int(ParticleBoxArray(0).size());
+    std::map<ParticleKey, SourceParticleData> source_particles;
 
-    amrex::Gpu::DeviceVector<int> d_num_per_grid(ngrids,0);
-    amrex::Gpu::HostVector<int> h_num_per_grid(ngrids);
-
-    // CPU version
     for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
     {
-        int gid = mfi.index();
-
-        if (gid != 0) { continue; }
-        int tid = mfi.LocalTileIndex();
-        auto index = std::make_pair(gid, tid);
-
+        auto index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
         auto& ptile = plev[index];
-        auto& aos   = ptile.GetArrayOfStructs();
-        auto& soa   = ptile.GetStructOfArrays();
-        const int np = aos.numTotalParticles();
+        auto const& aos = ptile.GetArrayOfStructs();
+        int const np = aos.numParticles();
 
-        ParticleType* pstruct = aos().dataPtr();
-        auto* rdata = soa.GetRealData(0).dataPtr();
-        auto* idata = soa.GetIntData(0).dataPtr();
+        if (np == 0) { continue; }
 
-        int* p_num_per_grid = d_num_per_grid.data();
-        amrex::ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
-        {
-            ParticleType& p1 = pstruct[i];
-            Gpu::Atomic::AddNoRet(&(p_num_per_grid[p1.idata(0)]),1);
-            AMREX_ALWAYS_ASSERT(p1.idata(0) == (int) rdata[i]);
-            AMREX_ALWAYS_ASSERT(p1.idata(0) == idata[i]);
-        });
+        Gpu::HostVector<ParticleType> h_pstruct(np);
+        Gpu::copy(Gpu::deviceToHost, aos().dataPtr(), aos().dataPtr() + np, h_pstruct.begin());
 
-        Gpu::copy(Gpu::deviceToHost,
-                  d_num_per_grid.begin(), d_num_per_grid.end(), h_num_per_grid.begin());
-        amrex::AllPrintToFile("neighbor_test") << "FOR GRID " << gid << "\n";;
+        for (int i = 0; i < np; ++i) {
+            auto const& p = h_pstruct[i];
+            ParticleKey key{p.id(), p.cpu()};
+            SourceParticleData pdata;
+            pdata.key = key;
+            pdata.cell = getParticleCell(p, plo, dxi, domain);
+            pdata.grid_id = p.idata(0);
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                pdata.pos[idim] = p.pos(idim);
+            }
+            auto [it, inserted] = source_particles.emplace(key, pdata);
+            amrex::ignore_unused(it);
+            AMREX_ALWAYS_ASSERT(inserted);
+        }
+    }
 
-        for (int i = 0; i < ngrids; i++) {
-          amrex::AllPrintToFile("neighbor_test") << "   there are " << h_num_per_grid[i] << " with grid id " << i << "\n";
+    auto match_shift = [&] (ParticleType const& p, SourceParticleData const& src,
+                            Box const& grown_tile_box) -> IntVect
+    {
+        constexpr ParticleReal tol = ParticleReal(1.0e-12);
+        IntVect matched_shift(std::numeric_limits<int>::max());
+        int nmatches = 0;
+        for (auto const& shift : pshifts) {
+            if (!grown_tile_box.contains(src.cell + shift)) { continue; }
+            bool matched = true;
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                ParticleReal expected_pos = src.pos[idim];
+                if (shift[idim] > 0) {
+                    expected_pos += probhi[idim] - problo[idim];
+                } else if (shift[idim] < 0) {
+                    expected_pos -= probhi[idim] - problo[idim];
+                }
+                if (std::abs(p.pos(idim) - expected_pos) > tol) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched) {
+                matched_shift = shift;
+                ++nmatches;
+            }
+        }
+        AMREX_ALWAYS_ASSERT(nmatches == 1);
+        return matched_shift;
+    };
+
+    for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+    {
+        int const gid = mfi.index();
+        int const tid = mfi.LocalTileIndex();
+        auto index = std::make_pair(gid, tid);
+        auto& ptile = plev[index];
+        auto const& aos = ptile.GetArrayOfStructs();
+        auto const& soa = ptile.GetStructOfArrays();
+
+        int const np_total = aos.numTotalParticles();
+        if (np_total == 0) { continue; }
+
+        Gpu::HostVector<ParticleType> h_pstruct(np_total);
+        Gpu::HostVector<ParticleReal> h_rdata(np_total);
+        Gpu::HostVector<int> h_idata(np_total);
+        Gpu::copy(Gpu::deviceToHost, aos().dataPtr(), aos().dataPtr() + np_total, h_pstruct.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetRealData(0).begin(), soa.GetRealData(0).begin() + np_total,
+                  h_rdata.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetIntData(0).begin(), soa.GetIntData(0).begin() + np_total,
+                  h_idata.begin());
+
+        Box grown_tile_box = mfi.tilebox();
+        if (hasNeighbors()) {
+            grown_tile_box.grow(m_num_neighbor_cells);
         }
 
-        amrex::AllPrintToFile("neighbor_test") << " \n";
-        amrex::AllPrintToFile("neighbor_test") << " \n";
+        std::vector<int> expected_per_grid(ngrids, 0);
+        std::vector<int> actual_per_grid(ngrids, 0);
+        std::vector<TileParticleRecord> expected_records;
+        std::vector<TileParticleRecord> actual_records;
+
+        for (auto const& [key, src] : source_particles) {
+            for (auto const& shift : pshifts) {
+                if (!grown_tile_box.contains(src.cell + shift)) { continue; }
+                int const expected_grid = use_source_grid ? src.grid_id : gid;
+                expected_records.push_back({key, expected_grid, shift});
+                ++expected_per_grid[expected_grid];
+            }
+        }
+
+        for (int i = 0; i < np_total; ++i) {
+            auto const& p = h_pstruct[i];
+            ParticleKey key{p.id(), p.cpu()};
+            auto it = source_particles.find(key);
+            AMREX_ALWAYS_ASSERT(it != source_particles.end());
+            auto const& src = it->second;
+            int const expected_grid = use_source_grid ? src.grid_id : gid;
+
+            AMREX_ALWAYS_ASSERT(p.idata(0) == expected_grid);
+            AMREX_ALWAYS_ASSERT(static_cast<int>(h_rdata[i]) == expected_grid);
+            AMREX_ALWAYS_ASSERT(h_idata[i] == expected_grid);
+
+            IntVect shift = match_shift(p, src, grown_tile_box);
+            actual_records.push_back({key, expected_grid, shift});
+            ++actual_per_grid[expected_grid];
+        }
+
+        for (int igrid = 0; igrid < ngrids; ++igrid) {
+            AMREX_ALWAYS_ASSERT(actual_per_grid[igrid] == expected_per_grid[igrid]);
+        }
+
+        std::sort(expected_records.begin(), expected_records.end());
+        std::sort(actual_records.begin(), actual_records.end());
+        AMREX_ALWAYS_ASSERT(actual_records == expected_records);
     }
 }
 

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -315,7 +315,6 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
 
     const int lev = 0;
     auto const& geom = Geom(lev);
-    auto const plo = geom.ProbLoArray();
     auto const dxi = geom.InvCellSizeArray();
     auto const domain = geom.Domain();
     auto const problo = geom.ProbLoArray();
@@ -344,7 +343,7 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
             pdata.id = p.id();
             pdata.cpu = p.cpu();
             pdata.grid_id = p.idata(0);
-            auto const cell = getParticleCell(p, plo, dxi, domain);
+            auto const cell = getParticleCell(p, problo, dxi, domain);
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
                 pdata.cell[idim] = cell[idim];
                 pdata.pos[idim] = p.pos(idim);

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -8,9 +8,11 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstring>
 #include <limits>
 #include <map>
 #include <tuple>
+#include <type_traits>
 
 using namespace amrex;
 
@@ -25,6 +27,17 @@ namespace
         int grid_id = -1;
         std::array<ParticleReal, AMREX_SPACEDIM> pos{};
     };
+
+    struct PackedSourceParticleData
+    {
+        Long id = 0;
+        int cpu = -1;
+        int grid_id = -1;
+        std::array<int, AMREX_SPACEDIM> cell{};
+        std::array<ParticleReal, AMREX_SPACEDIM> pos{};
+    };
+
+    static_assert(std::is_trivially_copyable_v<PackedSourceParticleData>);
 
     struct TileParticleRecord
     {
@@ -77,6 +90,28 @@ namespace
         u[0] = u_mean + ux_th;
         u[1] = u_mean + uy_th;
         u[2] = u_mean + uz_th;
+    }
+
+    auto unpack_source_particles (std::vector<PackedSourceParticleData> const& packed_particles)
+        -> std::map<ParticleKey, SourceParticleData>
+    {
+        std::map<ParticleKey, SourceParticleData> source_particles;
+
+        for (auto const& packed : packed_particles) {
+            ParticleKey key{packed.id, packed.cpu};
+            SourceParticleData pdata;
+            pdata.key = key;
+            pdata.grid_id = packed.grid_id;
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                pdata.cell[idim] = packed.cell[idim];
+                pdata.pos[idim] = packed.pos[idim];
+            }
+            auto [it, inserted] = source_particles.emplace(key, pdata);
+            amrex::ignore_unused(it);
+            AMREX_ALWAYS_ASSERT(inserted);
+        }
+
+        return source_particles;
     }
 }
 
@@ -289,7 +324,7 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
     auto& plev  = GetParticles(lev);
 
     auto ngrids = int(ParticleBoxArray(0).size());
-    std::map<ParticleKey, SourceParticleData> source_particles;
+    std::vector<PackedSourceParticleData> local_source_particles;
 
     for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
     {
@@ -305,18 +340,61 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
 
         for (int i = 0; i < np; ++i) {
             auto const& p = h_pstruct[i];
-            ParticleKey key{p.id(), p.cpu()};
-            SourceParticleData pdata;
-            pdata.key = key;
-            pdata.cell = getParticleCell(p, plo, dxi, domain);
+            PackedSourceParticleData pdata;
+            pdata.id = p.id();
+            pdata.cpu = p.cpu();
             pdata.grid_id = p.idata(0);
+            auto const cell = getParticleCell(p, plo, dxi, domain);
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                pdata.cell[idim] = cell[idim];
                 pdata.pos[idim] = p.pos(idim);
             }
-            auto [it, inserted] = source_particles.emplace(key, pdata);
-            amrex::ignore_unused(it);
-            AMREX_ALWAYS_ASSERT(inserted);
+            local_source_particles.push_back(pdata);
         }
+    }
+
+    std::map<ParticleKey, SourceParticleData> source_particles;
+    if (ParallelDescriptor::NProcs() == 1) {
+        source_particles = unpack_source_particles(local_source_particles);
+    } else {
+        int const root = ParallelDescriptor::IOProcessorNumber();
+        int const local_nbytes =
+            static_cast<int>(local_source_particles.size() * sizeof(PackedSourceParticleData));
+
+        auto recvcounts = ParallelDescriptor::Gather(local_nbytes, root);
+        std::vector<int> displs;
+        std::vector<char> packed_bytes;
+
+        if (ParallelDescriptor::MyProc() == root) {
+            displs.resize(recvcounts.size(), 0);
+            int offset = 0;
+            for (int i = 0, n = static_cast<int>(recvcounts.size()); i < n; ++i) {
+                displs[i] = offset;
+                offset += recvcounts[i];
+            }
+            packed_bytes.resize(offset);
+        }
+
+        auto const* send_ptr = reinterpret_cast<char const*>(local_source_particles.data());
+        ParallelDescriptor::Gatherv(send_ptr, local_nbytes,
+                                    packed_bytes.data(), recvcounts, displs, root);
+
+        int total_nbytes = static_cast<int>(packed_bytes.size());
+        ParallelDescriptor::Bcast(&total_nbytes, 1, root);
+        if (ParallelDescriptor::MyProc() != root) {
+            packed_bytes.resize(total_nbytes);
+        }
+        if (total_nbytes > 0) {
+            ParallelDescriptor::Bcast(packed_bytes.data(), total_nbytes, root);
+        }
+
+        AMREX_ALWAYS_ASSERT(total_nbytes % sizeof(PackedSourceParticleData) == 0);
+        std::vector<PackedSourceParticleData> global_source_particles(
+            total_nbytes / static_cast<int>(sizeof(PackedSourceParticleData)));
+        if (total_nbytes > 0) {
+            std::memcpy(global_source_particles.data(), packed_bytes.data(), total_nbytes);
+        }
+        source_particles = unpack_source_particles(global_source_particles);
     }
 
     auto match_shift = [&] (ParticleType const& p, SourceParticleData const& src,

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -322,7 +322,7 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
     auto match_shift = [&] (ParticleType const& p, SourceParticleData const& src,
                             Box const& grown_tile_box) -> IntVect
     {
-        constexpr ParticleReal tol = ParticleReal(1.0e-12);
+        constexpr auto tol = ParticleReal(1.0e-12);
         IntVect matched_shift(std::numeric_limits<int>::max());
         int nmatches = 0;
         for (auto const& shift : pshifts) {

--- a/Tests/Particles/NeighborParticles/inputs
+++ b/Tests/Particles/NeighborParticles/inputs
@@ -4,11 +4,9 @@ particles.tile_size = 4 4 4
 nbor_parts.size = (24, 24, 24)
 nbor_parts.max_grid_size = 8
 nbor_parts.is_periodic = 1
-nbor_parts.num_ppc = 1
 
 nbor_list.size = (24, 24, 24)
 nbor_list.max_grid_size = 8
 nbor_list.is_periodic = 1
-nbor_list.num_ppc = 1
 nbor_list.do_plotfile = 1
 nbor_list.check_answer = 1

--- a/Tests/Particles/NeighborParticles/inputs
+++ b/Tests/Particles/NeighborParticles/inputs
@@ -1,3 +1,6 @@
+particles.do_tiling = 1
+particles.tile_size = 4 4 4
+
 nbor_parts.size = (24, 24, 24)
 nbor_parts.max_grid_size = 8
 nbor_parts.is_periodic = 1

--- a/Tests/Particles/NeighborParticles/main.cpp
+++ b/Tests/Particles/NeighborParticles/main.cpp
@@ -208,7 +208,8 @@ void testNeighborList ()
     pc.clearNeighbors();
     pc.fillNeighbors();
     pc.selectActualNeighbors(CheckPair());
-    pc.updateNeighbors();
+    pc.updateNeighbors(true);
+    pc.checkNeighborParticles();
     pc.buildNeighborList(CheckPair());
     if (params.check_answer) {
         pc.checkNeighborList();

--- a/Tests/Particles/NeighborParticles/main.cpp
+++ b/Tests/Particles/NeighborParticles/main.cpp
@@ -118,7 +118,7 @@ void testNeighborParticles ()
     if (ParallelDescriptor::MyProc() == dm[0]) {
         amrex::PrintToFile("neighbor_test") << "Check neighbors after reset ... \n";
     }
-    pc.checkNeighborParticles();
+    pc.checkNeighborParticles(false);
 
     if (ParallelDescriptor::MyProc() == dm[0]) {
         amrex::PrintToFile("neighbor_test") << "Now updateNeighbors again ...  \n";
@@ -142,18 +142,21 @@ void testNeighborParticles ()
     amrex::PrintToFile("neighbor_test") << "Moving particles and updating neighbors \n";
     pc.moveParticles(static_cast<amrex::ParticleReal> (0.1));
     pc.updateNeighbors();
+    pc.checkNeighborParticles();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
 
     amrex::PrintToFile("neighbor_test") << "Moving particles and updating neighbors again \n";
     pc.moveParticles(static_cast<amrex::ParticleReal> (0.1));
     pc.updateNeighbors();
+    pc.checkNeighborParticles();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
 
     amrex::PrintToFile("neighbor_test") << "Moving particles and updating neighbors yet again \n";
     pc.moveParticles(static_cast<amrex::ParticleReal> (0.1));
     pc.updateNeighbors();
+    pc.checkNeighborParticles();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
 }

--- a/Tests/Particles/NeighborParticles/main.cpp
+++ b/Tests/Particles/NeighborParticles/main.cpp
@@ -15,11 +15,16 @@ struct TestParams
 {
     IntVect size;
     int max_grid_size;
-    int num_ppc;
     int is_periodic;
     int do_plotfile;
     int check_answer;
 };
+
+namespace
+{
+    // The test assumes we have 1 ppc when checking the answer
+    constexpr int fixed_num_ppc = 1;
+}
 
 void testNeighborParticles();
 
@@ -43,7 +48,6 @@ void get_test_params(TestParams& params, const std::string& prefix)
     ParmParse pp(prefix);
     pp.get("size", params.size);
     pp.get("max_grid_size", params.max_grid_size);
-    pp.get("num_ppc", params.num_ppc);
     pp.get("is_periodic", params.is_periodic);
 
     params.do_plotfile = true;
@@ -83,7 +87,7 @@ void testNeighborParticles ()
     const int ncells = 1;
     MDParticleContainer pc(geom, dm, ba, ncells);
 
-    IntVect nppc(params.num_ppc);
+    IntVect nppc(fixed_num_ppc);
 
     if (ParallelDescriptor::MyProc() == dm[0]) {
         amrex::PrintToFile("neighbor_test") << "About to initialize particles \n";
@@ -191,7 +195,7 @@ void testNeighborList ()
     const int ncells = 1;
     MDParticleContainer pc(geom, dm, ba, ncells);
 
-    IntVect nppc(params.num_ppc);
+    IntVect nppc(fixed_num_ppc);
 
     amrex::PrintToFile("neighbor_test") << "About to initialize particles" << '\n';
 


### PR DESCRIPTION
PR #5268 allowed particle tiling on GPU in Redistribute, but did not extend this support to neighbor particles. This PR adds support for this. It also extends to the existing test to support tiling and to more carefully check that the ghosted particle data is exactly right. Note that this test now reproduces all the particles on all ranks and therefore isn't suitable for running on many ranks. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
