### PR TITLE
Make memory management safer in Fortran APIs

### DIFF
--- a/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_flash_fluxregister_mod.F90
@@ -173,6 +173,12 @@ module amrex_flash_fluxregister_module
      end subroutine amrex_fi_flash_fluxregister_communicate
   end interface
 
+#ifdef __NVCOMPILER
+  interface amrex_flash_fluxregister_destroy
+     module procedure amrex_flash_fluxregister_destroy
+  end interface amrex_flash_fluxregister_destroy
+#endif
+
 contains
 
   subroutine amrex_flash_fluxregister_build (fr, fba, cba, fdm, cdm, fine_lev, ncomp)
@@ -182,6 +188,7 @@ contains
     type(amrex_distromap), intent(in) :: fdm, cdm
     !
     type(amrex_geometry) :: fgm, cgm
+    call amrex_flash_fluxregister_destroy(fr)
     fr%owner = .true.
     fr%flev  = fine_lev
     fgm = amrex_get_geometry(fine_lev)
@@ -204,6 +211,7 @@ contains
   subroutine amrex_flash_fluxregister_assign (dst, src)
     class(amrex_flash_fluxregister), intent(inout) :: dst
     type (amrex_flash_fluxregister), intent(in   ) :: src
+    call amrex_flash_fluxregister_destroy(dst)
     dst%owner = .false.
     dst%flev  = src%flev
     dst%p     = src%p

--- a/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_fluxregister_mod.F90
@@ -114,6 +114,7 @@ contains
     type(amrex_boxarray), intent(in) :: ba
     type(amrex_distromap), intent(in) :: dm
     integer, intent(in) :: ref_ratio, fine_lev, ncomp
+    call amrex_fluxregister_destroy(fr)
     fr%owner = .true.
     fr%flev  = fine_lev
     call amrex_fi_new_fluxregister(fr%p, ba%p, dm%p, ref_ratio, fine_lev, ncomp)
@@ -133,6 +134,7 @@ contains
   subroutine amrex_fluxregister_assign (dst, src)
     class(amrex_fluxregister), intent(inout) :: dst
     type (amrex_fluxregister), intent(in   ) :: src
+    call amrex_fluxregister_destroy(dst)
     dst%owner = .false.
     dst%flev  = src%flev
     dst%p     = src%p

--- a/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_boxarray_mod.F90
@@ -146,6 +146,7 @@ contains
   subroutine amrex_boxarray_build_bx (ba, bx)
     type(amrex_boxarray) :: ba
     type(amrex_box), intent(in ) :: bx
+    call amrex_boxarray_destroy(ba)
     ba%owner = .true.
     call amrex_fi_new_boxarray(ba%p, bx%lo, bx%hi)
   end subroutine amrex_boxarray_build_bx
@@ -153,6 +154,7 @@ contains
   subroutine amrex_boxarray_build_bxs (ba, bxs)
     type(amrex_boxarray) :: ba
     integer,intent(in) :: bxs(:,:,:) ! (lo:hi,dim,#ofboxs)
+    call amrex_boxarray_destroy(ba)
     ba%owner = .true.
     call amrex_fi_new_boxarray_from_bxfarr(ba%p, bxs, size(bxs,1), size(bxs,2), size(bxs,3))
   end subroutine amrex_boxarray_build_bxs
@@ -179,6 +181,7 @@ contains
   subroutine amrex_boxarray_install (this, p)
     class(amrex_boxarray), intent(inout) :: this
     type(c_ptr), intent(in) :: p
+    call amrex_boxarray_destroy(this)
     this%owner = .false.
     this%p     = p
   end subroutine amrex_boxarray_install
@@ -186,6 +189,7 @@ contains
   subroutine amrex_boxarray_clone (dst, src)
     class(amrex_boxarray), intent(inout) :: dst
     type (amrex_boxarray), intent(in   ) :: src
+    call amrex_boxarray_destroy(dst)
     dst%owner = .true.
     call amrex_fi_clone_boxarray(dst%p, src%p)
   end subroutine amrex_boxarray_clone

--- a/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_distromap_mod.F90
@@ -107,6 +107,7 @@ contains
   subroutine amrex_distromap_build_ba (dm, ba)
     type(amrex_distromap) :: dm
     type(amrex_boxarray), intent(in) :: ba
+    call amrex_distromap_destroy(dm)
     dm%owner = .true.
     call amrex_fi_new_distromap(dm%p, ba%p)
   end subroutine amrex_distromap_build_ba
@@ -114,6 +115,7 @@ contains
   subroutine amrex_distromap_build_pmap (dm, pmap)
     type(amrex_distromap) :: dm
     integer, intent(in) :: pmap(:)
+    call amrex_distromap_destroy(dm)
     dm%owner = .true.
     call amrex_fi_new_distromap_from_pmap(dm%p,pmap, size(pmap))
   end subroutine amrex_distromap_build_pmap
@@ -132,6 +134,7 @@ contains
   subroutine amrex_distromap_assign (dst, src)
     class(amrex_distromap), intent(inout) :: dst
     type (amrex_distromap), intent(in   ) :: src
+    call amrex_distromap_destroy(dst)
     dst%owner = .false.
     dst%p = src%p
   end subroutine amrex_distromap_assign
@@ -139,6 +142,7 @@ contains
   subroutine amrex_distromap_install (this, p)
     class(amrex_distromap), intent(inout) :: this
     type(c_ptr), intent(in) :: p
+    call amrex_distromap_destroy(this)
     this%owner = .false.
     this%p     = p
   end subroutine amrex_distromap_install
@@ -146,12 +150,14 @@ contains
   subroutine amrex_distromap_clone (dst, src)
     class(amrex_distromap), intent(inout) :: dst
     type (amrex_distromap), intent(in   ) :: src
+    call amrex_distromap_destroy(dst)
     dst%owner = .true.
     call amrex_fi_clone_distromap(dst%p, src%p)
   end subroutine amrex_distromap_clone
 
   subroutine amrex_distromap_move (dst, src)
     class(amrex_distromap) :: dst, src
+    call amrex_distromap_destroy(dst)
     dst%owner = src%owner
     dst%p = src%p
     src%owner = .false.

--- a/Src/F_Interfaces/Base/AMReX_geometry_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_geometry_mod.F90
@@ -128,6 +128,7 @@ contains
   subroutine amrex_geometry_build (geom, domain)
     type(amrex_geometry) :: geom
     type(amrex_box), intent(in) :: domain
+    call amrex_geometry_destroy(geom)
     geom%owner = .true.
     call amrex_fi_new_geometry(geom%p, domain%lo, domain%hi)
     call amrex_geometry_init_data(geom)
@@ -174,6 +175,7 @@ contains
   subroutine amrex_geometry_install (this, p)
     class(amrex_geometry), intent(inout) :: this
     type(c_ptr), intent(in) :: p
+    call amrex_geometry_destroy(this)
     this%owner  = .false.
     this%p      = p
     call amrex_geometry_init_data(this)

--- a/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_multifab_mod.F90
@@ -636,6 +636,7 @@ contains
     integer, intent(in) :: nc, ng(*)
     logical, intent(in), optional :: nodal(*)
     integer :: inodal(3), dir
+    call amrex_multifab_destroy(mf)
     mf%owner = .true.
     mf%nc = nc
     mf%ng(1:ndims) = ng(1:ndims)
@@ -700,6 +701,7 @@ contains
   subroutine amrex_multifab_install (this, p)
     class(amrex_multifab), intent(inout) :: this
     type(c_ptr), intent(in) :: p
+    call amrex_multifab_destroy(this)
     this%owner = .false.
     this%p     = p
     this%nc    = amrex_fi_multifab_ncomp(p)
@@ -1124,6 +1126,7 @@ contains
     integer, intent(in) :: nc, ng(*)
     logical, intent(in), optional :: nodal(*)
     integer :: inodal(3), dir
+    call amrex_imultifab_destroy(imf)
     imf%owner = .true.
     imf%nc = nc
     imf%ng(1:ndims) = ng(1:ndims)

--- a/Src/F_Interfaces/Base/AMReX_physbc_mod.F90
+++ b/Src/F_Interfaces/Base/AMReX_physbc_mod.F90
@@ -57,6 +57,7 @@ contains
     type(amrex_physbc), intent(inout) :: pbc
     procedure(amrex_physbc_proc) :: fill
     type(amrex_geometry), intent(in) :: geom
+    call amrex_physbc_destroy(pbc)
     pbc%owner = .true.
     call amrex_fi_new_physbc(pbc%p, c_funloc(fill), geom%p)
   end subroutine amrex_physbc_build

--- a/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_abeclaplacian_mod.F90
@@ -127,6 +127,7 @@ contains
        dm_cp(ilev) = dm(ilev)%p
     end do
 
+    call amrex_abeclaplacian_destroy(abeclap)
     abeclap%owner = .true.
     call amrex_fi_new_abeclaplacian(abeclap%p, nlevs, gm_cp, ba_cp, dm_cp, imt, iagg, icon, imcl)
   end subroutine amrex_abeclaplacian_build

--- a/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_multigrid_mod.F90
@@ -172,6 +172,7 @@ contains
   subroutine amrex_multigrid_build (mg, linop)
     type(amrex_multigrid), intent(inout) :: mg
     class(amrex_linop), intent(in) :: linop
+    call amrex_multigrid_destroy(mg)
     mg%owner = .true.
     call amrex_fi_new_multigrid(mg%p, linop%p)
   end subroutine amrex_multigrid_build

--- a/Src/F_Interfaces/LinearSolvers/AMReX_poisson_mod.F90
+++ b/Src/F_Interfaces/LinearSolvers/AMReX_poisson_mod.F90
@@ -104,6 +104,7 @@ contains
        dm_cp(ilev) = dm(ilev)%p
     end do
 
+    call amrex_poisson_destroy(poisson)
     poisson%owner = .true.
     call amrex_fi_new_poisson(poisson%p, nlevs, gm_cp, ba_cp, dm_cp, imt, iagg, icon, imcl)
   end subroutine amrex_poisson_build


### PR DESCRIPTION
Add destroy() calls before overwriting C++ pointers in _build, _assign, _install, _clone, and _move methods across the Fortran interfaces.  The destroy functions are no-ops when no C++ object is owned, so they are safe to call on freshly constructed or already-destroyed objects.

This guards against leaks if users call _build or similar methods multiple times without an intervening _destroy.
