### PR TITLE
Sphinx build: Stabilize PDF metadata across builds

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -27,6 +27,9 @@ cd ..
 # Build sphinx
 cd Docs/sphinx_documentation
 echo "Build the Sphinx documentation for Amrex."
+# Stabilize PDF metadata (CreationDate, ModDate, /ID) so identical
+# content produces byte-identical output across repeated builds.
+export SOURCE_DATE_EPOCH=441763200 # 1984-01-01 UTC
 make PYTHON="python3" latexpdf
 mv build/latex/amrex.pdf source/
 make clean


### PR DESCRIPTION
Setting SOURCE_DATE_EPOCH before make latexpdf so pdfTeX produces byte-identical amrex.pdf when the documentation source hasn't changed, avoiding a new ~7 MB blob in git on every deploy.  The fixed epoch (441763200 = 1984-01-01 UTC) pins CreationDate, ModDate, and /ID.
