### PR TITLE
CUDA: Prefer CUDART_VERSION for runtime API guards

### DIFF
--- a/Src/Base/AMReX_BCUtil.cpp
+++ b/Src/Base/AMReX_BCUtil.cpp
@@ -1,9 +1,6 @@
 #include <AMReX_BCUtil.H>
 #include <AMReX_PhysBCFunct.H>
 
-// CUDA 11.6 bug: https://github.com/AMReX-Codes/amrex/issues/2607
-#if !defined(__CUDACC__) || (__CUDACC_VER_MAJOR__ != 11) || (__CUDACC_VER_MINOR__ != 6)
-
 namespace amrex
 {
 
@@ -56,5 +53,3 @@ void FillDomainBoundary (MultiFab& phi, const Geometry& geom, const Vector<BCRec
 }
 
 }
-
-#endif

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1212,10 +1212,9 @@ BaseFab<T>::prefetchToHost () const noexcept
 #elif defined(AMREX_USE_CUDA) && !defined(_WIN32)
         if (Gpu::Device::devicePropMajor() >= 6) {
             std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 13000)
             cudaMemLocation location = {};
-            location.type = cudaMemLocationTypeDevice;
-            location.id = cudaCpuDeviceId;
+            location.type = cudaMemLocationTypeHost;
             AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(this->dptr, s, location, 0,
                                                       Gpu::gpuStream()));
 #else
@@ -1244,7 +1243,7 @@ BaseFab<T>::prefetchToDevice () const noexcept
 #elif defined(AMREX_USE_CUDA) && !defined(_WIN32)
         if (Gpu::Device::devicePropMajor() >= 6) {
             std::size_t s = sizeof(T)*this->nvar*this->domain.numPts();
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 13000)
             cudaMemLocation location = {};
             location.type = cudaMemLocationTypeDevice;
             location.id = Gpu::Device::deviceId();

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -231,7 +231,7 @@
 #if defined(__has_cpp_attribute) && __has_cpp_attribute(assume)
 #   define AMREX_ASSUME(ASSUMPTION) [[assume(ASSUMPTION)]]
 #else
-#   if defined(__CUDA_ARCH__) && defined(__CUDACC__) && ( (__CUDACC_VER_MAJOR__ > 11) || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)) )
+#   if defined(__CUDA_ARCH__) && defined(__CUDACC__)
 #       define AMREX_ASSUME(ASSUMPTION) __builtin_assume(ASSUMPTION)
 #   elif defined(AMREX_CXX_INTEL) || defined(__clang__)
 #       define AMREX_ASSUME(ASSUMPTION) __builtin_assume(ASSUMPTION)

--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -332,10 +332,9 @@ namespace amrex::Gpu {
         // Currently only implemented for CUDA.
 #if defined(AMREX_USE_CUDA) && !defined(_WIN32)
         if (Gpu::Device::devicePropMajor() >= 6) {
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 13000)
             cudaMemLocation location = {};
-            location.type = cudaMemLocationTypeDevice;
-            location.id = cudaCpuDeviceId;
+            location.type = cudaMemLocationTypeHost;
             AMREX_CUDA_SAFE_CALL(cudaMemPrefetchAsync(&(*begin),
                                                       size*sizeof(value_type),
                                                       location, 0,
@@ -378,7 +377,7 @@ namespace amrex::Gpu {
         // Currently only implemented for CUDA.
 #if defined(AMREX_USE_CUDA) && !defined(_WIN32)
         if (Gpu::Device::devicePropMajor() >= 6) {
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 13000)
             cudaMemLocation location = {};
             location.type = cudaMemLocationTypeDevice;
             location.id = Gpu::Device::deviceId();

--- a/Src/Base/AMReX_GpuControl.H
+++ b/Src/Base/AMReX_GpuControl.H
@@ -7,11 +7,7 @@
 
 #include <utility>
 
-#if defined(AMREX_USE_CUDA) && (__CUDACC_VER_MAJOR__ > 11 || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ >= 2)))
-#define AMREX_CUDA_GE_11_2 1
-#endif
-
-#if defined(AMREX_USE_HIP) || defined(AMREX_CUDA_GE_11_2)
+#if defined(AMREX_USE_HIP) || defined(AMREX_USE_CUDA)
 #define AMREX_GPU_STREAM_ALLOC_SUPPORT 1
 #endif
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -529,7 +529,7 @@ Device::initialize_gpu (bool minimal)
     cudaDeviceGetAttribute(&memory_pools_supported, cudaDevAttrMemoryPoolsSupported, device_id);
 #endif
 
-#if (__CUDACC_VER_MAJOR__ < 12) || ((__CUDACC_VER_MAJOR__ == 12) && (__CUDACC_VER_MINOR__ < 4))
+#if defined(CUDART_VERSION) && (CUDART_VERSION < 12040)
     if ( ! minimal ) {
         if (sizeof(Real) == 8) {
             AMREX_CUDA_SAFE_CALL(cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte));
@@ -1011,11 +1011,7 @@ Device::startGraphRecording(bool first_iter, void* h_ptr, void* d_ptr, size_t sz
         cudaEvent_t memcpy_event = {0};
         AMREX_CUDA_SAFE_CALL( cudaEventCreate(&memcpy_event, cudaEventDisableTiming) );
 
-#if (__CUDACC_VER_MAJOR__ == 10) && (__CUDACC_VER_MINOR__ == 0)
-        AMREX_CUDA_SAFE_CALL(cudaStreamBeginCapture(graph_stream));
-#else
         AMREX_CUDA_SAFE_CALL(cudaStreamBeginCapture(graph_stream, cudaStreamCaptureModeGlobal));
-#endif
 
         AMREX_CUDA_SAFE_CALL(cudaMemcpyAsync(d_ptr, h_ptr, sz, cudaMemcpyHostToDevice, graph_stream));
         AMREX_CUDA_SAFE_CALL(cudaEventRecord(memcpy_event, graph_stream));
@@ -1120,7 +1116,7 @@ Device::mem_advise_set_preferred (void* p, std::size_t sz, int device)
     if (device_prop.managedMemory == 1 && device_prop.concurrentManagedAccess == 1)
     {
 #if defined(AMREX_USE_CUDA)
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 13000)
         cudaMemLocation location = {};
         location.type = cudaMemLocationTypeDevice;
         location.id = device;
@@ -1152,10 +1148,9 @@ Device::mem_advise_set_readonly (void* p, std::size_t sz)
     if (device_prop.managedMemory == 1 && device_prop.concurrentManagedAccess == 1)
     {
 #if defined(AMREX_USE_CUDA)
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 13)
+#if defined(CUDART_VERSION) && (CUDART_VERSION >= 13000)
         cudaMemLocation location = {};
-        location.type = cudaMemLocationTypeDevice;
-        location.id = cudaCpuDeviceId;
+        location.type = cudaMemLocationTypeHost;
 #else
         auto location = cudaCpuDeviceId;
 #endif

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -10,11 +10,7 @@
 #include <AMReX_Functional.H>
 #include <AMReX_TypeTraits.H>
 
-#if !defined(AMREX_USE_CUB) && defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
-#define AMREX_USE_CUB 1
-#endif
-
-#if defined(AMREX_USE_CUB)
+#if defined(AMREX_USE_CUDA)
 #include <cub/cub.cuh>
 #if defined(CCCL_MAJOR_VERSION) && defined(CCCL_MINOR_VERSION) && ((CCCL_MAJOR_VERSION >= 3) || ((CCCL_MAJOR_VERSION >= 2) && (CCCL_MINOR_VERSION >= 8)))
 #define AMREX_CUDA_CCCL_VER_GE_2_8 1
@@ -366,7 +362,7 @@ template <int BLOCKDIMX, typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 T blockReduceSum (T source) noexcept
 {
-#if defined(AMREX_USE_CUB)
+#if defined(AMREX_USE_CUDA)
     using BlockReduce = cub::BlockReduce<T,BLOCKDIMX>;
     __shared__ typename BlockReduce::TempStorage temp_storage;
     // __syncthreads() prior to writing to shared memory is necessary
@@ -416,7 +412,7 @@ template <int BLOCKDIMX, typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 T blockReduceMin (T source) noexcept
 {
-#if defined(AMREX_USE_CUB)
+#if defined(AMREX_USE_CUDA)
     using BlockReduce = cub::BlockReduce<T,BLOCKDIMX>;
     __shared__ typename BlockReduce::TempStorage temp_storage;
     // __syncthreads() prior to writing to shared memory is necessary
@@ -471,7 +467,7 @@ template <int BLOCKDIMX, typename T>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 T blockReduceMax (T source) noexcept
 {
-#if defined(AMREX_USE_CUB)
+#if defined(AMREX_USE_CUDA)
     using BlockReduce = cub::BlockReduce<T,BLOCKDIMX>;
     __shared__ typename BlockReduce::TempStorage temp_storage;
     // __syncthreads() prior to writing to shared memory is necessary
@@ -523,7 +519,7 @@ template <int BLOCKDIMX>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 int blockReduceLogicalAnd (int source) noexcept
 {
-#if defined(AMREX_USE_CUB)
+#if defined(AMREX_USE_CUDA)
     using BlockReduce = cub::BlockReduce<int,BLOCKDIMX>;
     __shared__ typename BlockReduce::TempStorage temp_storage;
     // __syncthreads() prior to writing to shared memory is necessary
@@ -571,7 +567,7 @@ template <int BLOCKDIMX>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 int blockReduceLogicalOr (int source) noexcept
 {
-#if defined(AMREX_USE_CUB)
+#if defined(AMREX_USE_CUDA)
     using BlockReduce = cub::BlockReduce<int,BLOCKDIMX>;
     __shared__ typename BlockReduce::TempStorage temp_storage;
     // __syncthreads() prior to writing to shared memory is necessary

--- a/Src/Base/AMReX_PhysBCFunct.H
+++ b/Src/Base/AMReX_PhysBCFunct.H
@@ -260,14 +260,6 @@ GpuBndryFuncFab<F>::operator() (Box const& bx, FArrayBox& dest,
                                 const Vector<BCRec>& bcr, int bcomp,
                                 int orig_comp)
 {
-#if defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ == 6)
-    // The compiler is allowed to always reject static_assert(false,..) even
-    // without instantiating this function.  The following is to work around
-    // the issue.  Now the compiler is not allowed to reject the code unless
-    // GpuBndryFuncFab::operator() is instantiated.
-    static_assert(std::is_same_v<F,int>,
-                  "CUDA 11.6 bug: https://github.com/AMReX-Codes/amrex/issues/2607");
-#endif
     if (bx.ixType().cellCentered()) {
         ccfcdoit(bx,dest,dcomp,numcomp,geom,time,bcr,bcomp,orig_comp, FilccCell{});
     } else if (bx.ixType().nodeCentered()) {

--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -6,7 +6,7 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_Arena.H>
 
-#if defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
+#if defined(AMREX_USE_CUDA)
 #  include <cub/cub.cuh>
 #  ifdef AMREX_CUDA_CCCL_VER_GE_2_8
 #  include <thrust/iterator/transform_iterator.h>
@@ -803,7 +803,7 @@ T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = ret
     return ret;
 }
 
-#elif defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
+#elif defined(AMREX_USE_CUDA)
 
 template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
           typename M=std::enable_if_t<std::is_integral_v<N> &&
@@ -953,255 +953,6 @@ T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = ret
     return ret;
 }
 
-#else
-
-/// \ingroup amrex_collectives
-template <typename T, typename N, typename FIN, typename FOUT, typename TYPE,
-          typename M=std::enable_if_t<std::is_integral_v<N> &&
-                                      (std::is_same_v<std::decay_t<TYPE>,Type::Inclusive> ||
-                                       std::is_same_v<std::decay_t<TYPE>,Type::Exclusive>)> >
-T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum a_ret_sum = retSum)
-{
-    if (n <= 0) { return 0; }
-    constexpr int nwarps_per_block = 4;
-    constexpr int nthreads = nwarps_per_block*Gpu::Device::warp_size;
-    constexpr int nchunks = 12;
-    constexpr int nelms_per_block = nthreads * nchunks;
-    AMREX_ALWAYS_ASSERT(static_cast<Long>(n) < static_cast<Long>(
-                        std::numeric_limits<int>::max())*nelms_per_block);
-    int nblocks = (static_cast<Long>(n) + nelms_per_block - 1) / nelms_per_block;
-    std::size_t sm = sizeof(T) * (Gpu::Device::warp_size + nwarps_per_block) + sizeof(int);
-    auto stream = Gpu::gpuStream();
-
-    using BlockStatusT = std::conditional_t<sizeof(detail::STVA<T>) <= 8,
-        detail::BlockStatus<T,true>, detail::BlockStatus<T,false> >;
-
-    std::size_t nbytes_blockstatus = Arena::align(sizeof(BlockStatusT)*nblocks);
-    std::size_t nbytes_blockid = Arena::align(sizeof(unsigned int));
-    std::size_t nbytes_totalsum = Arena::align(sizeof(T));
-    auto dp = (char*)(The_Arena()->alloc(  nbytes_blockstatus
-                                         + nbytes_blockid
-                                         + nbytes_totalsum));
-    BlockStatusT* AMREX_RESTRICT block_status_p = (BlockStatusT*)dp;
-    unsigned int* AMREX_RESTRICT virtual_block_id_p = (unsigned int*)(dp + nbytes_blockstatus);
-    T* AMREX_RESTRICT totalsum_p = (T*)(dp + nbytes_blockstatus + nbytes_blockid);
-
-    amrex::ParallelFor(nblocks, [=] AMREX_GPU_DEVICE (int i) noexcept {
-        BlockStatusT& block_status = block_status_p[i];
-        block_status.set_status('x');
-        if (i == 0) {
-            *virtual_block_id_p = 0;
-            *totalsum_p = 0;
-        }
-    });
-
-    amrex::launch<nthreads>(nblocks, sm, stream,
-    [=] AMREX_GPU_DEVICE () noexcept
-    {
-        int lane = threadIdx.x % Gpu::Device::warp_size;
-        int warp = threadIdx.x / Gpu::Device::warp_size;
-        int nwarps = nthreads / Gpu::Device::warp_size;
-
-        amrex::Gpu::SharedMemory<T> gsm;
-        T* shared = gsm.dataPtr();
-        T* shared2 = shared + Gpu::Device::warp_size;
-
-        // First of all, get block virtual id.  We must do this to
-        // avoid deadlock because CUDA may launch blocks in any order.
-        // Anywhere in this function, we should not use blockIdx.
-        int virtual_block_id = 0;
-        if (gridDim.x > 1) {
-            int& virtual_block_id_shared = *((int*)(shared2+nwarps));
-            if (threadIdx.x == 0) {
-                unsigned int bid = Gpu::Atomic::Add(virtual_block_id_p, 1u);
-                virtual_block_id_shared = bid;
-            }
-            __syncthreads();
-            virtual_block_id = virtual_block_id_shared;
-        }
-
-        // Each block processes [ibegin,iend).
-        N ibegin = static_cast<N>(nelms_per_block) * virtual_block_id;
-        N iend = amrex::min(static_cast<N>(ibegin+nelms_per_block), n);
-        BlockStatusT& block_status = block_status_p[virtual_block_id];
-
-        //
-        // The overall algorithm is based on "Single-pass Parallel
-        // Prefix Scan with Decoupled Look-back" by D. Merrill &
-        // M. Garland.
-        //
-
-        // Each block is responsible for nchunks chunks of data,
-        // where each chunk has blockDim.x elements, one for each
-        // thread in the block.
-        T sum_prev_chunk = 0; // inclusive sum from previous chunks.
-        T tmp_out[nchunks]; // block-wide inclusive sum for chunks
-        for (int ichunk = 0; ichunk < nchunks; ++ichunk) {
-            N offset = ibegin + ichunk*nthreads;
-            if (offset >= iend) { break; }
-
-            offset += threadIdx.x;
-            T x0 = (offset < iend) ? fin(offset) : 0;
-            if  (std::is_same_v<std::decay_t<TYPE>,Type::Exclusive> && offset == n-1) {
-                *totalsum_p += x0;
-            }
-            T x = x0;
-            // Scan within a warp
-            for (int i = 1; i <= Gpu::Device::warp_size; i *= 2) {
-                AMREX_HIP_OR_CUDA( T s = __shfl_up(x,i);,
-                                   T s = __shfl_up_sync(0xffffffff, x, i); )
-                if (lane >= i) { x += s; }
-            }
-
-            // x now holds the inclusive sum within the warp.  The
-            // last thread in each warp holds the inclusive sum of
-            // this warp.  We will store it in shared memory.
-            if (lane == Gpu::Device::warp_size - 1) {
-                shared[warp] = x;
-            }
-
-            __syncthreads();
-
-            // The first warp will do scan on the warp sums for the
-            // whole block.  Not all threads in the warp need to
-            // participate.
-#ifdef AMREX_USE_CUDA
-            if (warp == 0 && lane < nwarps) {
-                T y = shared[lane];
-                int mask = (1 << nwarps) - 1;
-                for (int i = 1; i <= nwarps; i *= 2) {
-                    T s = __shfl_up_sync(mask, y, i, nwarps);
-                    if (lane >= i) { y += s; }
-                }
-                shared2[lane] = y;
-            }
-#else
-            if (warp == 0) {
-                T y = 0;
-                if (lane < nwarps) {
-                    y = shared[lane];
-                }
-                for (int i = 1; i <= nwarps; i *= 2) {
-                    T s = __shfl_up(y, i, nwarps);
-                    if (lane >= i) { y += s; }
-                }
-                if (lane < nwarps) {
-                    shared2[lane] = y;
-                }
-            }
-#endif
-
-            __syncthreads();
-
-            // shared[0:nwarps) holds the inclusive sum of warp sums.
-
-            // Also note x still holds the inclusive sum within the
-            // warp.  Given these two, we can compute the inclusive
-            // sum within this chunk.
-            T sum_prev_warp = (warp == 0) ? 0 : shared2[warp-1];
-            tmp_out[ichunk] = sum_prev_warp + sum_prev_chunk +
-                (std::is_same_v<std::decay_t<TYPE>,Type::Inclusive> ? x : x-x0);
-            sum_prev_chunk += shared2[nwarps-1];
-        }
-
-        // sum_prev_chunk now holds the sum of the whole block.
-        if (threadIdx.x == 0 && gridDim.x > 1) {
-            block_status.write((virtual_block_id == 0) ? 'p' : 'a',
-                               sum_prev_chunk);
-        }
-
-        if (virtual_block_id == 0) {
-            for (int ichunk = 0; ichunk < nchunks; ++ichunk) {
-                N offset = ibegin + ichunk*nthreads + threadIdx.x;
-                if (offset >= iend) { break; }
-                fout(offset, tmp_out[ichunk]);
-                if (offset == n-1) {
-                    *totalsum_p += tmp_out[ichunk];
-                }
-            }
-        } else if (virtual_block_id > 0) {
-
-            if (warp == 0) {
-                T exclusive_prefix = 0;
-                BlockStatusT volatile* pbs = block_status_p;
-                for (int iblock0 = virtual_block_id-1; iblock0 >= 0; iblock0 -= Gpu::Device::warp_size)
-                {
-                    int iblock = iblock0-lane;
-                    detail::STVA<T> stva{'p', 0};
-                    if (iblock >= 0) {
-                        stva = pbs[iblock].wait();
-                    }
-
-                    T x = stva.value;
-
-                    AMREX_HIP_OR_CUDA( uint64_t const status_bf = __ballot(stva.status == 'p');,
-                                       unsigned const status_bf = __ballot_sync(0xffffffff, stva.status == 'p'));
-                    bool stop_lookback = status_bf & 0x1u;
-                    if (stop_lookback == false) {
-                        if (status_bf != 0) {
-                            T y = x;
-                            if (lane > 0) { x = 0; }
-                            AMREX_HIP_OR_CUDA(uint64_t bit_mask = 0x1ull;,
-                                              unsigned bit_mask = 0x1u);
-                            for (int i = 1; i < Gpu::Device::warp_size; ++i) {
-                                bit_mask <<= 1;
-                                if (i == lane) { x = y; }
-                                if (status_bf & bit_mask) {
-                                    stop_lookback = true;
-                                    break;
-                                }
-                            }
-                        }
-
-                        for (int i = Gpu::Device::warp_size/2; i > 0; i /= 2) {
-                            AMREX_HIP_OR_CUDA( x += __shfl_down(x,i);,
-                                               x += __shfl_down_sync(0xffffffff, x, i); )
-                        }
-                    }
-
-                    if (lane == 0) { exclusive_prefix += x; }
-                    if (stop_lookback) { break; }
-                }
-
-                if (lane == 0) {
-                    block_status.write('p', block_status.get_aggregate() + exclusive_prefix);
-                    shared[0] = exclusive_prefix;
-                }
-            }
-
-            __syncthreads();
-
-            T exclusive_prefix = shared[0];
-
-            for (int ichunk = 0; ichunk < nchunks; ++ichunk) {
-                N offset = ibegin + ichunk*nthreads + threadIdx.x;
-                if (offset >= iend) { break; }
-                T t = tmp_out[ichunk] + exclusive_prefix;
-                fout(offset, t);
-                if (offset == n-1) {
-                    *totalsum_p += t;
-                }
-            }
-        }
-    });
-
-    T totalsum = 0;
-    if (a_ret_sum) {
-        // xxxxx CUDA < 11 todo: Should test if using pinned memory and thus
-        // avoiding memcpy is faster.
-        Gpu::dtoh_memcpy_async(&totalsum, totalsum_p, sizeof(T));
-
-        Gpu::streamSynchronize();
-        The_Arena()->free(dp);
-
-        AMREX_GPU_ERROR_CHECK();
-    } else {
-        Gpu::freeAsync(The_Arena(), dp);
-    }
-
-    return totalsum;
-}
-
 #endif
 
 /**
@@ -1219,7 +970,7 @@ template <typename N, typename T, typename M=std::enable_if_t<std::is_integral_v
 T InclusiveSum (N n, T const* in, T * out, RetSum a_ret_sum = retSum)
 {
     if (n <= 0) { return 0; }
-#if defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
+#if defined(AMREX_USE_CUDA)
     void* d_temp = nullptr;
     std::size_t temp_bytes = 0;
     AMREX_GPU_SAFE_CALL(cub::DeviceScan::InclusiveSum(d_temp, temp_bytes, in, out, n,
@@ -1291,7 +1042,7 @@ template <typename N, typename T, typename M=std::enable_if_t<std::is_integral_v
 T ExclusiveSum (N n, T const* in, T * out, RetSum a_ret_sum = retSum)
 {
     if (n <= 0) { return 0; }
-#if defined(AMREX_USE_CUDA) && defined(__CUDACC__) && (__CUDACC_VER_MAJOR__ >= 11)
+#if defined(AMREX_USE_CUDA)
     T in_last = 0;
     if (a_ret_sum) {
         Gpu::dtoh_memcpy_async(&in_last, in+(n-1), sizeof(T));


### PR DESCRIPTION
CUDA runtime API signatures follow the runtime headers in use, which can differ from the nvcc front-end version on mixed-toolkit systems. Use CUDART_VERSION for these guards instead of `__CUDACC_VER_*`.

Also remove CUDA code paths older than the current minimum supported version, 12.2.
