### PR TITLE
Fix OMP issue in BoxArray

### DIFF
--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -103,12 +103,17 @@ struct BARef
 #endif
 
     [[nodiscard]] bool HasHashMap () const {
-        bool r;
 #ifdef AMREX_USE_OMP
+        bool r;
 #pragma omp atomic read
-#endif
         r = has_hashmap;
+        if (r) {
+#pragma omp flush
+        }
         return r;
+#else
+        return has_hashmap;
+#endif
     }
 
     //


### PR DESCRIPTION
An `omp flush` is missing for the reader. Without it a thread reads has_hashmap=true may still not see the constructed hash map, even though the writer constructs the hash map, flushes and then writes has_hasmap=true.
