### PR TITLE
FileSystem: Use std::filesystem

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -417,8 +417,11 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
     if (argc > 0)
     {
         if (argv[0][0] != '/') {
-            system::exename = FileSystem::CurrentPath();
-            system::exename += "/";
+            auto const cwd = FileSystem::CurrentPath();
+            if (!cwd.empty()) {
+                system::exename = cwd;
+                system::exename += "/";
+            }
         }
         system::exename += argv[0];
 

--- a/Src/Base/AMReX_FileSystem.H
+++ b/Src/Base/AMReX_FileSystem.H
@@ -12,20 +12,60 @@ using mode_t = unsigned short;
 
 namespace amrex::FileSystem {
 
+/**
+ * \brief Create a directory and any missing parent directories.
+ *
+ * @param path directory path to create
+ * @param mode requested permissions for newly-created directories on POSIX
+ *        platforms; ignored on Windows
+ * @param verbose print a diagnostic message when directory creation fails
+ * @return true if the directory already existed or was created without error,
+ *         false if directory creation failed. This differs from the return
+ *         value of `std::filesystem::create_directories`, which is true only
+ *         when a directory was actually created and false both when the
+ *         directory already existed and when creation failed with an error.
+ */
 bool
 CreateDirectories (std::string const& path, mode_t mode, bool verbose = false);
 
+/**
+ * \brief Return the current working directory.
+ *
+ * @return current working directory path, or an empty string if it cannot be
+ *         determined
+ */
 std::string
 CurrentPath ();
 
+/**
+ * \brief Check if the given path exists.
+ * Symbolic links are checked without following the link, so a dangling
+ * symbolic link is considered to exist.
+ *
+ * @param filename path to check
+ * @return true if the path exists, false otherwise
+ */
 bool
 Exists (std::string const& filename);
 
+/**
+ * \brief Remove a file, symbolic link, or empty directory.
+ *
+ * @param filename path to remove
+ * @return true if a path was removed, false otherwise
+ */
 bool
 Remove (std::string const& filename);
 
+/**
+ * \brief Recursively remove a path.
+ *
+ * @param p path to remove
+ * @return true if removal completed without error, including when the path did
+ *         not exist; false otherwise
+ */
 bool
-RemoveAll (std::string const& p); // recursive remove
+RemoveAll (std::string const& p);
 
 }
 

--- a/Src/Base/AMReX_FileSystem.cpp
+++ b/Src/Base/AMReX_FileSystem.cpp
@@ -3,32 +3,28 @@
 #include <AMReX_Vector.H>
 #include <AMReX.H>
 
-#if defined(_WIN32) // || __cplusplus >= 201703L
-
 #include <filesystem>
 #include <system_error>
 
-namespace amrex {
-namespace FileSystem {
+#if !defined(_WIN32)
+#include <cstdio>
+#include <cstddef>
+#include <cstring>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#endif
 
-bool
-CreateDirectories (std::string const& p, mode_t /*mode*/, bool verbose)
-{
-    std::error_code ec;
-    std::filesystem::create_directories(std::filesystem::path{p}, ec);
-    if (ec && verbose) {
-        amrex::AllPrint() << "amrex::UtilCreateDirectory failed to create "
-                          << p << ": " << ec.message() << '\n';
-    }
-    return !ec;
-}
+namespace amrex::FileSystem {
 
 bool
 Exists (std::string const& filename)
 {
     std::error_code ec;
-    bool r = std::filesystem::exists(std::filesystem::path{filename}, ec);
-    if (ec && amrex::Verbose() > 0) {
+    auto const status = std::filesystem::symlink_status(std::filesystem::path{filename}, ec);
+    bool const r = std::filesystem::exists(status);
+    if (ec && (status.type() != std::filesystem::file_type::not_found) && amrex::Verbose() > 0) {
         amrex::AllPrint() << "amrex::FileSystem::Exists failed. " << ec.message() << '\n';
     }
     return r;
@@ -50,7 +46,10 @@ Remove (std::string const& filename)
 {
     std::error_code ec;
     bool r = std::filesystem::remove(std::filesystem::path{filename},ec);
-    return !ec;
+    if (ec && amrex::Verbose() > 0) {
+        amrex::AllPrint() << "amrex::FileSystem::Remove failed. " << ec.message() << '\n';
+    }
+    return r;
 }
 
 bool
@@ -58,22 +57,30 @@ RemoveAll (std::string const& p)
 {
     std::error_code ec;
     std::filesystem::remove_all(std::filesystem::path{p},ec);
+    if (ec) {
+        amrex::Error("amrex::FileSystem::RemoveAll failed to remove " + p
+                     + ": " + ec.message());
+        return false;
+    } else {
+        return true;
+    }
+}
+
+#if defined(_WIN32) // || __cplusplus >= 201703L
+
+bool
+CreateDirectories (std::string const& p, mode_t /*mode*/, bool verbose)
+{
+    std::error_code ec;
+    std::filesystem::create_directories(std::filesystem::path{p}, ec);
+    if (ec && verbose) {
+        amrex::AllPrint() << "amrex::UtilCreateDirectory failed to create "
+                          << p << ": " << ec.message() << '\n';
+    }
     return !ec;
 }
 
-}}
-
 #else
-
-#include <cstdio>
-#include <cstddef>
-#include <cstring>
-#include <unistd.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-
-namespace amrex::FileSystem {
 
 bool
 CreateDirectories (std::string const& path, mode_t mode, bool verbose)
@@ -165,50 +172,6 @@ CreateDirectories (std::string const& path, mode_t mode, bool verbose)
     return retVal;
 }
 
-bool
-Exists (std::string const& filename)
-{
-    struct stat statbuff;
-    return (lstat(filename.c_str(), &statbuff) != -1);
-}
-
-std::string
-CurrentPath ()
-{
-    constexpr int bufSize = 1024;
-    char temp[bufSize];
-    char *rCheck = getcwd(temp, bufSize);
-    if(rCheck == nullptr) {
-        amrex::Abort("**** Error:  getcwd buffer too small.");
-        return std::string{};
-    } else {
-        return std::string(rCheck);
-    }
-}
-
-bool
-Remove (std::string const& filename)
-{
-    return (unlink(filename.c_str()) == 0);
-}
-
-bool
-RemoveAll (std::string const& p)
-{
-    if (p.size() >= 1990) {
-        amrex::Error("FileSystem::RemoveAll: Path name too long");
-        return false;
-    }
-    char command[2000];
-    std::snprintf(command, 2000, "\\rm -rf %s", p.c_str());;
-    int retVal = std::system(command);
-    if (retVal == -1 || WEXITSTATUS(retVal) != 0) {
-        amrex::Error("Removing old directory failed.");
-        return false;
-    }
-    return true;
-}
-
-}
-
 #endif
+
+}

--- a/Src/Base/AMReX_FileSystem.cpp
+++ b/Src/Base/AMReX_FileSystem.cpp
@@ -7,13 +7,9 @@
 #include <system_error>
 
 #if !defined(_WIN32)
-#include <cstdio>
-#include <cstddef>
+#include <cerrno>
 #include <cstring>
-#include <unistd.h>
 #include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 #endif
 
 namespace amrex::FileSystem {
@@ -164,7 +160,7 @@ CreateDirectories (std::string const& path, mode_t mode, bool verbose)
       for(auto & i : pathError) {
           amrex::AllPrint()<< "amrex::UtilCreateDirectory:: path errno:  "
                            << i.first << " :: "
-                           << strerror(i.second)
+                           << std::strerror(i.second)
                            << '\n';
       }
     }


### PR DESCRIPTION
Use std::filesystem for Exists, CurrentPath, Remove, and RemoveAll.  Keep the POSIX CreateDirectories implementation so mode_t continues to be honored for newly-created directories.

POSIX behavior changes:

- CreateDirectories: no intended behavior change. It still creates each missing path component with mkdir, honors the requested mode subject to umask, and treats EEXIST as success.
- Exists: no intended behavior change. It does not follow symlinks, so a dangling symlink is reported as existing.
- CurrentPath: now uses std::filesystem::current_path. Long paths are no longer limited by the old 1024-byte buffer, but failures now return an empty string instead of aborting.
- Remove: now uses std::filesystem::remove instead of unlink. It can remove empty directories in addition to files and symlinks, and returns true only when something was removed.
- RemoveAll: now uses std::filesystem::remove_all instead of invoking rm -rf through the shell. Missing paths are still treated as success, real removal errors still call amrex::Error, and paths are interpreted literally rather than by the shell.
