### PR TITLE
Remove dual_grid path from particle restart

### DIFF
--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -783,7 +783,10 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             // a placeholder so that MFIter below works uniformly.
             file_bas[lev] = BoxArray(Geom(lev).Domain());
         }
-        file_dms[lev] = DistributionMapping(file_bas[lev]);
+        const int NReaders = std::min(ParallelDescriptor::NProcs(), MaxReaders());
+        Vector<int> pmap(file_bas[lev].size());
+        for (int i = 0; i < (int)pmap.size(); ++i) { pmap[i] = i % NReaders; }
+        file_dms[lev] = DistributionMapping(pmap);
     }
 
     Vector<int> ngrids(finest_level_in_file+1);

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -759,17 +759,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     HdrFile >> finest_level_in_file;
     AMREX_ASSERT(finest_level_in_file >= 0);
 
-    // Determine whether this is a dual-grid restart or not.
-    // Size the vectors to cover both the levels present in the checkpoint
-    // file and the levels present in the current container, since the
-    // loops below iterate up to finestLevel()
-    int const max_level = std::max(finest_level_in_file, finestLevel());
-    Vector<DistributionMapping> old_dms(max_level + 1);
-    Vector<BoxArray> old_bas(max_level + 1);
-    Vector<BoxArray> particle_box_arrays(max_level + 1);
-    bool dual_grid = false;
-
-    bool have_pheaders = false;
+    // Read the BoxArrays stored in the checkpoint for each level so we can
+    // drive the read using the file's layout.  The container's own grids are
+    // never modified: Redistribute() will move every particle to the correct
+    // tile on whatever grids the container currently uses.
+    Vector<BoxArray>            file_bas(finest_level_in_file + 1);
+    Vector<DistributionMapping> file_dms(finest_level_in_file + 1);
     for (int lev = 0; lev <= finest_level_in_file; lev++)
     {
         std::string phdr_name = fullname;
@@ -778,57 +773,17 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         phdr_name += "/Particle_H";
 
         if (amrex::FileExists(phdr_name)) {
-            have_pheaders = true;
-            break;
-        }
-    }
-
-    if (have_pheaders)
-    {
-        for (int lev = 0; lev <= finestLevel(); lev++)
-        {
-            old_dms[lev] = ParticleDistributionMap(lev);
-            old_bas[lev] = ParticleBoxArray(lev);
-            std::string phdr_name = fullname;
-            phdr_name += "/Level_";
-            phdr_name = amrex::Concatenate(phdr_name, lev, 1);
-            phdr_name += "/Particle_H";
-
-            if (! amrex::FileExists(phdr_name)) {
-                // No particles were checkpointed at this level. Dual-grid
-                // restart will use a single-box domain BoxArray as the
-                // temporary layout for this level, so detect that mismatch
-                // here as well.
-                particle_box_arrays[lev] = BoxArray(Geom(lev).Domain());
-                if (! particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev))) {
-                    dual_grid = true;
-                }
-                continue;
-            }
-
             Vector<char> phdr_chars;
             ParallelDescriptor::ReadAndBcastFile(phdr_name, phdr_chars);
             std::string phdr_string(phdr_chars.dataPtr());
             std::istringstream phdr_file(phdr_string, std::istringstream::in);
-
-            particle_box_arrays[lev].readFrom(phdr_file);
-            if (! particle_box_arrays[lev].CellEqual(ParticleBoxArray(lev))) { dual_grid = true; }
+            file_bas[lev].readFrom(phdr_file);
+        } else {
+            // No particles were written at this level; use a single-box BA as
+            // a placeholder so that MFIter below works uniformly.
+            file_bas[lev] = BoxArray(Geom(lev).Domain());
         }
-    } else // if no particle box array information exists in the file, we assume a single grid restart
-    {
-        dual_grid = false;
-    }
-
-    if (dual_grid) {
-        for (int lev = 0; lev <= finestLevel(); lev++) {
-            // this can happen if there are no particles at a given level in the checkpoint
-            if (particle_box_arrays[lev].empty()) {
-                particle_box_arrays[lev] = BoxArray(Geom(lev).Domain());
-            }
-            SetParticleBoxArray(lev, particle_box_arrays[lev]);
-            DistributionMapping pdm(particle_box_arrays[lev]);
-            SetParticleDistributionMap(lev, pdm);
-        }
+        file_dms[lev] = DistributionMapping(file_bas[lev]);
     }
 
     Vector<int> ngrids(finest_level_in_file+1);
@@ -851,36 +806,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             HdrFile >> which[i] >> count[i] >> where[i];
         }
 
+        // Use the file's own layout to distribute reading across ranks.
+        MFInfo info;
+        info.SetAlloc(false);
+        MultiFab file_mf(file_bas[lev], file_dms[lev], 1, 0, info);
         Vector<int> grids_to_read;
-        if (lev <= finestLevel()) {
-            for (MFIter mfi(*m_dummy_mf[lev]); mfi.isValid(); ++mfi) {
-                grids_to_read.push_back(mfi.index());
-            }
-        } else {
-
-            // we lost a level on restart. we still need to read in particles
-            // on finer levels, and put them in the right place via Redistribute()
-
-            const int rank = ParallelDescriptor::MyProc();
-            const int NReaders = MaxReaders();
-            if (rank >= NReaders) { continue; }
-
-            const int Navg = ngrids[lev] / NReaders;
-            const int Nleft = ngrids[lev] - Navg * NReaders;
-
-            int lo, hi;
-            if (rank < Nleft) {
-                lo = rank*(Navg + 1);
-                hi = lo + Navg + 1;
-            }
-            else {
-                lo = rank * Navg + Nleft;
-                hi = lo + Navg;
-            }
-
-            for (int i = lo; i < hi; ++i) {
-                grids_to_read.push_back(i);
-            }
+        for (MFIter mfi(file_mf); mfi.isValid(); ++mfi) {
+            grids_to_read.push_back(mfi.index());
         }
 
         for(int grid : grids_to_read) {
@@ -937,13 +869,6 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             if (!ParticleFile.good()) {
                 amrex::Abort("ParticleContainer::Restart(): problem reading particles");
             }
-        }
-    }
-
-    if (dual_grid) {
-        for (int lev = 0; lev <= finestLevel(); lev++) {
-            SetParticleBoxArray(lev, old_bas[lev]);
-            SetParticleDistributionMap(lev, old_dms[lev]);
         }
     }
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -783,10 +783,14 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             // a placeholder so that MFIter below works uniformly.
             file_bas[lev] = BoxArray(Geom(lev).Domain());
         }
-        const int NReaders = std::min(ParallelDescriptor::NProcs(), MaxReaders());
-        Vector<int> pmap(file_bas[lev].size());
-        for (int i = 0; i < (int)pmap.size(); ++i) { pmap[i] = i % NReaders; }
-        file_dms[lev] = DistributionMapping(pmap);
+        const int NReaders = MaxReaders();
+        if (ParallelDescriptor::NProcs() <= NReaders) {
+            file_dms[lev] = DistributionMapping(file_bas[lev]);
+        } else {
+            Vector<int> pmap(file_bas[lev].size());
+            for (int i = 0; i < (int)pmap.size(); ++i) { pmap[i] = i % NReaders; }
+            file_dms[lev] = DistributionMapping(pmap);
+        }
     }
 
     Vector<int> ngrids(finest_level_in_file+1);


### PR DESCRIPTION
See #5496 for more background.

It is not clear to me that we need the dual_grid restart option at all. The caller of the restart function should not care what grids are actually stored in the restart file. The restart function should always use whatever grid layout is stored in the checkpoint file to read the particles, but not change the ParticleContainer grids at all. Then, Redistribute() will move the particles to the proper place on the actual grids used by simulation.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
