### PR TITLE
Use std::atomic instead omp flush

### DIFF
--- a/Src/Base/AMReX_BoxArray.H
+++ b/Src/Base/AMReX_BoxArray.H
@@ -10,6 +10,7 @@
 #include <AMReX_Vector.H>
 
 #include <iosfwd>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <map>
@@ -102,18 +103,8 @@ struct BARef
     void updateMemoryUsage_hash (int s);
 #endif
 
-    [[nodiscard]] bool HasHashMap () const {
-#ifdef AMREX_USE_OMP
-        bool r;
-#pragma omp atomic read
-        r = has_hashmap;
-        if (r) {
-#pragma omp flush
-        }
-        return r;
-#else
-        return has_hashmap;
-#endif
+    [[nodiscard]] bool HasHashMap () const noexcept {
+        return has_hashmap.load(std::memory_order_acquire);
     }
 
     //
@@ -130,7 +121,7 @@ struct BARef
 
     mutable HashType hash;
 
-    mutable bool has_hashmap = false;
+    mutable std::atomic<bool> has_hashmap = false;
 
     static int  numboxarrays;
     static int  numboxarrays_hwm;

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -192,7 +192,7 @@ BARef::resize (Long n) {
 #endif
     m_abox.resize(n);
     hash.clear();
-    has_hashmap = false;
+    has_hashmap.store(false, std::memory_order_release);
 #ifdef AMREX_MEM_PROFILING
     updateMemoryUsage_box(1);
 #endif
@@ -1445,7 +1445,7 @@ BoxArray::clear_hash_bin () const
         m_ref->updateMemoryUsage_hash(-1);
 #endif
         m_ref->hash.clear();
-        m_ref->has_hashmap = false;
+        m_ref->has_hashmap.store(false, std::memory_order_release);
     }
 }
 
@@ -1569,7 +1569,7 @@ BoxArray::getHashMap () const
 #pragma omp critical(intersections_lock)
 #endif
     {
-        if (BoxHashMap.empty() && size() > 0)
+        if (!m_ref->HasHashMap() && size() > 0)
         {
             //
             // Calculate the bounding box & maximum extent of the boxes.
@@ -1601,11 +1601,7 @@ BoxArray::getHashMap () const
             m_ref->updateMemoryUsage_hash(1);
 #endif
 
-#ifdef AMREX_USE_OMP
-#pragma omp flush
-#pragma omp atomic write
-#endif
-            m_ref->has_hashmap = true;
+            m_ref->has_hashmap.store(true, std::memory_order_release);
         }
     }
 


### PR DESCRIPTION
This makes thread sanitizer happy because it does not appear to understand omp flush.
