### PR TITLE
GNU Make: Fix AMD wavefron size for gfx12??

### DIFF
--- a/Src/Base/AMReX_Math.H
+++ b/Src/Base/AMReX_Math.H
@@ -25,8 +25,7 @@ inline namespace disabled {
     // amrex::disabled, unqualified abs functions are disabled with a compile time error such as,
     // call of overload abs(int&) is ambiguous, or a link time error such as, undefined reference to
     // `amrex::disabled::abs(double)'.  To fix it, one can use `std::abs` or `amrex::Math::abs`.
-    // The latter works in both host and device functions, whereas `std::abs` does not currently
-    // work on device with HIP and SYCL.
+    // We have amrex::Math::abs, because std::abs did not work with HIP and SYCL in the past.
     AMREX_GPU_HOST_DEVICE double abs (double);
     AMREX_GPU_HOST_DEVICE float abs (float);
     AMREX_GPU_HOST_DEVICE long double abs (long double);

--- a/Tools/GNUMake/Make.defs
+++ b/Tools/GNUMake/Make.defs
@@ -1140,8 +1140,8 @@ else ifeq ($(USE_HIP),TRUE)
       AMD_ARCH = $(AMREX_AMD_ARCH)
     endif
 
-    # For AMD GPUs, the wavefront is 64 except for gfx10?? and gfx11??.
-    ifeq ($(filter gfx10% gfx11%,$(AMD_ARCH)),)
+    # For AMD GPUs, the wavefront is 64 except for RDNA (gfx10??, gfx11??, gfx12??, etc.).
+    ifeq ($(filter gfx1%,$(AMD_ARCH)),)
        DEFINES += -DAMREX_AMDGCN_WAVEFRONT_SIZE=64
     else
        DEFINES += -DAMREX_AMDGCN_WAVEFRONT_SIZE=32


### PR DESCRIPTION
This is a follow-up on #5429.

Also fix a comment on abs.
