### PR TITLE
Fix deterministic GPU copy masks for non-atomic types

### DIFF
--- a/Src/Base/AMReX_PCI.H
+++ b/Src/Base/AMReX_PCI.H
@@ -102,10 +102,11 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
     Vector<BaseFab<int> > maskfabs;
     Vector<Array4Tag<int> > masks_unique;
     Vector<Array4Tag<int> > masks;
-    if (!is_thread_safe && !deterministic)
+    if (!is_thread_safe)
     {
         if ((op == FabArrayBase::COPY && !amrex::IsStoreAtomic<value_type>::value) ||
-            (op == FabArrayBase::ADD  && !amrex::HasAtomicAdd <value_type>::value))
+            (op == FabArrayBase::ADD  && !amrex::HasAtomicAdd <value_type>::value &&
+             !deterministic))
         {
             maskfabs.resize(this->local_size());
             masks_unique.reserve(this->local_size());


### PR DESCRIPTION
PC_local_gpu skipped mask allocation whenever deterministic was true. That is only valid for ADD, where the deterministic path avoids atomic-add masking.

For COPY, non-thread-safe local copies still call fab_to_fab_atomic_cpy. If the value type is not store-atomic, that path requires masks to serialize overlapping destination writes. The bug is triggered by GPU local ParallelCopy/COPY when all of these hold:

- deterministic is true
- the local copy pattern is not thread-safe
- the value type is not IsStoreAtomic, e.g. GpuComplex<Real> or GpuArray<Real,N>

In that case the code could pass an empty mask vector to the masked copy path, leading to out-of-bounds mask access or incorrect overlapping copies. Allocate masks for non-thread-safe COPY independently of deterministic, while keeping deterministic mask suppression for ADD.
