### PR TITLE
Refactor: Particle Header (Plotfile)

### DIFF
--- a/Src/Particle/AMReX_ParticleHeader.H
+++ b/Src/Particle/AMReX_ParticleHeader.H
@@ -1,0 +1,85 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef AMREX_PARTICLEHEADER_H_
+#define AMREX_PARTICLEHEADER_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_INT.H>
+#include <AMReX_Vector.H>
+
+#include <iosfwd>
+#include <string>
+
+namespace amrex {
+
+/**
+ * \brief Metadata prefix of an AMReX particle "Header" file.
+ *
+ * This is the single source of truth for parsing the leading metadata of a
+ * particle plotfile/checkpoint "Header" file, as written by
+ * WriteBinaryParticleData. It is used both by ParticleContainer::Restart (to
+ * read a file into a container) and standalone (e.g. from language bindings) to
+ * discover the on-disk layout - number and names of the real/int components,
+ * the precision, and whether the file is a checkpoint - before constructing or
+ * configuring a container to read it.
+ *
+ * The component counts follow the same convention as the on-disk format: for
+ * pure Struct-of-Arrays particles the AMREX_SPACEDIM position components are
+ * implicit and \p num_real counts only the remaining (runtime) real components.
+ */
+struct ParticleHeader
+{
+    //! raw version string, e.g. "Version_Two_Dot_One_double"
+    std::string version;
+    //! precision the particle data was written in: "single" or "double"
+    std::string how;
+    //! whether particle ids need to be converted (Version_Two_Dot_One and later)
+    bool convert_ids = false;
+    //! AMREX_SPACEDIM the file was written with
+    int dim = 0;
+    //! number of real components (pure SoA: excludes the AMREX_SPACEDIM positions)
+    int num_real = 0;
+    //! names of the real components, size() == num_real
+    Vector<std::string> real_comp_names;
+    //! number of integer components
+    int num_int = 0;
+    //! names of the integer components, size() == num_int
+    Vector<std::string> int_comp_names;
+    //! true if the file is a checkpoint (full restart), false for a plotfile
+    bool is_checkpoint = false;
+    //! total number of particles in the file
+    Long num_particles = 0;
+    //! the next particle id to hand out (maxnextid)
+    Long next_id = 0;
+    //! finest level present in the file
+    int finest_level = 0;
+
+    /**
+     * \brief Parse the metadata prefix from an input stream.
+     *
+     * Consumes exactly the leading metadata block (version through finest
+     * level), leaving the stream positioned right after the finest-level entry
+     * and before the per-level grid table. This lets ParticleContainer::Restart
+     * continue reading the grid offsets from the same stream.
+     *
+     * \param is input stream positioned at the start of a particle Header
+     */
+    void parse (std::istream& is);
+
+    /**
+     * \brief Read and parse the "Header" file of a particle plotfile/checkpoint.
+     *
+     * Collective: the file is read on the I/O process and broadcast.
+     *
+     * \param dir   plotfile/checkpoint directory
+     * \param file  particle sub-directory name (e.g. "particle0")
+     * \return the parsed header metadata
+     */
+    static ParticleHeader read (const std::string& dir, const std::string& file);
+};
+
+}
+
+#endif

--- a/Src/Particle/AMReX_ParticleHeader.cpp
+++ b/Src/Particle/AMReX_ParticleHeader.cpp
@@ -1,0 +1,107 @@
+/* Copyright 2026 The AMReX Community
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include <AMReX_ParticleHeader.H>
+
+#include <AMReX.H>
+#include <AMReX_ParallelDescriptor.H>
+
+#include <istream>
+#include <sstream>
+
+namespace amrex {
+
+void
+ParticleHeader::parse (std::istream& is)
+{
+    is >> version;
+    AMREX_ASSERT(!version.empty());
+
+    // What do our version strings mean?
+    // "Version_One_Dot_Zero" -- hard-wired to write out in double precision.
+    // "Version_One_Dot_One" -- can write out either as either single or double precision.
+    // Appended to the latter version string are either "_single" or "_double" to
+    // indicate how the particles were written.
+    // "Version_Two_Dot_Zero" -- this is the AMReX particle file format
+    // "Version_Two_Dot_One" -- expanded particle ids to allow for 2**39-1 per proc
+    convert_ids = false;
+    if (version.find("Version_Two_Dot_One") != std::string::npos) {
+        convert_ids = true;
+    }
+    if (version.find("Version_One_Dot_Zero") != std::string::npos) {
+        how = "double";
+    }
+    else if (version.find("Version_One_Dot_One")  != std::string::npos ||
+             version.find("Version_Two_Dot_Zero") != std::string::npos ||
+             version.find("Version_Two_Dot_One") != std::string::npos) {
+        if (version.find("_single") != std::string::npos) {
+            how = "single";
+        }
+        else if (version.find("_double") != std::string::npos) {
+            how = "double";
+        }
+        else {
+            std::string msg("ParticleHeader::parse(): bad version string: ");
+            msg += version;
+            amrex::Error(msg.c_str());
+        }
+    }
+    else {
+        std::string msg("ParticleHeader::parse(): unknown version string: ");
+        msg += version;
+        amrex::Abort(msg.c_str());
+    }
+
+    is >> dim;
+
+    is >> num_real;
+    real_comp_names.resize(num_real);
+    for (int i = 0; i < num_real; ++i) {
+        is >> real_comp_names[i];
+    }
+
+    is >> num_int;
+    int_comp_names.resize(num_int);
+    for (int i = 0; i < num_int; ++i) {
+        is >> int_comp_names[i];
+    }
+
+    is >> is_checkpoint;
+
+    is >> num_particles;
+
+    is >> next_id;
+
+    is >> finest_level;
+}
+
+ParticleHeader
+ParticleHeader::read (const std::string& dir, const std::string& file)
+{
+    AMREX_ASSERT(!dir.empty());
+    AMREX_ASSERT(!file.empty());
+
+    std::string fullname = dir;
+    if (!fullname.empty() && fullname.back() != '/') {
+        fullname += '/';
+    }
+    fullname += file;
+
+    std::string HdrFileName = fullname;
+    if (!HdrFileName.empty() && HdrFileName.back() != '/') {
+        HdrFileName += '/';
+    }
+    HdrFileName += "Header";
+
+    Vector<char> fileCharPtr;
+    ParallelDescriptor::ReadAndBcastFile(HdrFileName, fileCharPtr);
+    std::string fileCharPtrString(fileCharPtr.dataPtr());
+    std::istringstream HdrFile(fileCharPtrString, std::istringstream::in);
+
+    ParticleHeader header;
+    header.parse(HdrFile);
+    return header;
+}
+
+}

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -2,6 +2,7 @@
 #define AMREX_PARTICLEIO_H
 #include <AMReX_Config.H>
 
+#include <AMReX_ParticleHeader.H>
 #include <AMReX_WriteBinaryParticleData.H>
 #include <AMReX_VisMF.H>
 
@@ -675,88 +676,34 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     std::string fileCharPtrString(fileCharPtr.dataPtr());
     std::istringstream HdrFile(fileCharPtrString, std::istringstream::in);
 
-    std::string version;
-    HdrFile >> version;
-    AMREX_ASSERT(!version.empty());
+    // The metadata prefix (version through finest level) is parsed by the
+    // shared ParticleHeader, which leaves HdrFile positioned at the per-level
+    // grid table read below. See AMReX_ParticleHeader.{H,cpp}.
+    ParticleHeader header;
+    header.parse(HdrFile);
 
-    // What do our version strings mean?
-    // "Version_One_Dot_Zero" -- hard-wired to write out in double precision.
-    // "Version_One_Dot_One" -- can write out either as either single or double precision.
-    // Appended to the latter version string are either "_single" or "_double" to
-    // indicate how the particles were written.
-    // "Version_Two_Dot_Zero" -- this is the AMReX particle file format
-    // "Version_Two_Dot_One" -- expanded particle ids to allow for 2**39-1 per proc
-    std::string how;
-    bool convert_ids = false;
-    if (version.find("Version_Two_Dot_One") != std::string::npos) {
-        convert_ids = true;
-    }
-    if (version.find("Version_One_Dot_Zero") != std::string::npos) {
-        how = "double";
-    }
-    else if (version.find("Version_One_Dot_One")  != std::string::npos ||
-             version.find("Version_Two_Dot_Zero") != std::string::npos ||
-             version.find("Version_Two_Dot_One") != std::string::npos) {
-        if (version.find("_single") != std::string::npos) {
-            how = "single";
-        }
-        else if (version.find("_double") != std::string::npos) {
-            how = "double";
-        }
-        else {
-            std::string msg("ParticleContainer::Restart(): bad version string: ");
-            msg += version;
-            amrex::Error(version.c_str());
-        }
-    }
-    else {
-        std::string msg("ParticleContainer::Restart(): unknown version string: ");
-        msg += version;
-        amrex::Abort(msg.c_str());
-    }
+    const std::string& how = header.how;
+    const bool convert_ids = header.convert_ids;
 
-    int dm;
-    HdrFile >> dm;
-    if (dm != AMREX_SPACEDIM) {
+    if (header.dim != AMREX_SPACEDIM) {
         amrex::Abort("ParticleContainer::Restart(): dm != AMREX_SPACEDIM");
     }
 
-    int nr;
-    HdrFile >> nr;
-    int nrc = ParticleType::is_soa_particle ? NStructReal + NumRealComps() - AMREX_SPACEDIM : NStructReal + NumRealComps();
-    if (nr != nrc) {
+    const int nrc = ParticleType::is_soa_particle ? NStructReal + NumRealComps() - AMREX_SPACEDIM : NStructReal + NumRealComps();
+    if (header.num_real != nrc) {
         amrex::Abort("ParticleContainer::Restart(): nr not the expected value");
     }
 
-    std::string comp_name;
-    for (int i = 0; i < nr; ++i) {
-        HdrFile >> comp_name;
-    }
-
-    int ni;
-    HdrFile >> ni;
-    if (ni != NStructInt + NumIntComps()) {
+    if (header.num_int != NStructInt + NumIntComps()) {
         amrex::Abort("ParticleContainer::Restart(): ni != NStructInt");
     }
 
-    for (int i = 0; i < ni; ++i) {
-        HdrFile >> comp_name;
-    }
+    AMREX_ASSERT(header.num_particles >= 0);
 
-    bool checkpoint;
-    HdrFile >> checkpoint;
+    AMREX_ASSERT(header.next_id > 0);
+    ParticleType::NextID(header.next_id);
 
-    Long nparticles;
-    HdrFile >> nparticles;
-    AMREX_ASSERT(nparticles >= 0);
-
-    Long maxnextid;
-    HdrFile >> maxnextid;
-    AMREX_ASSERT(maxnextid > 0);
-    ParticleType::NextID(maxnextid);
-
-    int finest_level_in_file;
-    HdrFile >> finest_level_in_file;
+    const int finest_level_in_file = header.finest_level;
     AMREX_ASSERT(finest_level_in_file >= 0);
 
     // Determine whether this is a dual-grid restart or not.

--- a/Src/Particle/CMakeLists.txt
+++ b/Src/Particle/CMakeLists.txt
@@ -43,6 +43,8 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_ParticleMesh.H
        AMReX_ParticleLocator.H
        AMReX_ParticleIO.H
+       AMReX_ParticleHeader.H
+       AMReX_ParticleHeader.cpp
        AMReX_DenseBins.H
        AMReX_BinIterator.H
        AMReX_ParticleTransformation.H

--- a/Src/Particle/Make.package
+++ b/Src/Particle/Make.package
@@ -48,6 +48,8 @@ CEXE_headers += AMReX_ParticleMesh.H
 CEXE_headers += AMReX_ParticleInterpolators.H
 
 CEXE_headers += AMReX_ParticleIO.H
+CEXE_headers += AMReX_ParticleHeader.H
+CEXE_sources += AMReX_ParticleHeader.cpp
 CEXE_headers += AMReX_WriteBinaryParticleData.H
 
 CEXE_headers += AMReX_ParticleTransformation.H


### PR DESCRIPTION
## Summary

I want to implement a few more particle load functions, e.g., being able to load any plotfile into a PC that is polymorphic and has only SoA runtime components. For this to work, I need more fine-grained access to header read logic because I want to keep the implementation DRY. This refactors out that part for reuse.

## Additional background

https://github.com/AMReX-Codes/pyamrex/discussions/488

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
