### PR TITLE
OpenMP: tolerate invalid amrex.omp_threads values

### DIFF
--- a/Src/Base/AMReX_OpenMP.cpp
+++ b/Src/Base/AMReX_OpenMP.cpp
@@ -156,9 +156,17 @@ namespace amrex::OpenMP
         std::string omp_threads = "system";
         pp.queryAdd("omp_threads", omp_threads);
 
-        auto to_int = [](std::string const & str_omp_threads) {
-            std::optional<int> num = std::stoi(str_omp_threads);
-            return num;
+        auto to_int = [](std::string const & str_omp_threads) -> std::optional<int> {
+            int num = 0;
+            std::istringstream iss(str_omp_threads);
+            if (iss >> num) {
+                // Require a complete integer token; otherwise "4xxxx" would parse as 4.
+                char c;
+                if (!(iss >> c)) {
+                    return num;
+                }
+            }
+            return std::nullopt;
         };
 
         if (omp_threads == "system") {


### PR DESCRIPTION
std::stoi throws std::invalid_argument for non-numeric input and std::out_of_range for overflowing input. Because OpenMP::Initialize did not catch those exceptions, invalid amrex.omp_threads values could abort startup before reaching the existing warning/fallback path.

Parse amrex.omp_threads with stream extraction and return nullopt when conversion fails. This lets non-numeric or overflowing values reach the existing warning path and preserves the default OpenMP thread count instead of throwing during Initialize.

Use stream parsing instead of try/catch around std::stoi so this code remains compatible with builds that disable C++ exception handling. It also keeps input validation in the existing optional/fallback flow.

Close #5470.
