### PR TITLE
Fix cross-level rank lookup in sumNeighborsCPU

### DIFF
--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -319,11 +319,11 @@ NeighborParticleContainer_impl<T_ParticleType, NArrayReal, NArrayInt, Allocator,
             {
                 const auto& tag = tags[i];
                 const int dst_grid = tag.src_grid;
-                const int global_rank = this->ParticleDistributionMap(lev)[dst_grid];
+                const int dst_level = tag.src_level;
+                const int global_rank = this->ParticleDistributionMap(dst_level)[dst_grid];
                 const int dst_proc = ParallelContext::global_to_local_rank(global_rank);
                 const int dst_tile = tag.src_tile;
                 const int dst_index = tag.src_index;
-                const int dst_level = tag.src_level;
 
                 if (dst_proc == MyProc)
                 {


### PR DESCRIPTION
## Summary

`sumNeighborsCPU` looks up the owning rank with `ParticleDistributionMap(lev)`, but `dst_grid = tag.src_grid` indexes the **owner** level's BoxArray (= `tag.src_level`). For same-level entries this is harmless because `lev == tag.src_level`; cross-level entries read the wrong DM and can OOB when DM sizes differ across levels. `GetParticles(dst_level)` a few lines below already uses `dst_level` for the destination tile: this just makes the rank lookup consistent with it.

## Additional background

Found while running a multi-level `NeighborParticleContainer` with `setEnableInverse(true)`; without the fix `sumNeighbors` aborts in debug.

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
