### PR TITLE
Fix SIMD CI: Clang Tidy

### DIFF
--- a/Tests/SIMD/main.cpp
+++ b/Tests/SIMD/main.cpp
@@ -11,6 +11,7 @@
 #include <AMReX_Vector.H>
 
 #include <cmath>
+#include <cstddef>
 #include <numeric>
 #include <type_traits>
 
@@ -455,7 +456,7 @@ int main (int argc, char* argv[])
                 if (std::abs(got - expected) > ParticleReal(1.e-10)) { ++err; }
             };
 #ifdef AMREX_USE_SIMD
-            for (int lane = 0; lane < static_cast<int>(PReal_t::size()); ++lane) {
+            for (std::size_t lane = 0; lane < PReal_t::size(); ++lane) {
                 check(recip[lane], ParticleReal(0.5));
                 check(acc[lane],   ParticleReal(0.5));
             }


### PR DESCRIPTION
## Summary

Fix new clang-tidy rule `modernize-use-integer-sign-comparison`

## Additional background

Follow-up to #5095

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
