### PR TITLE
Remove regrid_on_restart assert and set dt_level in RegridOnly

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1935,8 +1935,6 @@ Amr::checkPoint ()
 void
 Amr::RegridOnly (Real time, bool do_io)
 {
-    BL_ASSERT(regrid_on_restart == 1);
-
     if (max_level == 0)
     {
         regrid_level_0_on_restart();
@@ -1946,7 +1944,17 @@ Amr::RegridOnly (Real time, bool do_io)
         int lev_top = std::min(finest_level, max_level-1);
         for (int i = 0; i <= lev_top; i++)
         {
-           regrid(i,time);
+            const int old_finest = finest_level;
+
+            regrid(i,time);
+
+            if (old_finest < finest_level)
+            {
+                for (int k(old_finest + 1); k <= finest_level; ++k)
+                {
+                    dt_level[k] = dt_level[k-1]/static_cast<Real>(n_cycle[k]);
+                }
+            }
         }
     }
 


### PR DESCRIPTION

## Summary

fix Amr::RegridOnly(): remove assertion and set dt_level

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
