### PR TITLE
MLNodeLaplacian: aniso-sigma support across coarse-fine boundaries

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -1189,6 +1189,114 @@ void mlndlap_Ax_fine_contrib_cs (int i, int j, int /*k*/, Box const& ndbx, Box c
          i,j,ndbx,ccbx,f,res,rhs,phi,msk,is_rz,dxinv);
 }
 
+// Anisotropic-sigma variants of mlndlap_sum_Ax, mlndlap_Ax_fine_contrib,
+// and mlndlap_res_cf_contrib used by the AMR-sync paths when m_use_mapped.
+// Per-axis sigma: facx-terms use sx, facy-terms (including RZ fp/fm) use sy.
+// Recover the scalar kernels when sx == sy.
+    template <typename P, typename SX, typename SY>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real mlndlap_sum_Ax_ha (P const& pred, SX const& sx, SY const& sy,
+                            int i, int j, Real facx, Real facy,
+                            Array4<Real const> const& phi, bool is_rz) noexcept
+    {
+        Real Ax = Real(0.0);
+        Real fp = Real(0.0), fm = Real(0.0);
+        if (is_rz) {
+            fp = facy / static_cast<Real>(2*i+1);
+            fm = facy / static_cast<Real>(2*i-1);
+        }
+        if (pred(i-1,j-1)) {
+            Ax += facx*sx(i-1,j-1,0)*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
+                                          +    (phi(i-1,j-1,0)-phi(i  ,j-1,0)))
+                + facy*sy(i-1,j-1,0)*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
+                                          +    (phi(i-1,j-1,0)-phi(i-1,j  ,0)))
+                + fm  *sy(i-1,j-1,0)*          (phi(i  ,j-1,0)-phi(i  ,j  ,0));
+        }
+        if (pred(i,j-1)) {
+            Ax += facx*sx(i,j-1,0)*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
+                                        +    (phi(i+1,j-1,0)-phi(i  ,j-1,0)))
+                + facy*sy(i,j-1,0)*(Real(2.)*(phi(i  ,j-1,0)-phi(i  ,j  ,0))
+                                        +    (phi(i+1,j-1,0)-phi(i+1,j  ,0)))
+                - fp  *sy(i,j-1,0)*          (phi(i  ,j-1,0)-phi(i  ,j  ,0));
+        }
+        if (pred(i-1,j)) {
+            Ax += facx*sx(i-1,j,0)*(Real(2.)*(phi(i-1,j  ,0)-phi(i  ,j  ,0))
+                                        +    (phi(i-1,j+1,0)-phi(i  ,j+1,0)))
+                + facy*sy(i-1,j,0)*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
+                                        +    (phi(i-1,j+1,0)-phi(i-1,j  ,0)))
+                + fm  *sy(i-1,j,0)*          (phi(i  ,j+1,0)-phi(i  ,j  ,0));
+        }
+        if (pred(i,j)) {
+            Ax += facx*sx(i,j,0)*(Real(2.)*(phi(i+1,j  ,0)-phi(i  ,j  ,0))
+                                     +     (phi(i+1,j+1,0)-phi(i  ,j+1,0)))
+                + facy*sy(i,j,0)*(Real(2.)*(phi(i  ,j+1,0)-phi(i  ,j  ,0))
+                                     +     (phi(i+1,j+1,0)-phi(i+1,j  ,0)))
+                - fp  *sy(i,j,0)*          (phi(i  ,j+1,0)-phi(i  ,j  ,0));
+        }
+        return Ax;
+    }
+
+    template <int rr, typename SX, typename SY>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void mlndlap_Ax_fine_contrib_doit_ha (SX const& sx, SY const& sy,
+                                          int i, int j, Box const& ndbx, Box const& ccbx,
+                                          Array4<Real> const& f, Array4<Real const> const& res,
+                                          Array4<Real const> const& rhs,
+                                          Array4<Real const> const& phi,
+                                          Array4<int const> const& msk, bool is_rz,
+                                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+    {
+        const int ii = rr*i;
+        const int jj = rr*j;
+        if (msk(ii,jj,0)) {
+            Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
+            Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
+
+            auto is_fine = [&ccbx] (int ix, int iy) -> bool {
+                return ccbx.contains(ix,iy,0);
+            };
+
+            Real Df = Real(0.0);
+
+            const int ilo = amrex::max(ii-rr+1, ndbx.smallEnd(0));
+            const int ihi = amrex::min(ii+rr-1, ndbx.bigEnd  (0));
+            const int jlo = amrex::max(jj-rr+1, ndbx.smallEnd(1));
+            const int jhi = amrex::min(jj+rr-1, ndbx.bigEnd  (1));
+
+            for (int joff = jlo; joff <= jhi; ++joff) {
+            for (int ioff = ilo; ioff <= ihi; ++ioff) {
+                Real scale = static_cast<Real>((rr-std::abs(ii-ioff)) *
+                                               (rr-std::abs(jj-joff)));
+                if (ndbx.strictly_contains(ioff,joff,0)) {
+                    Df += scale * (rhs(ioff,joff,0)-res(ioff,joff,0));
+                } else {
+                    Df += scale * mlndlap_sum_Ax_ha
+                        (is_fine, sx, sy, ioff, joff, facx, facy, phi, is_rz);
+                }
+            }}
+
+            f(i,j,0) = Df * (Real(1.0)/static_cast<Real>(rr*rr*rr*rr));
+        } else {
+            f(i,j,0) = Real(0.0);
+        }
+    }
+
+template <int rr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_Ax_fine_contrib_ha (int i, int j, int /*k*/, Box const& ndbx, Box const& ccbx,
+                                 Array4<Real> const& f, Array4<Real const> const& res,
+                                 Array4<Real const> const& rhs, Array4<Real const> const& phi,
+                                 Array4<Real const> const& sx, Array4<Real const> const& sy,
+                                 Array4<int const> const& msk,
+                                 bool is_rz,
+                                 GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    mlndlap_Ax_fine_contrib_doit_ha<rr>
+        ([&sx] (int ix, int iy, int) -> Real const& { return sx(ix,iy,0); },
+         [&sy] (int ix, int iy, int) -> Real const& { return sy(ix,iy,0); },
+         i,j,ndbx,ccbx,f,res,rhs,phi,msk,is_rz,dxinv);
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_res_cf_contrib (int i, int j, int, Array4<Real> const& res,
                              Array4<Real const> const& phi, Array4<Real const> const& rhs,
@@ -1218,6 +1326,46 @@ void mlndlap_res_cf_contrib (int i, int j, int, Array4<Real> const& res,
                                      return sig(ix,iy,0);
                                  },
                                  i, j, facx, facy, phi, is_rz);
+        Ax += fc(i,j,0);
+        Real const ns = (neumann_doubling) ? neumann_scale(i,j,nddom,bclo,bchi) : Real(1.0);
+        res(i,j,0) = rhs(i,j,0) - Ax*ns;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_res_cf_contrib_ha (int i, int j, int, Array4<Real> const& res,
+                                Array4<Real const> const& phi, Array4<Real const> const& rhs,
+                                Array4<Real const> const& sx, Array4<Real const> const& sy,
+                                Array4<int const> const& dmsk,
+                                Array4<int const> const& ndmsk, Array4<int const> const& ccmsk,
+                                Array4<Real const> const& fc,
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                                Box const& ccdom_p, Box const& nddom,
+                                bool is_rz,
+                                GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
+                                GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
+                                bool neumann_doubling) noexcept
+{
+    using namespace nodelap_detail;
+
+    if (!dmsk(i,j,0) && ndmsk(i,j,0) == crse_fine_node) {
+        Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
+        Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
+
+        Real Ax = mlndlap_sum_Ax_ha([&ccmsk, &ccdom_p] (int ix, int iy) -> bool
+                                    {
+                                        return ccdom_p.contains(ix,iy,0)
+                                            && (ccmsk(ix,iy,0) == crse_cell);
+                                    },
+                                    [&sx] (int ix, int iy, int) -> Real const&
+                                    {
+                                        return sx(ix,iy,0);
+                                    },
+                                    [&sy] (int ix, int iy, int) -> Real const&
+                                    {
+                                        return sy(ix,iy,0);
+                                    },
+                                    i, j, facx, facy, phi, is_rz);
         Ax += fc(i,j,0);
         Real const ns = (neumann_doubling) ? neumann_scale(i,j,nddom,bclo,bchi) : Real(1.0);
         res(i,j,0) = rhs(i,j,0) - Ax*ns;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_3D_K.H
@@ -1895,6 +1895,199 @@ void mlndlap_Ax_fine_contrib_cs (int i, int j, int k, Box const& ndbx, Box const
          i,j,k,ndbx,ccbx,f,res,rhs,phi,msk,dxinv);
 }
 
+// Anisotropic-sigma 3D variants of mlndlap_sum_Ax and
+// mlndlap_Ax_fine_contrib used by the AMR-sync paths when m_use_mapped.
+// Per-axis sigma: facx-terms use sx, facy-terms use sy, facz-terms use sz.
+// Recover the scalar kernels when sx == sy == sz.
+    template <typename P, typename SX, typename SY, typename SZ>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real mlndlap_sum_Ax_ha (P const& pred, SX const& sx, SY const& sy, SZ const& sz,
+                            int i, int j, int k, Real facx, Real facy, Real facz,
+                            Array4<Real const> const& phi) noexcept
+    {
+        Real Ax = Real(0.0);
+        if (pred(i-1,j-1,k-1)) {
+            Ax += facx*sx(i-1,j-1,k-1)*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
+                                       +Real(2.)*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
+                                       +         (phi(i-1,j-1,k-1)-phi(i  ,j-1,k-1)))
+                + facy*sy(i-1,j-1,k-1)*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i-1,j-1,k  )-phi(i-1,j  ,k  ))
+                                       +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j  ,k-1))
+                                       +         (phi(i-1,j-1,k-1)-phi(i-1,j  ,k-1)))
+                + facz*sz(i-1,j-1,k-1)*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
+                                       +Real(2.)*(phi(i-1,j  ,k-1)-phi(i-1,j  ,k  ))
+                                       +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
+                                       +         (phi(i-1,j-1,k-1)-phi(i-1,j-1,k  )));
+        }
+        if (pred(i,j-1,k-1)) {
+            Ax += facx*sx(i,j-1,k-1)*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
+                                     +Real(2.)*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
+                                     +         (phi(i+1,j-1,k-1)-phi(i  ,j-1,k-1)))
+                + facy*sy(i,j-1,k-1)*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i+1,j-1,k  )-phi(i+1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j  ,k-1))
+                                     +         (phi(i+1,j-1,k-1)-phi(i+1,j  ,k-1)))
+                + facz*sz(i,j-1,k-1)*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i+1,j  ,k-1)-phi(i+1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j-1,k-1)-phi(i  ,j-1,k  ))
+                                     +         (phi(i+1,j-1,k-1)-phi(i+1,j-1,k  )));
+        }
+        if (pred(i-1,j,k-1)) {
+            Ax += facx*sx(i-1,j,k-1)*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
+                                     +Real(2.)*(phi(i-1,j  ,k-1)-phi(i  ,j  ,k-1))
+                                     +         (phi(i-1,j+1,k-1)-phi(i  ,j+1,k-1)))
+                + facy*sy(i-1,j,k-1)*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i-1,j+1,k  )-phi(i-1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j  ,k-1))
+                                     +         (phi(i-1,j+1,k-1)-phi(i-1,j  ,k-1)))
+                + facz*sz(i-1,j,k-1)*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i-1,j  ,k-1)-phi(i-1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
+                                     +         (phi(i-1,j+1,k-1)-phi(i-1,j+1,k  )));
+        }
+        if (pred(i,j,k-1)) {
+            Ax += facx*sx(i,j,k-1)*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
+                                   +Real(2.)*(phi(i+1,j  ,k-1)-phi(i  ,j  ,k-1))
+                                   +         (phi(i+1,j+1,k-1)-phi(i  ,j+1,k-1)))
+                + facy*sy(i,j,k-1)*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i+1,j+1,k  )-phi(i+1,j  ,k  ))
+                                   +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j  ,k-1))
+                                   +         (phi(i+1,j+1,k-1)-phi(i+1,j  ,k-1)))
+                + facz*sz(i,j,k-1)*(Real(4.)*(phi(i  ,j  ,k-1)-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i+1,j  ,k-1)-phi(i+1,j  ,k  ))
+                                   +Real(2.)*(phi(i  ,j+1,k-1)-phi(i  ,j+1,k  ))
+                                   +         (phi(i+1,j+1,k-1)-phi(i+1,j+1,k  )));
+        }
+        if (pred(i-1,j-1,k)) {
+            Ax += facx*sx(i-1,j-1,k)*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i-1,j-1,k  )-phi(i  ,j-1,k  ))
+                                     +Real(2.)*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
+                                     +         (phi(i-1,j-1,k+1)-phi(i  ,j-1,k+1)))
+                + facy*sy(i-1,j-1,k)*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i-1,j-1,k  )-phi(i-1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j  ,k+1))
+                                     +         (phi(i-1,j-1,k+1)-phi(i-1,j  ,k+1)))
+                + facz*sz(i-1,j-1,k)*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
+                                     +Real(2.)*(phi(i-1,j  ,k+1)-phi(i-1,j  ,k  ))
+                                     +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
+                                     +         (phi(i-1,j-1,k+1)-phi(i-1,j-1,k  )));
+        }
+        if (pred(i,j-1,k)) {
+            Ax += facx*sx(i,j-1,k)*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i+1,j-1,k  )-phi(i  ,j-1,k  ))
+                                   +Real(2.)*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
+                                   +         (phi(i+1,j-1,k+1)-phi(i  ,j-1,k+1)))
+                + facy*sy(i,j-1,k)*(Real(4.)*(phi(i  ,j-1,k  )-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i+1,j-1,k  )-phi(i+1,j  ,k  ))
+                                   +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j  ,k+1))
+                                   +         (phi(i+1,j-1,k+1)-phi(i+1,j  ,k+1)))
+                + facz*sz(i,j-1,k)*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i+1,j  ,k+1)-phi(i+1,j  ,k  ))
+                                   +Real(2.)*(phi(i  ,j-1,k+1)-phi(i  ,j-1,k  ))
+                                   +         (phi(i+1,j-1,k+1)-phi(i+1,j-1,k  )));
+        }
+        if (pred(i-1,j,k)) {
+            Ax += facx*sx(i-1,j,k)*(Real(4.)*(phi(i-1,j  ,k  )-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i-1,j+1,k  )-phi(i  ,j+1,k  ))
+                                   +Real(2.)*(phi(i-1,j  ,k+1)-phi(i  ,j  ,k+1))
+                                   +         (phi(i-1,j+1,k+1)-phi(i  ,j+1,k+1)))
+                + facy*sy(i-1,j,k)*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i-1,j+1,k  )-phi(i-1,j  ,k  ))
+                                   +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j  ,k+1))
+                                   +         (phi(i-1,j+1,k+1)-phi(i-1,j  ,k+1)))
+                + facz*sz(i-1,j,k)*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
+                                   +Real(2.)*(phi(i-1,j  ,k+1)-phi(i-1,j  ,k  ))
+                                   +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
+                                   +         (phi(i-1,j+1,k+1)-phi(i-1,j+1,k  )));
+        }
+        if (pred(i,j,k)) {
+            Ax += facx*sx(i,j,k)*(Real(4.)*(phi(i+1,j  ,k  )-phi(i  ,j  ,k  ))
+                                 +Real(2.)*(phi(i+1,j+1,k  )-phi(i  ,j+1,k  ))
+                                 +Real(2.)*(phi(i+1,j  ,k+1)-phi(i  ,j  ,k+1))
+                                 +         (phi(i+1,j+1,k+1)-phi(i  ,j+1,k+1)))
+                + facy*sy(i,j,k)*(Real(4.)*(phi(i  ,j+1,k  )-phi(i  ,j  ,k  ))
+                                 +Real(2.)*(phi(i+1,j+1,k  )-phi(i+1,j  ,k  ))
+                                 +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j  ,k+1))
+                                 +         (phi(i+1,j+1,k+1)-phi(i+1,j  ,k+1)))
+                + facz*sz(i,j,k)*(Real(4.)*(phi(i  ,j  ,k+1)-phi(i  ,j  ,k  ))
+                                 +Real(2.)*(phi(i+1,j  ,k+1)-phi(i+1,j  ,k  ))
+                                 +Real(2.)*(phi(i  ,j+1,k+1)-phi(i  ,j+1,k  ))
+                                 +         (phi(i+1,j+1,k+1)-phi(i+1,j+1,k  )));
+        }
+        return Ax;
+    }
+
+    template <int rr, typename SX, typename SY, typename SZ>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void mlndlap_Ax_fine_contrib_doit_ha (SX const& sx, SY const& sy, SZ const& sz,
+                                          int i, int j, int k, Box const& ndbx, Box const& ccbx,
+                                          Array4<Real> const& f, Array4<Real const> const& res,
+                                          Array4<Real const> const& rhs,
+                                          Array4<Real const> const& phi,
+                                          Array4<int const> const& msk,
+                                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+    {
+        const int ii = rr*i;
+        const int jj = rr*j;
+        const int kk = rr*k;
+        if (msk(ii,jj,kk)) {
+            Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
+            Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
+            Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
+
+            auto is_fine = [&ccbx] (int ix, int iy, int iz) -> bool {
+                return ccbx.contains(ix,iy,iz);
+            };
+
+            Real Df = Real(0.0);
+
+            const int ilo = amrex::max(ii-rr+1, ndbx.smallEnd(0));
+            const int ihi = amrex::min(ii+rr-1, ndbx.bigEnd  (0));
+            const int jlo = amrex::max(jj-rr+1, ndbx.smallEnd(1));
+            const int jhi = amrex::min(jj+rr-1, ndbx.bigEnd  (1));
+            const int klo = amrex::max(kk-rr+1, ndbx.smallEnd(2));
+            const int khi = amrex::min(kk+rr-1, ndbx.bigEnd  (2));
+
+            for (int koff = klo; koff <= khi; ++koff) {
+            for (int joff = jlo; joff <= jhi; ++joff) {
+            for (int ioff = ilo; ioff <= ihi; ++ioff) {
+                Real scale = static_cast<Real>((rr-std::abs(ii-ioff)) *
+                                               (rr-std::abs(jj-joff)) *
+                                               (rr-std::abs(kk-koff)));
+                if (ndbx.strictly_contains(ioff,joff,koff)) {
+                    Df += scale * (rhs(ioff,joff,koff)-res(ioff,joff,koff));
+                } else {
+                    Df += scale * mlndlap_sum_Ax_ha
+                        (is_fine, sx, sy, sz, ioff, joff, koff, facx, facy, facz, phi);
+                }
+            }}}
+
+            f(i,j,k) = Df * (Real(1.0)/static_cast<Real>(rr*rr*rr*rr*rr*rr));
+        } else {
+            f(i,j,k) = Real(0.0);
+        }
+    }
+
+template <int rr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_Ax_fine_contrib_ha (int i, int j, int k, Box const& ndbx, Box const& ccbx,
+                                 Array4<Real> const& f, Array4<Real const> const& res,
+                                 Array4<Real const> const& rhs, Array4<Real const> const& phi,
+                                 Array4<Real const> const& sx, Array4<Real const> const& sy,
+                                 Array4<Real const> const& sz, Array4<int const> const& msk,
+                                 GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+{
+    mlndlap_Ax_fine_contrib_doit_ha<rr>
+        ([&sx] (int ix, int iy, int iz) -> Real const& { return sx(ix,iy,iz); },
+         [&sy] (int ix, int iy, int iz) -> Real const& { return sy(ix,iy,iz); },
+         [&sz] (int ix, int iy, int iz) -> Real const& { return sz(ix,iy,iz); },
+         i,j,k,ndbx,ccbx,f,res,rhs,phi,msk,dxinv);
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                              Array4<Real const> const& phi, Array4<Real const> const& rhs,
@@ -1924,6 +2117,51 @@ void mlndlap_res_cf_contrib (int i, int j, int k, Array4<Real> const& res,
                                      return sig(ix,iy,iz);
                                  },
                                  i, j, k, facx, facy, facz, phi);
+        Ax += fc(i,j,k);
+        Real const ns = (neumann_doubling) ? neumann_scale(i,j,k,nddom,bclo,bchi) : Real(1.0);
+        res(i,j,k) = rhs(i,j,k) - Ax*ns;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlndlap_res_cf_contrib_ha (int i, int j, int k, Array4<Real> const& res,
+                                Array4<Real const> const& phi, Array4<Real const> const& rhs,
+                                Array4<Real const> const& sx, Array4<Real const> const& sy,
+                                Array4<Real const> const& sz,
+                                Array4<int const> const& dmsk,
+                                Array4<int const> const& ndmsk, Array4<int const> const& ccmsk,
+                                Array4<Real const> const& fc,
+                                GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                                Box const& ccdom_p, Box const& nddom,
+                                GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bclo,
+                                GpuArray<LinOpBCType, AMREX_SPACEDIM> const& bchi,
+                                bool neumann_doubling) noexcept
+{
+    using namespace nodelap_detail;
+
+    if (!dmsk(i,j,k) && ndmsk(i,j,k) == crse_fine_node) {
+        Real facx = Real(1./36.)*dxinv[0]*dxinv[0];
+        Real facy = Real(1./36.)*dxinv[1]*dxinv[1];
+        Real facz = Real(1./36.)*dxinv[2]*dxinv[2];
+
+        Real Ax = mlndlap_sum_Ax_ha([&ccmsk, &ccdom_p] (int ix, int iy, int iz) -> bool
+                                    {
+                                        return ccdom_p.contains(ix,iy,iz)
+                                            && (ccmsk(ix,iy,iz) == crse_cell);
+                                    },
+                                    [&sx] (int ix, int iy, int iz) -> Real const&
+                                    {
+                                        return sx(ix,iy,iz);
+                                    },
+                                    [&sy] (int ix, int iy, int iz) -> Real const&
+                                    {
+                                        return sy(ix,iy,iz);
+                                    },
+                                    [&sz] (int ix, int iy, int iz) -> Real const&
+                                    {
+                                        return sz(ix,iy,iz);
+                                    },
+                                    i, j, k, facx, facy, facz, phi);
         Ax += fc(i,j,k);
         Real const ns = (neumann_doubling) ? neumann_scale(i,j,k,nddom,bclo,bchi) : Real(1.0);
         res(i,j,k) = rhs(i,j,k) - Ax*ns;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -92,11 +92,8 @@ MLNodeLaplacian::averageDownCoeffsToCoarseAmrLevel (int flev)
     // are independent allocations (see setSigma); restrict each.  In
     // the non-mapped / harmonic-average path idim>0 sigmas alias
     // idim=0 (or don't exist), so only idim=0 needs restriction.
-#if (AMREX_SPACEDIM == 1)
-    const int nsigma = 1;
-#else
+    // In 1D this is always 1 (AMREX_SPACEDIM == 1).
     const int nsigma = m_use_mapped ? AMREX_SPACEDIM : 1;
-#endif
     for (int idim = 0; idim < nsigma; ++idim) {
         if (m_sigma[flev][mglev][idim] && m_sigma[flev-1][mglev][idim]) {
 #ifdef AMREX_USE_EB

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -93,7 +93,11 @@ MLNodeLaplacian::averageDownCoeffsToCoarseAmrLevel (int flev)
     // the non-mapped / harmonic-average path idim>0 sigmas alias
     // idim=0 (or don't exist), so only idim=0 needs restriction.
     // In 1D this is always 1 (AMREX_SPACEDIM == 1).
+#if (AMREX_SPACEDIM == 1)
+    const int nsigma = 1;
+#else
     const int nsigma = m_use_mapped ? AMREX_SPACEDIM : 1;
+#endif
     for (int idim = 0; idim < nsigma; ++idim) {
         if (m_sigma[flev][mglev][idim] && m_sigma[flev-1][mglev][idim]) {
 #ifdef AMREX_USE_EB

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -88,14 +88,26 @@ MLNodeLaplacian::averageDownCoeffsToCoarseAmrLevel (int flev)
     if (m_sigma[0][0][0] == nullptr) { return; }
 
     const int mglev = 0;
-    const int idim = 0;  // other dimensions are just aliases
-#ifdef AMREX_USE_EB
-    amrex::EB_average_down(*m_sigma[flev][mglev][idim], *m_sigma[flev-1][mglev][idim], 0, 1,
-                           m_amr_ref_ratio[flev-1]);
+    // When m_use_mapped the per-direction sigma MultiFabs at mglev=0
+    // are independent allocations (see setSigma); restrict each.  In
+    // the non-mapped / harmonic-average path idim>0 sigmas alias
+    // idim=0 (or don't exist), so only idim=0 needs restriction.
+#if (AMREX_SPACEDIM == 1)
+    const int nsigma = 1;
 #else
-    amrex::average_down(*m_sigma[flev][mglev][idim], *m_sigma[flev-1][mglev][idim], 0, 1,
-                        m_amr_ref_ratio[flev-1]);
+    const int nsigma = m_use_mapped ? AMREX_SPACEDIM : 1;
 #endif
+    for (int idim = 0; idim < nsigma; ++idim) {
+        if (m_sigma[flev][mglev][idim] && m_sigma[flev-1][mglev][idim]) {
+#ifdef AMREX_USE_EB
+            amrex::EB_average_down(*m_sigma[flev][mglev][idim], *m_sigma[flev-1][mglev][idim], 0, 1,
+                                   m_amr_ref_ratio[flev-1]);
+#else
+            amrex::average_down(*m_sigma[flev][mglev][idim], *m_sigma[flev-1][mglev][idim], 0, 1,
+                                m_amr_ref_ratio[flev-1]);
+#endif
+        }
+    }
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -313,6 +313,8 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                         Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};
 #if (AMREX_SPACEDIM == 3)
                         Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};
+#else
+                        Array4<Real> szarr_w{};
 #endif
 
                         if (sigma_orig) {
@@ -320,10 +322,14 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
 #if (AMREX_SPACEDIM >= 2)
                             Array4<Real const> syarr_orig = aniso_sigma
                                 ? sigma_orig_y->const_array(mfi) : Array4<Real const>{};
+#else
+                            Array4<Real const> syarr_orig{};
 #endif
 #if (AMREX_SPACEDIM == 3)
                             Array4<Real const> szarr_orig = aniso_sigma
                                 ? sigma_orig_z->const_array(mfi) : Array4<Real const>{};
+#else
+                            Array4<Real const> szarr_orig{};
 #endif
                             const bool is_aniso = aniso_sigma;
                             AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -330,20 +330,20 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                             {
                                 if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)) {
                                     sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
-#if (AMREX_SPACEDIM >= 2)
-                                    if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
-#endif
-#if (AMREX_SPACEDIM == 3)
-                                    if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
-#endif
+									if constexpr (AMREX_SPACEDIM >= 2) {
+									  if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
+									}
+									if constexpr (AMREX_SPACEDIM == 3) {
+									  if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+									}
                                 } else {
                                     sigmaarr(i,j,k) = 0.0;
-#if (AMREX_SPACEDIM >= 2)
-                                    if (is_aniso) { syarr_w(i,j,k) = 0.0; }
-#endif
-#if (AMREX_SPACEDIM == 3)
-                                    if (is_aniso) { szarr_w(i,j,k) = 0.0; }
-#endif
+									if constexpr (AMREX_SPACEDIM >= 2) {
+									  if (is_aniso) { syarr_w(i,j,k) = 0.0; }
+									}
+									if constexpr (AMREX_SPACEDIM == 3) {
+									  if (is_aniso) { szarr_w(i,j,k) = 0.0; }
+									}
                                 }
                             });
                         } else {
@@ -669,20 +669,20 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
                         {
                             if (ovlp2.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
                                 sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
-#if (AMREX_SPACEDIM >= 2)
-                                if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
-#endif
-#if (AMREX_SPACEDIM == 3)
-                                if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
-#endif
+								if constexpr (AMREX_SPACEDIM >= 2) {
+								  if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
+								}
+								if constexpr (AMREX_SPACEDIM == 3) {
+								  if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+								}
                             } else {
                                 sigmaarr(i,j,k) = 0.0;
-#if (AMREX_SPACEDIM >= 2)
-                                if (is_aniso) { syarr_w(i,j,k) = 0.0; }
-#endif
-#if (AMREX_SPACEDIM == 3)
-                                if (is_aniso) { szarr_w(i,j,k) = 0.0; }
-#endif
+								if constexpr (AMREX_SPACEDIM >= 2) {
+								  if (is_aniso) { syarr_w(i,j,k) = 0.0; }
+								}
+								if constexpr (AMREX_SPACEDIM == 3) {
+									if (is_aniso) { szarr_w(i,j,k) = 0.0; }
+								}
                             }
                         });
                     } else {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -81,6 +81,14 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
 #endif
 
     const auto& sigma_orig = m_sigma[0][0][0];
+    // Anisotropic (mapped) path: capture per-axis sigmas.
+    const bool aniso_sigma = m_use_mapped;
+#if (AMREX_SPACEDIM >= 2)
+    const MultiFab* sigma_orig_y = aniso_sigma ? m_sigma[0][0][1].get() : nullptr;
+#endif
+#if (AMREX_SPACEDIM == 3)
+    const MultiFab* sigma_orig_z = aniso_sigma ? m_sigma[0][0][2].get() : nullptr;
+#endif
     const iMultiFab& dmsk = *m_dirichlet_mask[0][0];
 
 #ifdef AMREX_USE_EB
@@ -99,6 +107,11 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
 #endif
     {
         FArrayBox rhs, u;
+        // Per-axis sigma scratch for the anisotropic path.
+        FArrayBox sig_y_local;
+#if (AMREX_SPACEDIM == 3)
+        FArrayBox sig_z_local;
+#endif
 #ifdef AMREX_USE_EB
         FArrayBox sten, cn;
 #endif
@@ -289,17 +302,52 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                     {
                         Array4<Real> sigmaarr = uarr;
                         const Box& ibx = ccbxg1 & amrex::enclosedCells(mfi.validbox());
+
+                        // Per-axis sigma scratch when mapped.
+                        if (aniso_sigma) {
+                            sig_y_local.resize(ccbxg1, 1, The_Async_Arena());
+#if (AMREX_SPACEDIM == 3)
+                            sig_z_local.resize(ccbxg1, 1, The_Async_Arena());
+#endif
+                        }
+                        Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};
+#if (AMREX_SPACEDIM == 3)
+                        Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};
+#endif
+
                         if (sigma_orig) {
                             Array4<Real const> const& sigmaarr_orig = sigma_orig->const_array(mfi);
+#if (AMREX_SPACEDIM >= 2)
+                            Array4<Real const> syarr_orig = aniso_sigma
+                                ? sigma_orig_y->const_array(mfi) : Array4<Real const>{};
+#endif
+#if (AMREX_SPACEDIM == 3)
+                            Array4<Real const> szarr_orig = aniso_sigma
+                                ? sigma_orig_z->const_array(mfi) : Array4<Real const>{};
+#endif
+                            const bool is_aniso = aniso_sigma;
                             AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                             {
                                 if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)) {
                                     sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
+#if (AMREX_SPACEDIM >= 2)
+                                    if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
+#endif
+#if (AMREX_SPACEDIM == 3)
+                                    if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+#endif
                                 } else {
                                     sigmaarr(i,j,k) = 0.0;
+#if (AMREX_SPACEDIM >= 2)
+                                    if (is_aniso) { syarr_w(i,j,k) = 0.0; }
+#endif
+#if (AMREX_SPACEDIM == 3)
+                                    if (is_aniso) { szarr_w(i,j,k) = 0.0; }
+#endif
                                 }
                             });
                         } else {
+                            // Const sigma: anisotropic n/a here.
                             Real const_sigma = m_const_sigma;
                             AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                             {
@@ -311,19 +359,44 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                             });
                         }
 
-#if (AMREX_SPACEDIM == 2)
-                        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
-                        {
-                            sync_resid_a(i,j,k) = mlndlap_adotx_aa(i, j, k, phiarr, sigmaarr, dmskarr, is_rz, dxinv);
-                            mlndlap_crse_resid(i, j, k, sync_resid_a, rhsarr, cccmsk, nddom, lobc, hibc, neumann_doubling);
-                        });
-#else
-                        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
-                        {
-                            sync_resid_a(i,j,k) = mlndlap_adotx_aa(i, j, k, phiarr, sigmaarr, dmskarr, dxinv);
-                            mlndlap_crse_resid(i, j, k, sync_resid_a, rhsarr, cccmsk, nddom, lobc, hibc, neumann_doubling);
-                        });
+                        if (aniso_sigma) {
+                            Array4<Real const> sxarr_c = sigmaarr;
+                            Array4<Real const> syarr_c = syarr_w;
+#if (AMREX_SPACEDIM == 3)
+                            Array4<Real const> szarr_c = szarr_w;
 #endif
+#if (AMREX_SPACEDIM == 2)
+                            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                            {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_ha(i,j,k, phiarr,
+                                                                       sxarr_c, syarr_c, dmskarr,
+                                                                       is_rz, dxinv);
+                                mlndlap_crse_resid(i,j,k, sync_resid_a, rhsarr, cccmsk, nddom, lobc, hibc, neumann_doubling);
+                            });
+#else
+                            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                            {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_ha(i,j,k, phiarr,
+                                                                       sxarr_c, syarr_c, szarr_c,
+                                                                       dmskarr, dxinv);
+                                mlndlap_crse_resid(i,j,k, sync_resid_a, rhsarr, cccmsk, nddom, lobc, hibc, neumann_doubling);
+                            });
+#endif
+                        } else {
+#if (AMREX_SPACEDIM == 2)
+                            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                            {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_aa(i, j, k, phiarr, sigmaarr, dmskarr, is_rz, dxinv);
+                                mlndlap_crse_resid(i, j, k, sync_resid_a, rhsarr, cccmsk, nddom, lobc, hibc, neumann_doubling);
+                            });
+#else
+                            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                            {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_aa(i, j, k, phiarr, sigmaarr, dmskarr, dxinv);
+                                mlndlap_crse_resid(i, j, k, sync_resid_a, rhsarr, cccmsk, nddom, lobc, hibc, neumann_doubling);
+                            });
+#endif
+                        }
                     }
                 }
             }
@@ -342,6 +415,14 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
 #endif
 
     const auto& sigma_orig = m_sigma[0][0][0];
+    // Per-axis sigma for the anisotropic (mapped) path.
+    const bool aniso_sigma = m_use_mapped;
+#if (AMREX_SPACEDIM >= 2)
+    const MultiFab* sigma_orig_y = aniso_sigma ? m_sigma[0][0][1].get() : nullptr;
+#endif
+#if (AMREX_SPACEDIM == 3)
+    const MultiFab* sigma_orig_z = aniso_sigma ? m_sigma[0][0][2].get() : nullptr;
+#endif
     const iMultiFab& dmsk = *m_dirichlet_mask[0][0];
 
     const auto lobc = LoBC();
@@ -370,6 +451,11 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
     {
         FArrayBox rhs, u;
         IArrayBox tmpmask;
+        // Per-axis sigma scratch for the anisotropic path.
+        FArrayBox sig_y_local;
+#if (AMREX_SPACEDIM == 3)
+        FArrayBox sig_z_local;
+#endif
 #ifdef AMREX_USE_EB
         FArrayBox sten, cn;
 #endif
@@ -556,14 +642,47 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
                 {
                     Array4<Real> sigmaarr = uarr;
                     const Box& ovlp2 = ccvbx & ccbxg1;
+
+                    if (aniso_sigma) {
+                        sig_y_local.resize(ccbxg1, 1, The_Async_Arena());
+#if (AMREX_SPACEDIM == 3)
+                        sig_z_local.resize(ccbxg1, 1, The_Async_Arena());
+#endif
+                    }
+                    Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};
+#if (AMREX_SPACEDIM == 3)
+                    Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};
+#endif
+
                     if (sigma_orig) {
                         Array4<Real const> const& sigmaarr_orig = sigma_orig->const_array(mfi);
+#if (AMREX_SPACEDIM >= 2)
+                        Array4<Real const> syarr_orig = aniso_sigma
+                            ? sigma_orig_y->const_array(mfi) : Array4<Real const>{};
+#endif
+#if (AMREX_SPACEDIM == 3)
+                        Array4<Real const> szarr_orig = aniso_sigma
+                            ? sigma_orig_z->const_array(mfi) : Array4<Real const>{};
+#endif
+                        const bool is_aniso = aniso_sigma;
                         AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                         {
                             if (ovlp2.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
                                 sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
+#if (AMREX_SPACEDIM >= 2)
+                                if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
+#endif
+#if (AMREX_SPACEDIM == 3)
+                                if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+#endif
                             } else {
                                 sigmaarr(i,j,k) = 0.0;
+#if (AMREX_SPACEDIM >= 2)
+                                if (is_aniso) { syarr_w(i,j,k) = 0.0; }
+#endif
+#if (AMREX_SPACEDIM == 3)
+                                if (is_aniso) { szarr_w(i,j,k) = 0.0; }
+#endif
                             }
                         });
                     } else {
@@ -578,29 +697,62 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
                         });
                     }
 
-#if (AMREX_SPACEDIM == 2)
-                    AMREX_HOST_DEVICE_FOR_3D(gbx, i, j, k,
-                    {
-                        if (bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                            sync_resid_a(i,j,k) = mlndlap_adotx_aa(i,j,k, phiarr, sigmaarr, tmpmaskarr,
-                                                                   is_rz, dxinv);
-                            sync_resid_a(i,j,k) = rhsarr(i,j,k) - sync_resid_a(i,j,k);
-                        } else {
-                            sync_resid_a(i,j,k) = 0.0;
-                        }
-                    });
-#else
-                    AMREX_HOST_DEVICE_FOR_3D(gbx, i, j, k,
-                    {
-                        if (bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
-                            sync_resid_a(i,j,k) = mlndlap_adotx_aa(i,j,k, phiarr, sigmaarr, tmpmaskarr,
-                                                                   dxinv);
-                            sync_resid_a(i,j,k) = rhsarr(i,j,k) - sync_resid_a(i,j,k);
-                        } else {
-                            sync_resid_a(i,j,k) = 0.0;
-                        }
-                    });
+                    if (aniso_sigma) {
+                        Array4<Real const> sxarr_c = sigmaarr;
+                        Array4<Real const> syarr_c = syarr_w;
+#if (AMREX_SPACEDIM == 3)
+                        Array4<Real const> szarr_c = szarr_w;
 #endif
+#if (AMREX_SPACEDIM == 2)
+                        AMREX_HOST_DEVICE_FOR_3D(gbx, i, j, k,
+                        {
+                            if (bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_ha(i,j,k, phiarr,
+                                                                       sxarr_c, syarr_c, tmpmaskarr,
+                                                                       is_rz, dxinv);
+                                sync_resid_a(i,j,k) = rhsarr(i,j,k) - sync_resid_a(i,j,k);
+                            } else {
+                                sync_resid_a(i,j,k) = 0.0;
+                            }
+                        });
+#else
+                        AMREX_HOST_DEVICE_FOR_3D(gbx, i, j, k,
+                        {
+                            if (bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_ha(i,j,k, phiarr,
+                                                                       sxarr_c, syarr_c, szarr_c,
+                                                                       tmpmaskarr, dxinv);
+                                sync_resid_a(i,j,k) = rhsarr(i,j,k) - sync_resid_a(i,j,k);
+                            } else {
+                                sync_resid_a(i,j,k) = 0.0;
+                            }
+                        });
+#endif
+                    } else {
+#if (AMREX_SPACEDIM == 2)
+                        AMREX_HOST_DEVICE_FOR_3D(gbx, i, j, k,
+                        {
+                            if (bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_aa(i,j,k, phiarr, sigmaarr, tmpmaskarr,
+                                                                       is_rz, dxinv);
+                                sync_resid_a(i,j,k) = rhsarr(i,j,k) - sync_resid_a(i,j,k);
+                            } else {
+                                sync_resid_a(i,j,k) = 0.0;
+                            }
+                        });
+#else
+                        AMREX_HOST_DEVICE_FOR_3D(gbx, i, j, k,
+                        {
+                            if (bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_aa(i,j,k, phiarr, sigmaarr, tmpmaskarr,
+                                                                       dxinv);
+                                sync_resid_a(i,j,k) = rhsarr(i,j,k) - sync_resid_a(i,j,k);
+                            } else {
+                                sync_resid_a(i,j,k) = 0.0;
+                            }
+                        });
+#endif
+                    }
                 }
             }
 
@@ -728,8 +880,31 @@ MLNodeLaplacian::reflux (int crse_amrlev,
 
         if (fsigma) {
             Array4<Real const> const& sigarr = fsigma->const_array(mfi);
+            const bool aniso_sigma = m_use_mapped;
+#if (AMREX_SPACEDIM >= 2)
+            Array4<Real const> syarr = aniso_sigma
+                ? m_sigma[crse_amrlev+1][0][1]->const_array(mfi) : Array4<Real const>{};
+#endif
+#if (AMREX_SPACEDIM == 3)
+            Array4<Real const> szarr = aniso_sigma
+                ? m_sigma[crse_amrlev+1][0][2]->const_array(mfi) : Array4<Real const>{};
+#endif
 #if (AMREX_SPACEDIM == 2)
-            if (amrrr == 2) {
+            if (aniso_sigma) {
+                if (amrrr == 2) {
+                    AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                    {
+                        mlndlap_Ax_fine_contrib_ha<2>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                                      sigarr,syarr,marr,is_rz,fdxinv);
+                    });
+                } else {
+                    AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                    {
+                        mlndlap_Ax_fine_contrib_ha<4>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                                      sigarr,syarr,marr,is_rz,fdxinv);
+                    });
+                }
+            } else if (amrrr == 2) {
                 AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
                 {
                     mlndlap_Ax_fine_contrib<2>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
@@ -743,7 +918,21 @@ MLNodeLaplacian::reflux (int crse_amrlev,
                 });
             }
 #elif (AMREX_SPACEDIM == 3)
-            if (amrrr == 2) {
+            if (aniso_sigma) {
+                if (amrrr == 2) {
+                    AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                    {
+                        mlndlap_Ax_fine_contrib_ha<2>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                                      sigarr,syarr,szarr,marr,fdxinv);
+                    });
+                } else {
+                    AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
+                    {
+                        mlndlap_Ax_fine_contrib_ha<4>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
+                                                      sigarr,syarr,szarr,marr,fdxinv);
+                    });
+                }
+            } else if (amrrr == 2) {
                 AMREX_HOST_DEVICE_FOR_3D(cbx, i, j, k,
                 {
                     mlndlap_Ax_fine_contrib<2>(i,j,k,fvbx,cc_fvbx,farr,resarr,rhsarr,solarr,
@@ -801,6 +990,7 @@ MLNodeLaplacian::reflux (int crse_amrlev,
     const auto& has_fine_bndry = m_has_fine_bndry[crse_amrlev];
 
     const auto& csigma = m_sigma[crse_amrlev][0][0];
+    const bool aniso_csigma = m_use_mapped;
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -820,23 +1010,54 @@ MLNodeLaplacian::reflux (int crse_amrlev,
 
             if (csigma) {
                 Array4<Real const> const& csigarr = csigma->const_array(mfi);
+#if (AMREX_SPACEDIM >= 2)
+                Array4<Real const> csigyarr = aniso_csigma
+                    ? m_sigma[crse_amrlev][0][1]->const_array(mfi) : Array4<Real const>{};
+#endif
+#if (AMREX_SPACEDIM == 3)
+                Array4<Real const> csigzarr = aniso_csigma
+                    ? m_sigma[crse_amrlev][0][2]->const_array(mfi) : Array4<Real const>{};
+#endif
 #if (AMREX_SPACEDIM == 2)
-                AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
-                {
-                    mlndlap_res_cf_contrib(i,j,k,resarr,csolarr,crhsarr,csigarr,
-                                           cdmskarr,ndmskarr,ccmskarr,fcocarr,
-                                           cdxinv,c_cc_domain_p,c_nd_domain,
-                                           is_rz,
-                                           lobc,hibc, neumann_doubling);
-                });
+                if (aniso_csigma) {
+                    AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
+                    {
+                        mlndlap_res_cf_contrib_ha(i,j,k,resarr,csolarr,crhsarr,
+                                                  csigarr,csigyarr,
+                                                  cdmskarr,ndmskarr,ccmskarr,fcocarr,
+                                                  cdxinv,c_cc_domain_p,c_nd_domain,
+                                                  is_rz,
+                                                  lobc,hibc, neumann_doubling);
+                    });
+                } else {
+                    AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
+                    {
+                        mlndlap_res_cf_contrib(i,j,k,resarr,csolarr,crhsarr,csigarr,
+                                               cdmskarr,ndmskarr,ccmskarr,fcocarr,
+                                               cdxinv,c_cc_domain_p,c_nd_domain,
+                                               is_rz,
+                                               lobc,hibc, neumann_doubling);
+                    });
+                }
 #elif (AMREX_SPACEDIM == 3)
-                AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
-                {
-                    mlndlap_res_cf_contrib(i,j,k,resarr,csolarr,crhsarr,csigarr,
-                                           cdmskarr,ndmskarr,ccmskarr,fcocarr,
-                                           cdxinv,c_cc_domain_p,c_nd_domain,
-                                           lobc,hibc, neumann_doubling);
-                });
+                if (aniso_csigma) {
+                    AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
+                    {
+                        mlndlap_res_cf_contrib_ha(i,j,k,resarr,csolarr,crhsarr,
+                                                  csigarr,csigyarr,csigzarr,
+                                                  cdmskarr,ndmskarr,ccmskarr,fcocarr,
+                                                  cdxinv,c_cc_domain_p,c_nd_domain,
+                                                  lobc,hibc, neumann_doubling);
+                    });
+                } else {
+                    AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
+                    {
+                        mlndlap_res_cf_contrib(i,j,k,resarr,csolarr,crhsarr,csigarr,
+                                               cdmskarr,ndmskarr,ccmskarr,fcocarr,
+                                               cdxinv,c_cc_domain_p,c_nd_domain,
+                                               lobc,hibc, neumann_doubling);
+                    });
+                }
 #endif
             } else {
                 Real const_sigma = m_const_sigma;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -987,7 +987,9 @@ MLNodeLaplacian::reflux (int crse_amrlev,
     const auto& has_fine_bndry = m_has_fine_bndry[crse_amrlev];
 
     const auto& csigma = m_sigma[crse_amrlev][0][0];
-    const bool aniso_csigma = m_use_mapped;
+    const bool aniso_csigma = m_use_mapped && (csigma != nullptr)
+        AMREX_D_TERM(, && (m_sigma[crse_amrlev][0][1] != nullptr),
+                     && (m_sigma[crse_amrlev][0][2] != nullptr));
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -83,12 +83,9 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
     const auto& sigma_orig = m_sigma[0][0][0];
     // Anisotropic (mapped) path: capture per-axis sigmas.
     const bool aniso_sigma = m_use_mapped;
-#if (AMREX_SPACEDIM >= 2)
-    const MultiFab* sigma_orig_y = aniso_sigma ? m_sigma[0][0][1].get() : nullptr;
-#endif
-#if (AMREX_SPACEDIM == 3)
-    const MultiFab* sigma_orig_z = aniso_sigma ? m_sigma[0][0][2].get() : nullptr;
-#endif
+    AMREX_D_TERM(,
+                 const MultiFab* sigma_orig_y = aniso_sigma ? m_sigma[0][0][1].get() : nullptr;,
+                 const MultiFab* sigma_orig_z = aniso_sigma ? m_sigma[0][0][2].get() : nullptr;)
     const iMultiFab& dmsk = *m_dirichlet_mask[0][0];
 
 #ifdef AMREX_USE_EB
@@ -305,53 +302,36 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
 
                         // Per-axis sigma scratch when mapped.
                         if (aniso_sigma) {
-                            sig_y_local.resize(ccbxg1, 1, The_Async_Arena());
-#if (AMREX_SPACEDIM == 3)
-                            sig_z_local.resize(ccbxg1, 1, The_Async_Arena());
-#endif
+                            AMREX_D_TERM(,
+                                         sig_y_local.resize(ccbxg1, 1, The_Async_Arena());,
+                                         sig_z_local.resize(ccbxg1, 1, The_Async_Arena());)
                         }
-#if (AMREX_SPACEDIM >= 2)
-                        Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};
-#else
-                        Array4<Real> syarr_w{};
-#endif
-#if (AMREX_SPACEDIM == 3)
-                        Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};
-#else
-                        Array4<Real> szarr_w{};
-#endif
+                        AMREX_D_TERM(,
+                                     Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};,
+                                     Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};)
 
                         if (sigma_orig) {
                             Array4<Real const> const& sigmaarr_orig = sigma_orig->const_array(mfi);
-#if (AMREX_SPACEDIM >= 2)
-                            Array4<Real const> syarr_orig = aniso_sigma
-                                ? sigma_orig_y->const_array(mfi) : Array4<Real const>{};
-#else
-                            Array4<Real const> syarr_orig{};
-#endif
-#if (AMREX_SPACEDIM == 3)
-                            Array4<Real const> szarr_orig = aniso_sigma
-                                ? sigma_orig_z->const_array(mfi) : Array4<Real const>{};
-#else
-                            Array4<Real const> szarr_orig{};
-#endif
+                            AMREX_D_TERM(,
+                                         Array4<Real const> syarr_orig = aniso_sigma
+                                             ? sigma_orig_y->const_array(mfi) : Array4<Real const>{};,
+                                         Array4<Real const> szarr_orig = aniso_sigma
+                                             ? sigma_orig_z->const_array(mfi) : Array4<Real const>{};)
                             AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                             {
                                 if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)) {
                                     sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
-                                    if constexpr (AMREX_SPACEDIM >= 2) {
-                                        if (aniso_sigma) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
-                                    }
-                                    if constexpr (AMREX_SPACEDIM == 3) {
-                                        if (aniso_sigma) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+                                    if (aniso_sigma) {
+                                        AMREX_D_TERM(,
+                                                     syarr_w(i,j,k) = syarr_orig(i,j,k);,
+                                                     szarr_w(i,j,k) = szarr_orig(i,j,k);)
                                     }
                                 } else {
                                     sigmaarr(i,j,k) = 0.0;
-                                    if constexpr (AMREX_SPACEDIM >= 2) {
-                                        if (aniso_sigma) { syarr_w(i,j,k) = 0.0; }
-                                    }
-                                    if constexpr (AMREX_SPACEDIM == 3) {
-                                        if (aniso_sigma) { szarr_w(i,j,k) = 0.0; }
+                                    if (aniso_sigma) {
+                                        AMREX_D_TERM(,
+                                                     syarr_w(i,j,k) = 0.0;,
+                                                     szarr_w(i,j,k) = 0.0;)
                                     }
                                 }
                             });
@@ -435,12 +415,9 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
     const auto& sigma_orig = m_sigma[0][0][0];
     // Per-axis sigma for the anisotropic (mapped) path.
     const bool aniso_sigma = m_use_mapped;
-#if (AMREX_SPACEDIM >= 2)
-    const MultiFab* sigma_orig_y = aniso_sigma ? m_sigma[0][0][1].get() : nullptr;
-#endif
-#if (AMREX_SPACEDIM == 3)
-    const MultiFab* sigma_orig_z = aniso_sigma ? m_sigma[0][0][2].get() : nullptr;
-#endif
+    AMREX_D_TERM(,
+                 const MultiFab* sigma_orig_y = aniso_sigma ? m_sigma[0][0][1].get() : nullptr;,
+                 const MultiFab* sigma_orig_z = aniso_sigma ? m_sigma[0][0][2].get() : nullptr;)
     const iMultiFab& dmsk = *m_dirichlet_mask[0][0];
 
     const auto lobc = LoBC();
@@ -662,53 +639,36 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
                     const Box& ovlp2 = ccvbx & ccbxg1;
 
                     if (aniso_sigma) {
-                        sig_y_local.resize(ccbxg1, 1, The_Async_Arena());
-#if (AMREX_SPACEDIM == 3)
-                        sig_z_local.resize(ccbxg1, 1, The_Async_Arena());
-#endif
+                        AMREX_D_TERM(,
+                                     sig_y_local.resize(ccbxg1, 1, The_Async_Arena());,
+                                     sig_z_local.resize(ccbxg1, 1, The_Async_Arena());)
                     }
-#if (AMREX_SPACEDIM >= 2)
-                    Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};
-#else
-                    Array4<Real> syarr_w{};
-#endif
-#if (AMREX_SPACEDIM == 3)
-                    Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};
-#else
-                    Array4<Real> szarr_w{};
-#endif
+                    AMREX_D_TERM(,
+                                 Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};,
+                                 Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};)
 
                     if (sigma_orig) {
                         Array4<Real const> const& sigmaarr_orig = sigma_orig->const_array(mfi);
-#if (AMREX_SPACEDIM >= 2)
-                        Array4<Real const> syarr_orig = aniso_sigma
-                            ? sigma_orig_y->const_array(mfi) : Array4<Real const>{};
-#else
-                        Array4<Real const> syarr_orig{};
-#endif
-#if (AMREX_SPACEDIM == 3)
-                        Array4<Real const> szarr_orig = aniso_sigma
-                            ? sigma_orig_z->const_array(mfi) : Array4<Real const>{};
-#else
-                        Array4<Real const> szarr_orig{};
-#endif
+                        AMREX_D_TERM(,
+                                     Array4<Real const> syarr_orig = aniso_sigma
+                                         ? sigma_orig_y->const_array(mfi) : Array4<Real const>{};,
+                                     Array4<Real const> szarr_orig = aniso_sigma
+                                         ? sigma_orig_z->const_array(mfi) : Array4<Real const>{};)
                         AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                         {
                             if (ovlp2.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
                                 sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
-                                if constexpr (AMREX_SPACEDIM >= 2) {
-                                    if (aniso_sigma) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
-                                }
-                                if constexpr (AMREX_SPACEDIM == 3) {
-                                    if (aniso_sigma) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+                                if (aniso_sigma) {
+                                    AMREX_D_TERM(,
+                                                 syarr_w(i,j,k) = syarr_orig(i,j,k);,
+                                                 szarr_w(i,j,k) = szarr_orig(i,j,k);)
                                 }
                             } else {
                                 sigmaarr(i,j,k) = 0.0;
-                                if constexpr (AMREX_SPACEDIM >= 2) {
-                                    if (aniso_sigma) { syarr_w(i,j,k) = 0.0; }
-                                }
-                                if constexpr (AMREX_SPACEDIM == 3) {
-                                    if (aniso_sigma) { szarr_w(i,j,k) = 0.0; }
+                                if (aniso_sigma) {
+                                    AMREX_D_TERM(,
+                                                 syarr_w(i,j,k) = 0.0;,
+                                                 szarr_w(i,j,k) = 0.0;)
                                 }
                             }
                         });
@@ -921,14 +881,11 @@ MLNodeLaplacian::reflux (int crse_amrlev,
         if (fsigma) {
             Array4<Real const> const& sigarr = fsigma->const_array(mfi);
             const bool aniso_sigma = m_use_mapped;
-#if (AMREX_SPACEDIM >= 2)
-            Array4<Real const> syarr = aniso_sigma
-                ? m_sigma[crse_amrlev+1][0][1]->const_array(mfi) : Array4<Real const>{};
-#endif
-#if (AMREX_SPACEDIM == 3)
-            Array4<Real const> szarr = aniso_sigma
-                ? m_sigma[crse_amrlev+1][0][2]->const_array(mfi) : Array4<Real const>{};
-#endif
+            AMREX_D_TERM(,
+                         Array4<Real const> syarr = aniso_sigma
+                             ? m_sigma[crse_amrlev+1][0][1]->const_array(mfi) : Array4<Real const>{};,
+                         Array4<Real const> szarr = aniso_sigma
+                             ? m_sigma[crse_amrlev+1][0][2]->const_array(mfi) : Array4<Real const>{};)
 #if (AMREX_SPACEDIM == 2)
             if (aniso_sigma) {
                 if (amrrr == 2) {
@@ -1050,14 +1007,11 @@ MLNodeLaplacian::reflux (int crse_amrlev,
 
             if (csigma) {
                 Array4<Real const> const& csigarr = csigma->const_array(mfi);
-#if (AMREX_SPACEDIM >= 2)
-                Array4<Real const> csigyarr = aniso_csigma
-                    ? m_sigma[crse_amrlev][0][1]->const_array(mfi) : Array4<Real const>{};
-#endif
-#if (AMREX_SPACEDIM == 3)
-                Array4<Real const> csigzarr = aniso_csigma
-                    ? m_sigma[crse_amrlev][0][2]->const_array(mfi) : Array4<Real const>{};
-#endif
+                AMREX_D_TERM(,
+                             Array4<Real const> csigyarr = aniso_csigma
+                                 ? m_sigma[crse_amrlev][0][1]->const_array(mfi) : Array4<Real const>{};,
+                             Array4<Real const> csigzarr = aniso_csigma
+                                 ? m_sigma[crse_amrlev][0][2]->const_array(mfi) : Array4<Real const>{};)
 #if (AMREX_SPACEDIM == 2)
                 if (aniso_csigma) {
                     AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -367,11 +367,20 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
 
                         if (aniso_sigma) {
                             Array4<Real const> sxarr_c = sigmaarr;
+#if (AMREX_SPACEDIM >= 2)
                             Array4<Real const> syarr_c = syarr_w;
+#endif
 #if (AMREX_SPACEDIM == 3)
                             Array4<Real const> szarr_c = szarr_w;
 #endif
-#if (AMREX_SPACEDIM == 2)
+#if (AMREX_SPACEDIM == 1)
+                            AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+                            {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_ha(i,j,k, phiarr,
+                                                                       sxarr_c, dmskarr, dxinv);
+                                mlndlap_crse_resid(i,j,k, sync_resid_a, rhsarr, cccmsk, nddom, lobc, hibc, neumann_doubling);
+                            });
+#elif (AMREX_SPACEDIM == 2)
                             AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
                             {
                                 sync_resid_a(i,j,k) = mlndlap_adotx_ha(i,j,k, phiarr,
@@ -658,6 +667,8 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
                     Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};
 #if (AMREX_SPACEDIM == 3)
                     Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};
+#else
+                    Array4<Real> szarr_w{};
 #endif
 
                     if (sigma_orig) {
@@ -665,10 +676,14 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
 #if (AMREX_SPACEDIM >= 2)
                         Array4<Real const> syarr_orig = aniso_sigma
                             ? sigma_orig_y->const_array(mfi) : Array4<Real const>{};
+#else
+                        Array4<Real const> syarr_orig{};
 #endif
 #if (AMREX_SPACEDIM == 3)
                         Array4<Real const> szarr_orig = aniso_sigma
                             ? sigma_orig_z->const_array(mfi) : Array4<Real const>{};
+#else
+                        Array4<Real const> szarr_orig{};
 #endif
                         const bool is_aniso = aniso_sigma;
                         AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
@@ -705,11 +720,24 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
 
                     if (aniso_sigma) {
                         Array4<Real const> sxarr_c = sigmaarr;
+#if (AMREX_SPACEDIM >= 2)
                         Array4<Real const> syarr_c = syarr_w;
+#endif
 #if (AMREX_SPACEDIM == 3)
                         Array4<Real const> szarr_c = szarr_w;
 #endif
-#if (AMREX_SPACEDIM == 2)
+#if (AMREX_SPACEDIM == 1)
+                        AMREX_HOST_DEVICE_FOR_3D(gbx, i, j, k,
+                        {
+                            if (bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
+                                sync_resid_a(i,j,k) = mlndlap_adotx_ha(i,j,k, phiarr,
+                                                                       sxarr_c, tmpmaskarr, dxinv);
+                                sync_resid_a(i,j,k) = rhsarr(i,j,k) - sync_resid_a(i,j,k);
+                            } else {
+                                sync_resid_a(i,j,k) = 0.0;
+                            }
+                        });
+#elif (AMREX_SPACEDIM == 2)
                         AMREX_HOST_DEVICE_FOR_3D(gbx, i, j, k,
                         {
                             if (bx.contains(IntVect(AMREX_D_DECL(i,j,k)))) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -330,20 +330,20 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                             {
                                 if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)) {
                                     sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
-									if constexpr (AMREX_SPACEDIM >= 2) {
-									  if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
-									}
-									if constexpr (AMREX_SPACEDIM == 3) {
-									  if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
-									}
+                                    if constexpr (AMREX_SPACEDIM >= 2) {
+                                        if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
+                                    }
+                                    if constexpr (AMREX_SPACEDIM == 3) {
+                                        if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+                                    }
                                 } else {
                                     sigmaarr(i,j,k) = 0.0;
-									if constexpr (AMREX_SPACEDIM >= 2) {
-									  if (is_aniso) { syarr_w(i,j,k) = 0.0; }
-									}
-									if constexpr (AMREX_SPACEDIM == 3) {
-									  if (is_aniso) { szarr_w(i,j,k) = 0.0; }
-									}
+                                    if constexpr (AMREX_SPACEDIM >= 2) {
+                                        if (is_aniso) { syarr_w(i,j,k) = 0.0; }
+                                    }
+                                    if constexpr (AMREX_SPACEDIM == 3) {
+                                        if (is_aniso) { szarr_w(i,j,k) = 0.0; }
+                                    }
                                 }
                             });
                         } else {
@@ -669,20 +669,20 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
                         {
                             if (ovlp2.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
                                 sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
-								if constexpr (AMREX_SPACEDIM >= 2) {
-								  if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
-								}
-								if constexpr (AMREX_SPACEDIM == 3) {
-								  if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
-								}
+                                if constexpr (AMREX_SPACEDIM >= 2) {
+                                    if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
+                                }
+                                if constexpr (AMREX_SPACEDIM == 3) {
+                                    if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+                                }
                             } else {
                                 sigmaarr(i,j,k) = 0.0;
-								if constexpr (AMREX_SPACEDIM >= 2) {
-								  if (is_aniso) { syarr_w(i,j,k) = 0.0; }
-								}
-								if constexpr (AMREX_SPACEDIM == 3) {
-									if (is_aniso) { szarr_w(i,j,k) = 0.0; }
-								}
+                                if constexpr (AMREX_SPACEDIM >= 2) {
+                                    if (is_aniso) { syarr_w(i,j,k) = 0.0; }
+                                }
+                                if constexpr (AMREX_SPACEDIM == 3) {
+                                    if (is_aniso) { szarr_w(i,j,k) = 0.0; }
+                                }
                             }
                         });
                     } else {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -310,7 +310,11 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
                             sig_z_local.resize(ccbxg1, 1, The_Async_Arena());
 #endif
                         }
+#if (AMREX_SPACEDIM >= 2)
                         Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};
+#else
+                        Array4<Real> syarr_w{};
+#endif
 #if (AMREX_SPACEDIM == 3)
                         Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};
 #else
@@ -331,24 +335,23 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
 #else
                             Array4<Real const> szarr_orig{};
 #endif
-                            const bool is_aniso = aniso_sigma;
                             AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                             {
                                 if (ibx.contains(IntVect(AMREX_D_DECL(i,j,k))) && cccmsk(i,j,k)) {
                                     sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
                                     if constexpr (AMREX_SPACEDIM >= 2) {
-                                        if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
+                                        if (aniso_sigma) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
                                     }
                                     if constexpr (AMREX_SPACEDIM == 3) {
-                                        if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+                                        if (aniso_sigma) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
                                     }
                                 } else {
                                     sigmaarr(i,j,k) = 0.0;
                                     if constexpr (AMREX_SPACEDIM >= 2) {
-                                        if (is_aniso) { syarr_w(i,j,k) = 0.0; }
+                                        if (aniso_sigma) { syarr_w(i,j,k) = 0.0; }
                                     }
                                     if constexpr (AMREX_SPACEDIM == 3) {
-                                        if (is_aniso) { szarr_w(i,j,k) = 0.0; }
+                                        if (aniso_sigma) { szarr_w(i,j,k) = 0.0; }
                                     }
                                 }
                             });
@@ -664,7 +667,11 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
                         sig_z_local.resize(ccbxg1, 1, The_Async_Arena());
 #endif
                     }
+#if (AMREX_SPACEDIM >= 2)
                     Array4<Real> syarr_w = aniso_sigma ? sig_y_local.array() : Array4<Real>{};
+#else
+                    Array4<Real> syarr_w{};
+#endif
 #if (AMREX_SPACEDIM == 3)
                     Array4<Real> szarr_w = aniso_sigma ? sig_z_local.array() : Array4<Real>{};
 #else
@@ -685,24 +692,23 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
 #else
                         Array4<Real const> szarr_orig{};
 #endif
-                        const bool is_aniso = aniso_sigma;
                         AMREX_HOST_DEVICE_FOR_3D(ccbxg1, i, j, k,
                         {
                             if (ovlp2.contains(IntVect(AMREX_D_DECL(i,j,k)))) {
                                 sigmaarr(i,j,k) = sigmaarr_orig(i,j,k);
                                 if constexpr (AMREX_SPACEDIM >= 2) {
-                                    if (is_aniso) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
+                                    if (aniso_sigma) { syarr_w(i,j,k) = syarr_orig(i,j,k); }
                                 }
                                 if constexpr (AMREX_SPACEDIM == 3) {
-                                    if (is_aniso) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
+                                    if (aniso_sigma) { szarr_w(i,j,k) = szarr_orig(i,j,k); }
                                 }
                             } else {
                                 sigmaarr(i,j,k) = 0.0;
                                 if constexpr (AMREX_SPACEDIM >= 2) {
-                                    if (is_aniso) { syarr_w(i,j,k) = 0.0; }
+                                    if (aniso_sigma) { syarr_w(i,j,k) = 0.0; }
                                 }
                                 if constexpr (AMREX_SPACEDIM == 3) {
-                                    if (is_aniso) { szarr_w(i,j,k) = 0.0; }
+                                    if (aniso_sigma) { szarr_w(i,j,k) = 0.0; }
                                 }
                             }
                         });


### PR DESCRIPTION
setSigma already supports a per-direction (AMREX_SPACEDIM-component) sigma for diagonal mesh-mapped grids, and the within-level Fapply / Fsmooth / MG paths handle it correctly via m_use_mapped.  However the AMR-level coarse/fine paths only touch the idim=0 sigma, which makes composite multi-level MLMG solves with anisotropic sigma diverge.

In this commit:

1. averageDownCoeffsToCoarseAmrLevel now restricts all SPACEDIM sigma components
2. New code in 2D and 3D for aniso operator
3. compSyncResidualCoarse, compSyncResidualFine, and reflux use the new kernels when m_use_mapped is set

All are no-ops unless m_use_mapped is set so there are no expected behavioral change for any existing AMReX downstream code that doesn't use `setSigma` with `nComp() == AMREX_SPACEDIM`.

## Validation

The PeleLMeX mesh-mapping AMR work (forthcoming follow-up PR to `AMReX-Combustion/PeleLMeX#656`) uses these changes for two test problems:

- 2D LidDrivenCavity at `TanhStretchMap β=2 2` with one AMR level, Re=100. Converges toward Ghia 1982 Table 1 centerline values; the composite nodal projection achieves 1e-7 relative residual in 10-15 iterations per step with `bicgstab` bottom solver.
- 3D PipeFlow half-channel at `ExpStretchMap β=4` with one AMR level, Re_τ=180. Composite nodal projection converges cleanly; initial state advances stably through the buffer-layer transient.

## Additional Notes

- The pre-existing comment `// other dimensions are just aliases` on line 91 of `AMReX_MLNodeLaplacian_misc.cpp` deserves to be kept in the harmonic-average path (where it's correct) and removed from the mapped path. The PR splits the cases explicitly.
- The new kernels add ~150 lines of mechanically-derived code in each of 2D/3D headers. They're long because the operator stencil has many terms, but each term is a per-axis split of the existing aa kernel.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
