### PR TITLE
Fix dual_grid restart for particle containers constructed with AmrCore*

### DIFF
--- a/Src/AmrCore/AMReX_AmrParGDB.H
+++ b/Src/AmrCore/AMReX_AmrParGDB.H
@@ -76,6 +76,11 @@ public:
     //! Clear the cached particle Geometry on level \p level.
     void ClearParticleGeometry (int level) override;
 
+    //! Return true if a particle BoxArray override is active on level \p level
+    //! (i.e. the container is not falling through to the AmrCore boxArray).
+    [[nodiscard]] bool ParticleBoxArraySet (int level) const override
+        { return !m_ba[level].empty(); }
+
     //! Return true if level \p level has been defined.
     [[nodiscard]] bool LevelDefined (int level) const override;
     //! Return the current finest level known to the owning AmrCore.

--- a/Src/Particle/AMReX_ParGDB.H
+++ b/Src/Particle/AMReX_ParGDB.H
@@ -46,6 +46,11 @@ public:
     virtual void ClearParticleDistributionMap (int level) = 0;
     virtual void ClearParticleGeometry (int level) = 0;
 
+    // Returns true if the particle BoxArray on this level is an explicit override
+    // rather than a pass-through to an underlying AmrCore. Used during checkpoint
+    // restart to determine whether restoring grids should call Set* or Clear*.
+    [[nodiscard]] virtual bool ParticleBoxArraySet (int level) const = 0;
+
     [[nodiscard]] virtual bool LevelDefined (int level) const = 0;
     [[nodiscard]] virtual int finestLevel () const = 0;
     [[nodiscard]] virtual int maxLevel () const = 0;
@@ -109,6 +114,9 @@ public:
     void ClearParticleBoxArray (int level) override;
     void ClearParticleDistributionMap (int level) override;
     void ClearParticleGeometry (int level) override;
+
+    [[nodiscard]] bool ParticleBoxArraySet (int level) const override
+        { amrex::ignore_unused(level); return true; }
 
     [[nodiscard]] bool LevelDefined (int level) const override;
     [[nodiscard]] int finestLevel () const override;

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -767,6 +767,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     Vector<DistributionMapping> old_dms(max_level + 1);
     Vector<BoxArray> old_bas(max_level + 1);
     Vector<BoxArray> particle_box_arrays(max_level + 1);
+    Vector<bool> ba_was_set(max_level + 1, false);
     bool dual_grid = false;
 
     bool have_pheaders = false;
@@ -789,6 +790,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         {
             old_dms[lev] = ParticleDistributionMap(lev);
             old_bas[lev] = ParticleBoxArray(lev);
+            ba_was_set[lev] = m_gdb->ParticleBoxArraySet(lev);
             std::string phdr_name = fullname;
             phdr_name += "/Level_";
             phdr_name = amrex::Concatenate(phdr_name, lev, 1);
@@ -942,8 +944,15 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
     if (dual_grid) {
         for (int lev = 0; lev <= finestLevel(); lev++) {
-            SetParticleBoxArray(lev, old_bas[lev]);
-            SetParticleDistributionMap(lev, old_dms[lev]);
+            if (ba_was_set[lev]) {
+                SetParticleBoxArray(lev, old_bas[lev]);
+                SetParticleDistributionMap(lev, old_dms[lev]);
+            } else {
+                // The particle grids were tracking an AmrCore pass-through before
+                // the dual-grid override; restore that by clearing the cached overrides.
+                m_gdb->ClearParticleBoxArray(lev);
+                m_gdb->ClearParticleDistributionMap(lev);
+            }
         }
     }
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -767,7 +767,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     Vector<DistributionMapping> old_dms(max_level + 1);
     Vector<BoxArray> old_bas(max_level + 1);
     Vector<BoxArray> particle_box_arrays(max_level + 1);
-    Vector<bool> ba_was_set(max_level + 1, false);
+    Vector<int> ba_was_set(max_level + 1, 0);
     bool dual_grid = false;
 
     bool have_pheaders = false;


### PR DESCRIPTION
The problem, which as exposed by #5440, is that when we have constructed a ParticleContainer by giving it an AmrCore* so that it always tracks the fluid grids, calling `SetParticleBoxArray` the way we do in AMReX_ParticleIO.H unexpectedly breaks this tracking behavior. This bug was caught by a failing test in NyX. In this PR, we detect whether the ParticleContainer is currently tracking an AmrCore and clear the temporary BoxArrays and DistributionMappings instead of overriding.

For an alternative but less defensive fix, see: https://github.com/AMReX-Codes/amrex/pull/5497

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
