### PR TITLE
Support pure SoA for Neighbor particles

### DIFF
--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -39,6 +39,19 @@ namespace detail
 
     template <typename F,
               typename SrcData, typename DstData,
+              typename N1, typename N2,
+              std::enable_if_t<!std::remove_cv_t<SrcData>::ParticleType::is_soa_particle, int> = 0>
+    AMREX_GPU_HOST_DEVICE
+    auto call_check_pair (F const& check_pair,
+                          const SrcData& src_tile, const DstData& /*dst_tile*/,
+                          N1 i, N2 j)
+        noexcept -> decltype(check_pair(src_tile.m_aos, i, j))
+    {
+        return check_pair(src_tile.m_aos, i, j);
+    }
+
+    template <typename F,
+              typename SrcData, typename DstData,
               typename N1, typename N2>
     AMREX_GPU_HOST_DEVICE
     auto call_check_pair (F const& check_pair,
@@ -72,6 +85,19 @@ namespace detail
         noexcept -> decltype(check_pair(src_tile, dst_tile, i, j))
     {
         return check_pair(src_tile, dst_tile, i, j);
+    }
+
+    template <typename F,
+              typename SrcData, typename DstData,
+              typename N1, typename N2, typename N3, typename N4, typename N5,
+              std::enable_if_t<!std::remove_cv_t<SrcData>::ParticleType::is_soa_particle, int> = 0>
+    AMREX_GPU_HOST_DEVICE
+    auto call_check_pair (F const& check_pair,
+                          const SrcData& src_tile, const DstData& /*dst_tile*/,
+                          N1 i, N2 j, N3 /*type*/, N4 /*ghost_i*/, N5 /*ghost_pid*/)
+        noexcept -> decltype(check_pair(src_tile.m_aos, i, j))
+    {
+        return check_pair(src_tile.m_aos, i, j);
     }
 
     template <typename F,

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -20,9 +20,9 @@ namespace detail
     auto call_check_pair (F const& check_pair,
                           const SrcData& src_tile, const DstData& dst_tile,
                           N1 i, N2 j)
-        noexcept -> decltype(check_pair(src_tile.m_aos[i], dst_tile.m_aos[j]))
+        noexcept -> decltype(check_pair(src_tile[i], dst_tile[j]))
     {
-        return check_pair(src_tile.m_aos[i], dst_tile.m_aos[j]);
+        return check_pair(src_tile[i], dst_tile[j]);
     }
 
     template <typename F,
@@ -30,11 +30,11 @@ namespace detail
               typename N1, typename N2>
     AMREX_GPU_HOST_DEVICE
     auto call_check_pair (F const& check_pair,
-                          const SrcData& src_tile, const DstData& /*dst_tile*/,
+                          const SrcData& src_tile, const DstData& dst_tile,
                           N1 i, N2 j)
-        noexcept -> decltype(check_pair(src_tile.m_aos, i, j))
+        noexcept -> decltype(check_pair(src_tile, dst_tile, i, j))
     {
-        return check_pair(src_tile.m_aos, i, j);
+        return check_pair(src_tile, dst_tile, i, j);
     }
 
     template <typename F,
@@ -57,9 +57,9 @@ namespace detail
     auto call_check_pair (F const& check_pair,
                           const SrcData& src_tile, const DstData& dst_tile,
                           N1 i, N2 j, N3 /*type*/, N4 /*ghost_i*/, N5 /*ghost_pid*/)
-        noexcept -> decltype(check_pair(src_tile.m_aos[i], dst_tile.m_aos[j]))
+        noexcept -> decltype(check_pair(src_tile[i], dst_tile[j]))
     {
-        return check_pair(src_tile.m_aos[i], dst_tile.m_aos[j]);
+        return check_pair(src_tile[i], dst_tile[j]);
     }
 
     template <typename F,
@@ -67,11 +67,11 @@ namespace detail
               typename N1, typename N2, typename N3, typename N4, typename N5>
     AMREX_GPU_HOST_DEVICE
     auto call_check_pair (F const& check_pair,
-                          const SrcData& src_tile, const DstData& /*dst_tile*/,
+                          const SrcData& src_tile, const DstData& dst_tile,
                           N1 i, N2 j, N3 /*type*/, N4 /*ghost_i*/, N5 /*ghost_pid*/)
-        noexcept -> decltype(check_pair(src_tile.m_aos, i, j))
+        noexcept -> decltype(check_pair(src_tile, dst_tile, i, j))
     {
-        return check_pair(src_tile.m_aos, i, j);
+        return check_pair(src_tile, dst_tile, i, j);
     }
 
     template <typename F,
@@ -100,14 +100,17 @@ namespace detail
 }
 /// \endcond
 
-template <class ParticleType>
+template <class ParticleType, int NArrayReal, int NArrayInt>
 struct Neighbors
 {
+    using PTDType = ParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+    using ConstPTDType = ConstParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+
     struct iterator
     {
         AMREX_GPU_HOST_DEVICE
-        iterator (int start, int stop, const unsigned int * nbor_list_ptr, ParticleType* pstruct)
-            : m_index(start), m_stop(stop), m_nbor_list_ptr(nbor_list_ptr), m_pstruct(pstruct)
+        iterator (int start, int stop, const unsigned int * nbor_list_ptr, PTDType ptile_data)
+            : m_index(start), m_stop(stop), m_nbor_list_ptr(nbor_list_ptr), m_ptile_data(ptile_data)
         {}
 
         AMREX_GPU_HOST_DEVICE
@@ -117,7 +120,7 @@ struct Neighbors
         bool operator!= (iterator const& /*rhs*/) const { return m_index < m_stop; }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE
-        ParticleType& operator* () const { return m_pstruct[m_nbor_list_ptr[m_index]];  }
+        decltype(auto) operator* () const { return m_ptile_data[m_nbor_list_ptr[m_index]];  }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE
         unsigned int index () const { return m_nbor_list_ptr[m_index]; }
@@ -126,14 +129,14 @@ struct Neighbors
         int m_index;
         int m_stop;
         const unsigned int* m_nbor_list_ptr;
-        ParticleType* m_pstruct;
+        PTDType m_ptile_data;
     };
 
     struct const_iterator
     {
         AMREX_GPU_HOST_DEVICE
-        const_iterator (int start, int stop, const unsigned int * nbor_list_ptr, const ParticleType* pstruct)
-            : m_index(start), m_stop(stop), m_nbor_list_ptr(nbor_list_ptr), m_pstruct(pstruct)
+        const_iterator (int start, int stop, const unsigned int * nbor_list_ptr, ConstPTDType ptile_data)
+            : m_index(start), m_stop(stop), m_nbor_list_ptr(nbor_list_ptr), m_ptile_data(ptile_data)
         {}
 
         AMREX_GPU_HOST_DEVICE
@@ -143,7 +146,7 @@ struct Neighbors
         bool operator!= (const_iterator const& /*rhs*/) const { return m_index < m_stop; }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE
-        const ParticleType& operator* () const { return m_pstruct[m_nbor_list_ptr[m_index]];  }
+        decltype(auto) operator* () const { return m_ptile_data[m_nbor_list_ptr[m_index]];  }
 
         [[nodiscard]] AMREX_GPU_HOST_DEVICE
         unsigned int index () const { return m_nbor_list_ptr[m_index]; }
@@ -152,52 +155,53 @@ struct Neighbors
         int m_index;
         int m_stop;
         const unsigned int* m_nbor_list_ptr;
-        const ParticleType* m_pstruct;
+        ConstPTDType m_ptile_data;
     };
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
     iterator begin () noexcept {
         return iterator(m_nbor_offsets_ptr[m_i], m_nbor_offsets_ptr[m_i+1],
-                        m_nbor_list_ptr, m_pstruct);
+                        m_nbor_list_ptr, m_ptile_data);
     }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
     iterator end () noexcept {
         return iterator(m_nbor_offsets_ptr[m_i+1], m_nbor_offsets_ptr[m_i+1],
-                        m_nbor_list_ptr, m_pstruct);
+                        m_nbor_list_ptr, m_ptile_data);
     }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
     const_iterator begin () const noexcept {
         return const_iterator(m_nbor_offsets_ptr[m_i], m_nbor_offsets_ptr[m_i+1],
-                              m_nbor_list_ptr, m_pstruct);
+                              m_nbor_list_ptr, m_const_ptile_data);
     }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
     const_iterator end () const noexcept {
         return const_iterator(m_nbor_offsets_ptr[m_i+1], m_nbor_offsets_ptr[m_i+1],
-                              m_nbor_list_ptr, m_pstruct);
+                              m_nbor_list_ptr, m_const_ptile_data);
     }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
     const_iterator cbegin () const noexcept {
         return const_iterator(m_nbor_offsets_ptr[m_i], m_nbor_offsets_ptr[m_i+1],
-                              m_nbor_list_ptr, m_pstruct);
+                              m_nbor_list_ptr, m_const_ptile_data);
     }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
     const_iterator cend () const noexcept {
         return const_iterator(m_nbor_offsets_ptr[m_i+1], m_nbor_offsets_ptr[m_i+1],
-                              m_nbor_list_ptr, m_pstruct);
+                              m_nbor_list_ptr, m_const_ptile_data);
     }
 
     AMREX_GPU_HOST_DEVICE
     Neighbors (int i, const unsigned int *nbor_offsets_ptr, const unsigned int *nbor_list_ptr,
-               ParticleType* pstruct)
+               PTDType ptile_data, ConstPTDType const_ptile_data)
         : m_i(i),
           m_nbor_offsets_ptr(nbor_offsets_ptr),
           m_nbor_list_ptr(nbor_list_ptr),
-          m_pstruct(pstruct)
+          m_ptile_data(ptile_data),
+          m_const_ptile_data(const_ptile_data)
     {}
 
 private:
@@ -205,27 +209,36 @@ private:
     int m_i;
     const unsigned int * m_nbor_offsets_ptr;
     const unsigned int * m_nbor_list_ptr;
-    ParticleType * m_pstruct;
+    PTDType m_ptile_data;
+    ConstPTDType m_const_ptile_data;
 };
 
-template <class ParticleType>
+template <class ParticleType, int NArrayReal, int NArrayInt>
 struct NeighborData
 {
+    using PTDType = ParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+    using ConstPTDType = ConstParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+
     NeighborData (const Gpu::DeviceVector<unsigned int>& offsets,
                   const Gpu::DeviceVector<unsigned int>& list,
-                  ParticleType* pstruct)
+                  PTDType ptile_data, ConstPTDType const_ptile_data)
         : m_nbor_offsets_ptr(offsets.dataPtr()),
           m_nbor_list_ptr(list.dataPtr()),
-          m_pstruct(pstruct)
+          m_ptile_data(ptile_data),
+          m_const_ptile_data(const_ptile_data)
     {}
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
-    amrex::Neighbors<ParticleType> getNeighbors (int i) const
-    { return Neighbors<ParticleType>(i, m_nbor_offsets_ptr, m_nbor_list_ptr, m_pstruct); }
+    amrex::Neighbors<ParticleType, NArrayReal, NArrayInt> getNeighbors (int i) const
+    {
+        return Neighbors<ParticleType, NArrayReal, NArrayInt>(
+            i, m_nbor_offsets_ptr, m_nbor_list_ptr, m_ptile_data, m_const_ptile_data);
+    }
 
     const unsigned int * m_nbor_offsets_ptr;
     const unsigned int * m_nbor_list_ptr;
-    ParticleType * m_pstruct;
+    PTDType m_ptile_data;
+    ConstPTDType m_const_ptile_data;
 };
 
 template<typename A, typename B,
@@ -244,10 +257,12 @@ bool isSame (A const* /*pa*/, B const* /*pb*/)
     return false;
 }
 
-template <class ParticleType>
+template <class ParticleType, int NArrayReal=0, int NArrayInt=0>
 class NeighborList
 {
 public:
+    using PTDType = ParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+    using ConstPTDType = ConstParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
 
     template <class PTile, class CheckPair>
     void build (PTile& ptile,
@@ -306,13 +321,11 @@ public:
 
         // Bin particles to their respective grid(s)
         //---------------------------------------------------------------------------------------------------------
-        auto& aos = target_tile.GetArrayOfStructs();
-        const auto dst_ptile_data = target_tile.getConstParticleTileData();
+        auto const dst_ptile_data = target_tile.getConstParticleTileData();
+        m_ptile_data = target_tile.getParticleTileData();
+        m_const_ptile_data = dst_ptile_data;
 
-        m_pstruct = aos().dataPtr();
-        auto* const pstruct_ptr = aos().dataPtr();
-
-        const int np_total = aos.size();
+        const int np_total = target_tile.numTotalParticles();
         const int np_real  = src_tile.numRealParticles();
 
         auto const* off_bins_p = off_bins_v.data();
@@ -326,7 +339,7 @@ public:
         int tot_bins;
         Gpu::dtoh_memcpy( &tot_bins, off_bins_p + num_bin_types, sizeof(int) );
 
-        m_bins.build(np_total, pstruct_ptr, tot_bins, bm);
+        m_bins.build(np_total, dst_ptile_data, tot_bins, bm);
 
 
         // First pass: count the number of neighbors for each particle
@@ -342,7 +355,6 @@ public:
         auto poffset = m_bins.offsetsPtr();
 
         const auto src_ptile_data  = src_tile.getConstParticleTileData();
-        const auto* src_pstruct_ptr = src_tile.GetArrayOfStructs()().dataPtr();
 
         AMREX_FOR_1D ( np_size, i,
         {
@@ -353,9 +365,9 @@ public:
                 int off_bins = off_bins_p[type];
 
               IntVect iv(AMREX_D_DECL(
-                static_cast<int>(amrex::Math::floor((src_pstruct_ptr[i].pos(0)-plo_p[type][0])*dxi_p[type][0])) - lo_p[type].x,
-                static_cast<int>(amrex::Math::floor((src_pstruct_ptr[i].pos(1)-plo_p[type][1])*dxi_p[type][1])) - lo_p[type].y,
-                static_cast<int>(amrex::Math::floor((src_pstruct_ptr[i].pos(2)-plo_p[type][2])*dxi_p[type][2])) - lo_p[type].z));
+                static_cast<int>(amrex::Math::floor((src_ptile_data.pos(0, i)-plo_p[type][0])*dxi_p[type][0])) - lo_p[type].x,
+                static_cast<int>(amrex::Math::floor((src_ptile_data.pos(1, i)-plo_p[type][1])*dxi_p[type][1])) - lo_p[type].y,
+                static_cast<int>(amrex::Math::floor((src_ptile_data.pos(2, i)-plo_p[type][2])*dxi_p[type][2])) - lo_p[type].z));
               auto iv3 = iv.dim3();
 
               int ix = iv3.x;
@@ -409,9 +421,9 @@ public:
               int off_bins = off_bins_p[type];
 
             IntVect iv(AMREX_D_DECL(
-                static_cast<int>(amrex::Math::floor((src_pstruct_ptr[i].pos(0)-plo_p[type][0])*dxi_p[type][0])) - lo_p[type].x,
-                static_cast<int>(amrex::Math::floor((src_pstruct_ptr[i].pos(1)-plo_p[type][1])*dxi_p[type][1])) - lo_p[type].y,
-                static_cast<int>(amrex::Math::floor((src_pstruct_ptr[i].pos(2)-plo_p[type][2])*dxi_p[type][2])) - lo_p[type].z));
+                static_cast<int>(amrex::Math::floor((src_ptile_data.pos(0, i)-plo_p[type][0])*dxi_p[type][0])) - lo_p[type].x,
+                static_cast<int>(amrex::Math::floor((src_ptile_data.pos(1, i)-plo_p[type][1])*dxi_p[type][1])) - lo_p[type].y,
+                static_cast<int>(amrex::Math::floor((src_ptile_data.pos(2, i)-plo_p[type][2])*dxi_p[type][2])) - lo_p[type].z));
             auto iv3 = iv.dim3();
 
             int ix = iv3.x;
@@ -445,9 +457,10 @@ public:
         Gpu::Device::streamSynchronize();
     }
 
-    NeighborData<ParticleType> data ()
+    NeighborData<ParticleType, NArrayReal, NArrayInt> data ()
     {
-        return NeighborData<ParticleType>(m_nbor_offsets, m_nbor_list, m_pstruct);
+        return NeighborData<ParticleType, NArrayReal, NArrayInt>(
+            m_nbor_offsets, m_nbor_list, m_ptile_data, m_const_ptile_data);
     }
 
     [[nodiscard]] int numParticles () const { return m_nbor_offsets.size() - 1; }
@@ -483,14 +496,15 @@ public:
 
 protected:
 
-    ParticleType* m_pstruct;
+    PTDType m_ptile_data;
+    ConstPTDType m_const_ptile_data;
 
     // This is the neighbor list data structure
     Gpu::DeviceVector<unsigned int> m_nbor_offsets;
     Gpu::DeviceVector<unsigned int> m_nbor_list;
     Gpu::DeviceVector<unsigned int> m_nbor_counts;
 
-    DenseBins<ParticleType> m_bins;
+    DenseBins<ConstPTDType> m_bins;
 };
 
 }

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -126,11 +126,33 @@ namespace detail
 }
 /// \endcond
 
-template <class ParticleType, int NArrayReal, int NArrayInt>
+namespace detail
+{
+    template <class ParticleType, bool IsSoA = ParticleType::is_soa_particle>
+    struct NeighborParticleTypeTraits
+    {
+        using PTDType = ParticleType*;
+        using ConstPTDType = ParticleType const*;
+        using BinType = ParticleType;
+    };
+
+    template <class ParticleType>
+    struct NeighborParticleTypeTraits<ParticleType, true>
+    {
+        static constexpr int NArrayReal = ParticleType::NArrayReal;
+        static constexpr int NArrayInt = ParticleType::NArrayInt;
+        using PTDType = ParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+        using ConstPTDType = ConstParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+        using BinType = ConstPTDType;
+    };
+}
+
+template <class ParticleType>
 struct Neighbors
 {
-    using PTDType = ParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
-    using ConstPTDType = ConstParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+    using Traits = detail::NeighborParticleTypeTraits<ParticleType>;
+    using PTDType = typename Traits::PTDType;
+    using ConstPTDType = typename Traits::ConstPTDType;
 
     struct iterator
     {
@@ -239,11 +261,12 @@ private:
     ConstPTDType m_const_ptile_data;
 };
 
-template <class ParticleType, int NArrayReal, int NArrayInt>
+template <class ParticleType>
 struct NeighborData
 {
-    using PTDType = ParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
-    using ConstPTDType = ConstParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+    using Traits = detail::NeighborParticleTypeTraits<ParticleType>;
+    using PTDType = typename Traits::PTDType;
+    using ConstPTDType = typename Traits::ConstPTDType;
 
     NeighborData (const Gpu::DeviceVector<unsigned int>& offsets,
                   const Gpu::DeviceVector<unsigned int>& list,
@@ -255,9 +278,9 @@ struct NeighborData
     {}
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE
-    amrex::Neighbors<ParticleType, NArrayReal, NArrayInt> getNeighbors (int i) const
+    amrex::Neighbors<ParticleType> getNeighbors (int i) const
     {
-        return Neighbors<ParticleType, NArrayReal, NArrayInt>(
+        return Neighbors<ParticleType>(
             i, m_nbor_offsets_ptr, m_nbor_list_ptr, m_ptile_data, m_const_ptile_data);
     }
 
@@ -283,12 +306,14 @@ bool isSame (A const* /*pa*/, B const* /*pb*/)
     return false;
 }
 
-template <class ParticleType, int NArrayReal=0, int NArrayInt=0>
+template <class ParticleType>
 class NeighborList
 {
 public:
-    using PTDType = ParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
-    using ConstPTDType = ConstParticleTileData<typename ParticleType::StorageParticleType, NArrayReal, NArrayInt>;
+    using Traits = detail::NeighborParticleTypeTraits<ParticleType>;
+    using PTDType = typename Traits::PTDType;
+    using ConstPTDType = typename Traits::ConstPTDType;
+    using BinType = typename Traits::BinType;
 
     template <class PTile, class CheckPair>
     void build (PTile& ptile,
@@ -348,8 +373,14 @@ public:
         // Bin particles to their respective grid(s)
         //---------------------------------------------------------------------------------------------------------
         auto const dst_ptile_data = target_tile.getConstParticleTileData();
-        m_ptile_data = target_tile.getParticleTileData();
-        m_const_ptile_data = dst_ptile_data;
+        if constexpr (ParticleType::is_soa_particle) {
+            m_ptile_data = target_tile.getParticleTileData();
+            m_const_ptile_data = dst_ptile_data;
+        } else {
+            auto* const pstruct_ptr = target_tile.GetArrayOfStructs()().dataPtr();
+            m_ptile_data = pstruct_ptr;
+            m_const_ptile_data = pstruct_ptr;
+        }
 
         const int np_total = target_tile.numTotalParticles();
         const int np_real  = src_tile.numRealParticles();
@@ -365,7 +396,11 @@ public:
         int tot_bins;
         Gpu::dtoh_memcpy( &tot_bins, off_bins_p + num_bin_types, sizeof(int) );
 
-        m_bins.build(np_total, dst_ptile_data, tot_bins, bm);
+        if constexpr (ParticleType::is_soa_particle) {
+            m_bins.build(np_total, dst_ptile_data, tot_bins, bm);
+        } else {
+            m_bins.build(np_total, m_ptile_data, tot_bins, bm);
+        }
 
 
         // First pass: count the number of neighbors for each particle
@@ -483,9 +518,9 @@ public:
         Gpu::Device::streamSynchronize();
     }
 
-    NeighborData<ParticleType, NArrayReal, NArrayInt> data ()
+    NeighborData<ParticleType> data ()
     {
-        return NeighborData<ParticleType, NArrayReal, NArrayInt>(
+        return NeighborData<ParticleType>(
             m_nbor_offsets, m_nbor_list, m_ptile_data, m_const_ptile_data);
     }
 
@@ -530,7 +565,7 @@ protected:
     Gpu::DeviceVector<unsigned int> m_nbor_list;
     Gpu::DeviceVector<unsigned int> m_nbor_counts;
 
-    DenseBins<ConstPTDType> m_bins;
+    DenseBins<BinType> m_bins;
 };
 
 }

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -31,15 +31,20 @@ namespace amrex {
 /// in AMR subcycling to keep track of coarse level particles that may move on to fine
 /// levels during a fine level time step.
 ///
-template <int NStructReal, int NStructInt, int NArrayReal=0, int NArrayInt=0>
-class NeighborParticleContainer // NOLINT(cppcoreguidelines-virtual-class-destructor) // clang-tidy seems wrong.
-    : public ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+template <typename T_ParticleType, int T_NArrayReal=0, int T_NArrayInt=0,
+          template<class> class Allocator=DefaultAllocator,
+          class CellAssignor=DefaultAssignor>
+class NeighborParticleContainer_impl // NOLINT(cppcoreguidelines-virtual-class-destructor) // clang-tidy seems wrong.
+    : public ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, CellAssignor>
 {
 public:
-    using ParticleContainerType = ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>;
+    using ParticleContainerType =
+        ParticleContainer_impl<T_ParticleType, T_NArrayReal, T_NArrayInt, Allocator, CellAssignor>;
     using ParticleType = typename ParticleContainerType::ParticleType;
     using SuperParticleType = typename ParticleContainerType::SuperParticleType;
-    using NeighborListContainerType = Vector<std::map<std::pair<int, int>, amrex::NeighborList<ParticleType> > >;
+    using NeighborListContainerType =
+        Vector<std::map<std::pair<int, int>,
+            amrex::NeighborList<ParticleType, T_NArrayReal, T_NArrayInt> > >;
 private:
     struct MaskComps
     {
@@ -194,34 +199,43 @@ private:
 
 public:
 
-    using MyParIter = ParIter<NStructReal, NStructInt, NArrayReal, NArrayInt>;
+    static constexpr int NArrayReal = ParticleContainerType::NArrayReal;
+    static constexpr int NArrayInt = ParticleContainerType::NArrayInt;
+    static constexpr int NStructReal = ParticleContainerType::NStructReal;
+    static constexpr int NStructInt = ParticleContainerType::NStructInt;
+    static constexpr int RealCommCompStart = ParticleType::is_soa_particle ? 0 : AMREX_SPACEDIM + NStructReal;
+    static constexpr int IntCommCompStart = 2 + NStructInt;
+
+    using MyParIter = typename ParticleContainerType::ParIterType;
     using PairIndex = std::pair<int, int>;
     using NeighborCommMap = std::map<NeighborCommTag, Vector<char> >;
-    using AoS = typename ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::AoS;
-    using ParticleVector = typename ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::ParticleVector;
-    using ParticleTile = typename ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::ParticleTileType;
-    using IntVector  = typename ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::IntVector;
+    using AoS = typename ParticleContainerType::AoS;
+    using ParticleVector = typename ParticleContainerType::ParticleVector;
+    using ParticleTile = typename ParticleContainerType::ParticleTileType;
+    using IntVector  = typename ParticleContainerType::IntVector;
+    using PTDType = typename ParticleContainerType::PTDType;
+    using ConstPTDType = typename ParticleContainerType::ConstPTDType;
 
-    NeighborParticleContainer (ParGDBBase* gdb, int ncells);
+    NeighborParticleContainer_impl (ParGDBBase* gdb, int ncells);
 
-    NeighborParticleContainer (const Geometry            & geom,
-                               const DistributionMapping & dmap,
-                               const BoxArray            & ba,
-                               int                         nneighbor);
+    NeighborParticleContainer_impl (const Geometry            & geom,
+                                    const DistributionMapping & dmap,
+                                    const BoxArray            & ba,
+                                    int                         nneighbor);
 
-    NeighborParticleContainer (const Vector<Geometry>            & geom,
-                               const Vector<DistributionMapping> & dmap,
-                               const Vector<BoxArray>            & ba,
-                               const Vector<int>                 & rr,
-                               int                               nneighbor);
+    NeighborParticleContainer_impl (const Vector<Geometry>            & geom,
+                                    const Vector<DistributionMapping> & dmap,
+                                    const Vector<BoxArray>            & ba,
+                                    const Vector<int>                 & rr,
+                                    int                               nneighbor);
 
-    ~NeighborParticleContainer () override = default;
+    ~NeighborParticleContainer_impl () override = default;
 
-    NeighborParticleContainer ( const NeighborParticleContainer &) = delete;
-    NeighborParticleContainer& operator= ( const NeighborParticleContainer & ) = delete;
+    NeighborParticleContainer_impl ( const NeighborParticleContainer_impl &) = delete;
+    NeighborParticleContainer_impl& operator= ( const NeighborParticleContainer_impl & ) = delete;
 
-    NeighborParticleContainer ( NeighborParticleContainer && ) = default; // NOLINT(performance-noexcept-move-constructor)
-    NeighborParticleContainer& operator= ( NeighborParticleContainer && ) = default; // NOLINT(performance-noexcept-move-constructor)
+    NeighborParticleContainer_impl ( NeighborParticleContainer_impl && ) = default; // NOLINT(performance-noexcept-move-constructor)
+    NeighborParticleContainer_impl& operator= ( NeighborParticleContainer_impl && ) = default; // NOLINT(performance-noexcept-move-constructor)
 
     ///
     /// Regrid functions
@@ -263,7 +277,10 @@ public:
     ///
     template <class CheckPair, class OtherPCType>
     void buildNeighborList (CheckPair const& check_pair, OtherPCType& other,
-                            Vector<std::map<std::pair<int, int>, amrex::NeighborList<typename OtherPCType::ParticleType> > >& neighbor_lists,
+                            Vector<std::map<std::pair<int, int>,
+                                amrex::NeighborList<typename OtherPCType::ParticleType,
+                                                    OtherPCType::NArrayReal,
+                                                    OtherPCType::NArrayInt> > >& neighbor_lists,
                             bool sort=false);
 
     ///
@@ -295,8 +312,7 @@ public:
               std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
     void AddRealComp (T communicate=true)
     {
-        ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
-            AddRealComp(communicate);
+        ParticleContainerType::AddRealComp(communicate);
         ghost_real_comp.push_back(communicate);
         calcCommSize();
     }
@@ -305,8 +321,7 @@ public:
               std::enable_if_t<std::is_same_v<T,bool>,int> = 0>
     void AddIntComp (T communicate=true)
     {
-        ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
-            AddIntComp(communicate);
+        ParticleContainerType::AddIntComp(communicate);
         ghost_int_comp.push_back(communicate);
         calcCommSize();
     }
@@ -315,8 +330,7 @@ public:
                        bool remove_negative=true)
     {
         clearNeighbors();
-        ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
-            ::Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
+        ParticleContainerType::Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
     }
 
     void RedistributeLocal (bool remove_negative=true)
@@ -355,6 +369,9 @@ public:
 
 protected:
 
+    [[nodiscard]] int numRealCommComps () const { return RealCommCompStart + this->NumRealComps(); }
+    [[nodiscard]] int numIntCommComps () const { return IntCommCompStart + this->NumIntComps(); }
+
     void cacheNeighborInfo ();
 
     ///
@@ -391,13 +408,15 @@ protected:
     ///
     void getRcvCountsMPI ();
 
+    template <typename P>
     void getNeighborTags (Vector<NeighborCopyTag>& tags,
-                         const ParticleType& p,
+                          const P& p,
                           int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti);
 
+    template <typename P>
     void getNeighborTags (Vector<NeighborCopyTag>& tags,
-                         const ParticleType& p,
-                         const IntVect& nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti);
+                          const P& p,
+                          const IntVect& nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti);
 
     IntVect computeRefFac (int src_lev, int lev);
 
@@ -486,6 +505,17 @@ protected:
 
     bool m_has_neighbors = false;
 };
+
+template <int T_NStructReal, int T_NStructInt, int T_NArrayReal=0, int T_NArrayInt=0>
+using NeighborParticleContainer =
+    NeighborParticleContainer_impl<Particle<T_NStructReal, T_NStructInt>, T_NArrayReal, T_NArrayInt>;
+
+template <int T_NArrayReal, int T_NArrayInt,
+          template<class> class Allocator=DefaultAllocator,
+          class CellAssignor=DefaultAssignor>
+using NeighborParticleContainerPureSoA =
+    NeighborParticleContainer_impl<SoAParticle<T_NArrayReal, T_NArrayInt>,
+                                   T_NArrayReal, T_NArrayInt, Allocator, CellAssignor>;
 
 }
 

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -44,7 +44,7 @@ public:
     using SuperParticleType = typename ParticleContainerType::SuperParticleType;
     using NeighborListContainerType =
         Vector<std::map<std::pair<int, int>,
-            amrex::NeighborList<ParticleType, T_NArrayReal, T_NArrayInt> > >;
+            amrex::NeighborList<ParticleType> > >;
 private:
     struct MaskComps
     {
@@ -278,9 +278,7 @@ public:
     template <class CheckPair, class OtherPCType>
     void buildNeighborList (CheckPair const& check_pair, OtherPCType& other,
                             Vector<std::map<std::pair<int, int>,
-                                amrex::NeighborList<typename OtherPCType::ParticleType,
-                                                    OtherPCType::NArrayReal,
-                                                    OtherPCType::NArrayInt> > >& neighbor_lists,
+                                amrex::NeighborList<typename OtherPCType::ParticleType> > >& neighbor_lists,
                             bool sort=false);
 
     ///

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -38,7 +38,7 @@ void shiftNeighborParticlePositions (PTD const& ptd, int index, const IntVect& p
 
 template <typename PTD>
 AMREX_FORCE_INLINE
-void packNeighborParticleData (char* dst, PTD const& src, int src_index,
+void packNeighborParticleData (char*& dst, PTD const& src, int src_index,
                                int num_real_comps, int num_int_comps,
                                const Vector<int>& ghost_real_comp,
                                const Vector<int>& ghost_int_comp,
@@ -348,7 +348,8 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
                 {
                     auto& sdata = isend_data[dst_proc];
                     auto old_size = sdata.size();
-                    auto new_size = old_size + real_num_comp*sizeof(Real) + int_num_comp*sizeof(int) + 4*sizeof(int);
+                    auto new_size = old_size + real_num_comp*sizeof(ParticleReal) + int_num_comp*sizeof(int)
+                        + 4*sizeof(int);
                     sdata.resize(new_size);
                     char* dst = &sdata[old_size];
                     std::memcpy(dst, &dst_grid, sizeof(int)); dst += sizeof(int);
@@ -358,8 +359,8 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
                     for (int comp = real_start_comp; comp < real_start_comp + real_num_comp; ++comp)
                     {
                         ParticleReal data = detail::getSummedRealComp(neighbs, i, comp);
-                        std::memcpy(dst, &data, sizeof(Real));
-                        dst += sizeof(Real);
+                        std::memcpy(dst, &data, sizeof(ParticleReal));
+                        dst += sizeof(ParticleReal);
                     }
                     for (int comp = int_start_comp; comp < int_start_comp + int_num_comp; ++comp)
                     {
@@ -493,7 +494,8 @@ sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
     {
         ParallelDescriptor::Waitall(rreqs, stats);
 
-        const size_t data_size = real_num_comp*sizeof(Real) + int_num_comp*sizeof(int) + 4 * sizeof(int);
+        const size_t data_size =
+            real_num_comp*sizeof(ParticleReal) + int_num_comp*sizeof(int) + 4 * sizeof(int);
 
         if (recvdata.size() % data_size != 0) {
             amrex::Print() << recvdata.size() << " " << data_size << "\n";
@@ -522,9 +524,9 @@ sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
             for (int comp = real_start_comp; comp < real_start_comp + real_num_comp; ++comp)
             {
                 ParticleReal data;
-                std::memcpy(&data, buffer, sizeof(Real));
+                std::memcpy(&data, buffer, sizeof(ParticleReal));
                 detail::addSummedRealComp(dst_ptd, index, comp, data);
-                buffer += sizeof(Real);
+                buffer += sizeof(ParticleReal);
             }
 
             for (int comp = int_start_comp; comp < int_start_comp + int_num_comp; ++comp)

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -312,10 +312,10 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
             const auto& tags = inverse_tags[lev][src_index];
             const auto& neighb_tile = neighbors[lev][src_index];
             const auto neighbs = neighb_tile.getConstParticleTileData();
-            const int num_neighbs = static_cast<int>(neighb_tile.size());
-            AMREX_ASSERT(tags.size() == static_cast<std::size_t>(num_neighbs));
+            const auto num_neighbs = neighb_tile.size();
+            AMREX_ASSERT(tags.size() == num_neighbs);
 
-            for (int i = 0; i < num_neighbs; ++i)
+            for (int i = 0; i < static_cast<int>(num_neighbs); ++i)
             {
                 const auto& tag = tags[i];
                 const int dst_grid = tag.src_grid;

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -2,13 +2,196 @@
 #define AMREX_NEIGHBORPARTICLESCPUIMPL_H_
 #include <AMReX_Config.H>
 
+#include <array>
+#include <cstring>
+
 //! \cond CPU
 
 namespace amrex {
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+namespace detail {
+
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void applyNeighborPeriodicShift (T& value, int dir, const IntVect& periodic_shift,
+                                 const Periodicity& periodicity,
+                                 const RealBox& prob_domain) noexcept
+{
+    if (!periodicity.isPeriodic(dir)) { return; }
+    if (periodic_shift[dir] < 0) {
+        value += static_cast<T>(prob_domain.length(dir));
+    } else if (periodic_shift[dir] > 0) {
+        value -= static_cast<T>(prob_domain.length(dir));
+    }
+}
+
+template <typename PTD>
+AMREX_FORCE_INLINE
+void shiftNeighborParticlePositions (PTD const& ptd, int index, const IntVect& periodic_shift,
+                                     const Periodicity& periodicity,
+                                     const RealBox& prob_domain) noexcept
+{
+    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+        applyNeighborPeriodicShift(ptd.pos(dir, index), dir, periodic_shift, periodicity, prob_domain);
+    }
+}
+
+template <typename PTD>
+AMREX_FORCE_INLINE
+void packNeighborParticleData (char* dst, PTD const& src, int src_index,
+                               int num_real_comps, int num_int_comps,
+                               const Vector<int>& ghost_real_comp,
+                               const Vector<int>& ghost_int_comp,
+                               const IntVect& periodic_shift,
+                               const Periodicity& periodicity,
+                               const RealBox& prob_domain) noexcept
+{
+    using ParticleType = typename std::decay_t<PTD>::ParticleType;
+    constexpr int real_comm_comp_start =
+        ParticleType::is_soa_particle ? 0 : AMREX_SPACEDIM + ParticleType::NReal;
+    constexpr int int_comm_comp_start = 2 + ParticleType::NInt;
+
+    if constexpr (!ParticleType::is_soa_particle) {
+        auto const p = src[src_index];
+        for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+            if (!ghost_real_comp[dir]) { continue; }
+            auto value = p.pos(dir);
+            applyNeighborPeriodicShift(value, dir, periodic_shift, periodicity, prob_domain);
+            std::memcpy(dst, &value, sizeof(typename ParticleType::RealType));
+            dst += sizeof(typename ParticleType::RealType);
+        }
+        for (int ii = 0; ii < ParticleType::NReal; ++ii) {
+            if (!ghost_real_comp[AMREX_SPACEDIM + ii]) { continue; }
+            auto value = p.rdata(ii);
+            std::memcpy(dst, &value, sizeof(typename ParticleType::RealType));
+            dst += sizeof(typename ParticleType::RealType);
+        }
+    }
+
+    for (int ii = 0; ii < num_real_comps; ++ii) {
+        if (!ghost_real_comp[real_comm_comp_start + ii]) { continue; }
+
+        ParticleReal value;
+        if (ii < std::decay_t<PTD>::NAR) {
+            value = src.rdata(ii)[src_index];
+        } else {
+            value = src.m_runtime_rdata[ii - std::decay_t<PTD>::NAR][src_index];
+        }
+        if constexpr (ParticleType::is_soa_particle) {
+            if (ii < AMREX_SPACEDIM) {
+                applyNeighborPeriodicShift(value, ii, periodic_shift, periodicity, prob_domain);
+            }
+        }
+        std::memcpy(dst, &value, sizeof(ParticleReal));
+        dst += sizeof(ParticleReal);
+    }
+
+    std::array<int,2> idcpu_parts{};
+    auto const idcpu = src.idcpu(src_index);
+    std::memcpy(idcpu_parts.data(), &idcpu, sizeof(idcpu));
+    for (int ii = 0; ii < 2; ++ii) {
+        if (!ghost_int_comp[ii]) { continue; }
+        std::memcpy(dst, &idcpu_parts[ii], sizeof(int));
+        dst += sizeof(int);
+    }
+
+    if constexpr (!ParticleType::is_soa_particle) {
+        auto const p = src[src_index];
+        for (int ii = 0; ii < ParticleType::NInt; ++ii) {
+            if (!ghost_int_comp[2 + ii]) { continue; }
+            auto value = p.idata(ii);
+            std::memcpy(dst, &value, sizeof(int));
+            dst += sizeof(int);
+        }
+    }
+
+    for (int ii = 0; ii < num_int_comps; ++ii) {
+        if (!ghost_int_comp[int_comm_comp_start + ii]) { continue; }
+
+        int value;
+        if (ii < std::decay_t<PTD>::NAI) {
+            value = src.idata(ii)[src_index];
+        } else {
+            value = src.m_runtime_idata[ii - std::decay_t<PTD>::NAI][src_index];
+        }
+        std::memcpy(dst, &value, sizeof(int));
+        dst += sizeof(int);
+    }
+}
+
+template <typename PTD>
+AMREX_FORCE_INLINE
+void unpackNeighborParticleData (PTD const& dst_ptd, int dst_index, const char*& src,
+                                 int num_real_comps, int num_int_comps,
+                                 const Vector<int>& ghost_real_comp,
+                                 const Vector<int>& ghost_int_comp) noexcept
+{
+    using ParticleType = typename std::decay_t<PTD>::ParticleType;
+    constexpr int real_comm_comp_start =
+        ParticleType::is_soa_particle ? 0 : AMREX_SPACEDIM + ParticleType::NReal;
+    constexpr int int_comm_comp_start = 2 + ParticleType::NInt;
+
+    if constexpr (!ParticleType::is_soa_particle) {
+        for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+            if (!ghost_real_comp[dir]) { continue; }
+            std::memcpy(&(dst_ptd.pos(dir, dst_index)), src, sizeof(typename ParticleType::RealType));
+            src += sizeof(typename ParticleType::RealType);
+        }
+        for (int ii = 0; ii < ParticleType::NReal; ++ii) {
+            if (!ghost_real_comp[AMREX_SPACEDIM + ii]) { continue; }
+            std::memcpy(&(dst_ptd[dst_index].rdata(ii)), src, sizeof(typename ParticleType::RealType));
+            src += sizeof(typename ParticleType::RealType);
+        }
+    }
+
+    for (int ii = 0; ii < num_real_comps; ++ii) {
+        if (!ghost_real_comp[real_comm_comp_start + ii]) { continue; }
+
+        if (ii < std::decay_t<PTD>::NAR) {
+            std::memcpy(dst_ptd.rdata(ii) + dst_index, src, sizeof(ParticleReal));
+        } else {
+            std::memcpy(dst_ptd.m_runtime_rdata[ii - std::decay_t<PTD>::NAR] + dst_index, src,
+                        sizeof(ParticleReal));
+        }
+        src += sizeof(ParticleReal);
+    }
+
+    std::array<int,2> idcpu_parts{};
+    std::memcpy(idcpu_parts.data(), &(dst_ptd.idcpu(dst_index)), sizeof(uint64_t));
+    for (int ii = 0; ii < 2; ++ii) {
+        if (!ghost_int_comp[ii]) { continue; }
+        std::memcpy(&idcpu_parts[ii], src, sizeof(int));
+        src += sizeof(int);
+    }
+    std::memcpy(&(dst_ptd.idcpu(dst_index)), idcpu_parts.data(), sizeof(uint64_t));
+
+    if constexpr (!ParticleType::is_soa_particle) {
+        for (int ii = 0; ii < ParticleType::NInt; ++ii) {
+            if (!ghost_int_comp[2 + ii]) { continue; }
+            std::memcpy(&(dst_ptd[dst_index].idata(ii)), src, sizeof(int));
+            src += sizeof(int);
+        }
+    }
+
+    for (int ii = 0; ii < num_int_comps; ++ii) {
+        if (!ghost_int_comp[int_comm_comp_start + ii]) { continue; }
+
+        if (ii < std::decay_t<PTD>::NAI) {
+            std::memcpy(dst_ptd.idata(ii) + dst_index, src, sizeof(int));
+        } else {
+            std::memcpy(dst_ptd.m_runtime_idata[ii - std::decay_t<PTD>::NAI] + dst_index, src,
+                        sizeof(int));
+        }
+        src += sizeof(int);
+    }
+}
+
+}
+
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::fillNeighborsCPU () {
     BL_PROFILE("NeighborParticleContainer::fillNeighborsCPU");
     if (!areMasksValid()) {
@@ -19,9 +202,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     updateNeighborsCPU(false);
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::sumNeighborsCPU (int real_start_comp, int real_num_comp,
                    int int_start_comp,  int int_num_comp)
 {
@@ -106,9 +290,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     sumNeighborsMPI(isend_data, real_start_comp, real_num_comp, int_start_comp, int_num_comp);
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
                  int real_start_comp, int real_num_comp,
                  int int_start_comp, int int_num_comp)
@@ -272,9 +457,10 @@ sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
 #endif
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::updateNeighborsCPU (bool reuse_rcv_counts) {
 
     BL_PROFILE_VAR("NeighborParticleContainer::updateNeighborsCPU", update);
@@ -289,7 +475,7 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
         for (MyParIter pti(*this, lev); pti.isValid(); ++pti) {
             PairIndex src_index(pti.index(), pti.LocalTileIndex());
-            auto src = pti.GetParticleTile().getParticleTileData();
+            auto const src = pti.GetParticleTile().getConstParticleTileData();
             for (int j = 0; j < num_threads; ++j) {
                 auto& tags = buffer_tag_cache[lev][src_index][j];
                 int num_tags = tags.size();
@@ -305,16 +491,8 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                         auto dst = neighbors[tag.level][dst_index].getParticleTileData();
                         copyParticle(dst, src, tag.src_index, tag.dst_index);
                         if (periodicity.isAnyPeriodic()) {
-                            auto& aos = neighbors[tag.level][dst_index].GetArrayOfStructs();
-                            ParticleType& p = aos[tag.dst_index];
-                            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                                if (! periodicity.isPeriodic(dir)) { continue; }
-                                if (tag.periodic_shift[dir] < 0) {
-                                    p.pos(dir) += static_cast<ParticleReal> (prob_domain.length(dir));
-                                } else if (tag.periodic_shift[dir] > 0) {
-                                    p.pos(dir) -= static_cast<ParticleReal> (prob_domain.length(dir));
-                                }
-                            }
+                            detail::shiftNeighborParticlePositions(dst, tag.dst_index, tag.periodic_shift,
+                                                                  periodicity, prob_domain);
                         }
 
                         if ( enableInverse() )
@@ -327,52 +505,11 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
                             itags[tag.dst_index].src_level = lev;
                         }
                     } else {
-                        auto& aos = pti.GetArrayOfStructs();
-                        auto& soa = pti.GetStructOfArrays();
-                        ParticleType p = aos[tag.src_index];  // copy
-                        if (periodicity.isAnyPeriodic()) {
-                            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                                if (! periodicity.isPeriodic(dir)) { continue; }
-                                if (tag.periodic_shift[dir] < 0) {
-                                    p.pos(dir) += static_cast<ParticleReal> (prob_domain.length(dir));
-                                } else if (tag.periodic_shift[dir] > 0) {
-                                    p.pos(dir) -= static_cast<ParticleReal> (prob_domain.length(dir));
-                                }
-                            }
-                        }
-
                         char* dst_ptr = &send_data[who][tag.dst_index];
-                        char* src_ptr = (char *) &p;
-                        for (int ii = 0; ii < AMREX_SPACEDIM + NStructReal; ++ii) {
-                            if (ghost_real_comp[ii]) {
-                                std::memcpy(dst_ptr, src_ptr, sizeof(typename ParticleType::RealType));
-                                dst_ptr += sizeof(typename ParticleType::RealType);
-                            }
-                            src_ptr += sizeof(typename ParticleType::RealType);
-                        }
-                        for (int ii = 0; ii < this->NumRealComps(); ++ii) {
-                            if (ghost_real_comp[ii+AMREX_SPACEDIM+NStructReal])
-                            {
-                                std::memcpy(dst_ptr, &(soa.GetRealData(ii)[tag.src_index]),
-                                            sizeof(typename ParticleType::RealType));
-                                dst_ptr += sizeof(typename ParticleType::RealType);
-                            }
-                        }
-                        for (int ii = 0; ii < 2 + NStructInt; ++ii) {
-                            if (ghost_int_comp[ii]) {
-                                std::memcpy(dst_ptr, src_ptr, sizeof(int));
-                                dst_ptr += sizeof(int);
-                            }
-                            src_ptr += sizeof(int);
-                        }
-                        for (int ii = 0; ii < this->NumIntComps(); ++ii) {
-                            if (ghost_int_comp[ii+2+NStructInt])
-                            {
-                                std::memcpy(dst_ptr, &(soa.GetIntData(ii)[tag.src_index]),
-                                            sizeof(int));
-                                dst_ptr += sizeof(int);
-                            }
-                        }
+                        detail::packNeighborParticleData(dst_ptr, src, tag.src_index,
+                                                         this->NumRealComps(), this->NumIntComps(),
+                                                         ghost_real_comp, ghost_int_comp,
+                                                         tag.periodic_shift, periodicity, prob_domain);
                         if ( enableInverse() )
                         {
                             std::memcpy(dst_ptr,&(src_index.first),sizeof(int)); dst_ptr += sizeof(int);
@@ -418,9 +555,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::clearNeighborsCPU ()
 {
     BL_PROFILE("NeighborParticleContainer::clearNeighborsCPU");
@@ -444,9 +582,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     send_data.clear();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 getRcvCountsMPI () {
 
     BL_PROFILE("NeighborParticleContainer::getRcvCountsMPI");
@@ -505,9 +644,10 @@ getRcvCountsMPI () {
 #endif // AMREX_USE_MPI
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 fillNeighborsMPI (bool reuse_rcv_counts) {
 
     BL_PROFILE("NeighborParticleContainer::fillNeighborsMPI");
@@ -598,40 +738,12 @@ fillNeighborsMPI (bool reuse_rcv_counts) {
                 }
                 neighbors[lev][dst_index].resize(new_size);
 
-                char* src = buffer;
+                auto dst_ptd = neighbors[lev][dst_index].getParticleTileData();
+                char const* src = buffer;
                 for (int n = 0; n < np; ++n) {
-                    char* dst_aos = (char*) &neighbors[lev][dst_index].GetArrayOfStructs()[old_size+n];
-                    auto& dst_soa = neighbors[lev][dst_index].GetStructOfArrays();
-                    for (int ii = 0; ii < AMREX_SPACEDIM + NStructReal; ++ii) {
-                        if (ghost_real_comp[ii]) {
-                            std::memcpy(dst_aos, src, sizeof(typename ParticleType::RealType));
-                            src += sizeof(typename ParticleType::RealType);
-                        }
-                        dst_aos += sizeof(typename ParticleType::RealType);
-                    }
-                    for (int ii = 0; ii < this->NumRealComps(); ++ii) {
-                        if (ghost_real_comp[ii+AMREX_SPACEDIM+NStructReal])
-                        {
-                            std::memcpy(&(dst_soa.GetRealData(ii)[old_size+n]),
-                                        src, sizeof(typename ParticleType::RealType));
-                            src += sizeof(typename ParticleType::RealType);
-                        }
-                    }
-                    for (int ii = 0; ii < 2 + NStructInt; ++ii) {
-                        if (ghost_int_comp[ii]) {
-                            std::memcpy(dst_aos, src, sizeof(int));
-                            src += sizeof(int);
-                        }
-                        dst_aos += sizeof(int);
-                    }
-                    for (int ii = 0; ii < this->NumIntComps(); ++ii) {
-                        if (ghost_int_comp[ii+2+NStructInt])
-                        {
-                            std::memcpy(&(dst_soa.GetIntData(ii)[old_size+n]),
-                                        src, sizeof(int));
-                            src += sizeof(int);
-                        }
-                    }
+                    detail::unpackNeighborParticleData(dst_ptd, int(old_size+n), src,
+                                                       this->NumRealComps(), this->NumIntComps(),
+                                                       ghost_real_comp, ghost_int_comp);
 
                     if ( enableInverse() )
                     {

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -312,7 +312,7 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
             const auto& tags = inverse_tags[lev][src_index];
             const auto& neighb_tile = neighbors[lev][src_index];
             const auto neighbs = neighb_tile.getConstParticleTileData();
-            const auto num_neighbs = neighb_tile.size();
+            const Long num_neighbs = static_cast<Long>(neighb_tile.size());
             AMREX_ASSERT(tags.size() == num_neighbs);
 
             for (int i = 0; i < static_cast<int>(num_neighbs); ++i)

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -186,6 +186,90 @@ void unpackNeighborParticleData (PTD const& dst_ptd, int dst_index, const char*&
     }
 }
 
+template <typename PTD>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+ParticleReal getSummedRealComp (PTD const& ptd, int index, int comp) noexcept
+{
+    using ParticleType = typename std::decay_t<PTD>::ParticleType;
+
+    if constexpr (!ParticleType::is_soa_particle) {
+        if (comp < ParticleType::NReal) {
+            return ptd[index].rdata(comp);
+        }
+        comp -= ParticleType::NReal;
+    }
+
+    if (comp < std::decay_t<PTD>::NAR) {
+        return ptd.rdata(comp)[index];
+    }
+
+    return ptd.m_runtime_rdata[comp - std::decay_t<PTD>::NAR][index];
+}
+
+template <typename PTD>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int getSummedIntComp (PTD const& ptd, int index, int comp) noexcept
+{
+    using ParticleType = typename std::decay_t<PTD>::ParticleType;
+
+    if constexpr (!ParticleType::is_soa_particle) {
+        if (comp < ParticleType::NInt) {
+            return ptd[index].idata(comp);
+        }
+        comp -= ParticleType::NInt;
+    }
+
+    if (comp < std::decay_t<PTD>::NAI) {
+        return ptd.idata(comp)[index];
+    }
+
+    return ptd.m_runtime_idata[comp - std::decay_t<PTD>::NAI][index];
+}
+
+template <typename PTD>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void addSummedRealComp (PTD const& ptd, int index, int comp, ParticleReal value) noexcept
+{
+    using ParticleType = typename std::decay_t<PTD>::ParticleType;
+
+    if constexpr (!ParticleType::is_soa_particle) {
+        if (comp < ParticleType::NReal) {
+            ptd[index].rdata(comp) += value;
+            return;
+        }
+        comp -= ParticleType::NReal;
+    }
+
+    if (comp < std::decay_t<PTD>::NAR) {
+        ptd.rdata(comp)[index] += value;
+        return;
+    }
+
+    ptd.m_runtime_rdata[comp - std::decay_t<PTD>::NAR][index] += value;
+}
+
+template <typename PTD>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void addSummedIntComp (PTD const& ptd, int index, int comp, int value) noexcept
+{
+    using ParticleType = typename std::decay_t<PTD>::ParticleType;
+
+    if constexpr (!ParticleType::is_soa_particle) {
+        if (comp < ParticleType::NInt) {
+            ptd[index].idata(comp) += value;
+            return;
+        }
+        comp -= ParticleType::NInt;
+    }
+
+    if (comp < std::decay_t<PTD>::NAI) {
+        ptd.idata(comp)[index] += value;
+        return;
+    }
+
+    ptd.m_runtime_idata[comp - std::decay_t<PTD>::NAI][index] += value;
+}
+
 }
 
 template <typename T_ParticleType, int NArrayReal, int NArrayInt,
@@ -226,13 +310,13 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
         {
             PairIndex src_index(pti.index(), pti.LocalTileIndex());
             const auto& tags = inverse_tags[lev][src_index];
-            const auto& neighbs = neighbors[lev][src_index].GetArrayOfStructs();
-            AMREX_ASSERT(tags.size() == neighbs.size());
+            const auto& neighb_tile = neighbors[lev][src_index];
+            const auto neighbs = neighb_tile.getConstParticleTileData();
+            const int num_neighbs = static_cast<int>(neighb_tile.size());
+            AMREX_ASSERT(tags.size() == static_cast<std::size_t>(num_neighbs));
 
-            const int num_neighbs = neighbs.size();
             for (int i = 0; i < num_neighbs; ++i)
             {
-                const auto& neighb = neighbs[i];
                 const auto& tag = tags[i];
                 const int dst_grid = tag.src_grid;
                 const int global_rank = this->ParticleDistributionMap(lev)[dst_grid];
@@ -245,17 +329,18 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
                 {
                     auto pair = std::make_pair(dst_grid, dst_tile);
                     auto& dst_ptile = this->GetParticles(dst_level)[pair];
-                    auto& dst_parts = dst_ptile.GetArrayOfStructs();
-                    auto& p = dst_parts[dst_index];
+                    auto dst_ptd = dst_ptile.getParticleTileData();
 
                     for (int comp = real_start_comp; comp < real_start_comp + real_num_comp; ++comp)
                     {
-                        p.rdata(comp) += neighb.rdata(comp);
+                        detail::addSummedRealComp(
+                            dst_ptd, dst_index, comp, detail::getSummedRealComp(neighbs, i, comp));
                     }
 
                     for (int comp = int_start_comp; comp < int_start_comp + int_num_comp; ++comp)
                     {
-                        p.idata(comp) += neighb.idata(comp);
+                        detail::addSummedIntComp(
+                            dst_ptd, dst_index, comp, detail::getSummedIntComp(neighbs, i, comp));
                     }
                 }
 
@@ -272,13 +357,13 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
                     std::memcpy(dst, &dst_level, sizeof(int)); dst += sizeof(int);
                     for (int comp = real_start_comp; comp < real_start_comp + real_num_comp; ++comp)
                     {
-                        Real data = neighb.rdata(comp);
+                        ParticleReal data = detail::getSummedRealComp(neighbs, i, comp);
                         std::memcpy(dst, &data, sizeof(Real));
                         dst += sizeof(Real);
                     }
                     for (int comp = int_start_comp; comp < int_start_comp + int_num_comp; ++comp)
                     {
-                        int data = neighb.idata(comp);
+                        int data = detail::getSummedIntComp(neighbs, i, comp);
                         std::memcpy(dst, &data, sizeof(int));
                         dst += sizeof(int);
                     }
@@ -432,14 +517,13 @@ sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
 
             auto pair = std::make_pair(grid, tile);
             auto& ptile = this->GetParticles(lev)[pair];
-            auto& parts = ptile.GetArrayOfStructs();
-            auto& p = parts[index];
+            auto dst_ptd = ptile.getParticleTileData();
 
             for (int comp = real_start_comp; comp < real_start_comp + real_num_comp; ++comp)
             {
-                Real data;
+                ParticleReal data;
                 std::memcpy(&data, buffer, sizeof(Real));
-                p.rdata(comp) += data;
+                detail::addSummedRealComp(dst_ptd, index, comp, data);
                 buffer += sizeof(Real);
             }
 
@@ -447,7 +531,7 @@ sumNeighborsMPI (std::map<int, Vector<char> >& not_ours,
             {
                 int data;
                 std::memcpy(&data, buffer, sizeof(int));
-                p.idata(comp) += data;
+                detail::addSummedIntComp(dst_ptd, index, comp, data);
                 buffer += sizeof(int);
             }
         }

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -326,9 +326,6 @@ fillNeighborsGPU ()
 
     AMREX_ASSERT(numParticlesOutOfRange(*this, 0) == 0);
 
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(this->do_tiling == 0,
-        "Tiling on the GPU is not supported for neighbor particles.");
-
     buildNeighborMask();
     this->defineBufferMap();
 

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -108,12 +108,13 @@ namespace detail
 }
 /// \endcond
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 buildNeighborMask ()
 {
-    BL_PROFILE("NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::buildNeighborMask");
+    BL_PROFILE("NeighborParticleContainer_impl::buildNeighborMask");
     m_neighbor_mask_initialized = true;
     const int lev = 0;
     const Geometry& geom = this->Geom(lev);
@@ -180,12 +181,13 @@ buildNeighborMask ()
     }
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 buildNeighborCopyOp (bool use_boundary_neighbor)
 {
-    BL_PROFILE("NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::buildNeighborCopyOp()");
+    BL_PROFILE("NeighborParticleContainer_impl::buildNeighborCopyOp()");
 
     AMREX_ASSERT(!hasNeighbors() || use_boundary_neighbor);
 
@@ -206,8 +208,8 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
         auto index = std::make_pair(gid, tid);
 
         auto& src_tile = plev[index];
-        auto& aos   = src_tile.GetArrayOfStructs();
-        const size_t np_real = aos.numParticles();
+        auto const src_ptile_data = src_tile.getConstParticleTileData();
+        const size_t np_real = src_tile.numParticles();
 
         size_t np = np_real;
         if (use_boundary_neighbor) {
@@ -225,7 +227,6 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
         auto p_counts = counts.dataPtr();
         auto p_offsets = offsets.dataPtr();
 
-        ParticleType* p_ptr = aos.data();
         auto p_code_array   = m_code_array[gid].dataPtr();
         auto p_isec_boxes   = m_isec_boxes[gid].dataPtr();
         const int nisec_box = m_isec_boxes[gid].size();
@@ -242,7 +243,7 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
             if (use_boundary_neighbor) {
                 pid = p_bndry_pid[i];
             }
-            IntVect iv = getParticleCell(p_ptr[pid], plo, dxi, domain);
+            IntVect iv = getParticleCell(src_ptile_data, pid, plo, dxi, domain);
             for (int j=0; j<nisec_box; ++j) {
                 if (p_isec_boxes[j].contains(iv)) {
                     detail::forEachIntersectingTile(iv, nGrow,
@@ -285,7 +286,7 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
             if (use_boundary_neighbor) {
                 pid = p_bndry_pid[i];
             }
-            IntVect iv = getParticleCell(p_ptr[pid], plo, dxi, domain);
+            IntVect iv = getParticleCell(src_ptile_data, pid, plo, dxi, domain);
             int      k = p_offsets[i];
             for (int j=0; j<nisec_box; ++j) {
                 if (p_isec_boxes[j].contains(iv)) {
@@ -317,9 +318,10 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
     }
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 fillNeighborsGPU ()
 {
     BL_PROFILE("NeighborParticleContainer::fillNeighbors");
@@ -337,9 +339,10 @@ fillNeighborsGPU ()
     updateNeighborsGPU(false);
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 updateNeighborsGPU (bool boundary_neighbors_only)
 {
     BL_PROFILE("NeighborParticleContainer::updateNeighborsGPU");
@@ -393,9 +396,10 @@ updateNeighborsGPU (bool boundary_neighbors_only)
     Gpu::streamSynchronize();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 clearNeighborsGPU()
 {
     BL_PROFILE("NeighborParticleContainer::clearNeighborsGPU");

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -7,6 +7,65 @@ namespace amrex {
 /// \cond DOXYGEN_IGNORE
 namespace detail
 {
+    template <typename F>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void forEachIntersectingTile (IntVect const& iv, int nGrow,
+                                  Box const& grid_box, IntVect const& periodic_shift,
+                                  bool do_tiling, IntVect const& tile_size, F&& f)
+    {
+        Box cell_box(iv, iv);
+        cell_box.grow(nGrow);
+        cell_box += periodic_shift;
+        cell_box &= grid_box;
+
+        if (!cell_box.ok()) { return; }
+
+        auto const& cb_lo = cell_box.smallEnd();
+        auto const& cb_hi = cell_box.bigEnd();
+
+#if (AMREX_SPACEDIM == 1)
+        for (int i = cb_lo[0]; i <= cb_hi[0]; ++i) {
+            IntVect cell(AMREX_D_DECL(i, 0, 0));
+            Box tbx;
+            int tile = getTileIndex(cell, grid_box, do_tiling, tile_size, tbx);
+            IntVect rep(AMREX_D_DECL(amrex::max(cb_lo[0], tbx.smallEnd(0)), 0, 0));
+            if (cell == rep) {
+                f(tile);
+            }
+        }
+#elif (AMREX_SPACEDIM == 2)
+        for (int j = cb_lo[1]; j <= cb_hi[1]; ++j) {
+            for (int i = cb_lo[0]; i <= cb_hi[0]; ++i) {
+                IntVect cell(AMREX_D_DECL(i, j, 0));
+                Box tbx;
+                int tile = getTileIndex(cell, grid_box, do_tiling, tile_size, tbx);
+                IntVect rep(AMREX_D_DECL(amrex::max(cb_lo[0], tbx.smallEnd(0)),
+                                         amrex::max(cb_lo[1], tbx.smallEnd(1)),
+                                         0));
+                if (cell == rep) {
+                    f(tile);
+                }
+            }
+        }
+#else
+        for (int k = cb_lo[2]; k <= cb_hi[2]; ++k) {
+            for (int j = cb_lo[1]; j <= cb_hi[1]; ++j) {
+                for (int i = cb_lo[0]; i <= cb_hi[0]; ++i) {
+                    IntVect cell(AMREX_D_DECL(i, j, k));
+                    Box tbx;
+                    int tile = getTileIndex(cell, grid_box, do_tiling, tile_size, tbx);
+                    IntVect rep(AMREX_D_DECL(amrex::max(cb_lo[0], tbx.smallEnd(0)),
+                                             amrex::max(cb_lo[1], tbx.smallEnd(1)),
+                                             amrex::max(cb_lo[2], tbx.smallEnd(2))));
+                    if (cell == rep) {
+                        f(tile);
+                    }
+                }
+            }
+        }
+#endif
+    }
+
     inline Vector<Box> getBoundaryBoxes(const Box& box, int ncells)
     {
         AMREX_ASSERT_WITH_MESSAGE(box.size() > 2*IntVect(AMREX_D_DECL(ncells, ncells, ncells)),
@@ -86,7 +145,6 @@ buildNeighborMask ()
                 {
                     int nbor_grid = isec.first;
                     const Box isec_box = isec.second - pshift;
-                    if ( (grid == nbor_grid) && (pshift == 0)) { continue; }
                     neighbor_grids.insert(NeighborTask(nbor_grid, isec_box, pshift));
                     const int global_rank = dmap[nbor_grid];
                     neighbor_procs.push_back(ParallelContext::global_to_local_rank(global_rank));
@@ -173,6 +231,7 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
         const int nisec_box = m_isec_boxes[gid].size();
         const bool do_tiling = this->do_tiling;
         const IntVect tile_size = this->tile_size;
+        const int nGrow = m_num_neighbor_cells;
         // auto p_code_offsets = m_code_offsets[gid].dataPtr();
 
         AMREX_FOR_1D ( np, i,
@@ -186,7 +245,20 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
             IntVect iv = getParticleCell(p_ptr[pid], plo, dxi, domain);
             for (int j=0; j<nisec_box; ++j) {
                 if (p_isec_boxes[j].contains(iv)) {
-                    ++p_counts[i];
+                    detail::forEachIntersectingTile(iv, nGrow,
+                                                    p_code_array[j].grid_box,
+                                                    p_code_array[j].periodic_shift,
+                                                    do_tiling, tile_size,
+                                                    [&] (int dst_tile)
+                    {
+                        bool is_self = (p_code_array[j].grid_id == gid) && (dst_tile == tid)
+                            AMREX_D_TERM( && (p_code_array[j].periodic_shift[0] == 0),
+                                          && (p_code_array[j].periodic_shift[1] == 0),
+                                          && (p_code_array[j].periodic_shift[2] == 0));
+                        if (!is_self) {
+                            ++p_counts[i];
+                        }
+                    });
                 }
             }
         });
@@ -217,14 +289,25 @@ buildNeighborCopyOp (bool use_boundary_neighbor)
             int      k = p_offsets[i];
             for (int j=0; j<nisec_box; ++j) {
                 if (p_isec_boxes[j].contains(iv)) {
-                    p_boxes[k]          = p_code_array[j].grid_id;
-                    Box tbx;
-                    p_tiles[k]          = getTileIndex(iv, p_code_array[j].grid_box,
-                                                       do_tiling, tile_size, tbx);
-                    p_levs[k]           = 0;
-                    p_periodic_shift[k] = p_code_array[j].periodic_shift;
-                    p_src_indices[k]    = pid;
-                    ++k;
+                    detail::forEachIntersectingTile(iv, nGrow,
+                                                    p_code_array[j].grid_box,
+                                                    p_code_array[j].periodic_shift,
+                                                    do_tiling, tile_size,
+                                                    [&] (int dst_tile)
+                    {
+                        bool is_self = (p_code_array[j].grid_id == gid) && (dst_tile == tid)
+                            AMREX_D_TERM( && (p_code_array[j].periodic_shift[0] == 0),
+                                          && (p_code_array[j].periodic_shift[1] == 0),
+                                          && (p_code_array[j].periodic_shift[2] == 0));
+                        if (!is_self) {
+                            p_boxes[k]          = p_code_array[j].grid_id;
+                            p_tiles[k]          = dst_tile;
+                            p_levs[k]           = 0;
+                            p_periodic_shift[k] = p_code_array[j].periodic_shift;
+                            p_src_indices[k]    = pid;
+                            ++k;
+                        }
+                    });
                 }
             }
             AMREX_ALWAYS_ASSERT(k == p_offsets[i+1]);

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1,86 +1,95 @@
 
 namespace amrex {
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-bool NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::use_mask = false;
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
+bool NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::use_mask = false;
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-bool NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::enable_inverse = false;
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
+bool NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::enable_inverse = false;
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
-::NeighborParticleContainer (ParGDBBase* gdb, int ncells)
-    : ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> (gdb),
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
+::NeighborParticleContainer_impl (ParGDBBase* gdb, int ncells)
+    : ParticleContainerType(gdb),
     m_num_neighbor_cells(ncells)
 {
     initializeCommComps();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
-::NeighborParticleContainer (const Geometry            & geom,
-                             const DistributionMapping & dmap,
-                             const BoxArray            & ba,
-                             int                         nneighbor)
-    : ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> (geom, dmap, ba),
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
+::NeighborParticleContainer_impl (const Geometry            & geom,
+                                  const DistributionMapping & dmap,
+                                  const BoxArray            & ba,
+                                  int                         nneighbor)
+    : ParticleContainerType(geom, dmap, ba),
     m_num_neighbor_cells(nneighbor)
 {
     initializeCommComps();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
-::NeighborParticleContainer (const Vector<Geometry>            & geom,
-                             const Vector<DistributionMapping> & dmap,
-                             const Vector<BoxArray>            & ba,
-                             const Vector<int>                 & rr,
-                             int                               nneighbor)
-    : ParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt> (geom, dmap, ba, rr),
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
+::NeighborParticleContainer_impl (const Vector<Geometry>            & geom,
+                                  const Vector<DistributionMapping> & dmap,
+                                  const Vector<BoxArray>            & ba,
+                                  const Vector<int>                 & rr,
+                                  int                               nneighbor)
+    : ParticleContainerType(geom, dmap, ba, rr),
     m_num_neighbor_cells(nneighbor)
 {
     initializeCommComps();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::initializeCommComps () {
-    for (int ii = 0; ii < AMREX_SPACEDIM + NStructReal + this->NumRealComps(); ++ii) {
+    for (int ii = 0; ii < numRealCommComps(); ++ii) {
         ghost_real_comp.push_back(1);
     }
-    for (int ii = 0; ii < 2 + NStructInt + this->NumIntComps(); ++ii) {
+    for (int ii = 0; ii < numIntCommComps(); ++ii) {
         ghost_int_comp.push_back(1);
     }
     calcCommSize();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::setRealCommComp (int i, bool value) {
     ghost_real_comp[i] = value;
     calcCommSize();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::setIntCommComp (int i, bool value) {
     ghost_int_comp[i] = value;
     calcCommSize();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::calcCommSize () {
     size_t comm_size = 0;
-    for (int ii = 0; ii < AMREX_SPACEDIM + NStructReal + this->NumRealComps(); ++ii) {
+    for (int ii = 0; ii < numRealCommComps(); ++ii) {
         if (ghost_real_comp[ii]) {
             comm_size += sizeof(typename ParticleType::RealType);
         }
     }
-    for (int ii = 0; ii < 2 + NStructInt + this->NumIntComps(); ++ii) {
+    for (int ii = 0; ii < numIntCommComps(); ++ii) {
         if (ghost_int_comp[ii]) {
             comm_size += sizeof(int);
         }
@@ -89,9 +98,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     cdata_size = comm_size;
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::Regrid (const DistributionMapping &dmap, const BoxArray &ba ) {
     const int lev = 0;
     AMREX_ASSERT(this->finestLevel() == 0);
@@ -100,9 +110,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     this->Redistribute();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::Regrid (const DistributionMapping &dmap, const BoxArray &ba, int lev) {
     AMREX_ASSERT(lev <= this->finestLevel());
     this->SetParticleBoxArray(lev, ba);
@@ -110,9 +121,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     this->Redistribute();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::Regrid (const Vector<DistributionMapping>& dmap, const Vector<BoxArray>& ba) {
     AMREX_ASSERT(ba.size() == this->finestLevel()+1);
     for (int lev = 0; lev < this->numLevels(); ++lev)
@@ -123,9 +135,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     this->Redistribute();
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 bool
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::areMasksValid () {
 
     BL_PROFILE("NeighborParticleContainer::areMasksValid");
@@ -147,9 +160,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     return true;
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::BuildMasks () {
 
     BL_PROFILE("NeighborParticleContainer::BuildMasks");
@@ -186,9 +200,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     }
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::GetNeighborCommTags ()
 {
     BL_PROFILE("NeighborParticleContainer::GetNeighborCommTags");
@@ -242,9 +257,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     RemoveDuplicates(neighbor_procs);
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 IntVect
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::computeRefFac (int src_lev, int lev)
 {
     IntVect ref_fac(1);
@@ -261,9 +277,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     return ref_fac;
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::GetCommTagsBox (Vector<NeighborCommTag>& tags, int src_lev, const Box& in_box)
 {
     std::vector< std::pair<int, Box> > isects;
@@ -308,9 +325,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     }
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::cacheNeighborInfo () {
 
     BL_PROFILE("NeighborParticleContainer::cacheNeighborInfo");
@@ -369,11 +387,9 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 
                 auto& cache = buffer_tag_cache[lev][src_index][thread_num];
 
-                auto& particles = pti.GetArrayOfStructs();
+                auto const ptd = pti.GetParticleTile().getConstParticleTileData();
                 for (int i = 0; i < pti.numParticles(); ++i) {
-                    const ParticleType& p = particles[i];
-
-                    getNeighborTags(tags, p, m_num_neighbor_cells, src_tag, pti);
+                    getNeighborTags(tags, ptd[i], m_num_neighbor_cells, src_tag, pti);
 
                     // Add neighbors to buffers
                     for (int j = 0; j < static_cast<int>(tags.size()); ++j) {
@@ -532,19 +548,23 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     }
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
+template <typename P>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
-getNeighborTags (Vector<NeighborCopyTag>& tags, const ParticleType& p,
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
+getNeighborTags (Vector<NeighborCopyTag>& tags, const P& p,
                  int nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti)
 {
     getNeighborTags(tags, p, IntVect(AMREX_D_DECL(nGrow, nGrow, nGrow)), src_tag, pti);
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
+template <typename P>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
-getNeighborTags (Vector<NeighborCopyTag>& tags, const ParticleType& p,
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
+getNeighborTags (Vector<NeighborCopyTag>& tags, const P& p,
                  const IntVect& nGrow, const NeighborCopyTag& src_tag, const MyParIter& pti)
 {
     Box shrink_box = pti.tilebox();
@@ -634,9 +654,10 @@ getNeighborTags (Vector<NeighborCopyTag>& tags, const ParticleType& p,
     }
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::fillNeighbors () {
 #ifdef AMREX_USE_GPU
     fillNeighborsGPU();
@@ -646,9 +667,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     m_has_neighbors = true;
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::sumNeighbors (int real_start_comp, int real_num_comp,
                 int int_start_comp,  int int_num_comp) {
 #ifdef AMREX_USE_GPU
@@ -659,9 +681,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
 #endif
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::updateNeighbors (bool boundary_neighbors_only)
 {
 
@@ -676,9 +699,10 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     m_has_neighbors = true;
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::clearNeighbors ()
 {
 #ifdef AMREX_USE_GPU
@@ -689,10 +713,11 @@ NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>
     m_has_neighbors = false;
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 template <class CheckPair>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 buildNeighborList (CheckPair const& check_pair, bool /*sort*/)
 {
     AMREX_ASSERT(numParticlesOutOfRange(*this, m_num_neighbor_cells) == 0);
@@ -774,12 +799,16 @@ buildNeighborList (CheckPair const& check_pair, bool /*sort*/)
     }
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 template <class CheckPair, class OtherPCType>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 buildNeighborList (CheckPair const& check_pair, OtherPCType& other,
-                   Vector<std::map<std::pair<int, int>, amrex::NeighborList<typename OtherPCType::ParticleType> > >& neighbor_lists,
+                   Vector<std::map<std::pair<int, int>,
+                       amrex::NeighborList<typename OtherPCType::ParticleType,
+                                           OtherPCType::NArrayReal,
+                                           OtherPCType::NArrayInt> > >& neighbor_lists,
                    bool /*sort*/)
 {
     BL_PROFILE("NeighborParticleContainer::buildNeighborList");
@@ -843,10 +872,11 @@ buildNeighborList (CheckPair const& check_pair, OtherPCType& other,
     }
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 template <class CheckPair>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 buildNeighborList (CheckPair const& check_pair, int type_ind, int* ref_ratio,
                    int num_bin_types, bool /*sort*/)
 {
@@ -971,10 +1001,11 @@ buildNeighborList (CheckPair const& check_pair, int type_ind, int* ref_ratio,
     } //Lev
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 template <class CheckPair>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 selectActualNeighbors (CheckPair const& check_pair, int num_cells)
 {
     BL_PROFILE("NeighborParticleContainer::selectActualNeighbors");
@@ -1001,8 +1032,6 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
             m_boundary_particle_ids[lev][index].resize(pti.numNeighborParticles());
             auto* p_boundary_particle_ids = m_boundary_particle_ids[lev][index].dataPtr();
 
-            const auto& aos     = pti.GetArrayOfStructs();
-            const auto* pstruct = aos().dataPtr();
             const auto ptile_data = this->ParticlesAt(lev, pti).getConstParticleTileData();
 
             Box box       = pti.validbox();
@@ -1017,11 +1046,11 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
             const auto  plo     = geom.ProbLoArray();
 
             const size_t  np_real  = pti.numRealParticles();
-            const size_t  np_total = aos().size();
+            const size_t  np_total = pti.numTotalParticles();
 
-            DenseBins<ParticleType> bins;
-            bins.build(np_total, pstruct, grownBox,
-                      [=] AMREX_GPU_DEVICE (const ParticleType& p) noexcept -> IntVect
+            DenseBins<decltype(ptile_data)> bins;
+            bins.build(np_total, ptile_data, grownBox,
+                      [=] AMREX_GPU_DEVICE (auto const& p) noexcept -> IntVect
                       {
                           AMREX_D_TERM(int i = static_cast<int>(amrex::Math::floor((p.pos(0)-plo[0])*dxi[0]) - lo.x);,
                                        int j = static_cast<int>(amrex::Math::floor((p.pos(1)-plo[1])*dxi[1]) - lo.y);,
@@ -1039,10 +1068,8 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
 
             AMREX_FOR_1D ( np_real, i,
             {
-                IntVect iv(AMREX_D_DECL(
-                    static_cast<int>(amrex::Math::floor((pstruct[i].pos(0)-plo[0])*dxi[0])) - lo.x,
-                    static_cast<int>(amrex::Math::floor((pstruct[i].pos(1)-plo[1])*dxi[1])) - lo.y,
-                    static_cast<int>(amrex::Math::floor((pstruct[i].pos(2)-plo[2])*dxi[2])) - lo.z));
+                IntVect iv = getParticleCell(ptile_data, i, plo, dxi, domain);
+                iv -= grownBox.smallEnd();
                 auto iv3 = iv.dim3();
 
                 int ix = iv3.x;
@@ -1066,7 +1093,7 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
                             for (auto p = poffset[nbr_cell_id]; p < poffset[nbr_cell_id+1]; ++p) {
                                 if (pperm[p] == int(i)) { continue; }
                                 if (detail::call_check_pair(check_pair, ptile_data, ptile_data, i, pperm[p])) {
-                                    IntVect cell_ijk = getParticleCell(pstruct[pperm[p]], plo, dxi, domain);
+                                    IntVect cell_ijk = getParticleCell(ptile_data, pperm[p], plo, dxi, domain);
                                     if (!box.contains(cell_ijk)) {
                                         unsigned int loc = Gpu::Atomic::Add(p_np_boundary, 1U);
                                         p_boundary_particle_ids[loc] = i;
@@ -1086,9 +1113,10 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
         }// end mypariter
     }// end lev
 }
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 printNeighborList ()
 {
     BL_PROFILE("NeighborParticleContainer::printNeighborList");
@@ -1105,9 +1133,10 @@ printNeighborList ()
     }
 }
 
-template <int NStructReal, int NStructInt, int NArrayReal, int NArrayInt>
+template <typename T_ParticleType, int NArrayReal, int NArrayInt,
+          template<class> class Allocator, class CellAssignor>
 void
-NeighborParticleContainer<NStructReal, NStructInt, NArrayReal, NArrayInt>::
+NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 resizeContainers (int num_levels)
 {
     this->reserveData();

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1032,7 +1032,8 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
             m_boundary_particle_ids[lev][index].resize(pti.numNeighborParticles());
             auto* p_boundary_particle_ids = m_boundary_particle_ids[lev][index].dataPtr();
 
-            const auto ptile_data = this->ParticlesAt(lev, pti).getConstParticleTileData();
+            auto const& ptile = this->ParticlesAt(lev, pti);
+            auto ptile_data = ptile.getConstParticleTileData();
 
             Box box       = pti.tilebox();
             Box grownBox  = box;
@@ -1046,7 +1047,7 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
             const auto  plo     = geom.ProbLoArray();
 
             const size_t  np_real  = pti.numRealParticles();
-            const size_t  np_total = pti.numTotalParticles();
+            const size_t  np_total = ptile.numTotalParticles();
 
             DenseBins<decltype(ptile_data)> bins;
             bins.build(np_total, ptile_data, grownBox,

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -811,9 +811,7 @@ void
 NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::
 buildNeighborList (CheckPair const& check_pair, OtherPCType& other,
                    Vector<std::map<std::pair<int, int>,
-                       amrex::NeighborList<typename OtherPCType::ParticleType,
-                                           OtherPCType::NArrayReal,
-                                           OtherPCType::NArrayInt> > >& neighbor_lists,
+                       amrex::NeighborList<typename OtherPCType::ParticleType> > >& neighbor_lists,
                    bool /*sort*/)
 {
     BL_PROFILE("NeighborParticleContainer::buildNeighborList");

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1,6 +1,11 @@
 
 namespace amrex {
 
+namespace detail {
+template <class>
+inline constexpr bool always_false_v = false;
+}
+
 template <typename T_ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 bool NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::use_mask = false;
@@ -675,7 +680,8 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
                 int int_start_comp,  int int_num_comp) {
 #ifdef AMREX_USE_GPU
     amrex::ignore_unused(real_start_comp,real_num_comp,int_start_comp,int_num_comp);
-    amrex::Abort("Not implemented.");
+    static_assert(detail::always_false_v<T_ParticleType>,
+                  "NeighborParticleContainer::sumNeighbors is not implemented for GPU builds");
 #else
     sumNeighborsCPU(real_start_comp, real_num_comp, int_start_comp, int_num_comp);
 #endif

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -86,7 +86,7 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
     size_t comm_size = 0;
     for (int ii = 0; ii < numRealCommComps(); ++ii) {
         if (ghost_real_comp[ii]) {
-            comm_size += sizeof(typename ParticleType::RealType);
+            comm_size += sizeof(ParticleReal);
         }
     }
     for (int ii = 0; ii < numIntCommComps(); ++ii) {

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -680,8 +680,7 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
                 int int_start_comp,  int int_num_comp) {
 #ifdef AMREX_USE_GPU
     amrex::ignore_unused(real_start_comp,real_num_comp,int_start_comp,int_num_comp);
-    static_assert(detail::always_false_v<T_ParticleType>,
-                  "NeighborParticleContainer::sumNeighbors is not implemented for GPU builds");
+    amrex::Abort("NeighborParticleContainer::sumNeighbors is not implemented for GPU builds");
 #else
     sumNeighborsCPU(real_start_comp, real_num_comp, int_start_comp, int_num_comp);
 #endif

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.H
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.H
@@ -50,6 +50,8 @@ public:
 
     void checkNeighborList ();
 
+    void checkInverseSumNeighbors ();
+
     std::pair<amrex::Real, amrex::Real>  minAndMaxDistance ();
 
     void moveParticles (amrex::ParticleReal dx);

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.H
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.H
@@ -45,7 +45,7 @@ public:
 
     void reset_test_id ();
 
-    void checkNeighborParticles ();
+    void checkNeighborParticles (bool use_source_grid = true);
 
     void checkNeighborList ();
 

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.H
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.H
@@ -16,6 +16,7 @@ struct PIdx
 class MDParticleContainer
     : public amrex::NeighborParticleContainer<PIdx::ncomps, 1, 1, 1>
 {
+    using Base = amrex::NeighborParticleContainer<PIdx::ncomps, 1, 1, 1>;
 
 public:
 
@@ -23,7 +24,7 @@ public:
                          const amrex::DistributionMapping & a_dmap,
                          const amrex::BoxArray            & a_ba,
                          int                                a_numcells)
-        : NeighborParticleContainer<PIdx::ncomps, 1, 1, 1>(a_geom, a_dmap, a_ba, a_numcells)
+        : Base(a_geom, a_dmap, a_ba, a_numcells)
     {
         int num_runtime_real = 1;
         int num_runtime_int  = 1;

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -95,6 +95,14 @@ namespace
         }
     };
 
+    bool almost_equal (ParticleReal lhs, ParticleReal rhs)
+    {
+        auto const scale = std::max({ParticleReal(1.0), std::abs(lhs), std::abs(rhs)});
+        auto const tol = std::max(ParticleReal(1.0e-12),
+                                  ParticleReal(64.0) * std::numeric_limits<ParticleReal>::epsilon());
+        return std::abs(lhs - rhs) <= tol * scale;
+    }
+
     void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
     {
         int nx = nppc[0];
@@ -435,7 +443,6 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
     auto match_shift = [&] (ParticleType const& p, SourceParticleData const& src,
                             Box const& grown_tile_box) -> IntVect
     {
-        constexpr auto tol = ParticleReal(1.0e-12);
         IntVect matched_shift(std::numeric_limits<int>::max());
         int nmatches = 0;
         for (auto const& shift : pshifts) {
@@ -448,7 +455,7 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
                 } else if (shift[idim] < 0) {
                     expected_pos -= static_cast<ParticleReal>(probhi[idim] - problo[idim]);
                 }
-                if (std::abs(p.pos(idim) - expected_pos) > tol) {
+                if (!almost_equal(p.pos(idim), expected_pos)) {
                     matched = false;
                     break;
                 }
@@ -876,18 +883,17 @@ void MDParticleContainer::checkInverseSumNeighbors ()
             }
 
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                AMREX_ALWAYS_ASSERT(std::abs(p.pos(idim) - src.pos[idim]) <= ParticleReal(1.0e-12));
+                AMREX_ALWAYS_ASSERT(almost_equal(p.pos(idim), src.pos[idim]));
             }
             for (int comp = 0; comp < PIdx::ncomps; ++comp) {
-                AMREX_ALWAYS_ASSERT(std::abs(
-                    p.rdata(comp) - (src.struct_real[comp] + contribution.struct_real[comp]))
-                    <= ParticleReal(1.0e-12));
+                AMREX_ALWAYS_ASSERT(almost_equal(
+                    p.rdata(comp), src.struct_real[comp] + contribution.struct_real[comp]));
             }
             AMREX_ALWAYS_ASSERT(p.idata(0) == src.struct_int + contribution.struct_int);
-            AMREX_ALWAYS_ASSERT(std::abs(h_array_real[i] - (src.array_real + contribution.array_real))
-                                <= ParticleReal(1.0e-12));
-            AMREX_ALWAYS_ASSERT(std::abs(h_runtime_real[i] - (src.runtime_real + contribution.runtime_real))
-                                <= ParticleReal(1.0e-12));
+            AMREX_ALWAYS_ASSERT(almost_equal(
+                h_array_real[i], src.array_real + contribution.array_real));
+            AMREX_ALWAYS_ASSERT(almost_equal(
+                h_runtime_real[i], src.runtime_real + contribution.runtime_real));
             AMREX_ALWAYS_ASSERT(h_array_int[i] == src.array_int + contribution.array_int);
             AMREX_ALWAYS_ASSERT(h_runtime_int[i] == src.runtime_int + contribution.runtime_int);
         }

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -331,9 +331,9 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
                 ParticleReal expected_pos = src.pos[idim];
                 if (shift[idim] > 0) {
-                    expected_pos += probhi[idim] - problo[idim];
+                    expected_pos += static_cast<ParticleReal>(probhi[idim] - problo[idim]);
                 } else if (shift[idim] < 0) {
-                    expected_pos -= probhi[idim] - problo[idim];
+                    expected_pos -= static_cast<ParticleReal>(probhi[idim] - problo[idim]);
                 }
                 if (std::abs(p.pos(idim) - expected_pos) > tol) {
                     matched = false;

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -5,10 +5,47 @@
 #include "Constants.H"
 #include "CheckPair.H"
 
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <tuple>
+
 using namespace amrex;
 
 namespace
 {
+    using ParticleKey = std::pair<Long, int>;
+
+    struct SourceParticleData
+    {
+        ParticleKey key;
+        IntVect cell;
+        int grid_id = -1;
+        std::array<ParticleReal, AMREX_SPACEDIM> pos{};
+    };
+
+    struct TileParticleRecord
+    {
+        ParticleKey key;
+        int grid_id = -1;
+        IntVect shift = IntVect(0);
+
+        bool operator< (TileParticleRecord const& other) const
+        {
+            return std::tie(key.first, key.second, grid_id,
+                            AMREX_D_DECL(shift[0], shift[1], shift[2]))
+                < std::tie(other.key.first, other.key.second, other.grid_id,
+                           AMREX_D_DECL(other.shift[0], other.shift[1], other.shift[2]));
+        }
+
+        bool operator== (TileParticleRecord const& other) const
+        {
+            return key == other.key && grid_id == other.grid_id && shift == other.shift;
+        }
+    };
+
     void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
     {
         int nx = nppc[0];
@@ -237,55 +274,145 @@ void MDParticleContainer::writeParticles(int n)
     WriteAsciiFile(pltfile);
 }
 
-void MDParticleContainer::checkNeighborParticles()
+void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
 {
     BL_PROFILE("MDParticleContainer::checkNeighborParticles");
 
     const int lev = 0;
+    auto const& geom = Geom(lev);
+    auto const plo = geom.ProbLoArray();
+    auto const dxi = geom.InvCellSizeArray();
+    auto const domain = geom.Domain();
+    auto const problo = geom.ProbLoArray();
+    auto const probhi = geom.ProbHiArray();
+    const auto& pshifts = geom.periodicity().shiftIntVect();
     auto& plev  = GetParticles(lev);
 
     auto ngrids = int(ParticleBoxArray(0).size());
+    std::map<ParticleKey, SourceParticleData> source_particles;
 
-    amrex::Gpu::DeviceVector<int> d_num_per_grid(ngrids,0);
-    amrex::Gpu::HostVector<int> h_num_per_grid(ngrids);
-
-    // CPU version
     for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
     {
-        int gid = mfi.index();
-
-        if (gid != 0) { continue; }
-        int tid = mfi.LocalTileIndex();
-        auto index = std::make_pair(gid, tid);
-
+        auto index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
         auto& ptile = plev[index];
-        auto& aos   = ptile.GetArrayOfStructs();
-        auto& soa   = ptile.GetStructOfArrays();
-        const int np = aos.numTotalParticles();
+        auto const& aos = ptile.GetArrayOfStructs();
+        int const np = aos.numParticles();
 
-        ParticleType* pstruct = aos().dataPtr();
-        auto* rdata = soa.GetRealData(0).dataPtr();
-        auto* idata = soa.GetIntData(0).dataPtr();
+        if (np == 0) { continue; }
 
-        int* p_num_per_grid = d_num_per_grid.data();
-        amrex::ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
-        {
-            ParticleType& p1 = pstruct[i];
-            Gpu::Atomic::AddNoRet(&(p_num_per_grid[p1.idata(0)]),1);
-            AMREX_ALWAYS_ASSERT(p1.idata(0) == (int) rdata[i]);
-            AMREX_ALWAYS_ASSERT(p1.idata(0) == idata[i]);
-        });
+        Gpu::HostVector<ParticleType> h_pstruct(np);
+        Gpu::copy(Gpu::deviceToHost, aos().dataPtr(), aos().dataPtr() + np, h_pstruct.begin());
 
-        Gpu::copy(Gpu::deviceToHost,
-                  d_num_per_grid.begin(), d_num_per_grid.end(), h_num_per_grid.begin());
-        amrex::AllPrintToFile("neighbor_test") << "FOR GRID " << gid << "\n";;
+        for (int i = 0; i < np; ++i) {
+            auto const& p = h_pstruct[i];
+            ParticleKey key{p.id(), p.cpu()};
+            SourceParticleData pdata;
+            pdata.key = key;
+            pdata.cell = getParticleCell(p, plo, dxi, domain);
+            pdata.grid_id = p.idata(0);
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                pdata.pos[idim] = p.pos(idim);
+            }
+            auto [it, inserted] = source_particles.emplace(key, pdata);
+            amrex::ignore_unused(it);
+            AMREX_ALWAYS_ASSERT(inserted);
+        }
+    }
 
-        for (int i = 0; i < ngrids; i++) {
-          amrex::AllPrintToFile("neighbor_test") << "   there are " << h_num_per_grid[i] << " with grid id " << i << "\n";
+    auto match_shift = [&] (ParticleType const& p, SourceParticleData const& src,
+                            Box const& grown_tile_box) -> IntVect
+    {
+        constexpr ParticleReal tol = ParticleReal(1.0e-12);
+        IntVect matched_shift(std::numeric_limits<int>::max());
+        int nmatches = 0;
+        for (auto const& shift : pshifts) {
+            if (!grown_tile_box.contains(src.cell + shift)) { continue; }
+            bool matched = true;
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                ParticleReal expected_pos = src.pos[idim];
+                if (shift[idim] > 0) {
+                    expected_pos += probhi[idim] - problo[idim];
+                } else if (shift[idim] < 0) {
+                    expected_pos -= probhi[idim] - problo[idim];
+                }
+                if (std::abs(p.pos(idim) - expected_pos) > tol) {
+                    matched = false;
+                    break;
+                }
+            }
+            if (matched) {
+                matched_shift = shift;
+                ++nmatches;
+            }
+        }
+        AMREX_ALWAYS_ASSERT(nmatches == 1);
+        return matched_shift;
+    };
+
+    for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+    {
+        int const gid = mfi.index();
+        int const tid = mfi.LocalTileIndex();
+        auto index = std::make_pair(gid, tid);
+        auto& ptile = plev[index];
+        auto const& aos = ptile.GetArrayOfStructs();
+        auto const& soa = ptile.GetStructOfArrays();
+
+        int const np_total = aos.numTotalParticles();
+        if (np_total == 0) { continue; }
+
+        Gpu::HostVector<ParticleType> h_pstruct(np_total);
+        Gpu::HostVector<ParticleReal> h_rdata(np_total);
+        Gpu::HostVector<int> h_idata(np_total);
+        Gpu::copy(Gpu::deviceToHost, aos().dataPtr(), aos().dataPtr() + np_total, h_pstruct.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetRealData(0).begin(), soa.GetRealData(0).begin() + np_total,
+                  h_rdata.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetIntData(0).begin(), soa.GetIntData(0).begin() + np_total,
+                  h_idata.begin());
+
+        Box grown_tile_box = mfi.tilebox();
+        if (hasNeighbors()) {
+            grown_tile_box.grow(m_num_neighbor_cells);
         }
 
-        amrex::AllPrintToFile("neighbor_test") << " \n";
-        amrex::AllPrintToFile("neighbor_test") << " \n";
+        std::vector<int> expected_per_grid(ngrids, 0);
+        std::vector<int> actual_per_grid(ngrids, 0);
+        std::vector<TileParticleRecord> expected_records;
+        std::vector<TileParticleRecord> actual_records;
+
+        for (auto const& [key, src] : source_particles) {
+            for (auto const& shift : pshifts) {
+                if (!grown_tile_box.contains(src.cell + shift)) { continue; }
+                int const expected_grid = use_source_grid ? src.grid_id : gid;
+                expected_records.push_back({key, expected_grid, shift});
+                ++expected_per_grid[expected_grid];
+            }
+        }
+
+        for (int i = 0; i < np_total; ++i) {
+            auto const& p = h_pstruct[i];
+            ParticleKey key{p.id(), p.cpu()};
+            auto it = source_particles.find(key);
+            AMREX_ALWAYS_ASSERT(it != source_particles.end());
+            auto const& src = it->second;
+            int const expected_grid = use_source_grid ? src.grid_id : gid;
+
+            AMREX_ALWAYS_ASSERT(p.idata(0) == expected_grid);
+            AMREX_ALWAYS_ASSERT(static_cast<int>(h_rdata[i]) == expected_grid);
+            AMREX_ALWAYS_ASSERT(h_idata[i] == expected_grid);
+
+            IntVect shift = match_shift(p, src, grown_tile_box);
+            actual_records.push_back({key, expected_grid, shift});
+            ++actual_per_grid[expected_grid];
+        }
+
+        for (int igrid = 0; igrid < ngrids; ++igrid) {
+            AMREX_ALWAYS_ASSERT(actual_per_grid[igrid] == expected_per_grid[igrid]);
+        }
+
+        std::sort(expected_records.begin(), expected_records.end());
+        std::sort(actual_records.begin(), actual_records.end());
+        AMREX_ALWAYS_ASSERT(actual_records == expected_records);
     }
 }
 

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -39,6 +39,42 @@ namespace
 
     static_assert(std::is_trivially_copyable_v<PackedSourceParticleData>);
 
+    struct OwnedParticleData
+    {
+        ParticleKey key;
+        std::array<ParticleReal, AMREX_SPACEDIM> pos{};
+        std::array<ParticleReal, PIdx::ncomps> struct_real{};
+        int struct_int = 0;
+        ParticleReal array_real = 0.0_rt;
+        ParticleReal runtime_real = 0.0_rt;
+        int array_int = 0;
+        int runtime_int = 0;
+    };
+
+    struct InverseContributionData
+    {
+        std::array<ParticleReal, PIdx::ncomps> struct_real{};
+        int struct_int = 0;
+        ParticleReal array_real = 0.0_rt;
+        ParticleReal runtime_real = 0.0_rt;
+        int array_int = 0;
+        int runtime_int = 0;
+    };
+
+    struct PackedContributionData
+    {
+        Long id = 0;
+        int cpu = -1;
+        std::array<ParticleReal, PIdx::ncomps> struct_real{};
+        int struct_int = 0;
+        ParticleReal array_real = 0.0_rt;
+        ParticleReal runtime_real = 0.0_rt;
+        int array_int = 0;
+        int runtime_int = 0;
+    };
+
+    static_assert(std::is_trivially_copyable_v<PackedContributionData>);
+
     struct TileParticleRecord
     {
         ParticleKey key;
@@ -574,6 +610,289 @@ void MDParticleContainer::checkNeighborList()
     }
 
     amrex::PrintToFile("neighbor_test") << "All the neighbor list particles match!" << '\n';
+}
+
+void MDParticleContainer::checkInverseSumNeighbors ()
+{
+    BL_PROFILE("MDParticleContainer::checkInverseSumNeighbors");
+
+    constexpr ParticleReal struct_real_delta = 1.5_rt;
+    constexpr int struct_int_delta = 9;
+    constexpr ParticleReal array_real_delta = 2.5_rt;
+    constexpr ParticleReal runtime_real_delta = 3.5_rt;
+    constexpr int array_int_delta = 11;
+    constexpr int runtime_int_delta = 13;
+
+    const int lev = 0;
+    auto& plev = GetParticles(lev);
+
+    std::map<ParticleKey, OwnedParticleData> local_owned_particles;
+    for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+    {
+        auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+        auto& ptile = plev[index];
+        auto& aos = ptile.GetArrayOfStructs();
+        auto& soa = ptile.GetStructOfArrays();
+        int const np = aos.numParticles();
+        if (np == 0) { continue; }
+
+        Gpu::HostVector<ParticleType> h_pstruct(np);
+        Gpu::HostVector<ParticleReal> h_array_real(np);
+        Gpu::HostVector<ParticleReal> h_runtime_real(np);
+        Gpu::HostVector<int> h_array_int(np);
+        Gpu::HostVector<int> h_runtime_int(np);
+        Gpu::copy(Gpu::deviceToHost, aos().dataPtr(), aos().dataPtr() + np, h_pstruct.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetRealData(0).begin(), soa.GetRealData(0).begin() + np,
+                  h_array_real.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetRealData(1).begin(), soa.GetRealData(1).begin() + np,
+                  h_runtime_real.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetIntData(0).begin(), soa.GetIntData(0).begin() + np,
+                  h_array_int.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetIntData(1).begin(), soa.GetIntData(1).begin() + np,
+                  h_runtime_int.begin());
+
+        for (int i = 0; i < np; ++i) {
+            auto const& p = h_pstruct[i];
+            OwnedParticleData pdata;
+            pdata.key = {p.id(), p.cpu()};
+            AMREX_D_TERM(pdata.pos[0] = p.pos(0);,
+                         pdata.pos[1] = p.pos(1);,
+                         pdata.pos[2] = p.pos(2);)
+            for (int comp = 0; comp < PIdx::ncomps; ++comp) {
+                pdata.struct_real[comp] = p.rdata(comp);
+            }
+            pdata.struct_int = p.idata(0);
+            pdata.array_real = h_array_real[i];
+            pdata.runtime_real = h_runtime_real[i];
+            pdata.array_int = h_array_int[i];
+            pdata.runtime_int = h_runtime_int[i];
+            auto [it, inserted] = local_owned_particles.emplace(pdata.key, pdata);
+            amrex::ignore_unused(it);
+            AMREX_ALWAYS_ASSERT(inserted);
+        }
+    }
+
+    std::map<ParticleKey, InverseContributionData> local_contributions;
+    for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+    {
+        auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+        auto& neighb_tile = GetNeighbors(lev, mfi.index(), mfi.LocalTileIndex());
+        auto& aos = neighb_tile.GetArrayOfStructs();
+        auto& soa = neighb_tile.GetStructOfArrays();
+        int const nneighbs = static_cast<int>(aos.size());
+        if (nneighbs == 0) { continue; }
+
+        Gpu::HostVector<ParticleType> h_pstruct(nneighbs);
+        Gpu::HostVector<ParticleReal> h_array_real(nneighbs);
+        Gpu::HostVector<ParticleReal> h_runtime_real(nneighbs);
+        Gpu::HostVector<int> h_array_int(nneighbs);
+        Gpu::HostVector<int> h_runtime_int(nneighbs);
+        Gpu::copy(Gpu::deviceToHost, aos().dataPtr(), aos().dataPtr() + nneighbs, h_pstruct.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetRealData(0).begin(), soa.GetRealData(0).begin() + nneighbs,
+                  h_array_real.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetRealData(1).begin(), soa.GetRealData(1).begin() + nneighbs,
+                  h_runtime_real.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetIntData(0).begin(), soa.GetIntData(0).begin() + nneighbs,
+                  h_array_int.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetIntData(1).begin(), soa.GetIntData(1).begin() + nneighbs,
+                  h_runtime_int.begin());
+
+        for (int i = 0; i < nneighbs; ++i) {
+            auto const& p = h_pstruct[i];
+            ParticleKey key{p.id(), p.cpu()};
+            auto& contribution = local_contributions[key];
+            for (int comp = 0; comp < PIdx::ncomps; ++comp) {
+                contribution.struct_real[comp] += p.rdata(comp) + struct_real_delta;
+            }
+            contribution.struct_int += p.idata(0) + struct_int_delta;
+            contribution.array_real += h_array_real[i] + array_real_delta;
+            contribution.runtime_real += h_runtime_real[i] + runtime_real_delta;
+            contribution.array_int += h_array_int[i] + array_int_delta;
+            contribution.runtime_int += h_runtime_int[i] + runtime_int_delta;
+        }
+
+        ParticleType* pstruct = aos().dataPtr();
+        auto* array_real = soa.GetRealData(0).dataPtr();
+        auto* runtime_real = soa.GetRealData(1).dataPtr();
+        auto* array_int = soa.GetIntData(0).dataPtr();
+        auto* runtime_int = soa.GetIntData(1).dataPtr();
+        AMREX_FOR_1D(nneighbs, i,
+        {
+            ParticleType& p = pstruct[i];
+            for (int comp = 0; comp < PIdx::ncomps; ++comp) {
+                p.rdata(comp) += struct_real_delta;
+            }
+            p.idata(0) += struct_int_delta;
+            array_real[i] += array_real_delta;
+            runtime_real[i] += runtime_real_delta;
+            array_int[i] += array_int_delta;
+            runtime_int[i] += runtime_int_delta;
+        });
+    }
+
+    Gpu::streamSynchronize();
+
+    auto gather_contribution_data =
+        [&] (std::map<ParticleKey, InverseContributionData> const& local_data)
+    {
+        std::vector<PackedContributionData> local_packed;
+        local_packed.reserve(local_data.size());
+        for (auto const& [key, contribution] : local_data) {
+            local_packed.push_back(PackedContributionData{
+                key.first, key.second, contribution.struct_real, contribution.struct_int,
+                contribution.array_real, contribution.runtime_real,
+                contribution.array_int, contribution.runtime_int
+            });
+        }
+
+        auto unpack = [] (std::vector<PackedContributionData> const& packed) {
+            std::map<ParticleKey, InverseContributionData> result;
+            for (auto const& item : packed) {
+                auto& contribution = result[{item.id, item.cpu}];
+                for (int comp = 0; comp < PIdx::ncomps; ++comp) {
+                    contribution.struct_real[comp] += item.struct_real[comp];
+                }
+                contribution.struct_int += item.struct_int;
+                contribution.array_real += item.array_real;
+                contribution.runtime_real += item.runtime_real;
+                contribution.array_int += item.array_int;
+                contribution.runtime_int += item.runtime_int;
+            }
+            return result;
+        };
+
+        if (ParallelDescriptor::NProcs() == 1) {
+            return unpack(local_packed);
+        }
+
+        int const root = ParallelDescriptor::IOProcessorNumber();
+        int const local_nbytes =
+            static_cast<int>(local_packed.size() * sizeof(PackedContributionData));
+        auto recvcounts = ParallelDescriptor::Gather(local_nbytes, root);
+
+        std::vector<int> displs;
+        std::vector<char> recv_bytes;
+
+        if (ParallelDescriptor::MyProc() == root) {
+            displs.resize(recvcounts.size(), 0);
+            int offset = 0;
+            for (int i = 0, n = static_cast<int>(recvcounts.size()); i < n; ++i) {
+                displs[i] = offset;
+                offset += recvcounts[i];
+            }
+            recv_bytes.resize(offset);
+        }
+
+        auto const* send_ptr = reinterpret_cast<char const*>(local_packed.data());
+        ParallelDescriptor::Gatherv(send_ptr, local_nbytes,
+                                    recv_bytes.data(), recvcounts, displs, root);
+
+        std::vector<PackedContributionData> global_packed;
+        if (ParallelDescriptor::MyProc() == root) {
+            AMREX_ALWAYS_ASSERT(recv_bytes.size() % sizeof(PackedContributionData) == 0);
+            std::vector<PackedContributionData> gathered(
+                recv_bytes.size() / sizeof(PackedContributionData));
+            if (!recv_bytes.empty()) {
+                std::memcpy(gathered.data(), recv_bytes.data(), recv_bytes.size());
+            }
+
+            auto const global_data = unpack(gathered);
+            global_packed.reserve(global_data.size());
+            for (auto const& [key, contribution] : global_data) {
+                global_packed.push_back(PackedContributionData{
+                    key.first, key.second, contribution.struct_real, contribution.struct_int,
+                    contribution.array_real, contribution.runtime_real,
+                    contribution.array_int, contribution.runtime_int
+                });
+            }
+        }
+
+        int total_nbytes =
+            static_cast<int>(global_packed.size() * sizeof(PackedContributionData));
+        ParallelDescriptor::Bcast(&total_nbytes, 1, root);
+
+        std::vector<char> packed_bytes(total_nbytes);
+        if (ParallelDescriptor::MyProc() == root && total_nbytes > 0) {
+            std::memcpy(packed_bytes.data(), global_packed.data(), total_nbytes);
+        }
+
+        if (total_nbytes > 0) {
+            ParallelDescriptor::Bcast(packed_bytes.data(), total_nbytes, root);
+        }
+
+        AMREX_ALWAYS_ASSERT(total_nbytes % sizeof(PackedContributionData) == 0);
+        std::vector<PackedContributionData> unpacked(
+            total_nbytes / static_cast<int>(sizeof(PackedContributionData)));
+        if (total_nbytes > 0) {
+            std::memcpy(unpacked.data(), packed_bytes.data(), total_nbytes);
+        }
+        return unpack(unpacked);
+    };
+
+    auto const global_contributions = gather_contribution_data(local_contributions);
+    int total_contributions = 0;
+    for (auto const& [key, contribution] : global_contributions) {
+        amrex::ignore_unused(key);
+        total_contributions += contribution.struct_int;
+    }
+    AMREX_ALWAYS_ASSERT(total_contributions > 0);
+
+    sumNeighbors(0, PIdx::ncomps + NumRealComps(), 0, 1 + NumIntComps());
+
+    for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+    {
+        auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+        auto& ptile = plev[index];
+        auto& aos = ptile.GetArrayOfStructs();
+        auto& soa = ptile.GetStructOfArrays();
+        int const np = aos.numParticles();
+        if (np == 0) { continue; }
+
+        Gpu::HostVector<ParticleType> h_pstruct(np);
+        Gpu::HostVector<ParticleReal> h_array_real(np);
+        Gpu::HostVector<ParticleReal> h_runtime_real(np);
+        Gpu::HostVector<int> h_array_int(np);
+        Gpu::HostVector<int> h_runtime_int(np);
+        Gpu::copy(Gpu::deviceToHost, aos().dataPtr(), aos().dataPtr() + np, h_pstruct.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetRealData(0).begin(), soa.GetRealData(0).begin() + np,
+                  h_array_real.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetRealData(1).begin(), soa.GetRealData(1).begin() + np,
+                  h_runtime_real.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetIntData(0).begin(), soa.GetIntData(0).begin() + np,
+                  h_array_int.begin());
+        Gpu::copy(Gpu::deviceToHost, soa.GetIntData(1).begin(), soa.GetIntData(1).begin() + np,
+                  h_runtime_int.begin());
+
+        for (int i = 0; i < np; ++i) {
+            auto const& p = h_pstruct[i];
+            ParticleKey key{p.id(), p.cpu()};
+            auto const src_it = local_owned_particles.find(key);
+            AMREX_ALWAYS_ASSERT(src_it != local_owned_particles.end());
+            auto const& src = src_it->second;
+
+            auto const contribution_it = global_contributions.find(key);
+            InverseContributionData contribution;
+            if (contribution_it != global_contributions.end()) {
+                contribution = contribution_it->second;
+            }
+
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                AMREX_ALWAYS_ASSERT(std::abs(p.pos(idim) - src.pos[idim]) <= ParticleReal(1.0e-12));
+            }
+            for (int comp = 0; comp < PIdx::ncomps; ++comp) {
+                AMREX_ALWAYS_ASSERT(std::abs(
+                    p.rdata(comp) - (src.struct_real[comp] + contribution.struct_real[comp]))
+                    <= ParticleReal(1.0e-12));
+            }
+            AMREX_ALWAYS_ASSERT(p.idata(0) == src.struct_int + contribution.struct_int);
+            AMREX_ALWAYS_ASSERT(std::abs(h_array_real[i] - (src.array_real + contribution.array_real))
+                                <= ParticleReal(1.0e-12));
+            AMREX_ALWAYS_ASSERT(std::abs(h_runtime_real[i] - (src.runtime_real + contribution.runtime_real))
+                                <= ParticleReal(1.0e-12));
+            AMREX_ALWAYS_ASSERT(h_array_int[i] == src.array_int + contribution.array_int);
+            AMREX_ALWAYS_ASSERT(h_runtime_int[i] == src.runtime_int + contribution.runtime_int);
+        }
+    }
 }
 
 void MDParticleContainer::reset_test_id()

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -675,7 +675,6 @@ void MDParticleContainer::checkInverseSumNeighbors ()
     std::map<ParticleKey, InverseContributionData> local_contributions;
     for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
     {
-        auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
         auto& neighb_tile = GetNeighbors(lev, mfi.index(), mfi.LocalTileIndex());
         auto& aos = neighb_tile.GetArrayOfStructs();
         auto& soa = neighb_tile.GetStructOfArrays();

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -8,9 +8,11 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstring>
 #include <limits>
 #include <map>
 #include <tuple>
+#include <type_traits>
 
 using namespace amrex;
 
@@ -25,6 +27,17 @@ namespace
         int grid_id = -1;
         std::array<ParticleReal, AMREX_SPACEDIM> pos{};
     };
+
+    struct PackedSourceParticleData
+    {
+        Long id = 0;
+        int cpu = -1;
+        int grid_id = -1;
+        std::array<int, AMREX_SPACEDIM> cell{};
+        std::array<ParticleReal, AMREX_SPACEDIM> pos{};
+    };
+
+    static_assert(std::is_trivially_copyable_v<PackedSourceParticleData>);
 
     struct TileParticleRecord
     {
@@ -77,6 +90,28 @@ namespace
         u[0] = u_mean + ux_th;
         u[1] = u_mean + uy_th;
         u[2] = u_mean + uz_th;
+    }
+
+    auto unpack_source_particles (std::vector<PackedSourceParticleData> const& packed_particles)
+        -> std::map<ParticleKey, SourceParticleData>
+    {
+        std::map<ParticleKey, SourceParticleData> source_particles;
+
+        for (auto const& packed : packed_particles) {
+            ParticleKey key{packed.id, packed.cpu};
+            SourceParticleData pdata;
+            pdata.key = key;
+            pdata.grid_id = packed.grid_id;
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                pdata.cell[idim] = packed.cell[idim];
+                pdata.pos[idim] = packed.pos[idim];
+            }
+            auto [it, inserted] = source_particles.emplace(key, pdata);
+            amrex::ignore_unused(it);
+            AMREX_ALWAYS_ASSERT(inserted);
+        }
+
+        return source_particles;
     }
 }
 
@@ -289,7 +324,7 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
     auto& plev  = GetParticles(lev);
 
     auto ngrids = int(ParticleBoxArray(0).size());
-    std::map<ParticleKey, SourceParticleData> source_particles;
+    std::vector<PackedSourceParticleData> local_source_particles;
 
     for(MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
     {
@@ -305,18 +340,61 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
 
         for (int i = 0; i < np; ++i) {
             auto const& p = h_pstruct[i];
-            ParticleKey key{p.id(), p.cpu()};
-            SourceParticleData pdata;
-            pdata.key = key;
-            pdata.cell = getParticleCell(p, plo, dxi, domain);
+            PackedSourceParticleData pdata;
+            pdata.id = p.id();
+            pdata.cpu = p.cpu();
             pdata.grid_id = p.idata(0);
+            auto const cell = getParticleCell(p, plo, dxi, domain);
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                pdata.cell[idim] = cell[idim];
                 pdata.pos[idim] = p.pos(idim);
             }
-            auto [it, inserted] = source_particles.emplace(key, pdata);
-            amrex::ignore_unused(it);
-            AMREX_ALWAYS_ASSERT(inserted);
+            local_source_particles.push_back(pdata);
         }
+    }
+
+    std::map<ParticleKey, SourceParticleData> source_particles;
+    if (ParallelDescriptor::NProcs() == 1) {
+        source_particles = unpack_source_particles(local_source_particles);
+    } else {
+        int const root = ParallelDescriptor::IOProcessorNumber();
+        int const local_nbytes =
+            static_cast<int>(local_source_particles.size() * sizeof(PackedSourceParticleData));
+
+        auto recvcounts = ParallelDescriptor::Gather(local_nbytes, root);
+        std::vector<int> displs;
+        std::vector<char> packed_bytes;
+
+        if (ParallelDescriptor::MyProc() == root) {
+            displs.resize(recvcounts.size(), 0);
+            int offset = 0;
+            for (int i = 0, n = static_cast<int>(recvcounts.size()); i < n; ++i) {
+                displs[i] = offset;
+                offset += recvcounts[i];
+            }
+            packed_bytes.resize(offset);
+        }
+
+        auto const* send_ptr = reinterpret_cast<char const*>(local_source_particles.data());
+        ParallelDescriptor::Gatherv(send_ptr, local_nbytes,
+                                    packed_bytes.data(), recvcounts, displs, root);
+
+        int total_nbytes = static_cast<int>(packed_bytes.size());
+        ParallelDescriptor::Bcast(&total_nbytes, 1, root);
+        if (ParallelDescriptor::MyProc() != root) {
+            packed_bytes.resize(total_nbytes);
+        }
+        if (total_nbytes > 0) {
+            ParallelDescriptor::Bcast(packed_bytes.data(), total_nbytes, root);
+        }
+
+        AMREX_ALWAYS_ASSERT(total_nbytes % sizeof(PackedSourceParticleData) == 0);
+        std::vector<PackedSourceParticleData> global_source_particles(
+            total_nbytes / static_cast<int>(sizeof(PackedSourceParticleData)));
+        if (total_nbytes > 0) {
+            std::memcpy(global_source_particles.data(), packed_bytes.data(), total_nbytes);
+        }
+        source_particles = unpack_source_particles(global_source_particles);
     }
 
     auto match_shift = [&] (ParticleType const& p, SourceParticleData const& src,

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -322,7 +322,7 @@ void MDParticleContainer::checkNeighborParticles(bool use_source_grid)
     auto match_shift = [&] (ParticleType const& p, SourceParticleData const& src,
                             Box const& grown_tile_box) -> IntVect
     {
-        constexpr ParticleReal tol = ParticleReal(1.0e-12);
+        constexpr auto tol = ParticleReal(1.0e-12);
         IntVect matched_shift(std::numeric_limits<int>::max());
         int nmatches = 0;
         for (auto const& shift : pshifts) {

--- a/Tests/Particles/NeighborParticles/inputs
+++ b/Tests/Particles/NeighborParticles/inputs
@@ -1,3 +1,6 @@
+particles.do_tiling = 1
+particles.tile_size = 4 4 4
+
 nbor_parts.size = (24, 24, 24)
 nbor_parts.max_grid_size = 8
 nbor_parts.is_periodic = 1

--- a/Tests/Particles/NeighborParticles/main.cpp
+++ b/Tests/Particles/NeighborParticles/main.cpp
@@ -163,6 +163,15 @@ void testNeighborParticles ()
     pc.checkNeighborParticles();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
+
+#ifndef AMREX_USE_GPU
+    amrex::PrintToFile("neighbor_test") << "Testing inverse sumNeighbors \n";
+    pc.clearNeighbors();
+    pc.setEnableInverse(true);
+    pc.fillNeighbors();
+    pc.checkNeighborParticles();
+    pc.checkInverseSumNeighbors();
+#endif
 }
 
 void testNeighborList ()

--- a/Tests/Particles/NeighborParticles/main.cpp
+++ b/Tests/Particles/NeighborParticles/main.cpp
@@ -118,7 +118,7 @@ void testNeighborParticles ()
     if (ParallelDescriptor::MyProc() == dm[0]) {
         amrex::PrintToFile("neighbor_test") << "Check neighbors after reset ... \n";
     }
-    pc.checkNeighborParticles();
+    pc.checkNeighborParticles(false);
 
     if (ParallelDescriptor::MyProc() == dm[0]) {
         amrex::PrintToFile("neighbor_test") << "Now updateNeighbors again ...  \n";
@@ -142,18 +142,21 @@ void testNeighborParticles ()
     amrex::PrintToFile("neighbor_test") << "Moving particles and updating neighbors \n";
     pc.moveParticles(static_cast<amrex::ParticleReal> (0.1));
     pc.updateNeighbors();
+    pc.checkNeighborParticles();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
 
     amrex::PrintToFile("neighbor_test") << "Moving particles and updating neighbors again \n";
     pc.moveParticles(static_cast<amrex::ParticleReal> (0.1));
     pc.updateNeighbors();
+    pc.checkNeighborParticles();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
 
     amrex::PrintToFile("neighbor_test") << "Moving particles and updating neighbors yet again \n";
     pc.moveParticles(static_cast<amrex::ParticleReal> (0.1));
     pc.updateNeighbors();
+    pc.checkNeighborParticles();
 
     amrex::PrintToFile("neighbor_test") << "Min distance is " << pc.minAndMaxDistance() << ", should be (1, 1) \n";
 }

--- a/Tests/Particles/NeighborParticlesPureSoA/CMakeLists.txt
+++ b/Tests/Particles/NeighborParticlesPureSoA/CMakeLists.txt
@@ -1,0 +1,11 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+
+    set(_sources main.cpp)
+
+    set(_input_files inputs)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Particles/NeighborParticlesPureSoA/GNUmakefile
+++ b/Tests/Particles/NeighborParticlesPureSoA/GNUmakefile
@@ -1,0 +1,22 @@
+AMREX_HOME = ../../../
+
+DEBUG = FALSE
+
+DIM = 3
+
+COMP = gcc
+
+USE_MPI = TRUE
+USE_OMP = FALSE
+USE_CUDA = TRUE
+
+TINY_PROFILE = TRUE
+USE_PARTICLES = TRUE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Particles/NeighborParticlesPureSoA/Make.package
+++ b/Tests/Particles/NeighborParticlesPureSoA/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Particles/NeighborParticlesPureSoA/inputs
+++ b/Tests/Particles/NeighborParticlesPureSoA/inputs
@@ -1,0 +1,7 @@
+particles.do_tiling = 1
+particles.tile_size = 4 4 4
+
+nbor_parts.size = (24, 24, 24)
+nbor_parts.max_grid_size = 8
+nbor_parts.is_periodic = 1
+nbor_parts.num_ppc = 1

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -295,9 +295,6 @@ public:
     {
         const int lev = 0;
         auto const& geom = Geom(lev);
-        auto const plo = geom.ProbLoArray();
-        auto const dxi = geom.InvCellSizeArray();
-        auto const domain = geom.Domain();
         auto const problo = geom.ProbLoArray();
         auto const probhi = geom.ProbHiArray();
         auto const& pshifts = geom.periodicity().shiftIntVect();

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -676,8 +676,8 @@ private:
         }
     }
 
-    std::map<ParticleKey, InverseContributionData>
-    gatherContributionData (std::map<ParticleKey, InverseContributionData> const& local_contributions) const
+    static std::map<ParticleKey, InverseContributionData>
+    gatherContributionData (std::map<ParticleKey, InverseContributionData> const& local_contributions)
     {
         std::vector<PackedContributionData> local_packed;
         local_packed.reserve(local_contributions.size());

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -1,0 +1,647 @@
+#include <AMReX.H>
+#include <AMReX_NeighborParticles.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Particles.H>
+#include <AMReX_SPACE.H>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <set>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+using namespace amrex;
+
+namespace
+{
+    constexpr int NumReal = AMREX_SPACEDIM + 2;
+    constexpr int NumInt = 2;
+    constexpr int MarkerRealComp = AMREX_SPACEDIM;
+    constexpr int PayloadRealComp = AMREX_SPACEDIM + 1;
+    constexpr int GridIntComp = 0;
+    constexpr int MarkerIntComp = 1;
+    constexpr ParticleReal Cutoff = 0.2_rt;
+
+    struct TestParams
+    {
+        IntVect size;
+        int max_grid_size = 0;
+        int num_ppc = 0;
+        int is_periodic = 0;
+    };
+
+    struct CheckPair
+    {
+        template <class P1, class P2>
+        AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+        bool operator() (const P1& p1, const P2& p2) const
+        {
+            AMREX_D_TERM(Real d0 = p1.pos(0) - p2.pos(0);,
+                         Real d1 = p1.pos(1) - p2.pos(1);,
+                         Real d2 = p1.pos(2) - p2.pos(2);)
+            Real dsquared = AMREX_D_TERM(d0*d0, + d1*d1, + d2*d2);
+            return dsquared <= 25.0_rt*Cutoff*Cutoff;
+        }
+    };
+
+    using ParticleKey = std::pair<Long, int>;
+
+    struct SourceParticleData
+    {
+        ParticleKey key;
+        IntVect cell;
+        int grid_id = -1;
+        int marker_int = 0;
+        int runtime_int = 0;
+        std::array<ParticleReal, AMREX_SPACEDIM> pos{};
+        ParticleReal marker_real = 0.0_rt;
+        ParticleReal payload_real = 0.0_rt;
+        ParticleReal runtime_real = 0.0_rt;
+    };
+
+    struct PackedSourceParticleData
+    {
+        Long id = 0;
+        int cpu = -1;
+        int grid_id = -1;
+        int marker_int = 0;
+        int runtime_int = 0;
+        std::array<int, AMREX_SPACEDIM> cell{};
+        std::array<ParticleReal, AMREX_SPACEDIM> pos{};
+        ParticleReal marker_real = 0.0_rt;
+        ParticleReal payload_real = 0.0_rt;
+        ParticleReal runtime_real = 0.0_rt;
+    };
+
+    static_assert(std::is_trivially_copyable_v<PackedSourceParticleData>);
+
+    struct TileParticleRecord
+    {
+        ParticleKey key;
+        int grid_id = -1;
+        IntVect shift = IntVect(0);
+
+        bool operator< (TileParticleRecord const& other) const
+        {
+            return std::tie(key.first, key.second, grid_id,
+                            AMREX_D_DECL(shift[0], shift[1], shift[2]))
+                < std::tie(other.key.first, other.key.second, other.grid_id,
+                           AMREX_D_DECL(other.shift[0], other.shift[1], other.shift[2]));
+        }
+
+        bool operator== (TileParticleRecord const& other) const
+        {
+            return key == other.key && grid_id == other.grid_id && shift == other.shift;
+        }
+    };
+
+    void get_position_unit_cell (Real* r, const IntVect& nppc, int i_part)
+    {
+        int nx = nppc[0];
+#if AMREX_SPACEDIM > 1
+        int ny = nppc[1];
+#else
+        int ny = 1;
+#endif
+#if AMREX_SPACEDIM > 2
+        int nz = nppc[2];
+#else
+        int nz = 1;
+#endif
+
+        AMREX_D_TERM(int ix_part = i_part/(ny*nz);,
+                     int iy_part = (i_part % (ny*nz)) % ny;,
+                     int iz_part = (i_part % (ny*nz)) / ny;)
+
+        AMREX_D_TERM(r[0] = (0.5_rt + ix_part)/nx;,
+                     r[1] = (0.5_rt + iy_part)/ny;,
+                     r[2] = (0.5_rt + iz_part)/nz;)
+    }
+
+    void get_test_params (TestParams& params)
+    {
+        ParmParse pp("nbor_parts");
+        pp.get("size", params.size);
+        pp.get("max_grid_size", params.max_grid_size);
+        pp.get("num_ppc", params.num_ppc);
+        pp.get("is_periodic", params.is_periodic);
+    }
+
+    bool almost_equal (ParticleReal lhs, ParticleReal rhs, ParticleReal tol = 1.0e-12_rt)
+    {
+        return std::abs(lhs-rhs) <= tol;
+    }
+}
+
+class PureSoANeighborContainer
+    : public NeighborParticleContainerPureSoA<NumReal, NumInt>
+{
+public:
+    using Base = NeighborParticleContainerPureSoA<NumReal, NumInt>;
+    using ParticleType = typename Base::ParticleType;
+    using ParticleTile = typename Base::ParticleTile;
+
+    struct HostTileData
+    {
+        Gpu::HostVector<uint64_t> idcpu;
+        std::array<Gpu::HostVector<ParticleReal>, NumReal> real;
+        std::array<Gpu::HostVector<int>, NumInt> idata;
+        std::vector<Gpu::HostVector<ParticleReal>> runtime_real;
+        std::vector<Gpu::HostVector<int>> runtime_int;
+    };
+
+    PureSoANeighborContainer (const Geometry& geom,
+                              const DistributionMapping& dmap,
+                              const BoxArray& ba,
+                              int num_neighbor_cells)
+        : Base(geom, dmap, ba, num_neighbor_cells)
+    {
+        AddRealComp(true);
+        AddIntComp(true);
+    }
+
+    void InitParticles (const IntVect& nppc, const IntVect& domain_size)
+    {
+        const int lev = 0;
+        const Real* dx = Geom(lev).CellSize();
+        const Real* plo = Geom(lev).ProbLo();
+        const int num_ppc = AMREX_D_TERM(nppc[0], *nppc[1], *nppc[2]);
+
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            const Box& tile_box = mfi.tilebox();
+
+            Gpu::HostVector<uint64_t> host_idcpu;
+            std::array<Gpu::HostVector<ParticleReal>, NumReal> host_real;
+            std::array<Gpu::HostVector<int>, NumInt> host_int;
+            Gpu::HostVector<ParticleReal> host_runtime_real;
+            Gpu::HostVector<int> host_runtime_int;
+
+            for (IntVect iv = tile_box.smallEnd(); iv <= tile_box.bigEnd(); tile_box.next(iv))
+            {
+                for (int i_part = 0; i_part < num_ppc; ++i_part) {
+                    Real r[AMREX_SPACEDIM];
+                    get_position_unit_cell(r, nppc, i_part);
+
+                    int marker = AMREX_D_TERM(iv[0], + domain_size[0]*iv[1],
+                                              + domain_size[0]*domain_size[1]*iv[2]);
+                    marker = marker*num_ppc + i_part;
+
+                    Long id = ParticleType::NextID();
+                    host_idcpu.push_back(0);
+                    ParticleIDWrapper(host_idcpu.back()) = id;
+                    ParticleCPUWrapper(host_idcpu.back()) = ParallelDescriptor::MyProc();
+
+                    AMREX_D_TERM(host_real[0].push_back(static_cast<ParticleReal>(plo[0] + (iv[0] + r[0])*dx[0]));,
+                                 host_real[1].push_back(static_cast<ParticleReal>(plo[1] + (iv[1] + r[1])*dx[1]));,
+                                 host_real[2].push_back(static_cast<ParticleReal>(plo[2] + (iv[2] + r[2])*dx[2]));)
+                    host_real[MarkerRealComp].push_back(static_cast<ParticleReal>(marker));
+                    host_real[PayloadRealComp].push_back(static_cast<ParticleReal>(marker) + 0.5_rt);
+
+                    host_int[GridIntComp].push_back(mfi.index());
+                    host_int[MarkerIntComp].push_back(marker);
+
+                    host_runtime_real.push_back(static_cast<ParticleReal>(marker) + 1.25_rt);
+                    host_runtime_int.push_back(marker + 17);
+                }
+            }
+
+            auto& particle_tile = DefineAndReturnParticleTile(lev, mfi);
+            Long old_size = particle_tile.size();
+            Long new_size = old_size + static_cast<Long>(host_idcpu.size());
+            particle_tile.resize(new_size);
+
+            auto& soa = particle_tile.GetStructOfArrays();
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_idcpu.begin(), host_idcpu.end(),
+                           soa.GetIdCPUData().begin() + old_size);
+
+            for (int i = 0; i < NumReal; ++i) {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_real[i].begin(), host_real[i].end(),
+                               soa.GetRealData(i).begin() + old_size);
+            }
+            for (int i = 0; i < NumInt; ++i) {
+                Gpu::copyAsync(Gpu::hostToDevice,
+                               host_int[i].begin(), host_int[i].end(),
+                               soa.GetIntData(i).begin() + old_size);
+            }
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_runtime_real.begin(), host_runtime_real.end(),
+                           soa.GetRealData(NumReal).begin() + old_size);
+            Gpu::copyAsync(Gpu::hostToDevice,
+                           host_runtime_int.begin(), host_runtime_int.end(),
+                           soa.GetIntData(NumInt).begin() + old_size);
+        }
+
+        Gpu::streamSynchronize();
+        RedistributeLocal();
+    }
+
+    void moveParticles (ParticleReal shift)
+    {
+        const int lev = 0;
+        auto& plev = GetParticles(lev);
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            auto& ptile = plev[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
+            auto ptd = ptile.getParticleTileData();
+            const size_t np = ptile.numParticles();
+            amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept
+            {
+                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                    ptd.pos(dir, i) += shift;
+                }
+            });
+        }
+    }
+
+    void bumpPayload (int delta)
+    {
+        const int lev = 0;
+        auto& plev = GetParticles(lev);
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            auto& ptile = plev[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
+            auto ptd = ptile.getParticleTileData();
+            const size_t np = ptile.numParticles();
+            amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept
+            {
+                ptd.rdata(MarkerRealComp)[i] += static_cast<ParticleReal>(delta);
+                ptd.rdata(PayloadRealComp)[i] += static_cast<ParticleReal>(delta);
+                ptd.idata(MarkerIntComp)[i] += delta;
+                ptd.m_runtime_rdata[0][i] += static_cast<ParticleReal>(delta);
+                ptd.m_runtime_idata[0][i] += delta;
+            });
+        }
+    }
+
+    void assertNoNeighbors () const
+    {
+        for (int lev = 0; lev < numLevels(); ++lev) {
+            for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi) {
+                auto const& ptile = GetParticles(lev).at(std::make_pair(mfi.index(), mfi.LocalTileIndex()));
+                AMREX_ALWAYS_ASSERT(ptile.numNeighborParticles() == 0);
+            }
+        }
+    }
+
+    void checkNeighbors () const
+    {
+        const int lev = 0;
+        auto const& geom = Geom(lev);
+        auto const plo = geom.ProbLoArray();
+        auto const dxi = geom.InvCellSizeArray();
+        auto const domain = geom.Domain();
+        auto const problo = geom.ProbLoArray();
+        auto const probhi = geom.ProbHiArray();
+        auto const& pshifts = geom.periodicity().shiftIntVect();
+        auto const source_particles = gatherSourceParticles();
+        auto const& plev = GetParticles(lev);
+
+        auto match_shift = [&] (SourceParticleData const& src,
+                                std::array<ParticleReal, AMREX_SPACEDIM> const& pos,
+                                Box const& grown_tile_box) -> IntVect
+        {
+            IntVect matched_shift(std::numeric_limits<int>::max());
+            int nmatches = 0;
+            for (auto const& shift : pshifts) {
+                if (!grown_tile_box.contains(src.cell + shift)) { continue; }
+
+                bool matched = true;
+                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                    ParticleReal expected_pos = src.pos[dir];
+                    if (shift[dir] > 0) {
+                        expected_pos += static_cast<ParticleReal>(probhi[dir] - problo[dir]);
+                    } else if (shift[dir] < 0) {
+                        expected_pos -= static_cast<ParticleReal>(probhi[dir] - problo[dir]);
+                    }
+                    if (!almost_equal(pos[dir], expected_pos)) {
+                        matched = false;
+                        break;
+                    }
+                }
+
+                if (matched) {
+                    matched_shift = shift;
+                    ++nmatches;
+                }
+            }
+
+            AMREX_ALWAYS_ASSERT(nmatches == 1);
+            return matched_shift;
+        };
+
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+            auto const& ptile = plev.at(index);
+            int const np = ptile.numParticles();
+            int const np_total = ptile.numTotalParticles();
+
+            HostTileData host;
+            copyTileToHost(ptile, np_total, host);
+
+            std::set<TileParticleRecord> expected_records;
+            std::set<TileParticleRecord> actual_records;
+
+            Box tile_box = mfi.tilebox();
+            Box grown_tile_box = tile_box;
+            grown_tile_box.grow(1);
+
+            for (auto const& [key, src] : source_particles) {
+                for (auto const& shift : pshifts) {
+                    if (!grown_tile_box.contains(src.cell + shift)) { continue; }
+                    if (tile_box.contains(src.cell + shift)) { continue; }
+                    expected_records.insert(TileParticleRecord{key, src.grid_id, shift});
+                }
+            }
+
+            for (int i = np; i < np_total; ++i) {
+                ParticleKey key{
+                    static_cast<Long>(ParticleIDWrapper(host.idcpu[i])),
+                    static_cast<int>(ParticleCPUWrapper(host.idcpu[i]))
+                };
+                auto it = source_particles.find(key);
+                AMREX_ALWAYS_ASSERT(it != source_particles.end());
+                auto const& src = it->second;
+
+                AMREX_ALWAYS_ASSERT(host.idata[GridIntComp][i] == src.grid_id);
+                AMREX_ALWAYS_ASSERT(host.idata[MarkerIntComp][i] == src.marker_int);
+                AMREX_ALWAYS_ASSERT(almost_equal(host.real[MarkerRealComp][i], src.marker_real));
+                AMREX_ALWAYS_ASSERT(almost_equal(host.real[PayloadRealComp][i], src.payload_real));
+                AMREX_ALWAYS_ASSERT(almost_equal(host.runtime_real[0][i], src.runtime_real));
+                AMREX_ALWAYS_ASSERT(host.runtime_int[0][i] == src.runtime_int);
+
+                std::array<ParticleReal, AMREX_SPACEDIM> pos{
+                    AMREX_D_DECL(host.real[0][i], host.real[1][i], host.real[2][i])
+                };
+                IntVect shift = match_shift(src, pos, grown_tile_box);
+                actual_records.insert(TileParticleRecord{key, src.grid_id, shift});
+            }
+
+            AMREX_ALWAYS_ASSERT(actual_records == expected_records);
+        }
+    }
+
+    void checkNeighborList () const
+    {
+        const int lev = 0;
+        auto const& plev = GetParticles(lev);
+        Real const cutoff_sq = 25.0_rt*Cutoff*Cutoff;
+
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+            auto const& ptile = plev.at(index);
+            int const np = ptile.numParticles();
+            int const np_total = ptile.numTotalParticles();
+
+            HostTileData host;
+            copyTileToHost(ptile, np_total, host);
+
+            Gpu::HostVector<unsigned int> full_count(np, 0);
+            Gpu::HostVector<unsigned int> full_nbors;
+
+            for (int i = 0; i < np; ++i) {
+                for (int j = 0; j < np_total; ++j) {
+                    if (i == j) { continue; }
+
+                    Real dsquared = 0.0_rt;
+                    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                        Real d = host.real[dir][i] - host.real[dir][j];
+                        dsquared += d*d;
+                    }
+                    if (dsquared <= cutoff_sq) {
+                        ++full_count[i];
+                        full_nbors.push_back(j);
+                    }
+                }
+            }
+
+            auto const& d_counts = m_neighbor_list.at(lev).at(index).GetCounts();
+            Gpu::HostVector<unsigned int> h_counts(d_counts.size());
+            Gpu::copy(Gpu::deviceToHost, d_counts.begin(), d_counts.end(), h_counts.begin());
+
+            auto const& d_list = m_neighbor_list.at(lev).at(index).GetList();
+            Gpu::HostVector<unsigned int> h_list(d_list.size());
+            Gpu::copy(Gpu::deviceToHost, d_list.begin(), d_list.end(), h_list.begin());
+
+            for (int i = 0; i < np; ++i) {
+                AMREX_ALWAYS_ASSERT(h_counts[i] == full_count[i]);
+            }
+
+            unsigned int start = 0;
+            for (int i = 0; i < np; ++i) {
+                std::sort(full_nbors.begin() + start, full_nbors.begin() + start + full_count[i]);
+                std::sort(h_list.begin() + start, h_list.begin() + start + full_count[i]);
+                start += full_count[i];
+            }
+
+            for (unsigned int i = 0; i < h_list.size(); ++i) {
+                AMREX_ALWAYS_ASSERT(h_list[i] == full_nbors[i]);
+            }
+        }
+    }
+
+private:
+    void copyTileToHost (ParticleTile const& ptile, int np, HostTileData& host) const
+    {
+        auto const& soa = ptile.GetStructOfArrays();
+
+        host.idcpu.resize(np);
+        Gpu::copy(Gpu::deviceToHost,
+                  soa.GetIdCPUData().begin(), soa.GetIdCPUData().begin() + np,
+                  host.idcpu.begin());
+
+        for (int i = 0; i < NumReal; ++i) {
+            host.real[i].resize(np);
+            Gpu::copy(Gpu::deviceToHost,
+                      soa.GetRealData(i).begin(), soa.GetRealData(i).begin() + np,
+                      host.real[i].begin());
+        }
+
+        for (int i = 0; i < NumInt; ++i) {
+            host.idata[i].resize(np);
+            Gpu::copy(Gpu::deviceToHost,
+                      soa.GetIntData(i).begin(), soa.GetIntData(i).begin() + np,
+                      host.idata[i].begin());
+        }
+
+        host.runtime_real.resize(NumRuntimeRealComps());
+        for (int i = 0; i < NumRuntimeRealComps(); ++i) {
+            host.runtime_real[i].resize(np);
+            Gpu::copy(Gpu::deviceToHost,
+                      soa.GetRealData(NumReal + i).begin(), soa.GetRealData(NumReal + i).begin() + np,
+                      host.runtime_real[i].begin());
+        }
+
+        host.runtime_int.resize(NumRuntimeIntComps());
+        for (int i = 0; i < NumRuntimeIntComps(); ++i) {
+            host.runtime_int[i].resize(np);
+            Gpu::copy(Gpu::deviceToHost,
+                      soa.GetIntData(NumInt + i).begin(), soa.GetIntData(NumInt + i).begin() + np,
+                      host.runtime_int[i].begin());
+        }
+    }
+
+    std::map<ParticleKey, SourceParticleData> gatherSourceParticles () const
+    {
+        const int lev = 0;
+        auto const plo = Geom(lev).ProbLoArray();
+        auto const dxi = Geom(lev).InvCellSizeArray();
+        auto const domain = Geom(lev).Domain();
+        auto const& plev = GetParticles(lev);
+        std::vector<PackedSourceParticleData> local_source_particles;
+
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+            auto const& ptile = plev.at(index);
+            int const np = ptile.numParticles();
+            if (np == 0) { continue; }
+
+            HostTileData host;
+            copyTileToHost(ptile, np, host);
+
+            for (int i = 0; i < np; ++i) {
+                PackedSourceParticleData pdata;
+                pdata.id = ParticleIDWrapper(host.idcpu[i]);
+                pdata.cpu = ParticleCPUWrapper(host.idcpu[i]);
+                pdata.grid_id = host.idata[GridIntComp][i];
+                pdata.marker_int = host.idata[MarkerIntComp][i];
+                pdata.runtime_int = host.runtime_int[0][i];
+                pdata.marker_real = host.real[MarkerRealComp][i];
+                pdata.payload_real = host.real[PayloadRealComp][i];
+                pdata.runtime_real = host.runtime_real[0][i];
+                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                    pdata.pos[dir] = host.real[dir][i];
+                    pdata.cell[dir] = static_cast<int>(
+                        amrex::Math::floor((pdata.pos[dir] - plo[dir])*dxi[dir])) + domain.smallEnd(dir);
+                }
+                local_source_particles.push_back(pdata);
+            }
+        }
+
+        auto unpack = [] (std::vector<PackedSourceParticleData> const& packed) {
+            std::map<ParticleKey, SourceParticleData> result;
+            for (auto const& p : packed) {
+                SourceParticleData src;
+                src.key = {p.id, p.cpu};
+                src.grid_id = p.grid_id;
+                src.marker_int = p.marker_int;
+                src.runtime_int = p.runtime_int;
+                src.marker_real = p.marker_real;
+                src.payload_real = p.payload_real;
+                src.runtime_real = p.runtime_real;
+                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                    src.cell[dir] = p.cell[dir];
+                    src.pos[dir] = p.pos[dir];
+                }
+                auto [it, inserted] = result.emplace(src.key, src);
+                amrex::ignore_unused(it);
+                AMREX_ALWAYS_ASSERT(inserted);
+            }
+            return result;
+        };
+
+        if (ParallelDescriptor::NProcs() == 1) {
+            return unpack(local_source_particles);
+        }
+
+        int const root = ParallelDescriptor::IOProcessorNumber();
+        int const local_nbytes =
+            static_cast<int>(local_source_particles.size() * sizeof(PackedSourceParticleData));
+        auto recvcounts = ParallelDescriptor::Gather(local_nbytes, root);
+
+        std::vector<int> displs;
+        std::vector<char> packed_bytes;
+
+        if (ParallelDescriptor::MyProc() == root) {
+            displs.resize(recvcounts.size(), 0);
+            int offset = 0;
+            for (int i = 0, n = static_cast<int>(recvcounts.size()); i < n; ++i) {
+                displs[i] = offset;
+                offset += recvcounts[i];
+            }
+            packed_bytes.resize(offset);
+        }
+
+        auto const* send_ptr = reinterpret_cast<char const*>(local_source_particles.data());
+        ParallelDescriptor::Gatherv(send_ptr, local_nbytes,
+                                    packed_bytes.data(), recvcounts, displs, root);
+
+        int total_nbytes = static_cast<int>(packed_bytes.size());
+        ParallelDescriptor::Bcast(&total_nbytes, 1, root);
+        if (ParallelDescriptor::MyProc() != root) {
+            packed_bytes.resize(total_nbytes);
+        }
+        if (total_nbytes > 0) {
+            ParallelDescriptor::Bcast(packed_bytes.data(), total_nbytes, root);
+        }
+
+        AMREX_ALWAYS_ASSERT(total_nbytes % sizeof(PackedSourceParticleData) == 0);
+        std::vector<PackedSourceParticleData> global_source_particles(
+            total_nbytes / static_cast<int>(sizeof(PackedSourceParticleData)));
+        if (total_nbytes > 0) {
+            std::memcpy(global_source_particles.data(), packed_bytes.data(), total_nbytes);
+        }
+        return unpack(global_source_particles);
+    }
+};
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+
+    TestParams params;
+    get_test_params(params);
+    AMREX_ALWAYS_ASSERT(params.num_ppc == 1);
+
+    RealBox real_box;
+    for (int dir = 0; dir < BL_SPACEDIM; ++dir)
+    {
+        real_box.setLo(dir, 0.0);
+        real_box.setHi(dir, params.size[dir]);
+    }
+
+    IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
+    IntVect domain_hi(AMREX_D_DECL(params.size[0]-1, params.size[1]-1, params.size[2]-1));
+    Box const domain(domain_lo, domain_hi);
+
+    int is_per[] = {AMREX_D_DECL(params.is_periodic, params.is_periodic, params.is_periodic)};
+    Geometry geom(domain, &real_box, 0, is_per);
+
+    BoxArray ba(domain);
+    ba.maxSize(params.max_grid_size);
+    DistributionMapping dm(ba);
+
+    PureSoANeighborContainer pc(geom, dm, ba, 1);
+    pc.InitParticles(IntVect(params.num_ppc), params.size);
+    pc.assertNoNeighbors();
+
+    pc.fillNeighbors();
+    pc.checkNeighbors();
+    pc.buildNeighborList(CheckPair());
+    pc.checkNeighborList();
+
+    pc.bumpPayload(1000);
+    pc.updateNeighbors();
+    pc.checkNeighbors();
+    pc.buildNeighborList(CheckPair());
+    pc.checkNeighborList();
+
+    pc.moveParticles(0.1_rt);
+    pc.bumpPayload(2000);
+    pc.updateNeighbors();
+    pc.checkNeighbors();
+    pc.buildNeighborList(CheckPair());
+    pc.checkNeighborList();
+
+    amrex::Finalize();
+}

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -80,6 +80,28 @@ namespace
 
     static_assert(std::is_trivially_copyable_v<PackedSourceParticleData>);
 
+    struct InverseContributionData
+    {
+        ParticleReal marker_real = 0.0_rt;
+        ParticleReal payload_real = 0.0_rt;
+        ParticleReal runtime_real = 0.0_rt;
+        int marker_int = 0;
+        int runtime_int = 0;
+    };
+
+    struct PackedContributionData
+    {
+        Long id = 0;
+        int cpu = -1;
+        ParticleReal marker_real = 0.0_rt;
+        ParticleReal payload_real = 0.0_rt;
+        ParticleReal runtime_real = 0.0_rt;
+        int marker_int = 0;
+        int runtime_int = 0;
+    };
+
+    static_assert(std::is_trivially_copyable_v<PackedContributionData>);
+
     struct TileParticleRecord
     {
         ParticleKey key;
@@ -470,6 +492,107 @@ public:
         }
     }
 
+    void checkInverseSumNeighbors ()
+    {
+        constexpr ParticleReal marker_real_delta = 1.25_rt;
+        constexpr ParticleReal payload_real_delta = 2.5_rt;
+        constexpr ParticleReal runtime_real_delta = 3.75_rt;
+        constexpr int marker_int_delta = 11;
+        constexpr int runtime_int_delta = 13;
+
+        const int lev = 0;
+        std::map<ParticleKey, InverseContributionData> local_contributions;
+
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            auto& neighb_tile = GetNeighbors(lev, mfi.index(), mfi.LocalTileIndex());
+            int const nneighbs = static_cast<int>(neighb_tile.size());
+            if (nneighbs == 0) { continue; }
+
+            HostTileData host;
+            copyTileToHost(neighb_tile, nneighbs, host);
+
+            for (int i = 0; i < nneighbs; ++i) {
+                ParticleKey key{
+                    static_cast<Long>(ParticleIDWrapper(host.idcpu[i])),
+                    static_cast<int>(ParticleCPUWrapper(host.idcpu[i]))
+                };
+                auto& contribution = local_contributions[key];
+                contribution.marker_real += host.real[MarkerRealComp][i] + marker_real_delta;
+                contribution.payload_real += host.real[PayloadRealComp][i] + payload_real_delta;
+                contribution.runtime_real += host.runtime_real[0][i] + runtime_real_delta;
+                contribution.marker_int += host.idata[MarkerIntComp][i] + marker_int_delta;
+                contribution.runtime_int += host.runtime_int[0][i] + runtime_int_delta;
+            }
+
+            auto ptd = neighb_tile.getParticleTileData();
+            amrex::ParallelFor(nneighbs, [=] AMREX_GPU_DEVICE (int i) noexcept
+            {
+                ptd.rdata(MarkerRealComp)[i] += marker_real_delta;
+                ptd.rdata(PayloadRealComp)[i] += payload_real_delta;
+                ptd.m_runtime_rdata[0][i] += runtime_real_delta;
+                ptd.idata(MarkerIntComp)[i] += marker_int_delta;
+                ptd.m_runtime_idata[0][i] += runtime_int_delta;
+            });
+        }
+
+        Gpu::streamSynchronize();
+
+        auto const global_contributions = gatherContributionData(local_contributions);
+
+        int total_contributions = 0;
+        for (auto const& [key, contribution] : global_contributions) {
+            amrex::ignore_unused(key);
+            total_contributions += contribution.marker_int;
+        }
+        AMREX_ALWAYS_ASSERT(total_contributions > 0);
+
+        sumNeighbors(MarkerRealComp, 3, MarkerIntComp, 2);
+
+        auto const& plev = GetParticles(lev);
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+            auto const& ptile = plev.at(index);
+            int const np = ptile.numParticles();
+            if (np == 0) { continue; }
+
+            HostTileData host;
+            copyTileToHost(ptile, np, host);
+
+            for (int i = 0; i < np; ++i) {
+                ParticleKey key{
+                    static_cast<Long>(ParticleIDWrapper(host.idcpu[i])),
+                    static_cast<int>(ParticleCPUWrapper(host.idcpu[i]))
+                };
+                auto const src_it = m_local_source_particles.find(key);
+                AMREX_ALWAYS_ASSERT(src_it != m_local_source_particles.end());
+                auto const& src = src_it->second;
+
+                auto const contribution_it = global_contributions.find(key);
+                InverseContributionData contribution;
+                if (contribution_it != global_contributions.end()) {
+                    contribution = contribution_it->second;
+                }
+
+                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                    AMREX_ALWAYS_ASSERT(almost_equal(host.real[dir][i], src.pos[dir]));
+                }
+                AMREX_ALWAYS_ASSERT(host.idata[GridIntComp][i] == src.grid_id);
+                AMREX_ALWAYS_ASSERT(host.idata[MarkerIntComp][i] == src.marker_int + contribution.marker_int);
+                AMREX_ALWAYS_ASSERT(host.runtime_int[0][i] == src.runtime_int + contribution.runtime_int);
+                AMREX_ALWAYS_ASSERT(almost_equal(
+                    host.real[MarkerRealComp][i], src.marker_real + contribution.marker_real));
+                AMREX_ALWAYS_ASSERT(almost_equal(
+                    host.real[PayloadRealComp][i], src.payload_real + contribution.payload_real));
+                AMREX_ALWAYS_ASSERT(almost_equal(
+                    host.runtime_real[0][i], src.runtime_real + contribution.runtime_real));
+            }
+        }
+
+        captureOwnedParticles();
+    }
+
 private:
     void captureOwnedParticles ()
     {
@@ -551,6 +674,100 @@ private:
                       soa.GetIntData(NumInt + i).begin(), soa.GetIntData(NumInt + i).begin() + np,
                       host.runtime_int[i].begin());
         }
+    }
+
+    std::map<ParticleKey, InverseContributionData>
+    gatherContributionData (std::map<ParticleKey, InverseContributionData> const& local_contributions) const
+    {
+        std::vector<PackedContributionData> local_packed;
+        local_packed.reserve(local_contributions.size());
+        for (auto const& [key, contribution] : local_contributions) {
+            local_packed.push_back(PackedContributionData{
+                key.first, key.second,
+                contribution.marker_real, contribution.payload_real, contribution.runtime_real,
+                contribution.marker_int, contribution.runtime_int
+            });
+        }
+
+        auto unpack = [] (std::vector<PackedContributionData> const& packed) {
+            std::map<ParticleKey, InverseContributionData> result;
+            for (auto const& item : packed) {
+                auto& contribution = result[{item.id, item.cpu}];
+                contribution.marker_real += item.marker_real;
+                contribution.payload_real += item.payload_real;
+                contribution.runtime_real += item.runtime_real;
+                contribution.marker_int += item.marker_int;
+                contribution.runtime_int += item.runtime_int;
+            }
+            return result;
+        };
+
+        if (ParallelDescriptor::NProcs() == 1) {
+            return unpack(local_packed);
+        }
+
+        int const root = ParallelDescriptor::IOProcessorNumber();
+        int const local_nbytes =
+            static_cast<int>(local_packed.size() * sizeof(PackedContributionData));
+        auto recvcounts = ParallelDescriptor::Gather(local_nbytes, root);
+
+        std::vector<int> displs;
+        std::vector<char> recv_bytes;
+
+        if (ParallelDescriptor::MyProc() == root) {
+            displs.resize(recvcounts.size(), 0);
+            int offset = 0;
+            for (int i = 0, n = static_cast<int>(recvcounts.size()); i < n; ++i) {
+                displs[i] = offset;
+                offset += recvcounts[i];
+            }
+            recv_bytes.resize(offset);
+        }
+
+        auto const* send_ptr = reinterpret_cast<char const*>(local_packed.data());
+        ParallelDescriptor::Gatherv(send_ptr, local_nbytes,
+                                    recv_bytes.data(), recvcounts, displs, root);
+
+        std::vector<PackedContributionData> global_packed;
+        if (ParallelDescriptor::MyProc() == root) {
+            AMREX_ALWAYS_ASSERT(recv_bytes.size() % sizeof(PackedContributionData) == 0);
+            std::vector<PackedContributionData> gathered(
+                recv_bytes.size() / sizeof(PackedContributionData));
+            if (!recv_bytes.empty()) {
+                std::memcpy(gathered.data(), recv_bytes.data(), recv_bytes.size());
+            }
+
+            auto const global_contributions = unpack(gathered);
+            global_packed.reserve(global_contributions.size());
+            for (auto const& [key, contribution] : global_contributions) {
+                global_packed.push_back(PackedContributionData{
+                    key.first, key.second,
+                    contribution.marker_real, contribution.payload_real, contribution.runtime_real,
+                    contribution.marker_int, contribution.runtime_int
+                });
+            }
+        }
+
+        int total_nbytes =
+            static_cast<int>(global_packed.size() * sizeof(PackedContributionData));
+        ParallelDescriptor::Bcast(&total_nbytes, 1, root);
+
+        std::vector<char> packed_bytes(total_nbytes);
+        if (ParallelDescriptor::MyProc() == root && total_nbytes > 0) {
+            std::memcpy(packed_bytes.data(), global_packed.data(), total_nbytes);
+        }
+
+        if (total_nbytes > 0) {
+            ParallelDescriptor::Bcast(packed_bytes.data(), total_nbytes, root);
+        }
+
+        AMREX_ALWAYS_ASSERT(total_nbytes % sizeof(PackedContributionData) == 0);
+        std::vector<PackedContributionData> unpacked(
+            total_nbytes / static_cast<int>(sizeof(PackedContributionData)));
+        if (total_nbytes > 0) {
+            std::memcpy(unpacked.data(), packed_bytes.data(), total_nbytes);
+        }
+        return unpack(unpacked);
     }
 
     std::map<ParticleKey, SourceParticleData> gatherSourceParticles () const
@@ -691,6 +908,13 @@ int main (int argc, char* argv[])
     pc.checkNeighbors();
     pc.buildNeighborList(CheckPair());
     pc.checkNeighborList();
+
+#ifndef AMREX_USE_GPU
+    // sumNeighbors() is currently only implemented on the CPU path.
+    pc.setEnableInverse(true);
+    pc.fillNeighbors();
+    pc.checkInverseSumNeighbors();
+#endif
 
     amrex::Finalize();
 }

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -203,19 +203,20 @@ public:
                     AMREX_D_TERM(host_real[0].push_back(static_cast<ParticleReal>(plo[0] + (iv[0] + r[0])*dx[0]));,
                                  host_real[1].push_back(static_cast<ParticleReal>(plo[1] + (iv[1] + r[1])*dx[1]));,
                                  host_real[2].push_back(static_cast<ParticleReal>(plo[2] + (iv[2] + r[2])*dx[2]));)
-                    host_real[MarkerRealComp].push_back(static_cast<ParticleReal>(marker));
-                    host_real[PayloadRealComp].push_back(static_cast<ParticleReal>(marker) + 0.5_rt);
+                    auto const marker_real = static_cast<ParticleReal>(marker);
+                    host_real[MarkerRealComp].push_back(marker_real);
+                    host_real[PayloadRealComp].push_back(marker_real + ParticleReal(0.5_rt));
 
                     host_int[GridIntComp].push_back(mfi.index());
                     host_int[MarkerIntComp].push_back(marker);
 
-                    host_runtime_real.push_back(static_cast<ParticleReal>(marker) + 1.25_rt);
+                    host_runtime_real.push_back(marker_real + ParticleReal(1.25_rt));
                     host_runtime_int.push_back(marker + 17);
                 }
             }
 
             auto& particle_tile = DefineAndReturnParticleTile(lev, mfi);
-            Long old_size = particle_tile.size();
+            Long old_size = static_cast<Long>(particle_tile.size());
             Long new_size = old_size + static_cast<Long>(host_idcpu.size());
             particle_tile.resize(new_size);
 

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -237,10 +237,10 @@ public:
             Gpu::copyAsync(Gpu::hostToDevice,
                            host_runtime_int.begin(), host_runtime_int.end(),
                            soa.GetIntData(NumInt).begin() + old_size);
-        }
 
-        Gpu::streamSynchronize();
-        RedistributeLocal();
+            Gpu::streamSynchronize();
+        }
+        captureOwnedParticles();
     }
 
     void moveParticles (ParticleReal shift)
@@ -258,6 +258,17 @@ public:
                     ptd.pos(dir, i) += shift;
                 }
             });
+        }
+
+        for (auto& [key, src] : m_local_source_particles) {
+            amrex::ignore_unused(key);
+            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                src.pos[dir] += shift;
+                src.cell[dir] = static_cast<int>(
+                    amrex::Math::floor((src.pos[dir] - Geom(lev).ProbLoArray()[dir])
+                                       * Geom(lev).InvCellSizeArray()[dir]))
+                    + Geom(lev).Domain().smallEnd(dir);
+            }
         }
     }
 
@@ -278,6 +289,15 @@ public:
                 ptd.m_runtime_rdata[0][i] += static_cast<ParticleReal>(delta);
                 ptd.m_runtime_idata[0][i] += delta;
             });
+        }
+
+        for (auto& [key, src] : m_local_source_particles) {
+            amrex::ignore_unused(key);
+            src.marker_int += delta;
+            src.runtime_int += delta;
+            src.marker_real += static_cast<ParticleReal>(delta);
+            src.payload_real += static_cast<ParticleReal>(delta);
+            src.runtime_real += static_cast<ParticleReal>(delta);
         }
     }
 
@@ -447,6 +467,48 @@ public:
     }
 
 private:
+    void captureOwnedParticles ()
+    {
+        const int lev = 0;
+        auto const plo = Geom(lev).ProbLoArray();
+        auto const dxi = Geom(lev).InvCellSizeArray();
+        auto const domain = Geom(lev).Domain();
+        auto const& plev = GetParticles(lev);
+
+        m_local_source_particles.clear();
+
+        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
+        {
+            auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
+            auto const& ptile = plev.at(index);
+            int const np = ptile.numParticles();
+            if (np == 0) { continue; }
+
+            HostTileData host;
+            copyTileToHost(ptile, np, host);
+
+            for (int i = 0; i < np; ++i) {
+                SourceParticleData src;
+                src.key = {ParticleIDWrapper(host.idcpu[i]), ParticleCPUWrapper(host.idcpu[i])};
+                src.grid_id = host.idata[GridIntComp][i];
+                src.marker_int = host.idata[MarkerIntComp][i];
+                src.runtime_int = host.runtime_int[0][i];
+                src.marker_real = host.real[MarkerRealComp][i];
+                src.payload_real = host.real[PayloadRealComp][i];
+                src.runtime_real = host.runtime_real[0][i];
+                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                    src.pos[dir] = host.real[dir][i];
+                    src.cell[dir] = static_cast<int>(
+                        amrex::Math::floor((src.pos[dir] - plo[dir])*dxi[dir])) + domain.smallEnd(dir);
+                }
+
+                auto [it, inserted] = m_local_source_particles.emplace(src.key, src);
+                amrex::ignore_unused(it);
+                AMREX_ALWAYS_ASSERT(inserted);
+            }
+        }
+    }
+
     void copyTileToHost (ParticleTile const& ptile, int np, HostTileData& host) const
     {
         auto const& soa = ptile.GetStructOfArrays();
@@ -489,40 +551,24 @@ private:
 
     std::map<ParticleKey, SourceParticleData> gatherSourceParticles () const
     {
-        const int lev = 0;
-        auto const plo = Geom(lev).ProbLoArray();
-        auto const dxi = Geom(lev).InvCellSizeArray();
-        auto const domain = Geom(lev).Domain();
-        auto const& plev = GetParticles(lev);
         std::vector<PackedSourceParticleData> local_source_particles;
 
-        for (MFIter mfi = MakeMFIter(lev); mfi.isValid(); ++mfi)
-        {
-            auto const index = std::make_pair(mfi.index(), mfi.LocalTileIndex());
-            auto const& ptile = plev.at(index);
-            int const np = ptile.numParticles();
-            if (np == 0) { continue; }
-
-            HostTileData host;
-            copyTileToHost(ptile, np, host);
-
-            for (int i = 0; i < np; ++i) {
-                PackedSourceParticleData pdata;
-                pdata.id = ParticleIDWrapper(host.idcpu[i]);
-                pdata.cpu = ParticleCPUWrapper(host.idcpu[i]);
-                pdata.grid_id = host.idata[GridIntComp][i];
-                pdata.marker_int = host.idata[MarkerIntComp][i];
-                pdata.runtime_int = host.runtime_int[0][i];
-                pdata.marker_real = host.real[MarkerRealComp][i];
-                pdata.payload_real = host.real[PayloadRealComp][i];
-                pdata.runtime_real = host.runtime_real[0][i];
-                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                    pdata.pos[dir] = host.real[dir][i];
-                    pdata.cell[dir] = static_cast<int>(
-                        amrex::Math::floor((pdata.pos[dir] - plo[dir])*dxi[dir])) + domain.smallEnd(dir);
-                }
-                local_source_particles.push_back(pdata);
+        local_source_particles.reserve(m_local_source_particles.size());
+        for (auto const& [key, src] : m_local_source_particles) {
+            PackedSourceParticleData pdata;
+            pdata.id = key.first;
+            pdata.cpu = key.second;
+            pdata.grid_id = src.grid_id;
+            pdata.marker_int = src.marker_int;
+            pdata.runtime_int = src.runtime_int;
+            pdata.marker_real = src.marker_real;
+            pdata.payload_real = src.payload_real;
+            pdata.runtime_real = src.runtime_real;
+            for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                pdata.pos[dir] = src.pos[dir];
+                pdata.cell[dir] = src.cell[dir];
             }
+            local_source_particles.push_back(pdata);
         }
 
         auto unpack = [] (std::vector<PackedSourceParticleData> const& packed) {
@@ -590,6 +636,8 @@ private:
         }
         return unpack(global_source_particles);
     }
+
+    std::map<ParticleKey, SourceParticleData> m_local_source_particles;
 };
 
 int main (int argc, char* argv[])

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -167,6 +167,9 @@ public:
 
     void InitParticles (const IntVect& nppc, const IntVect& domain_size)
     {
+#if AMREX_SPACEDIM == 1
+        amrex::ignore_unused(domain_size);
+#endif
         const int lev = 0;
         const Real* dx = Geom(lev).CellSize();
         const Real* plo = Geom(lev).ProbLo();


### PR DESCRIPTION
Adds a pure SoA version of NeighborParticleContainer, allowing that layout to be used in MFiX-Exa, FHDeX, etc. This is also needed in order to drop Python support for the FHDeX particle container type. Also adds a new test for pure SoA neighbor particles and expands coverage of the existing NeighborParticles test to cover the sumNeighbors function.

After this is merged, the next step is to update FHDeX to use pure SoA + polymorphic memory allocation.

This will also allow MFiX-Exa to use the pure SoA layout - currently it does a transposition of the particle positions.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
