### PR TITLE
Fix SUNDIALS integrator cleanup

### DIFF
--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -749,13 +749,17 @@ public:
         }
 
         // Clean up allocated memory
+        if (use_mri) {
+            MRIStepInnerStepper_Free(&fast_stepper);
+            ARKStepFree(&arkode_fast_mem);
+            MRIStepFree(&arkode_mem);
+        } else if (use_ark) {
+            ARKStepFree(&arkode_mem);
+        }
         SUNLinSolFree(LS);
         SUNLinSolFree(fast_LS);
         SUNNonlinSolFree(NLS);
         SUNNonlinSolFree(fast_NLS);
-        MRIStepInnerStepper_Free(&fast_stepper);
-        MRIStepFree(&arkode_fast_mem);
-        ARKStepFree(&arkode_mem);
     }
 
     /**


### PR DESCRIPTION
Free ARKStep and MRIStep memory with their matching APIs in the SundialsIntegrator destructor.

The MRI setup creates the fast integrator with ARKStepCreate and the slow integrator with MRIStepCreate, so the destructor must call ARKStepFree on arkode_fast_mem and MRIStepFree on arkode_mem.
