### PR TITLE
Runtime `amrex::Math::powi`

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -250,6 +250,60 @@ constexpr T powi (T x) noexcept
     }
 }
 
+} // namespace amrex::Math
+
+#if defined(AMREX_USE_CUDA)
+// Forward-declare libdevice integer-exponent intrinsics. They are part of
+// NVIDIA's libdevice and linked at PTX time but are not declared in standard
+// CUDA cmath headers outside __CUDACC_RTC__ / _LIBCPP_VERSION blocks.
+// See https://docs.nvidia.com/cuda/libdevice-users-guide/__nv_powif.html
+extern "C" __device__ float  __nv_powif (float,  int);
+extern "C" __device__ double __nv_powi  (double, int);
+#endif
+
+namespace amrex::Math {
+
+//! Return pow(x, n) with a runtime integer exponent.
+//!
+//! On GPU backends this routes to the integer-exponent intrinsic
+//! (libdevice __nv_powif / __nv_powi on CUDA, __ocml_pown_f32 /
+//! __ocml_pown_f64 on HIP, sycl::pown on SYCL), which is faster than the
+//! general pow and avoids the C++11 mixed-arg promotion that would
+//! otherwise call the slower double-precision pow(double, double) and
+//! narrow on return. On host it casts the int exponent to the
+//! floating-point type and calls std::pow.
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+float powi (float x, int n) noexcept
+{
+#if defined(AMREX_USE_SYCL)
+    return sycl::pown(x, n);
+#elif defined(AMREX_USE_HIP)
+    AMREX_IF_ON_DEVICE(( return ::powif(x, n); ))
+    AMREX_IF_ON_HOST(( return std::pow(x, static_cast<float>(n)); ))
+#elif defined(AMREX_USE_CUDA)
+    AMREX_IF_ON_DEVICE(( return __nv_powif(x, n); ))
+    AMREX_IF_ON_HOST(( return std::pow(x, static_cast<float>(n)); ))
+#else
+    return std::pow(x, static_cast<float>(n));
+#endif
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+double powi (double x, int n) noexcept
+{
+#if defined(AMREX_USE_SYCL)
+    return sycl::pown(x, n);
+#elif defined(AMREX_USE_HIP)
+    AMREX_IF_ON_DEVICE(( return ::powi(x, n); ))
+    AMREX_IF_ON_HOST(( return std::pow(x, n); ))
+#elif defined(AMREX_USE_CUDA)
+    AMREX_IF_ON_DEVICE(( return __nv_powi(x, n); ))
+    AMREX_IF_ON_HOST(( return std::pow(x, n); ))
+#else
+    return std::pow(x, n);
+#endif
+}
+
 #if defined(AMREX_INT128_SUPPORTED)
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 std::uint64_t umulhi (std::uint64_t a, std::uint64_t b)


### PR DESCRIPTION
## Summary

After C++11, `std::pow` overloads are a bit of a nightmare: https://en.cppreference.com/cpp/numeric/math/pow

A call to `std::pow(float, int)` promotes to `std::pow(double, double)` and there are no `int` overloads at all after C++17.

Now, if we just call into `std::pow(float, float)` by casting the variable of the exponent, then the compiler backend (e.g., in NVCC) likely misses that the 2nd variable is an int and will not replace to the cheaper int power math.

But especially SYCL/HIP libraries have int overloads (`powi`/`pown`) that are optimized for whole integer exponents.
Interestingly, [CUDA](https://docs.nvidia.com/cuda/cuda-math-api/cuda_math_api/group__CUDA__MATH__DOUBLE.html) seems to have no int overload advertised, but it seems to exist in device headers... ah [here they are](https://docs.nvidia.com/cuda/libdevice-users-guide/)

We already have a compile-time int in `amrex::Math::powi` and this adds a runtime overload as well that we can use on hot code paths.

## Additional background

Triggered investigation in https://github.com/BLAST-ImpactX/impactx/pull/1465

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
