### PR TITLE
Add FFT fast-length helper and pad OpenBC FFT domains

### DIFF
--- a/Docs/sphinx_documentation/source/FFT.rst
+++ b/Docs/sphinx_documentation/source/FFT.rst
@@ -72,7 +72,7 @@ Choosing FFT lengths
 :cpp:`FFT::nextFastLen(target, nfactors)` returns the smallest FFT length
 greater than or equal to :cpp:`target` whose prime factors are limited to the
 first :cpp:`nfactors` values from :cpp:`{2, 3, 5, 7, 11}`. The default is
-:cpp:`nfactors = 3`. This helper can be used to choose a padded FFT domain
+:cpp:`nfactors = 5`. This helper can be used to choose a padded FFT domain
 size that is expected to perform well with common FFT backends.
 
 

--- a/Docs/sphinx_documentation/source/FFT.rst
+++ b/Docs/sphinx_documentation/source/FFT.rst
@@ -71,9 +71,12 @@ Choosing FFT lengths
 
 :cpp:`FFT::nextFastLen(target, nfactors)` returns the smallest FFT length
 greater than or equal to :cpp:`target` whose prime factors are limited to the
-first :cpp:`nfactors` values from :cpp:`{2, 3, 5, 7, 11}`. The default is
-:cpp:`nfactors = 5`. This helper can be used to choose a padded FFT domain
-size that is expected to perform well with common FFT backends.
+first :cpp:`nfactors` values from :cpp:`{2, 3, 5, 7, 11, 13}`. If
+:cpp:`nfactors` is omitted, :cpp:`FFT::FastNumPrimeFactors()` provides the
+platform-dependent default. It currently returns 5 for CUDA and 6 for other
+backends. This default is a performance tuning policy and may change in the
+future. This helper can be used to choose a padded FFT domain size that is
+expected to perform well with common FFT backends.
 
 
 Class template `FFT::R2C` also supports batched FFTs. The batch size is set
@@ -188,10 +191,11 @@ boundaries.
 solve. It does not support :cpp:`FFT::Info::setBatchSize` values greater than
 one. The solver uses an internal doubled convolution domain in each transformed
 direction. By default, the one-sided length is rounded up with
-:cpp:`FFT::nextFastLen(n, 5)` before doubling, adding extra padding only for
-FFT performance. This extra padding changes only the internal FFT work arrays,
-not the user-provided :cpp:`MultiFab` domains. Users can disable it with
-:cpp:`FFT::Info::setOpenBCPadding(false)` or tune it with
+:cpp:`FFT::nextFastLen(n)` before doubling, using the platform-dependent
+:cpp:`FFT::FastNumPrimeFactors()` default described above. This extra padding
+changes only the internal FFT work arrays, not the user-provided
+:cpp:`MultiFab` domains. Users can disable it with
+:cpp:`FFT::Info::setOpenBCPadding(false)` or tune the factor count with
 :cpp:`FFT::Info::setOpenBCPaddingNumPrimeFactors(nfactors)`.
 
 .. highlight:: c++

--- a/Docs/sphinx_documentation/source/FFT.rst
+++ b/Docs/sphinx_documentation/source/FFT.rst
@@ -66,6 +66,15 @@ object. Therefore, one should cache it for reuse if possible. Although
 :cpp:`FFT::R2C` does not have a default constructor, one could always use
 :cpp:`std::unique_ptr<FFT::R2C<Real>>` to store an object in one's class.
 
+Choosing FFT lengths
+--------------------
+
+:cpp:`FFT::nextFastLen(target, nfactors)` returns the smallest FFT length
+greater than or equal to :cpp:`target` whose prime factors are limited to the
+first :cpp:`nfactors` values from :cpp:`{2, 3, 5, 7, 11}`. The default is
+:cpp:`nfactors = 3`. This helper can be used to choose a padded FFT domain
+size that is expected to perform well with common FFT backends.
+
 
 Class template `FFT::R2C` also supports batched FFTs. The batch size is set
 in an :cpp:`FFT::Info` object passed to the constructor of
@@ -177,7 +186,13 @@ boundaries.
 
 :cpp:`FFT::OpenBCSolver` currently supports one right-hand-side component per
 solve. It does not support :cpp:`FFT::Info::setBatchSize` values greater than
-one.
+one. The solver uses an internal doubled convolution domain in each transformed
+direction. By default, the one-sided length is rounded up with
+:cpp:`FFT::nextFastLen(n, 3)` before doubling, adding extra padding only for
+FFT performance. This extra padding changes only the internal FFT work arrays,
+not the user-provided :cpp:`MultiFab` domains. Users can disable it with
+:cpp:`FFT::Info::setOpenBCPadding(false)` or tune it with
+:cpp:`FFT::Info::setOpenBCPaddingFactors(nfactors)`.
 
 .. highlight:: c++
 

--- a/Docs/sphinx_documentation/source/FFT.rst
+++ b/Docs/sphinx_documentation/source/FFT.rst
@@ -188,11 +188,11 @@ boundaries.
 solve. It does not support :cpp:`FFT::Info::setBatchSize` values greater than
 one. The solver uses an internal doubled convolution domain in each transformed
 direction. By default, the one-sided length is rounded up with
-:cpp:`FFT::nextFastLen(n, 3)` before doubling, adding extra padding only for
+:cpp:`FFT::nextFastLen(n, 5)` before doubling, adding extra padding only for
 FFT performance. This extra padding changes only the internal FFT work arrays,
 not the user-provided :cpp:`MultiFab` domains. Users can disable it with
 :cpp:`FFT::Info::setOpenBCPadding(false)` or tune it with
-:cpp:`FFT::Info::setOpenBCPaddingFactors(nfactors)`.
+:cpp:`FFT::Info::setOpenBCPaddingNumPrimeFactors(nfactors)`.
 
 .. highlight:: c++
 

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -93,7 +93,7 @@ struct Info
     bool openbc_padding = true;
 
     //! Number of factors used by FFT::nextFastLen for OpenBCSolver padding.
-    int openbc_padding_nfactors = 3;
+    int openbc_padding_nfactors = 5;
 
     /**
      * \brief Select how the domain is decomposed across MPI ranks.
@@ -154,11 +154,11 @@ struct Info
      * \param n Number of factors passed to FFT::nextFastLen. It must be between 3 and 5.
      * \return Reference to this Info.
      */
-    Info& setOpenBCPaddingFactors (int n)
+    Info& setOpenBCPaddingNumPrimeFactors (int n)
     {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             3 <= n && 5 >= n,
-            "amrex::FFT::Info::setOpenBCPaddingFactors: nfactors must be between 3 and 5");
+            "amrex::FFT::Info::setOpenBCPaddingNumPrimeFactors: nfactors must be between 3 and 5");
         openbc_padding_nfactors = n;
         return *this;
     }

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -60,6 +60,24 @@ AMREX_ENUM( Boundary, periodic, even, odd );
 enum struct Kind { none, r2c_f, r2c_b, c2c_f, c2c_b, r2r_ee_f, r2r_ee_b,
                    r2r_oo_f, r2r_oo_b, r2r_eo, r2r_oe };
 
+/**
+ * \brief Return the default factor count used for selecting fast FFT lengths.
+ *
+ * The default is platform dependent. CUDA currently uses 5; other backends
+ * currently use 6. This tuning default may change in the future.
+ *
+ * \return Default number of prime factors used by FFT::nextFastLen.
+ */
+[[nodiscard]] inline constexpr int
+FastNumPrimeFactors () noexcept
+{
+#if defined(AMREX_USE_CUDA)
+    return 5;
+#else
+    return 6;
+#endif
+}
+
 struct Info
 {
     //! Domain composition strategy.
@@ -92,8 +110,9 @@ struct Info
     //! Whether OpenBCSolver pads internal FFT lengths for better performance.
     bool openbc_padding = true;
 
-    //! Number of factors used by FFT::nextFastLen for OpenBCSolver padding.
-    int openbc_padding_nfactors = 5;
+    //! Number of prime factors used by FFT::nextFastLen for OpenBCSolver padding.
+    //! Defaults to FFT::FastNumPrimeFactors().
+    int openbc_padding_nfactors = FastNumPrimeFactors();
 
     /**
      * \brief Select how the domain is decomposed across MPI ranks.
@@ -151,14 +170,14 @@ struct Info
     /**
      * \brief Set the factor count used for OpenBCSolver FFT padding.
      *
-     * \param n Number of factors passed to FFT::nextFastLen. It must be between 3 and 6.
+     * \param n Number of prime factors passed to FFT::nextFastLen. It must be between 3 and 6.
      * \return Reference to this Info.
      */
     Info& setOpenBCPaddingNumPrimeFactors (int n)
     {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             3 <= n && 6 >= n,
-            "amrex::FFT::Info::setOpenBCPaddingNumPrimeFactors: nfactors must be between 3 and 5");
+            "amrex::FFT::Info::setOpenBCPaddingNumPrimeFactors: nfactors must be between 3 and 6");
         openbc_padding_nfactors = n;
         return *this;
     }
@@ -195,19 +214,21 @@ inline void next_fast_len_doit (Long target, Long n, int const* factors,
 /**
  * \brief Return the smallest fast FFT length greater than or equal to \p target.
  *
- * The allowed factors are the first \p nfactors values from {2, 3, 5, 7, 11}.
+ * The allowed factors are the first \p nfactors values from {2, 3, 5, 7, 11, 13}.
+ * When \p nfactors is omitted, FFT::FastNumPrimeFactors() provides a
+ * platform-dependent default.
  *
  * \param target Minimum requested FFT length. It must be positive.
- * \param nfactors Number of supported factors. It must be between 3 and 5.
+ * \param nfactors Number of supported prime factors. It must be between 3 and 6.
  * \return A fast FFT length no smaller than \p target.
  */
 [[nodiscard]] inline int
-nextFastLen (int target, int nfactors = 5)
+nextFastLen (int target, int nfactors = FastNumPrimeFactors())
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(target > 0,
                                      "amrex::FFT::nextFastLen: target must be positive");
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(3 <= nfactors && 6 >= nfactors,
-                                     "amrex::FFT::nextFastLen: nfactors must be between 3 and 5");
+                                     "amrex::FFT::nextFastLen: nfactors must be between 3 and 6");
 
     int constexpr factors[] = {2, 3, 5, 7, 11, 13, 17}; // The extra '17" is to make the buggy GCC -Warray-bounds quiet.
 

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -230,7 +230,7 @@ nextFastLen (int target, int nfactors = FastNumPrimeFactors())
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(3 <= nfactors && 6 >= nfactors,
                                      "amrex::FFT::nextFastLen: nfactors must be between 3 and 6");
 
-    int constexpr factors[] = {2, 3, 5, 7, 11, 13, 17}; // The extra '17" is to make the buggy GCC -Warray-bounds quiet.
+    int constexpr factors[] = {2, 3, 5, 7, 11, 13, 17}; // The extra '17' is to make the buggy GCC -Warray-bounds quiet.
 
     Long const max_len = std::numeric_limits<int>::max();
     Long best = max_len + Long(1);

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -68,7 +68,7 @@ enum struct Kind { none, r2c_f, r2c_b, c2c_f, c2c_b, r2r_ee_f, r2r_ee_b,
  *
  * \return Default number of prime factors used by FFT::nextFastLen.
  */
-[[nodiscard]] inline constexpr int
+[[nodiscard]] constexpr int
 FastNumPrimeFactors () noexcept
 {
 #if defined(AMREX_USE_CUDA)

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -202,7 +202,7 @@ inline void next_fast_len_doit (Long target, Long n, int const* factors,
  * \return A fast FFT length no smaller than \p target.
  */
 [[nodiscard]] inline int
-nextFastLen (int target, int nfactors = 3)
+nextFastLen (int target, int nfactors = 5)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(target > 0,
                                      "amrex::FFT::nextFastLen: target must be positive");

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -151,13 +151,13 @@ struct Info
     /**
      * \brief Set the factor count used for OpenBCSolver FFT padding.
      *
-     * \param n Number of factors passed to FFT::nextFastLen. It must be between 3 and 5.
+     * \param n Number of factors passed to FFT::nextFastLen. It must be between 3 and 6.
      * \return Reference to this Info.
      */
     Info& setOpenBCPaddingNumPrimeFactors (int n)
     {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-            3 <= n && 5 >= n,
+            3 <= n && 6 >= n,
             "amrex::FFT::Info::setOpenBCPaddingNumPrimeFactors: nfactors must be between 3 and 5");
         openbc_padding_nfactors = n;
         return *this;
@@ -206,10 +206,10 @@ nextFastLen (int target, int nfactors = 5)
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(target > 0,
                                      "amrex::FFT::nextFastLen: target must be positive");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(3 <= nfactors && 5 >= nfactors,
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(3 <= nfactors && 6 >= nfactors,
                                      "amrex::FFT::nextFastLen: nfactors must be between 3 and 5");
 
-    int constexpr factors[] = {2, 3, 5, 7, 11, 13}; // The extra '13" is to make the buggy GCC -Warray-bounds quiet.
+    int constexpr factors[] = {2, 3, 5, 7, 11, 13, 17}; // The extra '17" is to make the buggy GCC -Warray-bounds quiet.
 
     Long const max_len = std::numeric_limits<int>::max();
     Long best = max_len + Long(1);

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -195,22 +195,21 @@ inline void next_fast_len_doit (Long target, Long n, int const* factors,
     }
 
     if (ifactor == nfactors) {
-        // Factors 2 and 3 are handled here.  For each power of 3 that
-        // keeps the product below the current best, multiply by 2 until
-        // the target is reached and update best accordingly.
+        // Factors 2 and 3 are handled here: try each n * 3^b, multiply it
+        // by the smallest power of 2 that reaches target, and keep the best.
         Long const max_m3 = std::numeric_limits<int>::max() / 3;
         Long const max_m2 = std::numeric_limits<int>::max() / 2;
-        Long const big = std::numeric_limits<int>::max() + Long(1);
         for (Long m3 = n; m3 < best; ) {
             Long k = m3;
+            bool overflow = false;
             while (k < target) {
                 if (k > max_m2) {
-                    k = big;
+                    overflow = true;
                     break;
                 }
                 k *= 2;
             }
-            if (k < best) {
+            if (!overflow && k < best) {
                 best = k;
             }
             if (m3 > max_m3) {

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -89,6 +89,12 @@ struct Info
     //! Max number of processes to use
     int nprocs = std::numeric_limits<int>::max();
 
+    //! Whether OpenBCSolver pads internal FFT lengths for better performance.
+    bool openbc_padding = true;
+
+    //! Number of factors used by FFT::nextFastLen for OpenBCSolver padding.
+    int openbc_padding_nfactors = 3;
+
     /**
      * \brief Select how the domain is decomposed across MPI ranks.
      *
@@ -135,7 +141,85 @@ struct Info
      * \return Reference to this Info.
      */
     Info& setNumProcs (int n) { nprocs = n; return *this; }
+    /**
+     * \brief Enable or disable OpenBCSolver internal FFT padding.
+     *
+     * \param x True to pad OpenBCSolver FFT lengths to fast sizes.
+     * \return Reference to this Info.
+     */
+    Info& setOpenBCPadding (bool x) { openbc_padding = x; return *this; }
+    /**
+     * \brief Set the factor count used for OpenBCSolver FFT padding.
+     *
+     * \param n Number of factors passed to FFT::nextFastLen. It must be between 3 and 5.
+     * \return Reference to this Info.
+     */
+    Info& setOpenBCPaddingFactors (int n)
+    {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            3 <= n && 5 >= n,
+            "amrex::FFT::Info::setOpenBCPaddingFactors: nfactors must be between 3 and 5");
+        openbc_padding_nfactors = n;
+        return *this;
+    }
 };
+
+/// \cond DOXYGEN_IGNORE
+namespace detail
+{
+inline void next_fast_len_doit (Long target, Long n, int const* factors,
+                                int nfactors, int ifactor, Long& best)
+{
+    if (n >= target) {
+        best = std::min(best, n);
+        return;
+    }
+
+    if (ifactor == nfactors) {
+        return;
+    }
+
+    int const factor = factors[ifactor];
+    Long const max_len = std::numeric_limits<int>::max();
+    for (Long m = n; m < best; ) {
+        next_fast_len_doit(target, m, factors, nfactors, ifactor+1, best);
+        if (m > max_len / factor) {
+            break;
+        }
+        m *= factor;
+    }
+}
+}
+/// \endcond
+
+/**
+ * \brief Return the smallest fast FFT length greater than or equal to \p target.
+ *
+ * The allowed factors are the first \p nfactors values from {2, 3, 5, 7, 11}.
+ *
+ * \param target Minimum requested FFT length. It must be positive.
+ * \param nfactors Number of supported factors. It must be between 3 and 5.
+ * \return A fast FFT length no smaller than \p target.
+ */
+[[nodiscard]] inline int
+nextFastLen (int target, int nfactors = 3)
+{
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(target > 0,
+                                     "amrex::FFT::nextFastLen: target must be positive");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(3 <= nfactors && 5 >= nfactors,
+                                     "amrex::FFT::nextFastLen: nfactors must be between 3 and 5");
+
+    int constexpr factors[] = {2, 3, 5, 7, 11, 13}; // The extra '13" is to make the buggy GCC -Warray-bounds quiet.
+
+    Long const max_len = std::numeric_limits<int>::max();
+    Long best = max_len + Long(1);
+
+    detail::next_fast_len_doit(target, Long(1), factors, nfactors, 0, best);
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(best <= max_len,
+                                     "amrex::FFT::nextFastLen: result exceeds int range");
+    return static_cast<int>(best);
+}
 
 #ifdef AMREX_USE_HIP
 /// \cond DOXYGEN_IGNORE

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -200,9 +200,10 @@ inline void next_fast_len_doit (Long target, Long n, int const* factors,
 
     int const factor = factors[ifactor];
     Long const max_len = std::numeric_limits<int>::max();
+    Long const max_m = max_len / factor;
     for (Long m = n; m < best; ) {
         next_fast_len_doit(target, m, factors, nfactors, ifactor+1, best);
-        if (m > max_len / factor) {
+        if (m > max_m) {
             break;
         }
         m *= factor;

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -195,14 +195,29 @@ inline void next_fast_len_doit (Long target, Long n, int const* factors,
     }
 
     if (ifactor == nfactors) {
-        Long const max_m = std::numeric_limits<int>::max() / 2;
-        while (n < target) {
-            if (n > max_m) {
-                return;
+        // Factors 2 and 3 are handled here.  For each power of 3 that
+        // keeps the product below the current best, multiply by 2 until
+        // the target is reached and update best accordingly.
+        Long const max_m3 = std::numeric_limits<int>::max() / 3;
+        Long const max_m2 = std::numeric_limits<int>::max() / 2;
+        Long const big = std::numeric_limits<int>::max() + Long(1);
+        for (Long m3 = n; m3 < best; ) {
+            Long k = m3;
+            while (k < target) {
+                if (k > max_m2) {
+                    k = big;
+                    break;
+                }
+                k *= 2;
             }
-            n *= 2;
+            if (k < best) {
+                best = k;
+            }
+            if (m3 > max_m3) {
+                break;
+            }
+            m3 *= 3;
         }
-        best = std::min(best, n);
         return;
     }
 
@@ -239,13 +254,13 @@ nextFastLen (int target, int nfactors = FastNumPrimeFactors())
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(3 <= nfactors && 6 >= nfactors,
                                      "amrex::FFT::nextFastLen: nfactors must be between 3 and 6");
 
-    int constexpr factors[] = {3, 5, 7, 11, 13, 17}; // The extra '17' is to make the buggy GCC -Warray-bounds quiet.
+    int constexpr factors[] = {5, 7, 11, 13, 17}; // The extra '17' is to make the buggy GCC -Warray-bounds quiet.
 
     Long const max_len = std::numeric_limits<int>::max();
     Long best = max_len + Long(1);
 
-    // Factor 2 is handled directly in the base case.
-    detail::next_fast_len_doit(target, Long(1), factors, nfactors-1, 0, best);
+    // Factors 2 and 3 are handled directly in the base case.
+    detail::next_fast_len_doit(target, Long(1), factors, nfactors-2, 0, best);
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(best <= max_len,
                                      "amrex::FFT::nextFastLen: result exceeds int range");

--- a/Src/FFT/AMReX_FFT_Helper.H
+++ b/Src/FFT/AMReX_FFT_Helper.H
@@ -195,6 +195,14 @@ inline void next_fast_len_doit (Long target, Long n, int const* factors,
     }
 
     if (ifactor == nfactors) {
+        Long const max_m = std::numeric_limits<int>::max() / 2;
+        while (n < target) {
+            if (n > max_m) {
+                return;
+            }
+            n *= 2;
+        }
+        best = std::min(best, n);
         return;
     }
 
@@ -231,12 +239,13 @@ nextFastLen (int target, int nfactors = FastNumPrimeFactors())
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(3 <= nfactors && 6 >= nfactors,
                                      "amrex::FFT::nextFastLen: nfactors must be between 3 and 6");
 
-    int constexpr factors[] = {2, 3, 5, 7, 11, 13, 17}; // The extra '17' is to make the buggy GCC -Warray-bounds quiet.
+    int constexpr factors[] = {3, 5, 7, 11, 13, 17}; // The extra '17' is to make the buggy GCC -Warray-bounds quiet.
 
     Long const max_len = std::numeric_limits<int>::max();
     Long best = max_len + Long(1);
 
-    detail::next_fast_len_doit(target, Long(1), factors, nfactors, 0, best);
+    // Factor 2 is handled directly in the base case.
+    detail::next_fast_len_doit(target, Long(1), factors, nfactors-1, 0, best);
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(best <= max_len,
                                      "amrex::FFT::nextFastLen: result exceeds int range");

--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -106,6 +106,8 @@ Box OpenBCSolver<T>::make_grown_domain (Box const& domain, IntVect const& padded
     int ndims = AMREX_SPACEDIM;
 #if (AMREX_SPACEDIM == 3)
     if (info.twod_mode) { ndims = 2; }
+#else
+    amrex::ignore_unused(info);
 #endif
     for (int idim = 0; idim < ndims; ++idim) {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -69,7 +69,8 @@ public:
 
 private:
     static IntVect make_padded_length (Box const& domain, Info const& info);
-    static Box make_grown_domain (Box const& domain, Info const& info);
+    static Box make_grown_domain (Box const& domain, IntVect const& padded_len,
+                                  Info const& info);
 
     Box m_domain;
     Info m_info;
@@ -98,9 +99,10 @@ IntVect OpenBCSolver<T>::make_padded_length (Box const& domain, Info const& info
 }
 
 template <typename T>
-Box OpenBCSolver<T>::make_grown_domain (Box const& domain, Info const& info)
+Box OpenBCSolver<T>::make_grown_domain (Box const& domain, IntVect const& padded_len,
+                                        Info const& info)
 {
-    IntVect len = make_padded_length(domain, info);
+    IntVect len = padded_len;
     int ndims = AMREX_SPACEDIM;
 #if (AMREX_SPACEDIM == 3)
     if (info.twod_mode) { ndims = 2; }
@@ -119,7 +121,7 @@ OpenBCSolver<T>::OpenBCSolver (Box const& domain, Info const& info)
     : m_domain(domain),
       m_info(info),
       m_padded_length(OpenBCSolver<T>::make_padded_length(domain, info)),
-      m_r2c(OpenBCSolver<T>::make_grown_domain(domain,info),
+      m_r2c(OpenBCSolver<T>::make_grown_domain(domain, m_padded_length, info),
             m_info.setDomainStrategy(FFT::DomainStrategy::slab))
 {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_info.batch_size == 1,
@@ -127,7 +129,7 @@ OpenBCSolver<T>::OpenBCSolver (Box const& domain, Info const& info)
 
 #if (AMREX_SPACEDIM == 3)
     if (m_info.twod_mode) {
-        auto gdom = make_grown_domain(domain,m_info);
+        auto gdom = make_grown_domain(domain, m_padded_length, m_info);
         gdom.enclosedCells(2);
         gdom.setSmall(2, 0);
         int nprocs = std::min({ParallelContext::NProcsSub(),

--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -60,32 +60,65 @@ public:
      */
     [[nodiscard]] Box const& Domain () const { return m_domain; }
 
+    /**
+     * \brief Access the one-sided padded length used to build the internal FFT domain.
+     *
+     * \return Padded length before the open-boundary convolution domain is doubled.
+     */
+    [[nodiscard]] IntVect const& PaddedLength () const { return m_padded_length; }
+
 private:
+    static IntVect make_padded_length (Box const& domain, Info const& info);
     static Box make_grown_domain (Box const& domain, Info const& info);
 
     Box m_domain;
     Info m_info;
+    IntVect m_padded_length;
     R2C<T> m_r2c;
     cMF m_G_fft;
     std::unique_ptr<R2C<T>> m_r2c_green;
 };
 
 template <typename T>
-Box OpenBCSolver<T>::make_grown_domain (Box const& domain, Info const& info)
+IntVect OpenBCSolver<T>::make_padded_length (Box const& domain, Info const& info)
 {
     IntVect len = domain.length();
+    int ndims = AMREX_SPACEDIM;
 #if (AMREX_SPACEDIM == 3)
-    if (info.twod_mode) { len[2] = 0; }
+    if (info.twod_mode) { ndims = 2; }
 #else
     amrex::ignore_unused(info);
 #endif
-    return Box(domain.smallEnd(), domain.bigEnd()+len, domain.ixType());
+    if (info.openbc_padding) {
+        for (int idim = 0; idim < ndims; ++idim) {
+            len[idim] = FFT::nextFastLen(len[idim], info.openbc_padding_nfactors);
+        }
+    }
+    return len;
+}
+
+template <typename T>
+Box OpenBCSolver<T>::make_grown_domain (Box const& domain, Info const& info)
+{
+    IntVect len = make_padded_length(domain, info);
+    int ndims = AMREX_SPACEDIM;
+#if (AMREX_SPACEDIM == 3)
+    if (info.twod_mode) { ndims = 2; }
+#endif
+    for (int idim = 0; idim < ndims; ++idim) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            len[idim] <= std::numeric_limits<int>::max()/2,
+            "FFT::OpenBCSolver: padded domain length exceeds int range");
+        len[idim] *= 2;
+    }
+    return Box(domain.smallEnd(), domain.smallEnd()+len-IntVect(1), domain.ixType());
 }
 
 template <typename T>
 OpenBCSolver<T>::OpenBCSolver (Box const& domain, Info const& info)
     : m_domain(domain),
       m_info(info),
+      m_padded_length(OpenBCSolver<T>::make_padded_length(domain, info)),
       m_r2c(OpenBCSolver<T>::make_grown_domain(domain,info),
             m_info.setDomainStrategy(FFT::DomainStrategy::slab))
 {
@@ -124,7 +157,8 @@ void OpenBCSolver<T>::setGreensFunction (F const& greens_function)
         :                             detail::get_fab(m_r2c.m_rx);
     auto const& lo = m_domain.smallEnd();
     auto const& lo3 = lo.dim3();
-    auto const& len = m_domain.length3d();
+    auto const len3d = m_padded_length.dim3();
+    GpuArray<int,3> len{len3d.x, len3d.y, len3d.z};
     if (infab) {
         auto const& a = infab->array();
         auto box = infab->box();

--- a/Src/FFT/AMReX_FFT_Poisson.H
+++ b/Src/FFT/AMReX_FFT_Poisson.H
@@ -149,12 +149,14 @@ public:
      * \param geom    Geometry describing the problem domain.
      * \param ixtype  Index type (cell vs. node) for the working arrays.
      * \param ngrow   Number of grow cells applied prior to solving.
+     * \param info    OpenBC solver options.
      */
     template <typename FA=MF>
     requires (IsFabArray_v<FA>)
     explicit PoissonOpenBC (Geometry const& geom,
                             IndexType ixtype = IndexType::TheCellType(),
-                            IntVect const& ngrow = IntVect(0));
+                            IntVect const& ngrow = IntVect(0),
+                            Info const& info = Info{});
 
     /**
      * \brief Solve the open-boundary Poisson problem.
@@ -169,7 +171,16 @@ public:
      */
     void define_doit (); // has to be public for cuda
 
+    /**
+     * \brief Access the one-sided padded length used by the internal OpenBC solver.
+     *
+     * \return Padded length before the open-boundary convolution domain is doubled.
+     */
+    [[nodiscard]] IntVect const& PaddedLength () const { return m_solver.PaddedLength(); }
+
 private:
+    static Info make_solver_info (Info const& info);
+
     Geometry m_geom;
     Box m_grown_domain;
     IntVect m_ngrow;
@@ -398,13 +409,22 @@ template <typename MF>
 template <typename FA>
 requires (IsFabArray_v<FA>)
 PoissonOpenBC<MF>::PoissonOpenBC (Geometry const& geom, IndexType ixtype,
-                                  IntVect const& ngrow)
+                                  IntVect const& ngrow, Info const& info)
     : m_geom(geom),
       m_grown_domain(amrex::grow(amrex::convert(geom.Domain(),ixtype),ngrow)),
       m_ngrow(ngrow),
-      m_solver(m_grown_domain)
+      m_solver(m_grown_domain, make_solver_info(info))
 {
     define_doit();
+}
+
+template <typename MF>
+Info PoissonOpenBC<MF>::make_solver_info (Info const& info)
+{
+    Info solver_info;
+    solver_info.openbc_padding = info.openbc_padding;
+    solver_info.openbc_padding_nfactors = info.openbc_padding_nfactors;
+    return solver_info;
 }
 
 template <typename MF>

--- a/Tests/FFT/OpenBC/main.cpp
+++ b/Tests/FFT/OpenBC/main.cpp
@@ -7,6 +7,44 @@
 
 using namespace amrex;
 
+namespace {
+
+void fill_rhs (MultiFab& rho, Geometry const& geom, IndexType ixtype)
+{
+    auto const& dx = geom.CellSizeArray();
+    auto const& problo = geom.ProbLoArray();
+    auto const& rhoma = rho.arrays();
+
+    constexpr int nsub = 4;
+    Real dxsub = dx[0]/nsub;
+    Real dysub = dx[1]/nsub;
+    Real dzsub = dx[2]/nsub;
+
+    ParallelFor(rho, [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
+    {
+        Real x = (i+0.5_rt/nsub)*dx[0] + problo[0];
+        Real y = (j+0.5_rt/nsub)*dx[1] + problo[1];
+        Real z = (k+0.5_rt/nsub)*dx[2] + problo[2];
+        if (ixtype.nodeCentered()) {
+            x -= 0.5_rt*dx[0];
+            y -= 0.5_rt*dx[1];
+            z -= 0.5_rt*dx[2];
+        }
+        int n = 0;
+        for (int isub = 0; isub < nsub; ++isub) {
+        for (int jsub = 0; jsub < nsub; ++jsub) {
+        for (int ksub = 0; ksub < nsub; ++ksub) {
+            auto xs = x + isub*dxsub;
+            auto ys = y + jsub*dysub;
+            auto zs = z + ksub*dzsub;
+            if ((xs*xs+ys*ys+zs*zs) < 0.25_rt) { ++n; }
+        }}}
+        rhoma[b](i,j,k) = Real(n) / Real(nsub*nsub*nsub);
+    });
+}
+
+}
+
 int main (int argc, char* argv[])
 {
     static_assert(AMREX_SPACEDIM == 3);
@@ -40,7 +78,6 @@ int main (int argc, char* argv[])
                       CoordSys::cartesian, {AMREX_D_DECL(0,0,0)});
 
         auto const& dx = geom.CellSizeArray();
-        auto const& problo = geom.ProbLoArray();
 
         std::array<IndexType,2> ixtypes{IndexType::TheCellType(),
                                         IndexType::TheNodeType()};
@@ -54,34 +91,7 @@ int main (int argc, char* argv[])
             MultiFab phi(iba,dm,1,ng);
             phi.setVal(std::numeric_limits<Real>::max());
 
-            auto const& rhoma = rho.arrays();
-
-            constexpr int nsub = 4;
-            Real dxsub = dx[0]/nsub;
-            Real dysub = dx[1]/nsub;
-            Real dzsub = dx[2]/nsub;
-
-            ParallelFor(rho, [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
-            {
-                Real x = (i+0.5_rt/nsub)*dx[0] + problo[0];
-                Real y = (j+0.5_rt/nsub)*dx[1] + problo[1];
-                Real z = (k+0.5_rt/nsub)*dx[2] + problo[2];
-                if (ixtype.nodeCentered()) {
-                    x -= 0.5_rt*dx[0];
-                    y -= 0.5_rt*dx[1];
-                    z -= 0.5_rt*dx[2];
-                }
-                int n = 0;
-                for (int isub = 0; isub < nsub; ++isub) {
-                for (int jsub = 0; jsub < nsub; ++jsub) {
-                for (int ksub = 0; ksub < nsub; ++ksub) {
-                    auto xs = x + isub*dxsub;
-                    auto ys = y + jsub*dysub;
-                    auto zs = z + ksub*dzsub;
-                    if ((xs*xs+ys*ys+zs*zs) < 0.25_rt) { ++n; }
-                }}}
-                rhoma[b](i,j,k) = Real(n) / Real(nsub*nsub*nsub);
-            });
+            fill_rhs(rho, geom, ixtype);
 
             FFT::PoissonOpenBC solver(geom, ixtype, IntVect(ng));
             solver.solve(phi, rho);
@@ -117,6 +127,50 @@ int main (int argc, char* argv[])
                     AMREX_ALWAYS_ASSERT(error < eps);
                 }
             }}}
+        }
+
+        {
+            amrex::Print() << "\nTesting OpenBC padding against unpadded solve\n";
+
+            Box domain2(IntVect(0), IntVect(64,66,68));
+            BoxArray ba2(domain2);
+            ba2.maxSize(IntVect(32, 32, 32));
+            DistributionMapping dm2(ba2);
+
+            Geometry geom2(domain2,
+                           RealBox(-1._rt, -1._rt, -1._rt, 1._rt, 1._rt, 1._rt),
+                           CoordSys::cartesian, {AMREX_D_DECL(0,0,0)});
+
+            MultiFab rho2(ba2, dm2, 1, 0);
+            MultiFab phi_padded(ba2, dm2, 1, 0);
+            MultiFab phi_unpadded(ba2, dm2, 1, 0);
+            fill_rhs(rho2, geom2, IndexType::TheCellType());
+
+            FFT::PoissonOpenBC padded_solver(geom2);
+            FFT::Info unpadded_info;
+            unpadded_info.setOpenBCPadding(false);
+            FFT::PoissonOpenBC unpadded_solver(geom2, IndexType::TheCellType(),
+                                               IntVect(0), unpadded_info);
+
+            AMREX_ALWAYS_ASSERT(padded_solver.PaddedLength() == IntVect(72, 72, 72));
+            AMREX_ALWAYS_ASSERT(unpadded_solver.PaddedLength() == domain2.length());
+
+            padded_solver.solve(phi_padded, rho2);
+            unpadded_solver.solve(phi_unpadded, rho2);
+
+            MultiFab diff(ba2, dm2, 1, 0);
+            MultiFab::Copy(diff, phi_padded, 0, 0, 1, 0);
+            MultiFab::Subtract(diff, phi_unpadded, 0, 0, 1, 0);
+
+            Real const refnorm = phi_unpadded.norm0(0);
+            Real const error = diff.norm0(0) / refnorm;
+            amrex::Print() << "  relative padded/unpadded error " << error << "\n";
+#ifdef AMREX_USE_FLOAT
+            constexpr Real eps = 1.e-5;
+#else
+            constexpr Real eps = 1.e-13;
+#endif
+            AMREX_ALWAYS_ASSERT(error < eps);
         }
     }
     amrex::Finalize();

--- a/Tests/FFT/OpenBC/main.cpp
+++ b/Tests/FFT/OpenBC/main.cpp
@@ -152,7 +152,11 @@ int main (int argc, char* argv[])
             FFT::PoissonOpenBC unpadded_solver(geom2, IndexType::TheCellType(),
                                                IntVect(0), unpadded_info);
 
-            AMREX_ALWAYS_ASSERT(padded_solver.PaddedLength() == IntVect(72, 72, 72));
+            IntVect expected_padded_length = domain2.length();
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                expected_padded_length[idim] = FFT::nextFastLen(expected_padded_length[idim]);
+            }
+            AMREX_ALWAYS_ASSERT(padded_solver.PaddedLength() == expected_padded_length);
             AMREX_ALWAYS_ASSERT(unpadded_solver.PaddedLength() == domain2.length());
 
             padded_solver.solve(phi_padded, rho2);

--- a/Tests/FFT/OpenBC/main.cpp
+++ b/Tests/FFT/OpenBC/main.cpp
@@ -132,6 +132,11 @@ int main (int argc, char* argv[])
         {
             amrex::Print() << "\nTesting OpenBC padding against unpadded solve\n";
 
+            AMREX_ALWAYS_ASSERT(FFT::Info{}.openbc_padding_nfactors ==
+                                FFT::FastNumPrimeFactors());
+            AMREX_ALWAYS_ASSERT(FFT::nextFastLen(13) ==
+                                FFT::nextFastLen(13, FFT::FastNumPrimeFactors()));
+
             Box domain2(IntVect(0), IntVect(64,66,68));
             BoxArray ba2(domain2);
             ba2.maxSize(IntVect(32, 32, 32));


### PR DESCRIPTION
Add FFT::nextFastLen for choosing 2/3/5/7/11-smooth padded FFT sizes.

Use the helper in OpenBCSolver to pad internal doubled convolution domains to fast lengths by default. Add FFT::Info controls to disable or tune OpenBC padding, pass Info through PoissonOpenBC, update docs, and test padded vs. unpadded OpenBC solves.
