### PR TITLE
Doxygen: No need to copy most of the xml files.

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -19,8 +19,8 @@ mkdir docs_html docs_xml
 mkdir -p docs_html/doxygen
 cp -rp ../Docs/Doxygen/html/* docs_html/doxygen/
 mkdir -p docs_xml/doxygen
-cp -rp ../Docs/Doxygen/xml/* docs_xml/doxygen/
-# add tagfile to allow other docs to interlink with amrex
+# add tagfile to allow other docs to interlink with amrex.
+# but we don't need to copy other xml files.
 cp ../Docs/Doxygen/amrex-doxygen-web.tag.xml docs_xml/doxygen/.
 cd ..
 

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -12,6 +12,11 @@ if grep -q "warning:" doxygen.out; then
 fi
 cd ../..
 
+# remove LaTeX temp files left by doxygen formula rendering
+cd Docs/Doxygen/html
+rm -f *.repository *.aux *.dvi *.log *.tex *.ps *.epsi
+cd ../../..
+
 # copy doxygen to target location
 mkdir build
 cd build


### PR DESCRIPTION
These files could allow amrex doxygen to be inlined into other sites, but no other sites are currently use these xml files. By not providing them, we could make the AMReX_Codes.github.io git repo much smaller.
