### PR TITLE
HDF5: Match SZ plotfile metadata to output precision

### DIFF
--- a/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
+++ b/Src/Extern/HDF5/AMReX_PlotFileUtilHDF5.cpp
@@ -726,7 +726,8 @@ void WriteMultiLevelPlotfileHDF5SingleDset (const std::string& plotfilename,
             size_t cd_nelmts;
             unsigned int* cd_values = NULL;
             unsigned filter_config;
-            SZ_metaDataToCdArray(&cd_nelmts, &cd_values, SZ_DOUBLE, 0, 0, 0, 0, hs_allprocsize[0]);
+            int const sz_type = (whichRDBytes == 4) ? SZ_FLOAT : SZ_DOUBLE;
+            SZ_metaDataToCdArray(&cd_nelmts, &cd_values, sz_type, 0, 0, 0, 0, hs_allprocsize[0]);
             H5Pset_filter(lev_dcpl_id, H5Z_FILTER_SZ, H5Z_FLAG_MANDATORY, cd_nelmts, cd_values);
         }
 #endif
@@ -1171,7 +1172,8 @@ void WriteMultiLevelPlotfileHDF5MultiDset (const std::string& plotfilename,
             size_t cd_nelmts;
             unsigned int* cd_values = NULL;
             unsigned filter_config;
-            SZ_metaDataToCdArray(&cd_nelmts, &cd_values, SZ_DOUBLE, 0, 0, 0, 0, hs_allprocsize[0]);
+            int const sz_type = (whichRDBytes == 4) ? SZ_FLOAT : SZ_DOUBLE;
+            SZ_metaDataToCdArray(&cd_nelmts, &cd_values, sz_type, 0, 0, 0, 0, hs_allprocsize[0]);
             H5Pset_filter(lev_dcpl_id, H5Z_FILTER_SZ, H5Z_FLAG_MANDATORY, cd_nelmts, cd_values);
         }
 #endif


### PR DESCRIPTION
Use the plotfile RealDescriptor byte size when selecting the SZ element type for HDF5 plotfile datasets.

The writers already create H5T_NATIVE_FLOAT for 4-byte output and H5T_NATIVE_DOUBLE otherwise. Keep the SZ filter metadata consistent with that dataset type instead of always using SZ_DOUBLE.
