### PR TITLE
Make Parser construction thread-safe

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -1024,12 +1024,14 @@ integer if it is reasonable to do so. For example, it's okay to have
 Thread Safety
 -------------
 
-Constructing a :cpp:`Parser` (or :cpp:`IParser`) object is **not** thread-safe
-because the underlying lex/yacc parser uses global state. If multiple threads
-need to construct parsers concurrently, external synchronization is required.
-Once compiled, the :cpp:`ParserExecutor` returned by :cpp:`compile` or
-:cpp:`compileHost` is thread-safe and can be called concurrently from multiple
-threads or GPU kernels.
+Different :cpp:`Parser` (or :cpp:`IParser`) objects may be constructed
+concurrently from multiple host threads. Once compiled, the
+:cpp:`ParserExecutor` or :cpp:`IParserExecutor` returned by :cpp:`compile` or
+:cpp:`compileHost` may be called concurrently from multiple threads or GPU
+kernels. However, it is usually unnecessary and less efficient to construct one
+parser per thread merely to evaluate an expression in parallel. Construct,
+configure, and compile the parser once, then share the compiled executor while
+keeping the owning parser object alive.
 
 .. _sec:basics:initialize:
 

--- a/Src/Base/Parser/AMReX_IParser.H
+++ b/Src/Base/Parser/AMReX_IParser.H
@@ -86,6 +86,10 @@ struct IParserExecutor
  * IParser parses expressions composed of integer literals, integer variables,
  * and integer-returning functions. It emits executors that evaluate to long long
  * on host or GPU.
+ *
+ * Different IParser objects may be constructed or defined concurrently from
+ * multiple host threads. For parallel evaluation, prefer sharing the compiled
+ * IParserExecutor across threads instead of constructing one IParser per thread.
  */
 class IParser
 {

--- a/Src/Base/Parser/AMReX_IParser.cpp
+++ b/Src/Base/Parser/AMReX_IParser.cpp
@@ -6,9 +6,14 @@
 #include <amrex_iparser.tab.h>
 
 #include <algorithm>
+#include <mutex>
 #include <stdexcept>
 
 namespace amrex {
+
+namespace {
+    std::mutex iparser_mutex;
+}
 
 IParser::IParser (std::string const& func_body)
 {
@@ -28,6 +33,7 @@ IParser::define (std::string const& func_body)
             m_data->m_expression.end());
         std::string f = m_data->m_expression + "\n";
 
+        std::lock_guard<std::mutex> iparser_lock(iparser_mutex);
         YY_BUFFER_STATE buffer = amrex_iparser_scan_string(f.c_str());
         try {
             amrex_iparserparse();

--- a/Src/Base/Parser/AMReX_IParser.cpp
+++ b/Src/Base/Parser/AMReX_IParser.cpp
@@ -33,7 +33,7 @@ IParser::define (std::string const& func_body)
             m_data->m_expression.end());
         std::string f = m_data->m_expression + "\n";
 
-        std::lock_guard<std::mutex> iparser_lock(iparser_mutex);
+        std::scoped_lock iparser_lock(iparser_mutex);
         YY_BUFFER_STATE buffer = amrex_iparser_scan_string(f.c_str());
         try {
             amrex_iparserparse();

--- a/Src/Base/Parser/AMReX_IParser_Y.cpp
+++ b/Src/Base/Parser/AMReX_IParser_Y.cpp
@@ -20,25 +20,29 @@ amrex_iparsererror (char const *s, ...)
 namespace amrex {
 
 namespace {
-    struct iparser_node* iparser_root = nullptr;
-    std::vector<void*>   iparser_ptrs;
+    struct IParserWorkspace {
+        struct iparser_node* root = nullptr;
+        std::vector<void*> ptrs;
+    };
+
+    thread_local IParserWorkspace iparser_workspace;
 }
 
 // This is called by a bison rule to store the original AST in a static variable.
 void
 iparser_defexpr (struct iparser_node* body)
 {
-    iparser_root = body;
+    iparser_workspace.root = body;
 }
 
 struct iparser_symbol*
 iparser_makesymbol (char* name)
 {
-    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_symbol)));
-    auto *symbol = (struct iparser_symbol*) iparser_ptrs.back();
+    iparser_workspace.ptrs.push_back(std::malloc(sizeof(struct iparser_symbol)));
+    auto *symbol = (struct iparser_symbol*) iparser_workspace.ptrs.back();
     symbol->type = IPARSER_SYMBOL;
     symbol->name = strdup(name);
-    iparser_ptrs.push_back((void*)symbol->name);
+    iparser_workspace.ptrs.push_back((void*)symbol->name);
     symbol->ip = -1;
     return symbol;
 }
@@ -46,8 +50,8 @@ iparser_makesymbol (char* name)
 struct iparser_node*
 iparser_newnode (enum iparser_node_t type, struct iparser_node* l, struct iparser_node* r)
 {
-    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_node)));
-    auto *tmp = (struct iparser_node*) iparser_ptrs.back();
+    iparser_workspace.ptrs.push_back(std::malloc(sizeof(struct iparser_node)));
+    auto *tmp = (struct iparser_node*) iparser_workspace.ptrs.back();
     tmp->type = type;
     tmp->l = l;
     tmp->r = r;
@@ -57,8 +61,8 @@ iparser_newnode (enum iparser_node_t type, struct iparser_node* l, struct iparse
 struct iparser_node*
 iparser_newnumber (long long d)
 {
-    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_number)));
-    auto *r = (struct iparser_number*) iparser_ptrs.back();
+    iparser_workspace.ptrs.push_back(std::malloc(sizeof(struct iparser_number)));
+    auto *r = (struct iparser_number*) iparser_workspace.ptrs.back();
     r->type = IPARSER_NUMBER;
     r->value = d;
     return (struct iparser_node*) r;
@@ -73,8 +77,8 @@ iparser_newsymbol (struct iparser_symbol* symbol)
 struct iparser_node*
 iparser_newf1 (enum iparser_f1_t ftype, struct iparser_node* l)
 {
-    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_f1)));
-    auto *tmp = (struct iparser_f1*) iparser_ptrs.back();
+    iparser_workspace.ptrs.push_back(std::malloc(sizeof(struct iparser_f1)));
+    auto *tmp = (struct iparser_f1*) iparser_workspace.ptrs.back();
     tmp->type = IPARSER_F1;
     tmp->l = l;
     tmp->ftype = ftype;
@@ -84,8 +88,8 @@ iparser_newf1 (enum iparser_f1_t ftype, struct iparser_node* l)
 struct iparser_node*
 iparser_newf2 (enum iparser_f2_t ftype, struct iparser_node* l, struct iparser_node* r)
 {
-    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_f2)));
-    auto *tmp = (struct iparser_f2*) iparser_ptrs.back();
+    iparser_workspace.ptrs.push_back(std::malloc(sizeof(struct iparser_f2)));
+    auto *tmp = (struct iparser_f2*) iparser_workspace.ptrs.back();
     tmp->type = IPARSER_F2;
     tmp->l = l;
     tmp->r = r;
@@ -97,8 +101,8 @@ struct iparser_node*
 iparser_newf3 (enum iparser_f3_t ftype, struct iparser_node* n1, struct iparser_node* n2,
                struct iparser_node* n3)
 {
-    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_f3)));
-    auto *tmp = (struct iparser_f3*) iparser_ptrs.back();
+    iparser_workspace.ptrs.push_back(std::malloc(sizeof(struct iparser_f3)));
+    auto *tmp = (struct iparser_f3*) iparser_workspace.ptrs.back();
     tmp->type = IPARSER_F3;
     tmp->n1 = n1;
     tmp->n2 = n2;
@@ -110,8 +114,8 @@ iparser_newf3 (enum iparser_f3_t ftype, struct iparser_node* n1, struct iparser_
 struct iparser_node*
 iparser_newassign (struct iparser_symbol* sym, struct iparser_node* v)
 {
-    iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_assign)));
-    auto *r = (struct iparser_assign*) iparser_ptrs.back();
+    iparser_workspace.ptrs.push_back(std::malloc(sizeof(struct iparser_assign)));
+    auto *r = (struct iparser_assign*) iparser_workspace.ptrs.back();
     r->type = IPARSER_ASSIGN;
     r->s = sym;
     r->v = v;
@@ -124,8 +128,8 @@ iparser_newlist (struct iparser_node* nl, struct iparser_node* nr)
     if (nr == nullptr) {
         return nl;
     } else {
-        iparser_ptrs.push_back(std::malloc(sizeof(struct iparser_node)));
-        auto *r = (struct iparser_node*) iparser_ptrs.back();
+        iparser_workspace.ptrs.push_back(std::malloc(sizeof(struct iparser_node)));
+        auto *r = (struct iparser_node*) iparser_workspace.ptrs.back();
         r->type = IPARSER_LIST;
         r->l = nl;
         r->r = nr;
@@ -184,11 +188,11 @@ amrex_iparser_new ()
 {
     auto *my_iparser = (struct amrex_iparser*) std::malloc(sizeof(struct amrex_iparser));
 
-    my_iparser->sz_mempool = iparser_ast_size(iparser_root);
+    my_iparser->sz_mempool = iparser_ast_size(iparser_workspace.root);
     my_iparser->p_root = std::malloc(my_iparser->sz_mempool);
     my_iparser->p_free = my_iparser->p_root;
 
-    my_iparser->ast = iparser_ast_dup(my_iparser, iparser_root);
+    my_iparser->ast = iparser_ast_dup(my_iparser, iparser_workspace.root);
 
     amrex_iparser_delete_ptrs();
 
@@ -211,10 +215,11 @@ amrex_iparser_delete (struct amrex_iparser* iparser)
 void
 amrex_iparser_delete_ptrs ()
 {
-    for (auto* p : iparser_ptrs) {
+    for (auto* p : iparser_workspace.ptrs) {
         std::free(p);
     }
-    iparser_ptrs.clear();
+    iparser_workspace.ptrs.clear();
+    iparser_workspace.root = nullptr;
 }
 
 namespace {

--- a/Src/Base/Parser/AMReX_Parser.H
+++ b/Src/Base/Parser/AMReX_Parser.H
@@ -117,6 +117,10 @@ struct ParserExecutor
  * registered variables. After calling define(), registerVariables(), and
  * (optionally) registerUserFn*, the expression can be compiled into a
  * ParserExecutor that evaluates it efficiently on host or device.
+ *
+ * Different Parser objects may be constructed or defined concurrently from
+ * multiple host threads. For parallel evaluation, prefer sharing the compiled
+ * ParserExecutor across threads instead of constructing one Parser per thread.
  */
 class Parser
 {

--- a/Src/Base/Parser/AMReX_Parser.cpp
+++ b/Src/Base/Parser/AMReX_Parser.cpp
@@ -6,9 +6,14 @@
 #include <amrex_parser.tab.h>
 
 #include <algorithm>
+#include <mutex>
 #include <stdexcept>
 
 namespace amrex {
+
+namespace {
+    std::mutex parser_mutex;
+}
 
 Parser::Parser (std::string const& func_body)
 {
@@ -28,6 +33,7 @@ Parser::define (std::string const& func_body)
             m_data->m_expression.end());
         std::string f = m_data->m_expression + "\n";
 
+        std::lock_guard<std::mutex> parser_lock(parser_mutex);
         YY_BUFFER_STATE buffer = amrex_parser_scan_string(f.c_str());
         try {
             amrex_parserparse();

--- a/Src/Base/Parser/AMReX_Parser.cpp
+++ b/Src/Base/Parser/AMReX_Parser.cpp
@@ -33,7 +33,7 @@ Parser::define (std::string const& func_body)
             m_data->m_expression.end());
         std::string f = m_data->m_expression + "\n";
 
-        std::lock_guard<std::mutex> parser_lock(parser_mutex);
+        std::scoped_lock parser_lock(parser_mutex);
         YY_BUFFER_STATE buffer = amrex_parser_scan_string(f.c_str());
         try {
             amrex_parserparse();

--- a/Src/Base/Parser/AMReX_Parser_Y.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Y.cpp
@@ -20,16 +20,19 @@ amrex_parsererror (char const *s, ...)
 namespace amrex {
 
 namespace {
-    // Not thread safe. Concurrent Parser construction will corrupt these.
-    struct parser_node* parser_root = nullptr;
-    std::vector<void*>  parser_ptrs;
+    struct ParserWorkspace {
+        struct parser_node* root = nullptr;
+        std::vector<void*> ptrs;
+    };
+
+    thread_local ParserWorkspace parser_workspace;
 }
 
 // This is called by a bison rule to store the original AST in a static variable.
 void
 parser_defexpr (struct parser_node* body)
 {
-    parser_root = body;
+    parser_workspace.root = body;
 }
 
 struct parser_symbol*
@@ -37,11 +40,11 @@ parser_makesymbol (char* name)
 {
     // We allocate more than enough space so that late we can turn parser_symbol
     // into into parser_node if necessary.
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto *symbol = (struct parser_symbol*) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *symbol = (struct parser_symbol*) parser_workspace.ptrs.back(); // NOLINT
     symbol->type = PARSER_SYMBOL;
     symbol->name = strdup(name);
-    parser_ptrs.push_back(symbol->name);
+    parser_workspace.ptrs.push_back(symbol->name);
     symbol->ip = -1;
     return symbol;
 }
@@ -49,8 +52,8 @@ parser_makesymbol (char* name)
 struct parser_node*
 parser_newnode (enum parser_node_t type, struct parser_node* l, struct parser_node* r)
 {
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto *tmp = (struct parser_node*) parser_ptrs.back();
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_node*) parser_workspace.ptrs.back();
     if (type == PARSER_SUB) {
         tmp->type = PARSER_ADD;
         tmp->l = l;
@@ -66,8 +69,8 @@ parser_newnode (enum parser_node_t type, struct parser_node* l, struct parser_no
 struct parser_node*
 parser_newneg (struct parser_node* n)
 {
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto *tmp = (struct parser_node*) parser_ptrs.back();
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_node*) parser_workspace.ptrs.back();
     tmp->type = PARSER_MUL;
     tmp->l = parser_newnumber(-1.0);
     tmp->r = n;
@@ -79,8 +82,8 @@ parser_newnumber (double d)
 {
     // We allocate more than enough space so that late we can turn parser_number
     // into into parser_node if necessary.
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto *r = (struct parser_number*) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *r = (struct parser_number*) parser_workspace.ptrs.back(); // NOLINT
     r->type = PARSER_NUMBER;
     r->value = d;
     return (struct parser_node*) r;
@@ -95,8 +98,8 @@ parser_newsymbol (struct parser_symbol* symbol)
 struct parser_node*
 parser_newf1 (enum parser_f1_t ftype, struct parser_node* l)
 {
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto *tmp = (struct parser_f1*) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_f1*) parser_workspace.ptrs.back(); // NOLINT
     tmp->type = PARSER_F1;
     tmp->l = l;
     tmp->ftype = ftype;
@@ -106,8 +109,8 @@ parser_newf1 (enum parser_f1_t ftype, struct parser_node* l)
 struct parser_node*
 parser_newf2 (enum parser_f2_t ftype, struct parser_node* l, struct parser_node* r)
 {
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto *tmp = (struct parser_f2*) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_f2*) parser_workspace.ptrs.back(); // NOLINT
     tmp->type = PARSER_F2;
     tmp->l = l;
     tmp->r = r;
@@ -119,8 +122,8 @@ struct parser_node*
 parser_newf3 (enum parser_f3_t ftype, struct parser_node* n1, struct parser_node* n2,
               struct parser_node* n3)
 {
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto *tmp = (struct parser_f3*) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *tmp = (struct parser_f3*) parser_workspace.ptrs.back(); // NOLINT
     tmp->type = PARSER_F3;
     tmp->n1 = n1;
     tmp->n2 = n2;
@@ -132,11 +135,11 @@ parser_newf3 (enum parser_f3_t ftype, struct parser_node* n1, struct parser_node
 struct parser_node*
 parser_newusrf1 (struct parser_symbol* fname, struct parser_node* l)
 {
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto* tmp = (struct parser_usrf1*) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto* tmp = (struct parser_usrf1*) parser_workspace.ptrs.back(); // NOLINT
     tmp->type = PARSER_USRF1;
     tmp->name = strdup(fname->name);
-    parser_ptrs.push_back(tmp->name);
+    parser_workspace.ptrs.push_back(tmp->name);
     tmp->l = l;
     return (struct parser_node*) tmp;
 }
@@ -145,11 +148,11 @@ struct parser_node*
 parser_newusrf2 (struct parser_symbol* fname, struct parser_node* l,
                  struct parser_node* r)
 {
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto* tmp = (struct parser_usrf2*) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto* tmp = (struct parser_usrf2*) parser_workspace.ptrs.back(); // NOLINT
     tmp->type = PARSER_USRF2;
     tmp->name = strdup(fname->name);
-    parser_ptrs.push_back(tmp->name);
+    parser_workspace.ptrs.push_back(tmp->name);
     tmp->l = l;
     tmp->r = r;
     return (struct parser_node*) tmp;
@@ -158,15 +161,15 @@ parser_newusrf2 (struct parser_symbol* fname, struct parser_node* l,
 struct parser_node*
 parser_newusrfn (struct parser_symbol* fname, std::vector<struct parser_node*> const& nv)
 {
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto* tmp = (struct parser_usrfn*) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto* tmp = (struct parser_usrfn*) parser_workspace.ptrs.back(); // NOLINT
     tmp->type = PARSER_USRFN;
     tmp->argc = short(nv.size());
     tmp->name = strdup(fname->name);
-    parser_ptrs.push_back(tmp->name);
+    parser_workspace.ptrs.push_back(tmp->name);
     tmp->n1 = nv[0];
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node*)*(tmp->argc-1)));
-    tmp->others = (struct parser_node**) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node*)*(tmp->argc-1)));
+    tmp->others = (struct parser_node**) parser_workspace.ptrs.back(); // NOLINT
     for (short iarg = 0; iarg < tmp->argc-1; ++iarg) {
         tmp->others[iarg] = nv[iarg+1];
     }
@@ -176,8 +179,8 @@ parser_newusrfn (struct parser_symbol* fname, std::vector<struct parser_node*> c
 struct parser_node*
 parser_newassign (struct parser_symbol* sym, struct parser_node* v)
 {
-    parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-    auto *r = (struct parser_assign*) parser_ptrs.back(); // NOLINT
+    parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+    auto *r = (struct parser_assign*) parser_workspace.ptrs.back(); // NOLINT
     r->type = PARSER_ASSIGN;
     r->s = sym;
     r->v = v;
@@ -190,8 +193,8 @@ parser_newlist (struct parser_node* nl, struct parser_node* nr)
     if (nr == nullptr) {
         return nl;
     } else {
-        parser_ptrs.push_back(std::malloc(sizeof(struct parser_node)));
-        auto *r = (struct parser_node*) parser_ptrs.back();
+        parser_workspace.ptrs.push_back(std::malloc(sizeof(struct parser_node)));
+        auto *r = (struct parser_node*) parser_workspace.ptrs.back();
         r->type = PARSER_LIST;
         r->l = nl;
         r->r = nr;
@@ -250,11 +253,11 @@ amrex_parser_new ()
 {
     auto *my_parser = (struct amrex_parser*) std::malloc(sizeof(struct amrex_parser));
 
-    my_parser->sz_mempool = parser_ast_size(parser_root);
+    my_parser->sz_mempool = parser_ast_size(parser_workspace.root);
     my_parser->p_root = std::malloc(my_parser->sz_mempool);
     my_parser->p_free = my_parser->p_root;
 
-    my_parser->ast = parser_ast_dup(my_parser, parser_root);
+    my_parser->ast = parser_ast_dup(my_parser, parser_workspace.root);
 
     amrex_parser_delete_ptrs();
 
@@ -282,10 +285,11 @@ amrex_parser_delete (struct amrex_parser* parser)
 void
 amrex_parser_delete_ptrs ()
 {
-    for (auto* p : parser_ptrs) {
+    for (auto* p : parser_workspace.ptrs) {
         std::free(p);
     }
-    parser_ptrs.clear();
+    parser_workspace.ptrs.clear();
+    parser_workspace.root = nullptr;
 }
 
 namespace {

--- a/Src/Base/Parser/amrex_iparser.y
+++ b/Src/Base/Parser/amrex_iparser.y
@@ -14,9 +14,9 @@ int amrex_iparserlex (void);
 #endif
 %}
 
-/* We do not need to make this reentrant safe, because we use flex and
-   bison for generating AST only and this part doesn't need to be
-   thread safe.
+/* The generated scanner/parser use global state. IParser::define serializes
+   parser calls, and AMReX_IParser_Y.cpp keeps AST construction scratch state
+   thread-local so different IParser objects can be constructed concurrently.
 */
 /*%define api.pure full */
 %define api.prefix {amrex_iparser}

--- a/Src/Base/Parser/amrex_parser.y
+++ b/Src/Base/Parser/amrex_parser.y
@@ -14,9 +14,9 @@ int amrex_parserlex (void);
 #endif
 %}
 
-/* We do not need to make this reentrant safe, because we use flex and
-   bison for generating AST only and this part doesn't need to be
-   thread safe.
+/* The generated scanner/parser use global state. Parser::define serializes
+   parser calls, and AMReX_Parser_Y.cpp keeps AST construction scratch state
+   thread-local so different Parser objects can be constructed concurrently.
 */
 /*%define api.pure full */
 %define api.prefix {amrex_parser}

--- a/Tests/Parser/main.cpp
+++ b/Tests/Parser/main.cpp
@@ -196,8 +196,8 @@ int test_concurrent_parser_construction ()
                     }
                     {
                         IParser iparser("a*x + b");
-                        auto const a = static_cast<long long>(tid+1);
-                        auto const b = static_cast<long long>(iter+3);
+                        auto const a = static_cast<long long>(tid) + 1;
+                        auto const b = static_cast<long long>(iter) + 3;
                         auto const x = static_cast<long long>((iter % 9) - 4);
                         iparser.setConstant("a", a);
                         iparser.setConstant("b", b);

--- a/Tests/Parser/main.cpp
+++ b/Tests/Parser/main.cpp
@@ -2,6 +2,8 @@
 #include <AMReX_Parser.H>
 #include <AMReX_IParser.H>
 #include <map>
+#include <thread>
+#include <vector>
 
 using namespace amrex;
 
@@ -142,6 +144,87 @@ int test4 (std::string const& f,
     }}}}
     if (nfail > 0) {
         amrex::Print() << "    failed " << nfail << " times\n";
+        return 1;
+    } else {
+        amrex::Print() << "    pass\n";
+        return 0;
+    }
+}
+
+int test_concurrent_parser_construction ()
+{
+    amrex::Print() << test_number++ << ". Testing concurrent Parser/IParser construction   ";
+
+    constexpr int nthreads = 2;
+    constexpr int niters = 64;
+    std::vector<int> nfail(nthreads, 0);
+    std::vector<std::thread> threads;
+    threads.reserve(nthreads);
+
+    for (int tid = 0; tid < nthreads; ++tid) {
+        threads.emplace_back([tid, &nfail] ()
+        {
+            int local_nfail = 0;
+            for (int iter = 0; iter < niters; ++iter) {
+                try {
+                    {
+                        Parser parser("a*x + b");
+                        auto const a = static_cast<double>(tid+1);
+                        auto const b = 0.25*static_cast<double>(iter+1);
+                        auto const x = static_cast<double>((iter % 7) - 3);
+                        parser.setConstant("a", a);
+                        parser.setConstant("b", b);
+                        parser.registerVariables({"x"});
+                        auto const exe = parser.compileHost<1>();
+                        if (std::abs(exe(x) - (a*x + b)) > 1.e-12) {
+                            ++local_nfail;
+                        }
+                    }
+                    {
+                        Parser parser("if(x > threshold, x*x + c, c-x)");
+                        auto const threshold = static_cast<double>((tid % 3) - 1);
+                        auto const c = 0.125*static_cast<double>(iter+1);
+                        auto const x = static_cast<double>((iter % 5) - 2);
+                        parser.setConstant("threshold", threshold);
+                        parser.setConstant("c", c);
+                        parser.registerVariables({"x"});
+                        auto const exe = parser.compileHost<1>();
+                        auto const expected = (x > threshold) ? x*x + c : c - x;
+                        if (std::abs(exe(x) - expected) > 1.e-12) {
+                            ++local_nfail;
+                        }
+                    }
+                    {
+                        IParser iparser("a*x + b");
+                        auto const a = static_cast<long long>(tid+1);
+                        auto const b = static_cast<long long>(iter+3);
+                        auto const x = static_cast<long long>((iter % 9) - 4);
+                        iparser.setConstant("a", a);
+                        iparser.setConstant("b", b);
+                        iparser.registerVariables({"x"});
+                        auto const exe = iparser.compileHost<1>();
+                        if (exe(x) != a*x + b) {
+                            ++local_nfail;
+                        }
+                    }
+                } catch (...) {
+                    ++local_nfail;
+                }
+            }
+            nfail[tid] = local_nfail;
+        });
+    }
+
+    int total_nfail = 0;
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    for (auto n : nfail) {
+        total_nfail += n;
+    }
+
+    if (total_nfail > 0) {
+        amrex::Print() << "    failed " << total_nfail << " times\n";
         return 1;
     } else {
         amrex::Print() << "    pass\n";
@@ -386,6 +469,7 @@ int main (int argc, char* argv[])
                         },
                         {0.e-6, 0.0, -20.e-6}, {20.e-6, 1.e-10, 20.e-6}, 100,
                         1.e-12, 1.e-15);
+        nerror += test_concurrent_parser_construction();
 
         amrex::Print() << "\nMax stack size is " << max_stack_size << "\n";
         if (nerror > 0) {


### PR DESCRIPTION
Parser and IParser used namespace-scope scratch state while building ASTs from the generated flex/bison parsers. Concurrent construction could overwrite the shared root pointer or free another thread's temporary nodes, leading to wrong expressions, use-after-free, or double-free failures.

Move the AMReX AST scratch state to thread-local workspaces for both Parser and IParser. Also guard the generated non-reentrant flex/bison parse calls with mutexes so their scanner/parser globals are not accessed concurrently.
