### PR TITLE
Check for failed integer vector I/O

### DIFF
--- a/Src/Base/AMReX_IntConv.H
+++ b/Src/Base/AMReX_IntConv.H
@@ -28,7 +28,9 @@ namespace amrex {
         for (std::size_t j = 0; j < size; ++j) {
             value = static_cast<To>(data[j]);
             if (swapEndian) { value = swapBytes(value); }
-            os.write((char*) &value, sizeof(To));
+            if (!os.write(reinterpret_cast<char const*>(&value), sizeof(To))) {
+                amrex::Error("Failed to write integer data.");
+            }
         }
     }
 

--- a/Src/Base/AMReX_IntConv.H
+++ b/Src/Base/AMReX_IntConv.H
@@ -39,7 +39,9 @@ namespace amrex {
         From value;
         bool swapEndian = (id.order() != amrex::FPC::NativeIntDescriptor().order());
         for (std::size_t j = 0; j < size; ++j) {
-            is.read((char*) &value, sizeof(From));
+            if (!is.read(reinterpret_cast<char*>(&value), sizeof(From))) {
+                amrex::Error("Failed to read integer data.");
+            }
             if (swapEndian) { value = swapBytes(value); }
             data[j] = static_cast<To>(value);
         }

--- a/Src/Base/AMReX_VectorIO.cpp
+++ b/Src/Base/AMReX_VectorIO.cpp
@@ -8,7 +8,11 @@ void amrex::writeIntData (const int* data, std::size_t size, std::ostream& os,
 {
     if (id == FPC::NativeIntDescriptor())
     {
-        os.write((char*) data, static_cast<std::streamsize>(size*sizeof(int)));
+        if (!os.write(reinterpret_cast<char const*>(data),
+                      static_cast<std::streamsize>(size*sizeof(int))))
+        {
+            amrex::Error("Failed to write integer data.");
+        }
     }
     else if (id.numBytes() == 2)
     {
@@ -60,7 +64,11 @@ void amrex::writeLongData (const Long* data, std::size_t size, std::ostream& os,
 {
     if (id == FPC::NativeLongDescriptor())
     {
-        os.write((char*) data, static_cast<std::streamsize>(size*sizeof(Long)));
+        if (!os.write(reinterpret_cast<char const*>(data),
+                      static_cast<std::streamsize>(size*sizeof(Long))))
+        {
+            amrex::Error("Failed to write long integer data.");
+        }
     }
     else if (id.numBytes() == 2)
     {

--- a/Src/Base/AMReX_VectorIO.cpp
+++ b/Src/Base/AMReX_VectorIO.cpp
@@ -32,7 +32,11 @@ void amrex::readIntData (int* data, std::size_t size, std::istream& is,
 {
     if (id == FPC::NativeIntDescriptor())
     {
-        is.read((char*) data, static_cast<std::streamsize>(size * id.numBytes()));
+        if (!is.read(reinterpret_cast<char*>(data),
+                     static_cast<std::streamsize>(size * id.numBytes())))
+        {
+            amrex::Error("Failed to read integer data.");
+        }
     }
     else if (id.numBytes() == 2)
     {
@@ -80,7 +84,11 @@ void amrex::readLongData (Long* data, std::size_t size, std::istream& is,
 {
     if (id == FPC::NativeLongDescriptor())
     {
-        is.read((char*) data, static_cast<std::streamsize>(size * id.numBytes()));
+        if (!is.read(reinterpret_cast<char*>(data),
+                     static_cast<std::streamsize>(size * id.numBytes())))
+        {
+            amrex::Error("Failed to read long integer data.");
+        }
     }
     else if (id.numBytes() == 2)
     {

--- a/Tests/Particles/TypeDescriptor/main.cpp
+++ b/Tests/Particles/TypeDescriptor/main.cpp
@@ -1,4 +1,6 @@
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <cstring>
 
@@ -11,6 +13,33 @@
 #include "AMReX_Utility.H"
 
 using namespace amrex;
+
+namespace {
+
+[[noreturn]] void ThrowingErrorHandler (const char* msg)
+{
+    throw std::runtime_error(msg ? msg : "amrex::Error");
+}
+
+class ErrorHandlerScope
+{
+public:
+    explicit ErrorHandlerScope (amrex::ErrorHandler handler) noexcept
+        : m_old_handler(amrex::system::error_handler)
+    {
+        amrex::SetErrorHandler(handler);
+    }
+
+    ~ErrorHandlerScope () noexcept
+    {
+        amrex::SetErrorHandler(m_old_handler);
+    }
+
+private:
+    amrex::ErrorHandler m_old_handler;
+};
+
+}
 
 void testIntIO(const IntDescriptor& id_out) {
 
@@ -84,6 +113,45 @@ void testLongIO(const IntDescriptor& id_out) {
     for (int i = 0; i < static_cast<int>(idata_in.size()); ++i) {
         AMREX_ALWAYS_ASSERT(idata_in[i] == idata_out[i]);
     }
+}
+
+void testTruncatedIntegerIO () {
+
+    ErrorHandlerScope scope(ThrowingErrorHandler);
+
+    bool native_int_failed = false;
+    try {
+        amrex::Vector<int> idata_in(2);
+        std::istringstream is(std::string(sizeof(int), '\0'));
+        readIntData(idata_in.data(), idata_in.size(), is, FPC::NativeIntDescriptor());
+    } catch (std::runtime_error const&) {
+        native_int_failed = true;
+    }
+    AMREX_ALWAYS_ASSERT(native_int_failed);
+
+    bool native_long_failed = false;
+    try {
+        amrex::Vector<Long> idata_in(2);
+        std::istringstream is(std::string(sizeof(Long), '\0'));
+        readLongData(idata_in.data(), idata_in.size(), is, FPC::NativeLongDescriptor());
+    } catch (std::runtime_error const&) {
+        native_long_failed = true;
+    }
+    AMREX_ALWAYS_ASSERT(native_long_failed);
+
+    bool converted_int_failed = false;
+    try {
+        auto const native_order = FPC::NativeIntDescriptor().order();
+        auto const converted_order = (native_order == IntDescriptor::NormalOrder)
+            ? IntDescriptor::ReverseOrder : IntDescriptor::NormalOrder;
+        IntDescriptor id_in(FPC::NativeIntDescriptor().numBytes(), converted_order);
+        amrex::Vector<int> idata_in(2);
+        std::istringstream is(std::string(static_cast<std::size_t>(id_in.numBytes()), '\0'));
+        readIntData(idata_in.data(), idata_in.size(), is, id_in);
+    } catch (std::runtime_error const&) {
+        converted_int_failed = true;
+    }
+    AMREX_ALWAYS_ASSERT(converted_int_failed);
 }
 
 void testRealIO(const RealDescriptor& rd_out) {
@@ -239,6 +307,8 @@ int main(int argc, char* argv[])
     testLongIO(big16);
     testLongIO(big32);
     testLongIO(big64);
+
+    testTruncatedIntegerIO();
 
     testRealIO(FPC::NativeRealDescriptor());
     testRealIO(FPC::Native32RealDescriptor());

--- a/Tests/Particles/TypeDescriptor/main.cpp
+++ b/Tests/Particles/TypeDescriptor/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <streambuf>
 #include <string>
 #include <cstring>
 
@@ -30,6 +31,11 @@ public:
         amrex::SetErrorHandler(handler);
     }
 
+    ErrorHandlerScope (ErrorHandlerScope const&) = delete;
+    ErrorHandlerScope (ErrorHandlerScope&&) = delete;
+    ErrorHandlerScope& operator= (ErrorHandlerScope const&) = delete;
+    ErrorHandlerScope& operator= (ErrorHandlerScope&&) = delete;
+
     ~ErrorHandlerScope () noexcept
     {
         amrex::SetErrorHandler(m_old_handler);
@@ -37,6 +43,21 @@ public:
 
 private:
     amrex::ErrorHandler m_old_handler;
+};
+
+class FailingOutputBuffer
+    : public std::streambuf
+{
+protected:
+    std::streamsize xsputn (const char*, std::streamsize n) override
+    {
+        return (n > std::streamsize{0}) ? n-1 : std::streamsize{0};
+    }
+
+    int_type overflow (int_type) override
+    {
+        return traits_type::eof();
+    }
 };
 
 }
@@ -148,6 +169,48 @@ void testTruncatedIntegerIO () {
         amrex::Vector<int> idata_in(2);
         std::istringstream is(std::string(static_cast<std::size_t>(id_in.numBytes()), '\0'));
         readIntData(idata_in.data(), idata_in.size(), is, id_in);
+    } catch (std::runtime_error const&) {
+        converted_int_failed = true;
+    }
+    AMREX_ALWAYS_ASSERT(converted_int_failed);
+}
+
+void testFailedIntegerWrite () {
+
+    ErrorHandlerScope scope(ThrowingErrorHandler);
+
+    bool native_int_failed = false;
+    try {
+        FailingOutputBuffer buffer;
+        std::ostream os(&buffer);
+        amrex::Vector<int> idata_out(2, 1);
+        writeIntData(idata_out.data(), idata_out.size(), os, FPC::NativeIntDescriptor());
+    } catch (std::runtime_error const&) {
+        native_int_failed = true;
+    }
+    AMREX_ALWAYS_ASSERT(native_int_failed);
+
+    bool native_long_failed = false;
+    try {
+        FailingOutputBuffer buffer;
+        std::ostream os(&buffer);
+        amrex::Vector<Long> idata_out(2, 1);
+        writeLongData(idata_out.data(), idata_out.size(), os, FPC::NativeLongDescriptor());
+    } catch (std::runtime_error const&) {
+        native_long_failed = true;
+    }
+    AMREX_ALWAYS_ASSERT(native_long_failed);
+
+    bool converted_int_failed = false;
+    try {
+        auto const native_order = FPC::NativeIntDescriptor().order();
+        auto const converted_order = (native_order == IntDescriptor::NormalOrder)
+            ? IntDescriptor::ReverseOrder : IntDescriptor::NormalOrder;
+        IntDescriptor id_out(FPC::NativeIntDescriptor().numBytes(), converted_order);
+        FailingOutputBuffer buffer;
+        std::ostream os(&buffer);
+        amrex::Vector<int> idata_out(2, 1);
+        writeIntData(idata_out.data(), idata_out.size(), os, id_out);
     } catch (std::runtime_error const&) {
         converted_int_failed = true;
     }
@@ -309,6 +372,7 @@ int main(int argc, char* argv[])
     testLongIO(big64);
 
     testTruncatedIntegerIO();
+    testFailedIntegerWrite();
 
     testRealIO(FPC::NativeRealDescriptor());
     testRealIO(FPC::Native32RealDescriptor());


### PR DESCRIPTION
Detect failed binary integer reads and writes in the VectorIO paths instead of leaving partially filled buffers or silently truncated output. This covers both native int/Long bulk I/O and converted-width integer I/O.
