### PR TITLE
SUNDIALS: Fix slow MRI tolerances for fixed-step implicit modes

### DIFF
--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -400,7 +400,7 @@ private:
         AMREX_ALWAYS_ASSERT(flag == 0);
 
         // Set integrator tolerances
-        if (BaseT::use_adaptive_time_step || fast_type == "IM-MRI" || fast_type == "IMEX-MRI") {
+        if (BaseT::use_adaptive_time_step || type == "IM-MRI" || type == "IMEX-MRI") {
             if (amrex::Verbose()) {
                 amrex::Print() << "Relative tolerance: " << BaseT::rel_tol << "\n";
                 amrex::Print() << "Absolute tolerance: " << BaseT::abs_tol << "\n";

--- a/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
+++ b/Src/Extern/SUNDIALS/AMReX_SundialsIntegrator.H
@@ -348,8 +348,8 @@ private:
                 amrex::Print() << "Fast relative tolerance: " << BaseT::fast_rel_tol << "\n";
                 amrex::Print() << "Fast absolute tolerance: " << BaseT::fast_abs_tol << "\n";
             }
-          flag = ARKStepSStolerances(arkode_fast_mem, BaseT::fast_rel_tol, BaseT::fast_abs_tol);
-          AMREX_ALWAYS_ASSERT(flag == 0);
+            flag = ARKStepSStolerances(arkode_fast_mem, BaseT::fast_rel_tol, BaseT::fast_abs_tol);
+            AMREX_ALWAYS_ASSERT(flag == 0);
         }
 
         // Set post stage and step function


### PR DESCRIPTION
Use the slow integrator type when deciding whether MRIStep needs tolerances. This looks like a copy-paste bug from earlier fast integrator setup.
