### PR TITLE
gfx1201 (RDNA4) HIP support

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -21,6 +21,12 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_Scan.H>
 #include <AMReX_Math.H>
+#include <new>
+#ifdef AMREX_USE_HIP
+// GCC's <new> marks placement new as host-only; provide a device version for ROCm.
+__device__ inline void* operator new   ([[maybe_unused]] std::size_t, void* p) noexcept { return p; }
+__device__ inline void  operator delete([[maybe_unused]] void*,       void*  ) noexcept {}
+#endif
 #include <AMReX_OpenMP.H>
 #include <AMReX_MemPool.H>
 #include <AMReX_TypeTraits.H>

--- a/Tools/CMake/AMReXSetDefines.cmake
+++ b/Tools/CMake/AMReXSetDefines.cmake
@@ -65,7 +65,7 @@ endif()
 if (AMReX_HIP)
    add_amrex_define( AMREX_USE_HIP NO_LEGACY )
    add_amrex_define( NDEBUG )  # This address a bug that causes slow build times
-   if (${AMReX_AMD_ARCH} MATCHES "gfx1[01].*")
+   if (${AMReX_AMD_ARCH} MATCHES "gfx1[012].*")
       add_amrex_define( AMREX_AMDGCN_WAVEFRONT_SIZE=32 NO_LEGACY )
    else ()
       add_amrex_define( AMREX_AMDGCN_WAVEFRONT_SIZE=64 NO_LEGACY )


### PR DESCRIPTION
Hello, I have been running the ERF model on a desktop and I found two modifications necessary to build and run on my RX 9070 XT (gfx1201, RDNA4). Full transparency, I'm not familiar with the AMReX internals and I used Claude to help track down and resolve the problems.

**Tools/CMake/AMReXSetDefines.cmake:** The regex `gfx1[01].*` that sets `AMREX_AMDGCN_WAVEFRONT_SIZE=32` doesn't match gfx12xx devices, so `gfx1201` was not picking up the correct wavefront size. Changed to `gfx1[012].*`.

**Src/Base/AMReX_BaseFab.H:** GCC's <new> marks placement new as host-only. Added (for HIP only) device-side operators new and delete.

My testing has been limited. I built AMReX with `-DAMReX_HIP=ON -DAMReX_AMD_ARCH=gfx1201`, which previously failed but now succeeds. ERF compiles and runs correctly.

**Environment:**
- ROCm 6.2.4 / HIP 6.2.41134 / AMD Clang 18.0.0
- GCC 13.3.0 (Ubuntu 24.04)
- CMake 3.28.3