### PR TITLE
Add Fortran Interface to CI

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -55,6 +55,7 @@ jobs:
             -DAMReX_FFT=ON                            \
             -DAMReX_EB=ON                             \
             -DAMReX_FORTRAN=ON                        \
+            -DAMReX_FORTRAN_INTERFACES=ON             \
             -DAMReX_MPI=OFF                           \
             -DAMReX_PLOTFILE_TOOLS=ON                 \
             -DAMReX_PRECISION=SINGLE                  \
@@ -120,6 +121,7 @@ jobs:
             -DAMReX_EB=ON                             \
             -DAMReX_ENABLE_TESTS=ON                   \
             -DAMReX_FORTRAN=ON                        \
+            -DAMReX_FORTRAN_INTERFACES=ON             \
             -DAMReX_MPI=OFF                           \
             -DAMReX_PRECISION=DOUBLE                  \
             -DAMReX_PARTICLES_PRECISION=SINGLE        \

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -54,6 +54,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=20               \
             -DAMReX_FFT=ON                        \
             -DAMReX_FORTRAN=ON                    \
+            -DAMReX_FORTRAN_INTERFACES=ON         \
             -DAMReX_PLOTFILE_TOOLS=ON             \
             -DCMAKE_VERBOSE_MAKEFILE=ON           \
             -DCMAKE_INSTALL_PREFIX=/tmp/my-amrex  \
@@ -117,6 +118,7 @@ jobs:
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
+            -DAMReX_FORTRAN_INTERFACES=ON \
             -DAMReX_SPACEDIM=3          \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 4
@@ -169,6 +171,7 @@ jobs:
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
+            -DAMReX_FORTRAN_INTERFACES=ON \
             -DAMReX_SPACEDIM=2          \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 4
@@ -222,6 +225,7 @@ jobs:
             -DAMReX_EB=OFF              \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
+            -DAMReX_FORTRAN_INTERFACES=ON \
             -DAMReX_SPACEDIM=1          \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build -j 4
@@ -292,6 +296,7 @@ jobs:
             -DAMReX_BOUND_CHECK=ON      \
             -DAMReX_FPE=ON              \
             -DAMReX_FORTRAN=ON          \
+            -DAMReX_FORTRAN_INTERFACES=ON \
             -DAMReX_OMP=ON              \
             -DAMReX_SIMD=ON             \
             -DCMAKE_C_COMPILER=$(which gcc-14)              \
@@ -355,6 +360,7 @@ jobs:
             -DAMReX_EB=ON               \
             -DAMReX_ENABLE_TESTS=ON     \
             -DAMReX_FORTRAN=ON          \
+            -DAMReX_FORTRAN_INTERFACES=ON \
             -DAMReX_MPI=OFF             \
             -DCMAKE_C_COMPILER=$(which gcc-14)     \
             -DCMAKE_CXX_COMPILER=$(which g++-14)   \

--- a/Src/F_Interfaces/Octree/AMReX_octree_fi.cpp
+++ b/Src/F_Interfaces/Octree/AMReX_octree_fi.cpp
@@ -71,6 +71,10 @@ extern "C" {
         const int myproc = ParallelDescriptor::MyProc();
 
         auto* famrcore = dynamic_cast<FAmrCore*>(amrcore);
+        if (famrcore == nullptr) {
+            amrex::Abort("amrex_fi_build_octree_leaves failed to dynamic_cast<FAmrCore*>");
+            return;
+        }
 
         famrcore->octree_leaf_grids.resize(finest_level+1);
         famrcore->octree_leaf_dmap.resize(finest_level+1);

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -4,7 +4,8 @@
 function (setup_test _dim _srcs  _inputs)
 
    cmake_parse_arguments( "" "HAS_FORTRAN_MODULES"
-      "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS;NTASKS;NTHREADS" "" ${ARGN} )
+      "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS;NTASKS;NTHREADS"
+      "CMDLINE_PARAMS_AFTER_INPUTS" ${ARGN} )
 
    if (_BASE_NAME)
       set(_base_name ${_BASE_NAME}_${_dim}d)
@@ -69,6 +70,10 @@ function (setup_test _dim _srcs  _inputs)
       list(GET ${_inputs} 0 _first_inputs)
       get_filename_component( _inputs_filename ${_first_inputs} NAME )
       list(APPEND _cmd ${_inputs_filename})
+   endif ()
+
+   if (_CMDLINE_PARAMS_AFTER_INPUTS)
+      list(APPEND _cmd ${_CMDLINE_PARAMS_AFTER_INPUTS})
    endif ()
 
    #

--- a/Tests/FortranInterface/Advection_F/CMakeLists.txt
+++ b/Tests/FortranInterface/Advection_F/CMakeLists.txt
@@ -17,10 +17,12 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        Exec/SingleVortex/Prob_${D}d.f90
        )
 
-    file( GLOB_RECURSE _input_files LIST_DIRECTORIES false
-       ${CMAKE_CURRENT_LIST_DIR}/input* )
+    set(_input_files inputs.rt)
+    list(TRANSFORM _input_files PREPEND "Exec/SingleVortex/")
 
-    setup_test(${D} _sources _input_files HAS_FORTRAN_MODULES)
+    setup_test(${D} _sources _input_files
+       CMDLINE_PARAMS_AFTER_INPUTS max_step=5
+       HAS_FORTRAN_MODULES)
 
     unset(_sources)
     unset(_input_files)

--- a/Tests/FortranInterface/Advection_F/CMakeLists.txt
+++ b/Tests/FortranInterface/Advection_F/CMakeLists.txt
@@ -1,7 +1,11 @@
 foreach(D IN LISTS AMReX_SPACEDIM)
-    if ( NOT AMReX_PARTICLES OR (D EQUAL 1) )
+    if ( D EQUAL 1 )
        continue()
     endif ()
+
+    if (AMReX_PARTICLES) # Particle currently does not work. Remove this block once the issue is resolved.
+       continue()
+    endif()
 
     set(_sources advect_${D}d_mod.F90 compute_flux_${D}d.f90 slope_${D}d.f90 )
     list(TRANSFORM _sources PREPEND Src_${D}d/ )

--- a/Tests/FortranInterface/Advection_octree_F/CMakeLists.txt
+++ b/Tests/FortranInterface/Advection_octree_F/CMakeLists.txt
@@ -1,26 +1,29 @@
-if (NOT 2 IN_LIST AMReX_SPACEDIM)
-   return ()
-endif ()
+foreach(D IN LISTS AMReX_SPACEDIM)
+    if (NOT D EQUAL 2)
+       continue()
+    endif ()
 
-set(_sources advect_2d_mod.F90 compute_flux_2d.f90 slope_2d.f90)
-list(TRANSFORM _sources PREPEND Src_2d/ )
+    set(_sources advect_2d_mod.F90 compute_flux_2d.f90 slope_2d.f90)
+    list(TRANSFORM _sources PREPEND Src_2d/ )
 
-list(APPEND _sources amr_data_mod.F90 averagedown_mod.F90 bc_mod.F90
-   compute_dt_mod.F90 evolve_mod.F90 fillpatch_mod.F90 fmain.F90
-   initdata.F90 my_amr_mod.F90 plotfile_mod.F90 tagging_mod.F90)
+    list(APPEND _sources amr_data_mod.F90 averagedown_mod.F90 bc_mod.F90
+       compute_dt_mod.F90 evolve_mod.F90 fillpatch_mod.F90 fmain.F90
+       initdata.F90 my_amr_mod.F90 plotfile_mod.F90 tagging_mod.F90)
 
-list(TRANSFORM _sources PREPEND Source/ )
+    list(TRANSFORM _sources PREPEND Source/ )
 
-list(APPEND _sources
-   Exec/SingleVortex/face_velocity_2d.F90
-   Exec/SingleVortex/Prob.f90
-   )
+    list(APPEND _sources
+        Exec/SingleVortex/face_velocity_2d.F90
+        Exec/SingleVortex/Prob.f90
+    )
 
-file(GLOB_RECURSE _input_files LIST_DIRECTORIES false
-   ${CMAKE_CURRENT_LIST_DIR}/input* )
+    set(_input_files inputs.rt)
+    list(TRANSFORM _input_files PREPEND "Exec/SingleVortex/")
 
+    setup_test(${D} _sources _input_files
+        CMDLINE_PARAMS_AFTER_INPUTS max_step=5
+        HAS_FORTRAN_MODULES)
 
-setup_test(2 _sources _input_files HAS_FORTRAN_MODULES)
-
-unset(_sources)
-unset(_input_files)
+    unset(_sources)
+    unset(_input_files)
+endforeach()


### PR DESCRIPTION
In our CMake build system, the AMReX_FORTRAN_INTERFACES option is off by default. None of the CIs was testing the Fortran interface. So we enable it in tests that Fortran language is enabled already.
