### PR TITLE
Use classic locale in Concatenate

### DIFF
--- a/Src/Base/AMReX_String.cpp
+++ b/Src/Base/AMReX_String.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cctype>
 #include <iomanip>
+#include <locale>
 #include <sstream>
 
 namespace amrex {
@@ -35,6 +36,7 @@ std::string Concatenate (const std::string& root, int num, int mindigits)
 {
     BL_ASSERT(mindigits >= 0);
     std::stringstream result;
+    result.imbue(std::locale::classic());
     result << root << std::setfill('0') << std::setw(mindigits) << num;
     return result.str();
 }


### PR DESCRIPTION
Force amrex::Concatenate to format numeric suffixes with the classic locale. This keeps generated file and path names deterministic even if an application has installed a C++ global locale with digit grouping.

Examples that could matter, assuming the app does something like std::locale::global(std::locale("")) before Concatenate is called:

  - en_US.UTF-8 United States: plt1,234,567
  - de_DE.UTF-8 Germany: plt1.234.567
  - fr_FR.UTF-8 France: plt1 234 567 or plt1_234_567
  - ru_RU.UTF-8 Russia: often space or non-breaking-space grouping
  - de_CH.UTF-8 Switzerland: often plt1'234'567
  - en_IN.UTF-8 or hi_IN.UTF-8 India: plt12,34,567
  - zh_CN.UTF-8 China: plt1,234,567
