### PR TITLE
Fix float conversion warnings

### DIFF
--- a/Src/EB/AMReX_algoim_K.H
+++ b/Src/EB/AMReX_algoim_K.H
@@ -439,7 +439,7 @@ struct ImplicitIntegral
 
         // In rare cases, degenerate segments can be found, filter out with a tolerance
         static constexpr Real eps = std::numeric_limits<Real>::epsilon();
-        constexpr Real tol = 50.0*eps;
+        constexpr auto tol = Real(50.0*eps);
 
         // Loop over segments of divided interval
         for (int i = 0; i < nroots - 1; ++i)

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -562,7 +562,7 @@ void mlebabeclap_gsrb (Box const& box,
                        bool is_dirichlet, bool beta_on_centroid, bool phi_on_centroid,
                        Box const& vbox, int redblack, int ncomp) noexcept
 {
-    constexpr Real omega = 1.15;
+    constexpr auto omega = Real(1.15);
 
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
@@ -188,7 +188,7 @@ MLEBTensorOp::prepareForSolve ()
     for (int amrlev = 0; amrlev < NAMRLevels(); ++amrlev) {
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             int icomp = idim;
-            MultiFab::Xpay(m_b_coeffs[amrlev][0][idim], 4./3.,
+            MultiFab::Xpay(m_b_coeffs[amrlev][0][idim], Real(4./3.),
                            m_kappa[amrlev][0][idim], 0, icomp, 1, 0);
         }
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
@@ -332,7 +332,7 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     Real divu = dudx + dvdy;
                     Real xi = kapb(i,j,0);
                     Real mu = etab(i,j,0);
-                    Real tautmp = (xi-(2./3.)*mu)*divu;
+                    Real tautmp = (xi-Real(2./3.)*mu)*divu;
                     // Note that mu*(grad v) has been included already in MLEBABecLap
                     Real tauxx = mu*dudx + tautmp;
                     Real tauyx = mu*dvdx;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
@@ -18,7 +18,7 @@ void mlebtensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
     const Real dyi = dxinv[1];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     int k = 0;
     for     (int j = lo.y; j <= hi.y; ++j) {
@@ -64,7 +64,7 @@ void mlebtensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
     const Real dxi = dxinv[0];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     int k = 0;
     for     (int j = lo.y; j <= hi.y; ++j) {
@@ -116,7 +116,7 @@ void mlebtensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
     const Real dyi = dxinv[1];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     int k = 0;
     for     (int j = lo.y; j <= hi.y; ++j) {
@@ -170,7 +170,7 @@ void mlebtensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
     const Real dxi = dxinv[0];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     int k = 0;
     for     (int j = lo.y; j <= hi.y; ++j) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_3D_K.H
@@ -59,7 +59,7 @@ void mlebtensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
     const Real dzi = dxinv[2];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
@@ -119,7 +119,7 @@ void mlebtensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
     const Real dzi = dxinv[2];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
@@ -179,7 +179,7 @@ void mlebtensor_cross_terms_fz (Box const& box, Array4<Real> const& fz,
     const Real dyi = dxinv[1];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
@@ -468,7 +468,7 @@ void mlebtensor_cross_terms_fx (Box const& box, Array4<Real> const& fx,
     const Real dzi = dxinv[2];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
@@ -538,7 +538,7 @@ void mlebtensor_cross_terms_fy (Box const& box, Array4<Real> const& fy,
     const Real dzi = dxinv[2];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {
@@ -608,7 +608,7 @@ void mlebtensor_cross_terms_fz (Box const& box, Array4<Real> const& fz,
     const Real dyi = dxinv[1];
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
-    constexpr Real twoThirds = 2./3.;
+    constexpr auto twoThirds = Real(2./3.);
 
     for         (int k = lo.z; k <= hi.z; ++k) {
         for     (int j = lo.y; j <= hi.y; ++j) {


### PR DESCRIPTION
The warnings are in EB code. Maybe we should add a single precision EB CI test compiled with `-Wfloat-conversion` in the future.
