### PR TITLE
Avoid stream string copies with view()

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -206,10 +206,9 @@ amrex::write_to_stderr_without_buffering (const char* str)
     {
         std::ostringstream procall;
         procall << ParallelDescriptor::MyProc() << "::";
-        auto tmp = procall.str();
-        const char *cprocall = tmp.c_str();
+        auto const tmp = procall.view();
         const char * const end = " !!!\n";
-        std::fwrite(cprocall, strlen(cprocall), 1, stderr);
+        std::fwrite(tmp.data(), tmp.size(), 1, stderr);
         std::fwrite(str, strlen(str), 1, stderr);
         std::fwrite(end, strlen(end), 1, stderr);
     }

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1144,7 +1144,7 @@ printCell (FabArray<FAB> const& mf, const IntVect& cell, int comp = -1,
                 }
                 ss << dp[n-1];
                 amrex::AllPrint() << " At cell " << cell << " in Box " << bx
-                                  << ": " << ss.str() << '\n';
+                                  << ": " << ss.view() << '\n';
             }
         }
     }

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -86,7 +86,7 @@ std::string pp_to_pretty_string (std::string const& name,
     }
     if (entry && entry->m_parsed && ! entry->m_last_vals.empty()) {
         int min_col = 36;
-        int pad = min_col - static_cast<int>(ss.str().size());
+        int pad = min_col - static_cast<int>(ss.view().size());
         if (pad > 0) {
             ss << std::string(pad, ' ');
         }

--- a/Src/Base/AMReX_Utility.cpp
+++ b/Src/Base/AMReX_Utility.cpp
@@ -158,9 +158,9 @@ amrex::UniqueString()
                                    /double(MaxResSteadyClock::period::num)))));
     std::stringstream tempstring;
     tempstring << std::setprecision(n) << std::fixed << amrex::second();
-    auto const ts = tempstring.str();
+    auto const ts = tempstring.view();
     auto const tsl = ts.length();
-    return ts.substr(tsl-len,tsl); // tsl-len >= 0 because n >= len
+    return std::string(ts.substr(tsl-len,len)); // tsl-len >= 0 because n >= len
 }
 
 void

--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -431,7 +431,7 @@ Write (const FabArray<FAB>& fa, const std::string& name)
                 std::stringstream hss;
                 fio.write_header(hss, fab, fab.nComp());
                 auto const tstr = hss.view();
-                nfi.Stream().write(tstr.data(), tstr.size());
+                nfi.Stream().write(tstr.data(), static_cast<std::streamsize>(tstr.size()));
                 nfi.Stream().flush();
             }
             auto const* fabdata = fab.dataPtr();

--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -430,9 +430,8 @@ Write (const FabArray<FAB>& fa, const std::string& name)
             {
                 std::stringstream hss;
                 fio.write_header(hss, fab, fab.nComp());
-                auto hLength = static_cast<std::streamoff>(hss.tellp());
-                auto tstr = hss.str();
-                nfi.Stream().write(tstr.c_str(), hLength);
+                auto const tstr = hss.view();
+                nfi.Stream().write(tstr.data(), tstr.size());
                 nfi.Stream().flush();
             }
             auto const* fabdata = fab.dataPtr();

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -1087,8 +1087,8 @@ VisMF::Write (const FabArray<FArrayBox>&    mf,
                     std::stringstream hss;
                     fio.write_header(hss, fab, fab.nComp());
                     hLength = static_cast<std::streamoff>(hss.tellp());
-                    auto tstr = hss.str();
-                    std::memcpy(afPtr, tstr.c_str(), hLength);  // ---- the fab header
+                    auto const tstr = hss.view();
+                    std::memcpy(afPtr, tstr.data(), hLength);  // ---- the fab header
                 }
                 Real const* fabdata = fab.dataPtr();
 #ifdef AMREX_USE_GPU
@@ -1118,16 +1118,14 @@ VisMF::Write (const FabArray<FArrayBox>&    mf,
 
         } else {    // ---- write fabs individually
             for(MFIter mfi(mf); mfi.isValid(); ++mfi) {
-                std::streamoff hLength = 0;
                 const FArrayBox &fab = mf[mfi];
                 writeDataItems = fab.box().numPts() * mf.nComp();
                 writeDataSize = writeDataItems * whichRDBytes;
                 if(oldHeader) {
                     std::stringstream hss;
                     fio.write_header(hss, fab, fab.nComp());
-                    hLength = static_cast<std::streamoff>(hss.tellp());
-                    auto tstr = hss.str();
-                    nfi.Stream().write(tstr.c_str(), hLength);    // ---- the fab header
+                    auto const tstr = hss.view();
+                    nfi.Stream().write(tstr.data(), tstr.size());    // ---- the fab header
                 }
                 Real const* fabdata = fab.dataPtr();
 #ifdef AMREX_USE_GPU

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -1125,7 +1125,7 @@ VisMF::Write (const FabArray<FArrayBox>&    mf,
                     std::stringstream hss;
                     fio.write_header(hss, fab, fab.nComp());
                     auto const tstr = hss.view();
-                    nfi.Stream().write(tstr.data(), tstr.size());    // ---- the fab header
+                    nfi.Stream().write(tstr.data(), static_cast<std::streamsize>(tstr.size()));    // ---- the fab header
                 }
                 Real const* fabdata = fab.dataPtr();
 #ifdef AMREX_USE_GPU


### PR DESCRIPTION
Use std::stringstream::view() in places where the stream buffer is consumed immediately and does not need ownership or null termination. This avoids temporary std::string copies.
