### PR TITLE
Fix eb_add_divergence_from_flow for anisotropic cells

### DIFF
--- a/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
@@ -607,7 +607,12 @@ void eb_add_divergence_from_flow (int i, int j, int k, int n, Array4<Real> const
         Real Ueb_dot_n = vel_eb(i,j,k,0)*bnorm(i,j,k,0)
                        + vel_eb(i,j,k,1)*bnorm(i,j,k,1);
 
-        divu(i,j,k,n) += Ueb_dot_n * barea(i,j,k) * dxinv[0] / vfrc(i,j,k);
+        Real nx_dxinv = bnorm(i,j,k,0) * dxinv[0];
+        Real ny_dyinv = bnorm(i,j,k,1) * dxinv[1];
+
+        Real dl_eb_inv = std::hypot(nx_dxinv, ny_dyinv);
+
+        divu(i,j,k,n) += Ueb_dot_n * barea(i,j,k) * dl_eb_inv / vfrc(i,j,k);
     }
 }
 

--- a/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_3D_C.H
@@ -1368,7 +1368,13 @@ void eb_add_divergence_from_flow (int i, int j, int k, int n, Array4<Real> const
                        + vel_eb(i,j,k,1)*bnorm(i,j,k,1)
                        + vel_eb(i,j,k,2)*bnorm(i,j,k,2);
 
-        divu(i,j,k,n) += Ueb_dot_n * barea(i,j,k) * dxinv[0] / vfrc(i,j,k);
+        Real nx_dxinv = bnorm(i,j,k,0) * dxinv[0];
+        Real ny_dyinv = bnorm(i,j,k,1) * dxinv[1];
+        Real nz_dzinv = bnorm(i,j,k,2) * dxinv[2];
+
+        Real dl_eb_inv = std::sqrt(nx_dxinv*nx_dxinv + ny_dyinv*ny_dyinv + nz_dzinv*nz_dzinv);
+
+        divu(i,j,k,n) += Ueb_dot_n * barea(i,j,k) * dl_eb_inv / vfrc(i,j,k);
     }
 }
 


### PR DESCRIPTION
## Summary
Change eb_add_divergence_from_flow to account for the scaling of the EB boundary area in the anisotropic case dx =/= dy


## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
