### PR TITLE
CTest: Disable CheckpointRestartDualGrid for GPU builds

### DIFF
--- a/Tests/Particles/CheckpointRestartDualGrid/CMakeLists.txt
+++ b/Tests/Particles/CheckpointRestartDualGrid/CMakeLists.txt
@@ -3,6 +3,11 @@ if (NOT AMReX_PARTICLES)
    return()
 endif ()
 
+# We can enable it again, once the test is fixed for GPU.
+if (NOT AMReX_GPU_BACKEND STREQUAL NONE)
+   return()
+endif ()
+
 foreach(D IN LISTS AMReX_SPACEDIM)
     set(_sources main.cpp)
 


### PR DESCRIPTION
This new test introduced in #5440 needs to be fixed for GPU builds.

