### PR TITLE
Preserve keep-ratio mapping on small knapsack fallback

### DIFF
--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -896,8 +896,11 @@ DistributionMapping::KnapSackProcessorMap (const DistributionMapping& olddm,
 
     if (static_cast<int>(wgts.size()) <= nprocs || nprocs < 2)
     {
-        RoundRobinProcessorMap(static_cast<int>(wgts.size()),nprocs, false);
-        new_efficiency = Real(1);
+        // Not enough boxes to reshuffle meaningfully; keep the existing
+        // mapping so keep_ratio is honored and the reported efficiency
+        // reflects reality.
+        *this = olddm;
+        new_efficiency = old_efficiency;
         return;
     }
     else


### PR DESCRIPTION
When the keep-ratio KnapSack path has too few boxes to reshuffle meaningfully, keep the existing DistributionMapping and report the existing efficiency instead of falling back to round-robin with a hard-coded efficiency of 1.
