### PR TITLE
Add in-class AMREX enum registration macro AMREX_ENUM_IN_CLASS

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -201,6 +201,54 @@ prints on the I/O process.  A common mistake in using it for debug
 printing is that one forgets that for non-I/O processes to print we should
 use :cpp:`AllPrint()` or :cpp:`Print(rank)`.
 
+.. _sec:basics:enum:
+
+Enum Class
+==========
+
+.. versionadded:: 24.09
+   Enum class support.
+
+AMReX provides :cpp:`AMREX_ENUM` in ``AMReX_Enum.H`` for defining a
+reflected :cpp:`enum class`. Use :cpp:`AMREX_ENUM` at namespace scope.
+
+.. highlight:: c++
+
+::
+
+   AMREX_ENUM(MyColor, red, green, blue);
+
+   void f ()
+   {
+       MyColor color = amrex::getEnum<MyColor>("red"); // MyColor::red
+       std::string name = amrex::getEnumNameString(MyColor::blue); // "blue"
+       std::vector<std::string> names = amrex::getEnumNameStrings<MyColor>();
+       // names = {"red", "green", "blue"};
+       std::string class_name = amrex::getEnumClassName<MyColor>(); // "MyColor"
+   }
+
+Use :cpp:`AMREX_ENUM_IN_CLASS` for an enum class declared inside a class or
+class template.
+
+.. versionadded:: 26.05
+   :cpp:`AMREX_ENUM_IN_CLASS`.
+
+.. highlight:: c++
+
+::
+
+   struct Options {
+       AMREX_ENUM_IN_CLASS(Solver, cg, bicgstab, gmres);
+   };
+
+   template <typename T>
+   struct State {
+       AMREX_ENUM_IN_CLASS(Mode, init, run, stop);
+   };
+
+:cpp:`AMREX_ENUM_IN_CLASS` must be used inside a class definition. Use
+:cpp:`AMREX_ENUM` at namespace scope.
+
 .. _sec:basics:parmparse:
 
 ParmParse
@@ -450,25 +498,8 @@ Enum Class
 .. versionadded:: 24.09
    Enum class support in :cpp:`ParmParse`.
 
-AMReX provides a macro :cpp:`AMREX_ENUM` for defining :cpp:`enum class` that
-supports reflection. For example,
-
-.. highlight:: c++
-
-::
-
-   AMREX_ENUM(MyColor, red, green, blue);
-
-   void f ()
-   {
-       MyColor color = amrex::getEnum<MyColor>("red"); // MyColor::red
-       std::string name = amrex::getEnumNameString(MyColor::blue); // "blue"
-       std::vector<std::string> names = amrex::getEnumNameStrings<MyColor>();
-       // names = {"red", "green", "blue"};
-       std::string class_name = amrex::getEnumClassName<MyColor>(); // "MyColor"
-   }
-
-This allows us to read :cpp:`ParmParse` parameters into enum class objects.
+:cpp:`ParmParse` can read enum types declared with :cpp:`AMREX_ENUM` or
+:cpp:`AMREX_ENUM_IN_CLASS` (see :ref:`sec:basics:enum`).
 
 .. highlight:: python
 
@@ -477,22 +508,18 @@ This allows us to read :cpp:`ParmParse` parameters into enum class objects.
    color1 = red
    color2 = BLue
 
-The following code shows how to query the enumerators.
-
 .. highlight:: c++
 
 ::
 
    AMREX_ENUM(MyColor, none, red, green, blue);
 
-   void f (MyColor& c1, MyColor& c2)
-   {
-       ParmParse pp;
-       pp.query("color1", c1); // c1 becomes MyColor::red
-       pp.query_enum_case_insensitive("color2", c2); // c2 becomes MyColor::blue
-       MyColor default_color; // MyColor::none
-       pp.query("color3", default_color); // Still MyColor::none
-   }
+   ParmParse pp;
+   MyColor c1 = MyColor::none;
+   MyColor c2 = MyColor::none;
+
+   pp.query("color1", c1); // c1 becomes MyColor::red
+   pp.query_enum_case_insensitive("color2", c2); // c2 becomes MyColor::blue
 
 Other Useful Functions
 ----------------------

--- a/Src/Base/AMReX_Enum.H
+++ b/Src/Base/AMReX_Enum.H
@@ -228,6 +228,7 @@ namespace detail
         static constexpr std::string_view enum_names{#__VA_ARGS__}; \
     }; \
     /** \endcond */ \
-    friend CLASS##_EnumTraits amrex_get_enum_traits(CLASS) { return {}; }
+    friend CLASS##_EnumTraits amrex_get_enum_traits(CLASS) { return {}; } \
+    /* This gets rid of trailing semicolon warning. */ static_assert(true, "")
 
 #endif

--- a/Src/Base/AMReX_Enum.H
+++ b/Src/Base/AMReX_Enum.H
@@ -218,4 +218,16 @@ namespace detail
     /** \endcond */ \
     CLASS##_EnumTraits amrex_get_enum_traits(CLASS)
 
+#define AMREX_ENUM_IN_CLASS(CLASS, ...) \
+    enum class CLASS : int { __VA_ARGS__ }; \
+    /** \cond DOXYGEN_IGNORE */ \
+    struct CLASS##_EnumTraits { \
+        using enum_class_t = CLASS; \
+        static constexpr bool value = true; \
+        static constexpr std::string_view class_name{#CLASS}; \
+        static constexpr std::string_view enum_names{#__VA_ARGS__}; \
+    }; \
+    /** \endcond */ \
+    friend CLASS##_EnumTraits amrex_get_enum_traits(CLASS) { return {}; }
+
 #endif

--- a/Tests/Enum/inputs
+++ b/Tests/Enum/inputs
@@ -9,3 +9,5 @@ color6 = G-r-e-e.n
 colors = cyan yellow orange
 
 colors_quoted = "cyan" "yellow" "orange"
+
+my_hero = Jason

--- a/Tests/Enum/main.cpp
+++ b/Tests/Enum/main.cpp
@@ -35,7 +35,7 @@ struct GreekMyth {
         pp.query("my_hero", m_my_hero);
     }
 
-    bool is_my_hero (std::string_view name) const {
+    [[nodiscard]] bool is_my_hero (std::string_view name) const {
         return m_my_hero == get_hero(name);
     }
 

--- a/Tests/Enum/main.cpp
+++ b/Tests/Enum/main.cpp
@@ -19,6 +19,34 @@ AMREX_ENUM(MyColor2,
 
 AMREX_ENUM(Location, entry = 1, exit = -1, after_exit);
 
+struct GreekMyth {
+    AMREX_ENUM_IN_CLASS(Hero, Achilles, Heracles, Jason);
+
+    static std::string get_name (Hero hero) {
+        return amrex::getEnumNameString(hero);
+    }
+
+    static Hero get_hero (std::string_view name) {
+        return amrex::getEnum<Hero>(name);
+    }
+
+    GreekMyth () {
+        ParmParse pp;
+        pp.query("my_hero", m_my_hero);
+    }
+
+    bool is_my_hero (std::string_view name) const {
+        return m_my_hero == get_hero(name);
+    }
+
+    Hero m_my_hero = Hero::Achilles;
+};
+
+template <typename T>
+struct GreekAlphabet {
+    AMREX_ENUM_IN_CLASS(Letter, alpha, beta, gamma);
+};
+
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc, argv);
@@ -177,6 +205,25 @@ int main (int argc, char* argv[])
         AMREX_ALWAYS_ASSERT(amrex::getEnumNameString(Location::entry) == "entry");
         AMREX_ALWAYS_ASSERT(amrex::getEnumNameString(Location::exit) == "exit");
         AMREX_ALWAYS_ASSERT(amrex::getEnumNameString(Location::after_exit) == "after_exit");
+    }
+
+    {
+        AMREX_ALWAYS_ASSERT
+            (GreekMyth::get_name(GreekMyth::Hero::Achilles) == "Achilles" &&
+             amrex::getEnumNameString(GreekMyth::Hero::Heracles) == "Heracles");
+        AMREX_ALWAYS_ASSERT
+            (GreekMyth::get_hero("Jason") == GreekMyth::Hero::Jason &&
+             amrex::getEnum<GreekMyth::Hero>("Jason") == GreekMyth::Hero::Jason);
+
+        GreekMyth myth;
+        AMREX_ALWAYS_ASSERT(myth.is_my_hero("Jason"));
+    }
+
+    {
+        AMREX_ALWAYS_ASSERT
+            (amrex::getEnumNameString(GreekAlphabet<int>::Letter::beta) == "beta" &&
+             amrex::getEnum<GreekAlphabet<Real>::Letter>("gamma") ==
+             GreekAlphabet<Real>::Letter::gamma);
     }
 
     {


### PR DESCRIPTION
Add AMREX_ENUM_IN_CLASS for declaring reflected enum classes inside class definitions, including class templates. The macro uses a hidden friend hook so the existing enum reflection helpers can find the generated traits through ADL.
