### PR TITLE
Reduce2Plane with Guards

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -461,6 +461,18 @@ namespace amrex
      * \param f         a callable object returning data fore reduction. It takes
      *                  four ints, where the first int is the local box index and
      *                  the others are spatial indices for x, y, and z-directions.
+     * \param nghost    number of guard cells to include in the reduction. Cells
+     *                  in the reduction \p direction are summed into the plane
+     *                  (e.g. to capture charge deposited outside the valid range
+     *                  when there is a single cell in that direction). Guard
+     *                  cells in the transverse directions are folded into the
+     *                  owning valid nodes of the result (\p period controls the
+     *                  domain-boundary behaviour), so the reduction conserves a
+     *                  summed quantity across box boundaries (MPI-safe). The
+     *                  caller must pass *un-synchronized* data (i.e. no prior
+     *                  SumBoundary), otherwise shared nodes are counted twice.
+     * \param period    periodicity used to fold the transverse guard cells back
+     *                  into the valid region (default: non-periodic).
      *
      * \return reduction result (std::pair<FA,FA>)
      */
@@ -470,7 +482,9 @@ namespace amrex
                            F,int,int,int,int>::value)
 #endif
     std::pair<FA,FA>
-    ReduceToPlaneMF2 (int direction, Box const& domain, FA const& mf, F const& f);
+    ReduceToPlaneMF2 (int direction, Box const& domain, FA const& mf, F const& f,
+                      IntVect const& nghost = IntVect(0),
+                      Periodicity const& period = Periodicity::NonPeriodic());
 
     /**
      * \brief Reduce FabArray/MultiFab data to plane FabArray for patchy BoxArrays
@@ -1374,7 +1388,8 @@ ReduceToPlane (int direction, Box const& a_domain, FabArray<FAB> const& mf, F co
 /// \cond DOXYGEN_IGNORE
 namespace detail {
 template <typename Op, MultiFabLike FA, typename F>
-FA reduce_to_plane (int direction, Box const& domain, FA const& mf, F const& f)
+FA reduce_to_plane (int direction, Box const& domain, FA const& mf, F const& f,
+                    IntVect const& nghost = IntVect(0))
 {
     using T = typename FA::value_type;
 
@@ -1388,17 +1403,24 @@ FA reduce_to_plane (int direction, Box const& domain, FA const& mf, F const& f)
     T initval;
     Op().init(initval);
 
+    // guard cells in the reduction direction are summed into the plane; guard
+    // cells in the transverse directions are stored in the result's ghost cells
+    // (and folded into the valid region by the caller's ParallelAdd)
+    IntVect ng2d = nghost;
+    ng2d[direction] = 0;
+    Box const gdomain = amrex::grow(ndomain, nghost);
+
     BoxList bl = mf.boxArray().boxList();
     for (auto& b : bl) {
         b.setRange(direction, 0);
     }
     BoxArray ba(std::move(bl));
-    FA tmpfa(ba, mf.DistributionMap(), 1, 0);
+    FA tmpfa(ba, mf.DistributionMap(), 1, ng2d);
     tmpfa.setVal(initval);
 
     for (MFIter mfi(mf); mfi.isValid(); ++mfi)
     {
-        Box bx = mfi.validbox() & ndomain;
+        Box bx = amrex::grow(mfi.validbox(), nghost) & gdomain;
         if (bx.ok()) {
             int box_no = mfi.LocalIndex();
             detail::reduce_to_plane<Op, T>(tmpfa.array(mfi), direction, bx, box_no, f);
@@ -1429,14 +1451,15 @@ requires (IsCallableR<typename FA::value_type,
                       F,int,int,int,int>::value)
 #endif
 std::pair<FA,FA>
-ReduceToPlaneMF2 (int direction, Box const& domain, FA const& mf, F const& f)
+ReduceToPlaneMF2 (int direction, Box const& domain, FA const& mf, F const& f,
+                  IntVect const& nghost, Periodicity const& period)
 {
     using T = typename FA::value_type;
 
     T initval;
     Op().init(initval);
 
-    auto tmpmf = detail::reduce_to_plane<Op>(direction, domain, mf, f);
+    auto tmpmf = detail::reduce_to_plane<Op>(direction, domain, mf, f, nghost);
 
     BoxList bl2d(mf.ixType());
     Vector<int> procmap2d;
@@ -1459,7 +1482,11 @@ ReduceToPlaneMF2 (int direction, Box const& domain, FA const& mf, F const& f)
     mf2d.setVal(initval);
 
     static_assert(std::is_same_v<Op, ReduceOpSum>, "Currently only ReduceOpSum is supported.");
-    mf2d.ParallelAdd(tmpmf);
+    // fold the transverse guard cells of the local results into the valid
+    // region of the unique result (sums the quantity across box seams)
+    IntVect ng2d = nghost;
+    ng2d[direction] = 0;
+    mf2d.ParallelAdd(tmpmf, 0, 0, 1, ng2d, IntVect(0), IntVect(0), period);
 
     return std::make_pair(std::move(tmpmf), std::move(mf2d));
 }

--- a/Src/Base/AMReX_MultiFabUtil.H
+++ b/Src/Base/AMReX_MultiFabUtil.H
@@ -1400,6 +1400,11 @@ FA reduce_to_plane (int direction, Box const& domain, FA const& mf, F const& f,
         amrex::Abort("ReduceToPlaneMF: mf's BoxArray must have a rectangular domain.");
     }
 
+    // the reduction reads mf's guard cells, so it cannot include more guard
+    // cells than mf actually has
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nghost.allLE(mf.nGrowVect()),
+        "ReduceToPlaneMF2: nghost must not exceed mf.nGrowVect().");
+
     T initval;
     Op().init(initval);
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -130,7 +130,7 @@ else()
    #
    set( AMREX_TESTS_SUBDIRS Amr ArrayND AsyncOut Base CallNoinline CLZ CommType CTOParFor DeviceGlobal
                             Enum HeatEquation MultiBlock MultiPeriod ParmParse Parser Parser2
-                            ParserUserFn Reducer ReduceToPlanePatchy Reinit RoundoffDomain SIMD
+                            ParserUserFn Reducer ReduceToPlaneGuards ReduceToPlanePatchy Reinit RoundoffDomain SIMD
                             SmallMatrix SumBoundary TOML)
 
    if (AMReX_PARTICLES)

--- a/Tests/ReduceToPlaneGuards/CMakeLists.txt
+++ b/Tests/ReduceToPlaneGuards/CMakeLists.txt
@@ -1,0 +1,9 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources     main.cpp)
+    set(_input_files)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/ReduceToPlaneGuards/GNUmakefile
+++ b/Tests/ReduceToPlaneGuards/GNUmakefile
@@ -1,0 +1,24 @@
+AMREX_HOME := ../..
+
+DEBUG	= FALSE
+
+DIM	= 3
+
+COMP    = gcc
+
+USE_MPI   = FALSE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+USE_HIP   = FALSE
+USE_SYCL  = FALSE
+
+BL_NO_FORT = TRUE
+
+TINY_PROFILE = FALSE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/ReduceToPlaneGuards/Make.package
+++ b/Tests/ReduceToPlaneGuards/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/ReduceToPlaneGuards/main.cpp
+++ b/Tests/ReduceToPlaneGuards/main.cpp
@@ -1,0 +1,163 @@
+#include <AMReX.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_MFIter.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_MultiFabUtil.H>
+
+#include <cmath>
+#include <vector>
+
+using namespace amrex;
+
+// Coverage for the guard-cell summing option of ReduceToPlaneMF2:
+//
+//   ReduceToPlaneMF2<Op>(dir, domain, mf, f, nghost, period)
+//
+// reduces `mf` to a plane normal to `dir`, summing `nghost` guard cells in the
+// reduction direction into the plane and folding the transverse guard cells
+// into the owning valid nodes (via ParallelAdd with `period`). On *raw*
+// (un-synchronized) data this conserves a summed quantity (e.g. a deposited
+// charge) regardless of the domain decomposition -- in particular it recovers
+// the charge that higher-order deposition leaves in the guard cells at internal
+// box seams and outside the single valid cell along `dir`.
+//
+// The test "deposits" a unit source straddling an internal box seam and the
+// single valid cell in `dir`, so part of it lands in guard cells, and checks:
+//   (1) ReduceToPlaneMF2 with nghost recovers the full source (conservation),
+//   (2) the result is independent of the number of boxes (MPI-safe),
+//   (3) the default (nghost = 0) drops the guard-resident part.
+
+#if (AMREX_SPACEDIM >= 2)
+
+namespace {
+
+constexpr int n = 8;            // cells per transverse direction
+constexpr int dir = AMREX_SPACEDIM - 1; // reduce over the last dimension
+
+// the single source sits on the dim-0 box seam (at n/2), interior in the other
+// transverse directions, and in the only valid cell along `dir`
+IntVect source_cell ()
+{
+    IntVect s(0);
+    s[0] = n/2;
+    for (int d = 1; d < AMREX_SPACEDIM - 1; ++d) { s[d] = n/4; }
+    return s; // s[dir] == 0
+}
+
+// build a cell-centered domain with a single cell along `dir`
+Box make_domain ()
+{
+    IntVect hi(n-1);
+    hi[dir] = 0;
+    return Box(IntVect(0), hi);
+}
+
+// deposit a unit source as a 3^SPACEDIM stencil of equal weights; each source
+// is added to the *owning* box only (the box whose valid region holds the
+// central cell), so the deposition is unique even when the stencil spills into
+// guard cells -- exactly like particle charge deposition.
+void deposit_unit_source (MultiFab& mf, IntVect const& s)
+{
+    Real const w = Real(1.0) / Real(std::pow(3, AMREX_SPACEDIM));
+    Box const stencil(s - IntVect(1), s + IntVect(1));
+    for (MFIter mfi(mf); mfi.isValid(); ++mfi) {
+        if (mfi.validbox().contains(s)) {
+            Box const dep = stencil & mfi.fabbox();
+            auto const& a = mf.array(mfi);
+            amrex::ParallelFor(dep, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            {
+                a(i,j,k) += w;
+            });
+        }
+    }
+}
+
+// total of the reduced-plane result, summing each unique cell once across ranks
+Real reduced_total (MultiFab const& mf, Box const& domain, IntVect const& nghost)
+{
+    auto const& ma = mf.const_arrays();
+    auto [plane_local, plane_unique] = ReduceToPlaneMF2<ReduceOpSum>(
+        dir, domain, mf,
+        [=] AMREX_GPU_DEVICE (int b, int i, int j, int k) -> Real
+        {
+            return ma[b](i,j,k);
+        },
+        nghost);
+    amrex::ignore_unused(plane_local);
+    return plane_unique.sum_unique(0, false);
+}
+
+// run the deposit + reduction for a given maximum grid size and return both the
+// guard-summing total (nghost = nGrow) and the default total (nghost = 0)
+std::pair<Real,Real> run (IntVect const& max_grid_size)
+{
+    Box const domain = make_domain();
+    IntVect const ng(1);
+
+    BoxArray ba(domain);
+    ba.maxSize(max_grid_size);
+    DistributionMapping dm(ba);
+
+    MultiFab mf(ba, dm, 1, ng);
+    mf.setVal(0.0);
+    deposit_unit_source(mf, source_cell());
+
+    Real const with_guards = reduced_total(mf, domain, ng);
+    Real const without_guards = reduced_total(mf, domain, IntVect(0));
+    return {with_guards, without_guards};
+}
+
+} // namespace
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+    {
+        Real const q_in = 1.0; // a single source, fully inside the domain
+
+        // multi-box: split dim 0 to create an internal seam under the source
+        IntVect mgs_multi(n);
+        mgs_multi[0] = n/2;
+        mgs_multi[dir] = 1;
+        auto const [multi_guards, multi_default] = run(mgs_multi);
+
+        // single box: no internal seams
+        IntVect mgs_single(1024);
+        mgs_single[dir] = 1;
+        auto const [single_guards, single_default] = run(mgs_single);
+
+        // (1) conservation: the guard-summing reduction recovers the full source
+        AMREX_ALWAYS_ASSERT(amrex::almostEqual(multi_guards, q_in));
+        AMREX_ALWAYS_ASSERT(amrex::almostEqual(single_guards, q_in));
+
+        // (2) decomposition independence (MPI-safe): same answer with seams
+        AMREX_ALWAYS_ASSERT(amrex::almostEqual(multi_guards, single_guards));
+
+        // (3) the default (no guards) drops the guard-resident charge: at least
+        //     the cells along `dir` outside the single valid cell are lost
+        AMREX_ALWAYS_ASSERT(multi_default < q_in);
+        AMREX_ALWAYS_ASSERT(single_default < q_in);
+
+        amrex::Print() << "ReduceToPlaneGuards: PASSED\n"
+                       << "  conserved (multi/single) = " << multi_guards
+                       << " / " << single_guards << " (expected " << q_in << ")\n"
+                       << "  default  (multi/single)  = " << multi_default
+                       << " / " << single_default << " (guard charge dropped)\n";
+    }
+    amrex::Finalize();
+    return 0;
+}
+
+#else // AMREX_SPACEDIM == 1
+
+int main (int argc, char* argv[])
+{
+    // The seam/guard scenario needs at least one transverse direction.
+    amrex::Initialize(argc, argv);
+    amrex::Print() << "ReduceToPlaneGuards: skipped in 1D\n";
+    amrex::Finalize();
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## Summary

Include potentially deposited values in guards in the reduction, if specified by the user. Needed for BLAST ImpactX 2D charge deposition projection from 3D.

## Additional background

Bug in https://github.com/BLAST-ImpactX/impactx/issues/1512

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
