### PR TITLE
Fix recursive TinyProfiler BL_PROFILE_REGION's

### DIFF
--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -134,6 +134,7 @@ private:
     static std::vector<std::string> all_memnames;
 
     static std::vector<std::string> regionstack;
+    static std::vector<std::pair<std::string,bool> > regionstartstack;
     static std::deque<std::tuple<double,double,std::string*> > ttstack;
     static std::map<std::string,std::map<std::string, Stats> > statsmap;
     static double t_init;

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -46,6 +46,7 @@ std::vector<std::map<std::string, MemStat>*> TinyProfiler::all_memstats;
 std::vector<std::string> TinyProfiler::all_memnames;
 
 std::vector<std::string>          TinyProfiler::regionstack;
+std::vector<std::pair<std::string,bool> > TinyProfiler::regionstartstack;
 std::deque<std::tuple<double,double,std::string*> > TinyProfiler::ttstack;
 std::map<std::string,std::map<std::string, TinyProfiler::Stats> > TinyProfiler::statsmap;
 double TinyProfiler::t_init = std::numeric_limits<double>::max();
@@ -443,6 +444,7 @@ TinyProfiler::Finalize (bool bFlushing)
 
     if (!bFlushing) {
         regionstack.clear();
+        regionstartstack.clear();
         ttstack.clear();
         statsmap.clear();
     }
@@ -950,9 +952,12 @@ TinyProfiler::StartRegion (std::string regname) noexcept
 {
     if (!enabled) { return; }
 
+    bool pushed = false;
     if (std::find(regionstack.begin(), regionstack.end(), regname) == regionstack.end()) {
-        regionstack.emplace_back(std::move(regname));
+        regionstack.emplace_back(regname);
+        pushed = true;
     }
+    regionstartstack.emplace_back(std::move(regname), pushed);
 }
 
 void
@@ -960,8 +965,13 @@ TinyProfiler::StopRegion (const std::string& regname) noexcept
 {
     if (!enabled) { return; }
 
-    if (regname == regionstack.back()) {
-        regionstack.pop_back();
+    if (!regionstartstack.empty() && regname == regionstartstack.back().first) {
+        if (regionstartstack.back().second) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!regionstack.empty() && regname == regionstack.back(),
+                "TinyProfiler regions must be nested with respect to each other");
+            regionstack.pop_back();
+        }
+        regionstartstack.pop_back();
     }
 }
 


### PR DESCRIPTION
Track whether each TinyProfiler region start actually pushed a new region onto the active region stack. This prevents nested regions with the same name from popping the outer region when the inner scope exits.
