### PR TITLE
Linear Solver: use the same index space to make factories

### DIFF
--- a/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
+++ b/Src/EB/AMReX_EB2_IndexSpace_STL.cpp
@@ -75,6 +75,8 @@ const Level&
 IndexSpaceSTL::getLevel (const Geometry& geom) const
 {
     auto it = std::find(std::begin(m_domain), std::end(m_domain), geom.Domain());
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(it != std::end(m_domain),
+                                     "IndexSpaceSTL::getLevel: Geometry not found");
     auto i = std::distance(m_domain.begin(), it);
     return m_stllevel[i];
 }
@@ -83,6 +85,8 @@ const Geometry&
 IndexSpaceSTL::getGeometry (const Box& dom) const
 {
     auto it = std::find(std::begin(m_domain), std::end(m_domain), dom);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(it != std::end(m_domain),
+                                     "IndexSpaceSTL::getLevel: domain not found");
     auto i = std::distance(m_domain.begin(), it);
     return m_geom[i];
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -32,7 +32,8 @@ MLEBABecLap::MLEBABecLap (const Vector<Geometry>& a_geom,
 std::unique_ptr<FabFactory<FArrayBox> >
 MLEBABecLap::makeFactory (int amrlev, int mglev) const
 {
-    return makeEBFabFactory(static_cast<EBFArrayBoxFactory const*>(Factory(0,0))->getEBIndexSpace(),
+    auto const* fact0 = Factory(amrlev,0) ? Factory(amrlev, 0) : Factory(0,0);
+    return makeEBFabFactory(static_cast<EBFArrayBoxFactory const*>(fact0)->getEBIndexSpace(),
                             m_geom[amrlev][mglev],
                             m_grids[amrlev][mglev],
                             m_dmap[amrlev][mglev],

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -154,7 +154,9 @@ std::unique_ptr<FabFactory<FArrayBox> >
 MLEBNodeFDLaplacian::makeFactory (int amrlev, int mglev) const
 {
     if (EB2::TopIndexSpaceIfPresent()) {
-        return makeEBFabFactory(m_geom[amrlev][mglev],
+        auto const* fact0 = Factory(amrlev,0) ? Factory(amrlev, 0) : Factory(0,0);
+        return makeEBFabFactory(static_cast<EBFArrayBoxFactory const*>(fact0)->getEBIndexSpace(),
+                                m_geom[amrlev][mglev],
                                 m_grids[amrlev][mglev],
                                 m_dmap[amrlev][mglev],
                                 {1,1,1}, EBSupport::full);


### PR DESCRIPTION
in case there are multiple EB index spaces.
