### PR TITLE
Sphinx: Fix copyright year.

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -34,7 +34,7 @@ cd Docs/sphinx_documentation
 echo "Build the Sphinx documentation for Amrex."
 # Stabilize PDF metadata (CreationDate, ModDate, /ID) so identical
 # content produces byte-identical output across repeated builds.
-export SOURCE_DATE_EPOCH=441763200 # 1984-01-01 UTC
+export SOURCE_DATE_EPOCH=$(date -d "$(date +%Y)-04-01 00:00:00 UTC" +%s) # yyyy-04-01 UTC
 make PYTHON="python3" latexpdf
 mv build/latex/amrex.pdf source/
 make clean


### PR DESCRIPTION
In #5447, we use a fixed date for SOURCE_DATE_EPOCH to avoid duplicated pdf files. But one issue is that the copyright year becomes 1984. In this PR, we change it the current year. The meta-data in pdf files will still be stable enough, because the date only changes once a year.
