### PR TITLE
Fix index ordering convention in DenseBins and SparseBins.

### DIFF
--- a/Src/Particle/AMReX_DenseBins.H
+++ b/Src/Particle/AMReX_DenseBins.H
@@ -197,7 +197,7 @@ public:
                   index_type uix = amrex::min(nx-1,amrex::max(0,iv3.x));
                   index_type uiy = amrex::min(ny-1,amrex::max(0,iv3.y));
                   index_type uiz = amrex::min(nz-1,amrex::max(0,iv3.z));
-                  return (uix * ny + uiy) * nz + uiz;
+                  return (uiz * ny + uiy) * nx + uix;
               });
     }
 
@@ -301,7 +301,7 @@ public:
                   index_type uix = amrex::min(nx-1,amrex::max(0,iv3.x));
                   index_type uiy = amrex::min(ny-1,amrex::max(0,iv3.y));
                   index_type uiz = amrex::min(nz-1,amrex::max(0,iv3.z));
-                  return (uix * ny + uiy) * nz + uiz;
+                  return (uiz * ny + uiy) * nx + uix;
               });
     }
 
@@ -442,7 +442,7 @@ public:
                   index_type uix = amrex::min(nx-1,amrex::max(0,iv3.x));
                   index_type uiy = amrex::min(ny-1,amrex::max(0,iv3.y));
                   index_type uiz = amrex::min(nz-1,amrex::max(0,iv3.z));
-                  return (uix * ny + uiy) * nz + uiz;
+                  return (uiz * ny + uiy) * nx + uix;
               });
     }
 

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -439,9 +439,9 @@ public:
               int ny = hi_p[type].y-lo_p[type].y+1;
               int nz = hi_p[type].z-lo_p[type].z+1;
 
-              for (int kk = amrex::max(ix-num_cells, 0); kk <= amrex::min(ix+num_cells, nx-1); ++kk) {
+              for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
                 for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
-                  for (int ii = amrex::max(iz-num_cells, 0); ii <= amrex::min(iz+num_cells, nz-1); ++ii) {
+                  for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
                     int index = (kk * ny + jj) * nx + ii + off_bins;
                     for (auto p = poffset[index]; p < poffset[index+1]; ++p) {
                       const auto& pid = pperm[p];
@@ -495,9 +495,9 @@ public:
             int ny = hi_p[type].y-lo_p[type].y+1;
             int nz = hi_p[type].z-lo_p[type].z+1;
 
-            for (int kk = amrex::max(ix-num_cells, 0); kk <= amrex::min(ix+num_cells, nx-1); ++kk) {
+            for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
               for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
-                for (int ii = amrex::max(iz-num_cells, 0); ii <= amrex::min(iz+num_cells, nz-1); ++ii) {
+                for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
                   int index = (kk * ny + jj) * nx + ii + off_bins;
                   for (auto p = poffset[index]; p < poffset[index+1]; ++p) {
                     const auto& pid = pperm[p];

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -439,9 +439,9 @@ public:
               int ny = hi_p[type].y-lo_p[type].y+1;
               int nz = hi_p[type].z-lo_p[type].z+1;
 
-              for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
+              for (int kk = amrex::max(ix-num_cells, 0); kk <= amrex::min(ix+num_cells, nx-1); ++kk) {
                 for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
-                  for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
+                  for (int ii = amrex::max(iz-num_cells, 0); ii <= amrex::min(iz+num_cells, nz-1); ++ii) {
                     int index = (kk * ny + jj) * nx + ii + off_bins;
                     for (auto p = poffset[index]; p < poffset[index+1]; ++p) {
                       const auto& pid = pperm[p];
@@ -495,9 +495,9 @@ public:
             int ny = hi_p[type].y-lo_p[type].y+1;
             int nz = hi_p[type].z-lo_p[type].z+1;
 
-            for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
+            for (int kk = amrex::max(ix-num_cells, 0); kk <= amrex::min(ix+num_cells, nx-1); ++kk) {
               for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
-                for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
+                for (int ii = amrex::max(iz-num_cells, 0); ii <= amrex::min(iz+num_cells, nz-1); ++ii) {
                   int index = (kk * ny + jj) * nx + ii + off_bins;
                   for (auto p = poffset[index]; p < poffset[index+1]; ++p) {
                     const auto& pid = pperm[p];

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -442,7 +442,7 @@ public:
               for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
                 for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
                   for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
-                    int index = (ii * ny + jj) * nz + kk + off_bins;
+                    int index = (kk * ny + jj) * nx + ii + off_bins;
                     for (auto p = poffset[index]; p < poffset[index+1]; ++p) {
                       const auto& pid = pperm[p];
                       bool  ghost_pid = (pid >= np_real);
@@ -498,7 +498,7 @@ public:
             for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
               for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
                 for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
-                  int index = (ii * ny + jj) * nz + kk + off_bins;
+                  int index = (kk * ny + jj) * nx + ii + off_bins;
                   for (auto p = poffset[index]; p < poffset[index+1]; ++p) {
                     const auto& pid = pperm[p];
                     bool  ghost_pid = (pid >= np_real);

--- a/Src/Particle/AMReX_NeighborList.H
+++ b/Src/Particle/AMReX_NeighborList.H
@@ -453,9 +453,9 @@ public:
                           count += 1;
                       }
                     } // p
-                  } // kk
+                  } // ii
                 } // jj
-              } // ii
+              } // kk
             } // type
 
             pnbor_counts[i] = count;
@@ -510,9 +510,9 @@ public:
                         ++n;
                     }
                   }// p
-                }// kk
+                }// ii
               }// jj
-            }// ii
+            }// kk
           } // type
         });
         Gpu::Device::streamSynchronize();

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1091,10 +1091,10 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
                 // it adds a call to check_pair. Thus the maximum number value of "loc" below is the
                 // number of neighbors minus 1, and the buffer pointed to by p_boundary_particle_ids
                 // will not be overwritten.
-                for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
+                for (int kk = amrex::max(ix-num_cells, 0); kk <= amrex::min(ix+num_cells, nx-1); ++kk) {
                     for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
-                        for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
-                            if (isActualNeighbor) { break; }
+                        for (int ii = amrex::max(iz-num_cells, 0); ii <= amrex::min(iz+num_cells, nz-1); ++ii) {
+                            if (isActualNeighbor) break;
                             int nbr_cell_id = (kk * ny + jj) * nx + ii;
                             for (auto p = poffset[nbr_cell_id]; p < poffset[nbr_cell_id+1]; ++p) {
                                 if (pperm[p] == int(i)) { continue; }

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1091,9 +1091,9 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
                 // it adds a call to check_pair. Thus the maximum number value of "loc" below is the
                 // number of neighbors minus 1, and the buffer pointed to by p_boundary_particle_ids
                 // will not be overwritten.
-                for (int kk = amrex::max(ix-num_cells, 0); kk <= amrex::min(ix+num_cells, nx-1); ++kk) {
+                for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
                     for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
-                        for (int ii = amrex::max(iz-num_cells, 0); ii <= amrex::min(iz+num_cells, nz-1); ++ii) {
+                        for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
                             if (isActualNeighbor) break;
                             int nbr_cell_id = (kk * ny + jj) * nx + ii;
                             for (auto p = poffset[nbr_cell_id]; p < poffset[nbr_cell_id+1]; ++p) {

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1095,7 +1095,7 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
                     for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
                         for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
                             if (isActualNeighbor) { break; }
-                            int nbr_cell_id = (ii * ny + jj) * nz + kk;
+                            int nbr_cell_id = (kk * ny + jj) * nx + ii;
                             for (auto p = poffset[nbr_cell_id]; p < poffset[nbr_cell_id+1]; ++p) {
                                 if (pperm[p] == int(i)) { continue; }
                                 if (detail::call_check_pair(check_pair, ptile_data, ptile_data, i, pperm[p])) {

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -1094,7 +1094,7 @@ selectActualNeighbors (CheckPair const& check_pair, int num_cells)
                 for (int kk = amrex::max(iz-num_cells, 0); kk <= amrex::min(iz+num_cells, nz-1); ++kk) {
                     for (int jj = amrex::max(iy-num_cells, 0); jj <= amrex::min(iy+num_cells, ny-1); ++jj) {
                         for (int ii = amrex::max(ix-num_cells, 0); ii <= amrex::min(ix+num_cells, nx-1); ++ii) {
-                            if (isActualNeighbor) break;
+                            if (isActualNeighbor) { break; }
                             int nbr_cell_id = (kk * ny + jj) * nx + ii;
                             for (auto p = poffset[nbr_cell_id]; p < poffset[nbr_cell_id+1]; ++p) {
                                 if (pperm[p] == int(i)) { continue; }

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -86,7 +86,7 @@ struct AssignGrid
         for (int ii = ix_lo; ii <= ix_hi; ++ii) {
             for (int jj = iy_lo; jj <= iy_hi; ++jj) {
                 for (int kk = iz_lo; kk <= iz_hi; ++kk) {
-                    int index = (ii * m_num_bins.y + jj) * m_num_bins.z + kk;
+                    int index = (kk * m_num_bins.y + jj) * m_num_bins.x + ii;
                     for (const auto& nbor : m_bif.getBinIterator(index)) {
                         Box bx = nbor.second;
                         if (bx.contains(iv)) {

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -83,9 +83,9 @@ struct AssignGrid
         int iz_hi = amrex::min((lo.z + nGrow - m_lo.z) / m_bin_size.z, m_num_bins.z-1);
         int loc_gid = -1;
         int loc_tid = -1;
-        for (int kk = ix_lo; kk <= ix_hi; ++kk) {
+        for (int kk = iz_lo; kk <= iz_hi; ++kk) {
             for (int jj = iy_lo; jj <= iy_hi; ++jj) {
-                for (int ii = iz_lo; ii <= iz_hi; ++ii) {
+                for (int ii = ix_lo; ii <= ix_hi; ++ii) {
                     int index = (kk * m_num_bins.y + jj) * m_num_bins.x + ii;
                     for (const auto& nbor : m_bif.getBinIterator(index)) {
                         Box bx = nbor.second;

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -83,9 +83,9 @@ struct AssignGrid
         int iz_hi = amrex::min((lo.z + nGrow - m_lo.z) / m_bin_size.z, m_num_bins.z-1);
         int loc_gid = -1;
         int loc_tid = -1;
-        for (int ii = ix_lo; ii <= ix_hi; ++ii) {
+        for (int kk = ix_lo; kk <= ix_hi; ++kk) {
             for (int jj = iy_lo; jj <= iy_hi; ++jj) {
-                for (int kk = iz_lo; kk <= iz_hi; ++kk) {
+                for (int ii = iz_lo; ii <= iz_hi; ++ii) {
                     int index = (kk * m_num_bins.y + jj) * m_num_bins.x + ii;
                     for (const auto& nbor : m_bif.getBinIterator(index)) {
                         Box bx = nbor.second;

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -288,7 +288,7 @@ struct BinMapper
         int uix = amrex::min(nx-1,amrex::max(0,iv3.x));
         int uiy = amrex::min(ny-1,amrex::max(0,iv3.y));
         int uiz = amrex::min(nz-1,amrex::max(0,iv3.z));
-        return static_cast<unsigned int>( (uix * ny + uiy) * nz + uiz + offset );
+        return static_cast<unsigned int>( (uiz * ny + uiy) * nx + uix + offset );
     }
 
 private:

--- a/Src/Particle/AMReX_SparseBins.H
+++ b/Src/Particle/AMReX_SparseBins.H
@@ -141,7 +141,7 @@ public:
             index_type uix = amrex::min(nx-1,amrex::max(0,iv3.x));
             index_type uiy = amrex::min(ny-1,amrex::max(0,iv3.y));
             index_type uiz = amrex::min(nz-1,amrex::max(0,iv3.z));
-            host_cells[i] = (uix * ny + uiy) * nz + uiz;
+            host_cells[i] = (uiz * ny + uiy) * nx + uix;
             bins_map[host_cells[i]] += 1;
         }
 


### PR DESCRIPTION
Currently, in the particle code - particularly in `DenseBins`, `NeighborList`, and `NeighborParticleContainer`, we use a z-fastest index ordering convention. This is not consistent with elsewhere in amrex, for example `Box::atOffset`. This PR changes the particle code to use the same x-fastest convention as elsewhere in the code. This should be less surprising for users, for example see this PR: https://github.com/BLAST-WarpX/warpx/pull/6827

Closes #5432. Supersedes PR #3195. 

Note: on the older version of this PR, I verified that this change is performance-neutral, as expected.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
