### PR TITLE
CSR: Fix const CSR view return type

### DIFF
--- a/Src/LinearSolvers/AMReX_CSR.H
+++ b/Src/LinearSolvers/AMReX_CSR.H
@@ -81,8 +81,11 @@ struct CSR {
 
     //! Const view of the underlying buffers.
     [[nodiscard]] CsrView<T const> view () const {
-        return CsrView<T>{mat.data(), col_index.data(), row_offset.data(),
-                          nnz, Long(row_offset.size())-1};
+        return CsrView<T const>{.mat = mat.data(),
+                                .col_index = col_index.data(),
+                                .row_offset = row_offset.data(),
+                                .nnz = nnz,
+                                .nrows = Long(row_offset.size())-1};
     }
 
     //! Convenience alias for view() const.


### PR DESCRIPTION
Fix the const CSR::view() overload to construct the declared CsrView<T const> return type. Use designated initializers at that return site to make the field mapping explicit.
