### PR TITLE
Add 2D Cartesian/RZ EB Neumann support to MLNodeLaplacian

### DIFF
--- a/Docs/sphinx_documentation/source/EB.rst
+++ b/Docs/sphinx_documentation/source/EB.rst
@@ -633,7 +633,7 @@ AMReX supports multi-level
 1) cell-centered solvers with homogeneous Neumann, homogeneous Dirichlet,
 or inhomogeneous Dirichlet boundary conditions on the EB faces, and
 2) nodal solvers with homogeneous Neumann boundary conditions,
-or inflow velocity conditions on the EB faces.
+2D inhomogeneous Neumann data, or inflow velocity conditions on the EB faces.
 
 To use a cell-centered solver with EB, one builds a linear operator
 :cpp:`MLEBABecLap` with :cpp:`EBFArrayBoxFactory` (instead of a :cpp:`MLABecLaplacian`)
@@ -652,6 +652,12 @@ The usage of this EB-specific class is essentially the same as
 :cpp:`MLABecLaplacian`.
 
 The default boundary condition on EB faces is homogeneous Neumann.
+
+For 2D node-based EB solves, :cpp:`MLNodeLaplacian` can set inhomogeneous
+Neumann data on EB faces with :cpp:`setEBInhomogNeumannFlux`. The supplied
+data is the physical flux :math:`\sigma \partial \phi / \partial n_{EB}` at the
+EB surface. In cylindrical RZ solves, the supplied data should not include the
+radial metric factor; the node-based operator applies that factor internally.
 
 To set homogeneous Dirichlet boundary conditions, call
 

--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -503,12 +503,15 @@ Neumann data on EB faces with
     ml_node_laplacian.setEBInhomogNeumannFlux(lev, eb_neumann_flux);
 
 The first component of :cpp:`eb_neumann_flux` is a cell-centered cut-cell
-MultiFab containing :math:`\sigma \partial \phi / \partial n_{EB}` at the EB
-surface. The AMReX EB normal :math:`n_{EB}` points from the valid computational
-region toward the covered region. Physical domain boundary conditions are still
-set separately with :cpp:`setDomainBC` and related linear-operator calls. The
-same EB normal convention is used when :cpp:`setEBInflowVelocity` forms
-:math:`u \cdot n_{EB}` on EB faces.
+MultiFab containing the physical flux
+:math:`\sigma \partial \phi / \partial n_{EB}` at the EB surface. The AMReX EB
+normal :math:`n_{EB}` points from the valid computational region toward the
+covered region. For cylindrical RZ solves, :cpp:`eb_neumann_flux` should not
+include the radial metric factor; :cpp:`MLNodeLaplacian` applies that factor
+internally when forming the EB contribution to the right-hand side. Physical
+domain boundary conditions are still set separately with :cpp:`setDomainBC` and
+related linear-operator calls. The same EB normal convention is used when
+:cpp:`setEBInflowVelocity` forms :math:`u \cdot n_{EB}` on EB faces.
 
 To use a cell-centered solver with EB, one builds a linear operator
 :cpp:`MLEBABecLap` with :cpp:`EBFArrayBoxFactory` (instead of a :cpp:`MLABecLaplacian`)

--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -490,8 +490,25 @@ AMReX supports multi-level solvers for use with embedded boundaries.
 These include
 1) cell-centered solvers with homogeneous Neumann, homogeneous Dirichlet,
 or inhomogeneous Dirichlet boundary conditions on the EB faces, and
-2) nodal solvers with homogeneous Neumann boundary conditions,
-or inflow velocity conditions on the EB faces.
+2) nodal solvers with homogeneous Neumann boundary conditions, 2D
+inhomogeneous Neumann data, or inflow velocity conditions on the EB faces.
+
+For 2D node-based EB solves, :cpp:`MLNodeLaplacian` can set inhomogeneous
+Neumann data on EB faces with
+
+.. highlight:: c++
+
+::
+
+    ml_node_laplacian.setEBInhomogNeumannFlux(lev, eb_neumann_flux);
+
+The first component of :cpp:`eb_neumann_flux` is a cell-centered cut-cell
+MultiFab containing :math:`\sigma \partial \phi / \partial n_{EB}` at the EB
+surface. The AMReX EB normal :math:`n_{EB}` points from the valid computational
+region toward the covered region. Physical domain boundary conditions are still
+set separately with :cpp:`setDomainBC` and related linear-operator calls. The
+same EB normal convention is used when :cpp:`setEBInflowVelocity` forms
+:math:`u \cdot n_{EB}` on EB faces.
 
 To use a cell-centered solver with EB, one builds a linear operator
 :cpp:`MLEBABecLap` with :cpp:`EBFArrayBoxFactory` (instead of a :cpp:`MLABecLaplacian`)

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -1999,36 +1999,66 @@ void add_eb_flow_contribution (int i, int j, int, Array4<Real> const& rhs,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+Real eb_neumann_surface_term (int i, int j, Real weight,
+                              Array4<Real const> const& bcent,
+                              Array4<Real const> const& eb_neumann_flux,
+                              GpuArray<Real,AMREX_SPACEDIM> const& dx,
+                              GpuArray<Real,AMREX_SPACEDIM> const& problo,
+                              bool is_rz) noexcept
+{
+    if (weight == Real(0.0)) {
+        return Real(0.0);
+    }
+
+    Real metric = Real(1.0);
+    if (is_rz) {
+        metric = problo[0] + (static_cast<Real>(i) + Real(0.5) + bcent(i,j,0,0))*dx[0];
+    }
+
+    return metric * eb_neumann_flux(i,j,0) * weight;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void add_eb_neumann_contribution (int i, int j, int, Array4<Real> const& rhs,
                       Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                      GpuArray<Real,AMREX_SPACEDIM> const& dx,
+                      GpuArray<Real,AMREX_SPACEDIM> const& problo,
                       Array4<Real const> const& bareaarr,
+                      Array4<Real const> const& bcent,
                       Array4<Real const> const& sintg,
-                      Array4<Real const> const& eb_neumann_flux) noexcept
+                      Array4<Real const> const& eb_neumann_flux,
+                      bool is_rz) noexcept
 {
     using namespace nodelap_detail;
 
-    // eb_neumann_flux is sigma*dphi/dn_EB, with n_EB pointing from valid
-    // cells toward covered cells.
+    // eb_neumann_flux is the physical sigma*dphi/dn_EB, with n_EB pointing
+    // from valid cells toward covered cells. RZ metric weighting is applied
+    // here when needed.
     Real fac_eb = Real(0.25) * dxinv[0];
 
     if (!msk(i,j,0)) {
+        Real const w_im_jm =          bareaarr(i-1,j-1,0)
+                            + Real(2.)*sintg(i-1,j-1,0,i_B_x )
+                            + Real(2.)*sintg(i-1,j-1,0,i_B_y )
+                            + Real(4.)*sintg(i-1,j-1,0,i_B_xy);
+        Real const w_i_jm  =          bareaarr(i  ,j-1,0)
+                            - Real(2.)*sintg(i  ,j-1,0,i_B_x )
+                            + Real(2.)*sintg(i  ,j-1,0,i_B_y )
+                            - Real(4.)*sintg(i  ,j-1,0,i_B_xy);
+        Real const w_im_j  =          bareaarr(i-1,j  ,0)
+                            + Real(2.)*sintg(i-1,j  ,0,i_B_x )
+                            - Real(2.)*sintg(i-1,j  ,0,i_B_y )
+                            - Real(4.)*sintg(i-1,j  ,0,i_B_xy);
+        Real const w_i_j   =          bareaarr(i  ,j  ,0)
+                            - Real(2.)*sintg(i  ,j  ,0,i_B_x )
+                            - Real(2.)*sintg(i  ,j  ,0,i_B_y )
+                            + Real(4.)*sintg(i  ,j  ,0,i_B_xy);
+
         rhs(i,j,0) -= fac_eb*(
-           eb_neumann_flux(i-1,j-1,0)*(         bareaarr(i-1,j-1,0)
-                                      +Real(2.)*sintg(i-1,j-1,0,i_B_x )
-                                      +Real(2.)*sintg(i-1,j-1,0,i_B_y )
-                                      +Real(4.)*sintg(i-1,j-1,0,i_B_xy))
-          +eb_neumann_flux(i  ,j-1,0)*(         bareaarr(i  ,j-1,0)
-                                      -Real(2.)*sintg(i  ,j-1,0,i_B_x )
-                                      +Real(2.)*sintg(i  ,j-1,0,i_B_y )
-                                      -Real(4.)*sintg(i  ,j-1,0,i_B_xy))
-          +eb_neumann_flux(i-1,j  ,0)*(         bareaarr(i-1,j  ,0)
-                                      +Real(2.)*sintg(i-1,j  ,0,i_B_x )
-                                      -Real(2.)*sintg(i-1,j  ,0,i_B_y )
-                                      -Real(4.)*sintg(i-1,j  ,0,i_B_xy))
-          +eb_neumann_flux(i  ,j  ,0)*(         bareaarr(i  ,j  ,0)
-                                      -Real(2.)*sintg(i  ,j  ,0,i_B_x )
-                                      -Real(2.)*sintg(i  ,j  ,0,i_B_y )
-                                      +Real(4.)*sintg(i  ,j  ,0,i_B_xy)));
+           eb_neumann_surface_term(i-1,j-1,w_im_jm,bcent,eb_neumann_flux,dx,problo,is_rz)
+          +eb_neumann_surface_term(i  ,j-1,w_i_jm ,bcent,eb_neumann_flux,dx,problo,is_rz)
+          +eb_neumann_surface_term(i-1,j  ,w_im_j ,bcent,eb_neumann_flux,dx,problo,is_rz)
+          +eb_neumann_surface_term(i  ,j  ,w_i_j  ,bcent,eb_neumann_flux,dx,problo,is_rz));
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -1414,7 +1414,8 @@ void mlndlap_res_cf_contrib_cs (int i, int j, int, Array4<Real> const& res,
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_set_stencil (Box const& bx, Array4<Real> const& sten,
                           Array4<Real const> const& sigma,
-                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+                          GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                          bool is_rz = false) noexcept
 {
     Real facx = Real(1.0/6.0)*dxinv[0]*dxinv[0];
     Real facy = Real(1.0/6.0)*dxinv[1]*dxinv[1];
@@ -1427,6 +1428,11 @@ void mlndlap_set_stencil (Box const& bx, Array4<Real> const& sten,
         sten(i,j,k,1) = f2xmy*(sigma(i,j-1,k)+sigma(i,j,k));
         sten(i,j,k,2) = fmx2y*(sigma(i-1,j,k)+sigma(i,j,k));
         sten(i,j,k,3) = fxy*sigma(i,j,k);
+        if (is_rz) {
+            Real fp = facy / static_cast<Real>(2*i+1);
+            Real fm = facy / static_cast<Real>(2*i-1);
+            sten(i,j,k,2) += fm*sigma(i-1,j,k) - fp*sigma(i,j,k);
+        }
     });
 }
 
@@ -1883,7 +1889,8 @@ void mlndlap_set_connection (int i, int j, int, Array4<Real> const& conn,
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlndlap_set_stencil_eb (int i, int j, int, Array4<Real> const& sten,
                              Array4<Real const> const& sig, Array4<Real const> const& conn,
-                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv) noexcept
+                             GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                             bool is_rz = false) noexcept
 {
     Real facx = Real(1./6.)*dxinv[0]*dxinv[0];
     Real facy = Real(1./6.)*dxinv[1]*dxinv[1];
@@ -1893,6 +1900,12 @@ void mlndlap_set_stencil_eb (int i, int j, int, Array4<Real> const& sten,
     sten(i,j,0,2) = Real(2.)*facy*(sig(i-1,j,0)*conn(i-1,j,0,5)+sig(i,j,0)*conn(i,j,0,3))
                             -facx*(sig(i-1,j,0)*conn(i-1,j,0,1)+sig(i,j,0)*conn(i,j,0,1));
     sten(i,j,0,3) = (facx*conn(i,j,0,1)+facy*conn(i,j,0,4))*sig(i,j,0);
+    if (is_rz) {
+        Real fp = facy / static_cast<Real>(2*i+1);
+        Real fm = facy / static_cast<Real>(2*i-1);
+        sten(i,j,0,2) += fm*sig(i-1,j,0)*conn(i-1,j,0,5)
+                       - fp*sig(i  ,j,0)*conn(i  ,j,0,3);
+    }
 }
 
 
@@ -1979,6 +1992,40 @@ void add_eb_flow_contribution (int i, int j, int, Array4<Real> const& rhs,
                                       -Real(2.)*sintg(i-1,j  ,0,i_B_y )
                                       -Real(4.)*sintg(i-1,j  ,0,i_B_xy))
           +eb_vel_dot_n(i  ,j  ,0)*(         bareaarr(i  ,j  ,0)
+                                      -Real(2.)*sintg(i  ,j  ,0,i_B_x )
+                                      -Real(2.)*sintg(i  ,j  ,0,i_B_y )
+                                      +Real(4.)*sintg(i  ,j  ,0,i_B_xy)));
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void add_eb_neumann_contribution (int i, int j, int, Array4<Real> const& rhs,
+                      Array4<int const> const& msk, GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
+                      Array4<Real const> const& bareaarr,
+                      Array4<Real const> const& sintg,
+                      Array4<Real const> const& eb_neumann_flux) noexcept
+{
+    using namespace nodelap_detail;
+
+    // eb_neumann_flux is sigma*dphi/dn_EB, with n_EB pointing from valid
+    // cells toward covered cells.
+    Real fac_eb = Real(0.25) * dxinv[0];
+
+    if (!msk(i,j,0)) {
+        rhs(i,j,0) -= fac_eb*(
+           eb_neumann_flux(i-1,j-1,0)*(         bareaarr(i-1,j-1,0)
+                                      +Real(2.)*sintg(i-1,j-1,0,i_B_x )
+                                      +Real(2.)*sintg(i-1,j-1,0,i_B_y )
+                                      +Real(4.)*sintg(i-1,j-1,0,i_B_xy))
+          +eb_neumann_flux(i  ,j-1,0)*(         bareaarr(i  ,j-1,0)
+                                      -Real(2.)*sintg(i  ,j-1,0,i_B_x )
+                                      +Real(2.)*sintg(i  ,j-1,0,i_B_y )
+                                      -Real(4.)*sintg(i  ,j-1,0,i_B_xy))
+          +eb_neumann_flux(i-1,j  ,0)*(         bareaarr(i-1,j  ,0)
+                                      +Real(2.)*sintg(i-1,j  ,0,i_B_x )
+                                      -Real(2.)*sintg(i-1,j  ,0,i_B_y )
+                                      -Real(4.)*sintg(i-1,j  ,0,i_B_xy))
+          +eb_neumann_flux(i  ,j  ,0)*(         bareaarr(i  ,j  ,0)
                                       -Real(2.)*sintg(i  ,j  ,0,i_B_x )
                                       -Real(2.)*sintg(i  ,j  ,0,i_B_y )
                                       +Real(4.)*sintg(i  ,j  ,0,i_B_xy)));

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -126,6 +126,7 @@ public :
     void getFluxes (const Vector<MultiFab*>& a_flux,
                             const Vector<MultiFab*>& a_sol) const final;
     void unimposeNeumannBC (int amrlev, MultiFab& rhs) const final;
+    void applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const final;
     Vector<Real> getSolvabilityOffset (int amrlev, int mglev,
                                        MultiFab const& rhs) const override;
     void fixSolvabilityByOffset (int amrlev, int mglev, MultiFab& rhs,
@@ -151,8 +152,23 @@ public :
     void buildIntegral ();
     void buildSurfaceIntegral ();
 
-    // Tells the solver that EB boundaries have inflow specified by "eb_vel"
+    /**
+     * \brief Set velocity data on embedded boundaries.
+     *
+     * The solver uses `eb_vel dot n_EB` on EB faces, where the AMReX EB normal
+     * `n_EB` points from the valid/fluid region toward the covered/body region.
+     */
     void setEBInflowVelocity (int amrlev, const MultiFab& eb_vel);
+
+    /**
+     * \brief Set inhomogeneous Neumann data on embedded boundaries.
+     *
+     * The first component of `eb_neumann_flux` is the cell-centered cut-cell
+     * value of `sigma*dphi/dn_EB` at the EB surface. AMReX EB normals point
+     * from the valid/fluid region toward the covered/body region. This is
+     * currently implemented for 2D EB nodal solves.
+     */
+    void setEBInhomogNeumannFlux (int amrlev, const MultiFab& eb_neumann_flux);
 
 #endif
 
@@ -209,6 +225,7 @@ private:
     bool m_surface_integral_built = false;
     bool m_build_surface_integral = false;
     Vector<std::unique_ptr<MultiFab> > m_eb_vel_dot_n;
+    Vector<std::unique_ptr<MultiFab> > m_eb_neumann_flux;
 #endif
 
     bool m_use_gauss_seidel     = true;

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -164,9 +164,11 @@ public :
      * \brief Set inhomogeneous Neumann data on embedded boundaries.
      *
      * The first component of `eb_neumann_flux` is the cell-centered cut-cell
-     * value of `sigma*dphi/dn_EB` at the EB surface. AMReX EB normals point
-     * from the valid/fluid region toward the covered/body region. This is
-     * currently implemented for 2D EB nodal solves.
+     * value of the physical flux `sigma*dphi/dn_EB` at the EB surface. AMReX
+     * EB normals point from the valid/fluid region toward the covered/body
+     * region. For RZ solves, this flux should not include the radial metric
+     * factor; the solver applies that factor internally. This is currently
+     * implemented for 2D EB nodal solves.
      */
     void setEBInhomogNeumannFlux (int amrlev, const MultiFab& eb_neumann_flux);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -86,6 +86,7 @@ MLNodeLaplacian::define (const Vector<Geometry>& a_geom,
     m_integral.resize(m_num_amr_levels);
     m_surface_integral.resize(m_num_amr_levels);
     m_eb_vel_dot_n.resize(m_num_amr_levels);
+    m_eb_neumann_flux.resize(m_num_amr_levels);
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev)
     {
         m_integral[amrlev] = std::make_unique<MultiFab>(m_grids[amrlev][0],
@@ -1079,6 +1080,42 @@ MLNodeLaplacian::setEBInflowVelocity (int amrlev, const MultiFab& eb_vel)
                                                     *m_factory[amrlev][0]);
     // Turn on flag for building surface integrals
     m_build_surface_integral = true;
+    m_surface_integral_built = false;
+}
+
+void
+MLNodeLaplacian::setEBInhomogNeumannFlux (int amrlev, const MultiFab& eb_neumann_flux)
+{
+#if (AMREX_SPACEDIM != 2)
+    amrex::ignore_unused(amrlev, eb_neumann_flux);
+    amrex::Abort("MLNodeLaplacian::setEBInhomogNeumannFlux is currently implemented for 2D only");
+#else
+    const int mglev = 0;
+    const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(factory != nullptr,
+        "MLNodeLaplacian::setEBInhomogNeumannFlux requires an EB factory");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(eb_neumann_flux.nComp() >= 1,
+        "MLNodeLaplacian::setEBInhomogNeumannFlux requires at least one component");
+
+    if (m_eb_neumann_flux[amrlev] == nullptr || m_eb_neumann_flux[amrlev]->nComp() != 1) {
+        m_eb_neumann_flux[amrlev] = std::make_unique<MultiFab>(
+            m_grids[amrlev][mglev], m_dmap[amrlev][mglev],
+            1, 1, MFInfo(), *m_factory[amrlev][mglev]);
+    }
+
+    m_eb_neumann_flux[amrlev]->setVal(0.0);
+    m_eb_neumann_flux[amrlev]->ParallelCopy(eb_neumann_flux, 0, 0, 1,
+                                            m_geom[amrlev][mglev].periodicity());
+    m_eb_neumann_flux[amrlev]->FillBoundary(m_geom[amrlev][mglev].periodicity());
+
+    const int ncomp_si = 3;
+    m_surface_integral[amrlev] = std::make_unique<MultiFab>(m_grids[amrlev][0],
+                                                    m_dmap[amrlev][0],
+                                                    ncomp_si, 1, MFInfo(),
+                                                    *m_factory[amrlev][0]);
+    m_build_surface_integral = true;
+    m_surface_integral_built = false;
+#endif
 }
 #endif
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -1078,12 +1078,16 @@ MLNodeLaplacian::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
     const int mglev = 0;
     const Geometry& geom = m_geom[amrlev][mglev];
     const auto dxinvarr = geom.InvCellSizeArray();
+    const auto dxarr = geom.CellSizeArray();
+    const auto probloarr = geom.ProbLoArray();
+    const bool is_rz = m_is_rz;
 
     const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
     if (!factory || factory->isAllRegular()) { return; }
 
     const auto& flags = factory->getMultiEBCellFlagFab();
     const MultiCutFab& barea = factory->getBndryArea();
+    const MultiCutFab& bcent = factory->getBndryCent();
     const MultiFab& sintg = *m_surface_integral[amrlev];
     const MultiFab& eb_neumann_flux = *m_eb_neumann_flux[amrlev];
     const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][mglev];
@@ -1103,13 +1107,15 @@ MLNodeLaplacian::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
             Array4<Real> const& rhsarr = rhs.array(mfi);
             Array4<int const> const& dmskarr = dmsk.const_array(mfi);
             Array4<Real const> const& bareaarr = barea.const_array(mfi);
+            Array4<Real const> const& bcarr = bcent.const_array(mfi);
             Array4<Real const> const& sintgarr = sintg.const_array(mfi);
             Array4<Real const> const& ebneuarr = eb_neumann_flux.const_array(mfi);
 
             AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
             {
                 add_eb_neumann_contribution(i, j, k, rhsarr, dmskarr, dxinvarr,
-                                            bareaarr, sintgarr, ebneuarr);
+                                            dxarr, probloarr, bareaarr, bcarr,
+                                            sintgarr, ebneuarr, is_rz);
             });
         }
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -1060,6 +1060,65 @@ MLNodeLaplacian::compDivergence (const Vector<MultiFab*>& rhs, const Vector<Mult
 }
 
 void
+MLNodeLaplacian::applyInhomogNeumannTerm (int amrlev, MultiFab& rhs) const
+{
+#if !defined(AMREX_USE_EB)
+    amrex::ignore_unused(amrlev, rhs);
+#elif (AMREX_SPACEDIM != 2)
+    amrex::ignore_unused(amrlev, rhs);
+    if (!m_eb_neumann_flux.empty() && m_eb_neumann_flux[amrlev]) {
+        amrex::Abort("MLNodeLaplacian::applyInhomogNeumannTerm is currently implemented for 2D only");
+    }
+#else
+    if (m_eb_neumann_flux.empty() || m_eb_neumann_flux[amrlev] == nullptr) { return; }
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_surface_integral_built,
+        "MLNodeLaplacian::applyInhomogNeumannTerm requires built EB surface integrals");
+
+    const int mglev = 0;
+    const Geometry& geom = m_geom[amrlev][mglev];
+    const auto dxinvarr = geom.InvCellSizeArray();
+
+    const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
+    if (!factory || factory->isAllRegular()) { return; }
+
+    const auto& flags = factory->getMultiEBCellFlagFab();
+    const MultiCutFab& barea = factory->getBndryArea();
+    const MultiFab& sintg = *m_surface_integral[amrlev];
+    const MultiFab& eb_neumann_flux = *m_eb_neumann_flux[amrlev];
+    const iMultiFab& dmsk = *m_dirichlet_mask[amrlev][mglev];
+
+    MFItInfo mfi_info;
+    if (Gpu::notInLaunchRegion()) { mfi_info.EnableTiling().SetDynamic(true); }
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(rhs, mfi_info); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+        const auto& flag = flags[mfi];
+        FabType typ = flag.getType(amrex::enclosedCells(bx));
+        if (typ == FabType::singlevalued)
+        {
+            Array4<Real> const& rhsarr = rhs.array(mfi);
+            Array4<int const> const& dmskarr = dmsk.const_array(mfi);
+            Array4<Real const> const& bareaarr = barea.const_array(mfi);
+            Array4<Real const> const& sintgarr = sintg.const_array(mfi);
+            Array4<Real const> const& ebneuarr = eb_neumann_flux.const_array(mfi);
+
+            AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
+            {
+                add_eb_neumann_contribution(i, j, k, rhsarr, dmskarr, dxinvarr,
+                                            bareaarr, sintgarr, ebneuarr);
+            });
+        }
+    }
+
+    nodalSync(amrlev, mglev, rhs);
+#endif
+}
+
+void
 MLNodeLaplacian::compRHS (const Vector<MultiFab*>& rhs, const Vector<MultiFab*>& vel,  // NOLINT(readability-convert-member-functions-to-static)
                           const Vector<const MultiFab*>& rhnd,
                           const Vector<MultiFab*>& a_rhcc)

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sten.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sten.cpp
@@ -31,8 +31,6 @@ MLNodeLaplacian::buildStencil ()
     const int ncomp_s = (AMREX_SPACEDIM == 2) ? 5 : 9;
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(AMREX_SPACEDIM != 1,
                                      "MLNodeLaplacian::buildStencil: 1d not supported");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_geom[0][0].IsRZ(),
-                                     "MLNodeLaplacian::buildStencil: cylindrical not supported for RAP");
 
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev)
     {
@@ -56,6 +54,9 @@ MLNodeLaplacian::buildStencil ()
         {
             const Geometry& geom = m_geom[amrlev][0];
             const auto dxinvarr = geom.InvCellSizeArray();
+#if (AMREX_SPACEDIM == 2)
+            const bool is_rz = geom.IsRZ();
+#endif
 
 #ifdef AMREX_USE_EB
             const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][0].get());
@@ -137,7 +138,13 @@ MLNodeLaplacian::buildStencil ()
 
                             AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
                             {
-                                mlndlap_set_stencil_eb(i, j, k, starr, sgarr, cnarr, dxinvarr);
+#if (AMREX_SPACEDIM == 2)
+                                mlndlap_set_stencil_eb(i, j, k, starr, sgarr, cnarr,
+                                                       dxinvarr, is_rz);
+#else
+                                mlndlap_set_stencil_eb(i, j, k, starr, sgarr, cnarr,
+                                                       dxinvarr);
+#endif
                             });
 
                             if (ns_starr) {
@@ -147,7 +154,13 @@ MLNodeLaplacian::buildStencil ()
                                 });
                                 AMREX_HOST_DEVICE_FOR_3D(bx, i, j, k,
                                 {
-                                    mlndlap_set_stencil_eb(i,j,k, ns_starr, sgarr, cnarr, dxinvarr);
+#if (AMREX_SPACEDIM == 2)
+                                    mlndlap_set_stencil_eb(i, j, k, ns_starr, sgarr, cnarr,
+                                                           dxinvarr, is_rz);
+#else
+                                    mlndlap_set_stencil_eb(i, j, k, ns_starr, sgarr, cnarr,
+                                                           dxinvarr);
+#endif
                                 });
                             }
                         }
@@ -175,7 +188,11 @@ MLNodeLaplacian::buildStencil ()
 
                         AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
                         {
-                            mlndlap_set_stencil(tbx,starr,sgarr,dxinvarr);
+#if (AMREX_SPACEDIM == 2)
+                            mlndlap_set_stencil(tbx, starr, sgarr, dxinvarr, is_rz);
+#else
+                            mlndlap_set_stencil(tbx, starr, sgarr, dxinvarr);
+#endif
                         });
 
                         if (ns_starr) {
@@ -186,7 +203,11 @@ MLNodeLaplacian::buildStencil ()
 
                             AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
                             {
+#if (AMREX_SPACEDIM == 2)
+                                mlndlap_set_stencil(tbx, ns_starr, sgarr, dxinvarr, is_rz);
+#else
                                 mlndlap_set_stencil(tbx, ns_starr, sgarr, dxinvarr);
+#endif
                             });
                         }
                     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sync.cpp
@@ -286,7 +286,12 @@ MLNodeLaplacian::compSyncResidualCoarse (MultiFab& sync_resid, const MultiFab& a
 
                         AMREX_HOST_DEVICE_FOR_3D(stbx, i, j, k,
                         {
+#if (AMREX_SPACEDIM == 2)
+                            mlndlap_set_stencil_eb(i, j, k, stenarr, sgarr, cnarr,
+                                                   dxinv, is_rz);
+#else
                             mlndlap_set_stencil_eb(i, j, k, stenarr, sgarr, cnarr, dxinv);
+#endif
                         });
 
                         AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
@@ -627,7 +632,12 @@ MLNodeLaplacian::compSyncResidualFine (MultiFab& sync_resid, const MultiFab& phi
 
                     AMREX_HOST_DEVICE_FOR_3D(stbx, i, j, k,
                     {
+#if (AMREX_SPACEDIM == 2)
+                        mlndlap_set_stencil_eb(i, j, k, stenarr, sgarr, cnarr,
+                                               dxinv, is_rz);
+#else
                         mlndlap_set_stencil_eb(i, j, k, stenarr, sgarr, cnarr, dxinv);
+#endif
                     });
 
                     AMREX_HOST_DEVICE_FOR_3D(gbx, i, j, k,

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -118,6 +118,7 @@ if (AMReX_TEST_TYPE STREQUAL "Small")
 
    if (AMReX_LINEAR_SOLVERS)
       add_subdirectory("LinearSolvers/ABecLaplacian_C")
+      add_subdirectory("LinearSolvers/NodeRZEBBaseline")
    endif()
 
    if (AMReX_FFT)

--- a/Tests/LinearSolvers/NodeRZEBBaseline/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/CMakeLists.txt
@@ -1,0 +1,63 @@
+if ( (NOT AMReX_EB) OR (NOT AMReX_LINEAR_SOLVERS_INCFLO) OR NOT (2 IN_LIST AMReX_SPACEDIM))
+   return()
+endif ()
+
+set(_sources main.cpp)
+set(_input_files
+    inputs.cart_eb_neumann_sphere
+    inputs.cart_mms_rap
+    inputs.rz_eb_inflow_sphere
+    inputs.rz_eb_neumann_all_neumann
+    inputs.rz_eb_neumann_all_neumann_offset
+    inputs.rz_eb_neumann_mixed_bc
+    inputs.rz_eb_neumann_plane
+    inputs.rz_eb_neumann_sphere
+    inputs.rz_eb_rap_zero
+    inputs.rz_mms
+    inputs.rz_mms_rap)
+
+setup_test(2 _sources _input_files BASE_NAME LinearSolvers_NodeRZEBBaseline)
+
+set(_test_exe_dir ${CMAKE_CURRENT_BINARY_DIR}/2d)
+set(_test_exe ${_test_exe_dir}/Test_LinearSolvers_NodeRZEBBaseline_2d)
+set(_base_test_name LinearSolvers_NodeRZEBBaseline_2d)
+
+foreach(_input_file IN LISTS _input_files)
+   if (_input_file STREQUAL "inputs.cart_eb_neumann_sphere")
+      continue()
+   endif ()
+
+   get_filename_component(_input_name ${_input_file} NAME)
+   string(REPLACE "inputs." "" _case_name ${_input_name})
+   set(_test_name ${_base_test_name}_${_case_name})
+
+   if (AMReX_OMP)
+      add_test(
+         NAME               ${_test_name}
+         COMMAND            ${_test_exe} ${_input_name}
+         WORKING_DIRECTORY  ${_test_exe_dir}
+      )
+      set_tests_properties(${_test_name} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=2)
+   elseif (AMReX_MPI)
+      add_test(
+         NAME               ${_test_name}
+         COMMAND            mpiexec -n 2 ${_test_exe} ${_input_name}
+         WORKING_DIRECTORY  ${_test_exe_dir}
+      )
+   else ()
+      add_test(
+         NAME               ${_test_name}
+         COMMAND            ${_test_exe} ${_input_name}
+         WORKING_DIRECTORY  ${_test_exe_dir}
+      )
+   endif ()
+endforeach()
+
+unset(_test_exe_dir)
+unset(_test_exe)
+unset(_base_test_name)
+unset(_input_name)
+unset(_case_name)
+unset(_test_name)
+unset(_sources)
+unset(_input_files)

--- a/Tests/LinearSolvers/NodeRZEBBaseline/GNUmakefile
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/GNUmakefile
@@ -1,0 +1,31 @@
+DEBUG = FALSE
+
+TEST = TRUE
+USE_ASSERTION = TRUE
+
+USE_EB = TRUE
+
+USE_MPI  = TRUE
+USE_OMP  = FALSE
+
+USE_HYPRE = FALSE
+USE_PETSC = FALSE
+
+COMP = gnu
+
+DIM = 2
+
+AMREX_HOME = ../../..
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+include ./Make.package
+
+Pdirs := Base Boundary AmrCore
+Pdirs += EB
+Pdirs += LinearSolvers/MLMG
+
+Ppack += $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
+
+include $(Ppack)
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/LinearSolvers/NodeRZEBBaseline/Make.package
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.cart_eb_neumann_sphere
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.cart_eb_neumann_sphere
@@ -1,0 +1,19 @@
+mode = cart_eb_neumann_sphere
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+min_mg_levels = 4
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 2.00
+min_linf_order = 1.60
+max_finest_l2 = 8.e-5
+max_finest_linf = 2.e-4

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.cart_mms_rap
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.cart_mms_rap
@@ -1,0 +1,18 @@
+mode = cart_mms_rap
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 1.80
+min_linf_order = 1.80
+max_finest_l2 = 5.e-5
+max_finest_linf = 5.e-5

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_inflow_sphere
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_inflow_sphere
@@ -1,0 +1,19 @@
+mode = rz_eb_inflow_sphere
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+min_mg_levels = 4
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 1.75
+min_linf_order = 1.60
+max_finest_l2 = 8.e-5
+max_finest_linf = 2.e-4

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_all_neumann
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_all_neumann
@@ -1,0 +1,19 @@
+mode = rz_eb_neumann_all_neumann
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+min_mg_levels = 4
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 200
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 1.90
+min_linf_order = 1.70
+max_finest_l2 = 5.e-4
+max_finest_linf = 6.e-3

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_all_neumann_offset
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_all_neumann_offset
@@ -1,0 +1,19 @@
+mode = rz_eb_neumann_all_neumann_offset
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+min_mg_levels = 4
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 200
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 1.90
+min_linf_order = 1.70
+max_finest_l2 = 5.e-4
+max_finest_linf = 6.e-3

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_mixed_bc
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_mixed_bc
@@ -1,0 +1,19 @@
+mode = rz_eb_neumann_mixed_bc
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+min_mg_levels = 4
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 150
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 1.90
+min_linf_order = 1.70
+max_finest_l2 = 5.e-4
+max_finest_linf = 5.e-3

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_plane
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_plane
@@ -1,0 +1,19 @@
+mode = rz_eb_neumann_plane
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+min_mg_levels = 4
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 2.00
+min_linf_order = 2.00
+max_finest_l2 = 8.e-5
+max_finest_linf = 6.e-4

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_sphere
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_neumann_sphere
@@ -1,0 +1,19 @@
+mode = rz_eb_neumann_sphere
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+min_mg_levels = 4
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 1.75
+min_linf_order = 1.60
+max_finest_l2 = 8.e-5
+max_finest_linf = 2.e-4

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_rap_zero
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_eb_rap_zero
@@ -1,0 +1,17 @@
+mode = rz_eb_rap_zero
+
+n_cell = 32
+max_grid_size = 16
+max_coarsening_level = 100
+min_mg_levels = 4
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+max_finest_l2 = 1.e-12
+max_finest_linf = 1.e-12

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_mms
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_mms
@@ -1,0 +1,18 @@
+mode = rz_mms
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 1.80
+min_linf_order = 1.80
+max_finest_l2 = 5.e-5
+max_finest_linf = 1.e-4

--- a/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_mms_rap
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/inputs.rz_mms_rap
@@ -1,0 +1,19 @@
+mode = rz_mms_rap
+
+n_cell = 32 64 128
+max_grid_size = 16
+max_coarsening_level = 100
+min_mg_levels = 4
+
+verbose = 0
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0
+reltol = 1.e-11
+abstol = 0.0
+
+do_assert = 1
+min_l2_order = 1.80
+min_linf_order = 1.80
+max_finest_l2 = 1.e-4
+max_finest_linf = 2.e-4

--- a/Tests/LinearSolvers/NodeRZEBBaseline/main.cpp
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/main.cpp
@@ -246,7 +246,7 @@ void fill_rz_eb_neumann_mms (MultiFab& exact, MultiFab& sigma,
             Real const cr = std::cos(a*r);
             Real const sz = std::sin(a*z);
             rh(i,j,k) = (a*cr - Real(2.0)*r*a*a*sr) * sz;
-            ebneu(i,j,k) = eb_location * a * std::cos(a*eb_location) * sz;
+            ebneu(i,j,k) = a * std::cos(a*eb_location) * sz;
         });
     }
 }
@@ -327,7 +327,7 @@ void fill_rz_eb_neumann_curved_mms (MultiFab& exact, MultiFab& sigma,
                 Real const z = plo[1] + (static_cast<Real>(j) + Real(0.5) + bc(i,j,k,1)) * dx[1];
                 Real const dphidr = a * std::cos(a*r) * std::sin(a*z);
                 Real const dphidz = a * std::sin(a*r) * std::cos(a*z);
-                ebneu(i,j,k) = r * (dphidr * nx + dphidz * ny);
+                ebneu(i,j,k) = dphidr * nx + dphidz * ny;
             }
         });
     }
@@ -452,7 +452,7 @@ void fill_rz_eb_neumann_physical_bc_mms (MultiFab& exact, MultiFab& sigma,
                 Real const dzfac = all_neumann ? -az*std::sin(az*z) : az*std::cos(az*z);
                 Real const dphidr = -ar * sr * zfac;
                 Real const dphidz = cr * dzfac;
-                ebneu(i,j,k) = r * (dphidr * nx + dphidz * ny);
+                ebneu(i,j,k) = dphidr * nx + dphidz * ny;
             }
         });
     }

--- a/Tests/LinearSolvers/NodeRZEBBaseline/main.cpp
+++ b/Tests/LinearSolvers/NodeRZEBBaseline/main.cpp
@@ -1,0 +1,1639 @@
+#include <AMReX.H>
+#include <AMReX_EB2.H>
+#include <AMReX_EB2_IF.H>
+#include <AMReX_EBMultiFabUtil.H>
+#include <AMReX_MLNodeLaplacian.H>
+#include <AMReX_MLMG.H>
+#include <AMReX_ParmParse.H>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace amrex;
+
+namespace {
+
+struct Parameters
+{
+    std::string mode = "rz_mms";
+    std::vector<int> n_cell = {32, 64, 128};
+    int max_grid_size = 16;
+    int max_coarsening_level = 100;
+    int verbose = 0;
+    int bottom_verbose = 0;
+    int max_iter = 100;
+    int max_fmg_iter = 0;
+    int do_assert = 1;
+    int min_mg_levels = 1;
+    Real reltol = 1.e-11;
+    Real abstol = 0.0;
+    Real min_l2_order = 1.8;
+    Real min_linf_order = 1.8;
+    Real max_finest_l2 = 5.e-5;
+    Real max_finest_linf = 1.e-4;
+};
+
+struct SolveResult
+{
+    int n_cell = 0;
+    int nprocs = 1;
+    int mg_levels = 0;
+    int iterations = 0;
+    Real residual = 0.0;
+    Real l2 = 0.0;
+    Real linf = 0.0;
+    Real setup_time = 0.0;
+    Real solve_time = 0.0;
+    Real total_time = 0.0;
+};
+
+Parameters read_parameters ()
+{
+    Parameters p;
+    ParmParse pp;
+    pp.query("mode", p.mode);
+    pp.queryarr("n_cell", p.n_cell);
+    pp.query("max_grid_size", p.max_grid_size);
+    pp.query("max_coarsening_level", p.max_coarsening_level);
+    pp.query("verbose", p.verbose);
+    pp.query("bottom_verbose", p.bottom_verbose);
+    pp.query("max_iter", p.max_iter);
+    pp.query("max_fmg_iter", p.max_fmg_iter);
+    pp.query("min_mg_levels", p.min_mg_levels);
+    pp.query("reltol", p.reltol);
+    pp.query("abstol", p.abstol);
+    pp.query("do_assert", p.do_assert);
+    pp.query("min_l2_order", p.min_l2_order);
+    pp.query("min_linf_order", p.min_linf_order);
+    pp.query("max_finest_l2", p.max_finest_l2);
+    pp.query("max_finest_linf", p.max_finest_linf);
+    return p;
+}
+
+Geometry make_rz_geometry (int n_cell)
+{
+    Box domain(IntVect(AMREX_D_DECL(0, 0, 0)),
+               IntVect(AMREX_D_DECL(n_cell-1, n_cell-1, n_cell-1)));
+    RealBox rb({AMREX_D_DECL(0.0, 0.0, 0.0)},
+               {AMREX_D_DECL(1.0, 1.0, 1.0)});
+    Array<int,AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0, 0, 0)};
+    return Geometry(domain, rb, CoordSys::RZ, is_periodic);
+}
+
+Geometry make_cartesian_geometry (int n_cell)
+{
+    Box domain(IntVect(AMREX_D_DECL(0, 0, 0)),
+               IntVect(AMREX_D_DECL(n_cell-1, n_cell-1, n_cell-1)));
+    RealBox rb({AMREX_D_DECL(0.0, 0.0, 0.0)},
+               {AMREX_D_DECL(1.0, 1.0, 1.0)});
+    Array<int,AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0, 0, 0)};
+    return Geometry(domain, rb, CoordSys::cartesian, is_periodic);
+}
+
+void fill_rz_sigma (MultiFab& sigma, Geometry const& geom)
+{
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(sigma, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const sig = sigma.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            sig(i,j,k) = plo[0] + (static_cast<Real>(i) + Real(0.5)) * dx[0];
+        });
+    }
+}
+
+void fill_rz_radial_mms (MultiFab& exact, MultiFab& rhs, MultiFab& sigma,
+                         Geometry const& geom)
+{
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+    constexpr Real pi = std::numbers::pi_v<Real>;
+    constexpr Real a = pi;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(exact, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ex = exact.array(mfi);
+        Array4<Real> const rh = rhs.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const r = plo[0] + static_cast<Real>(i) * dx[0];
+            Real const s = std::sin(a*r);
+            Real const c = std::cos(a*r);
+            ex(i,j,k) = s;
+            rh(i,j,k) = a*c - r*a*a*s;
+        });
+    }
+
+    fill_rz_sigma(sigma, geom);
+}
+
+void fill_rz_full_mms (MultiFab& exact, MultiFab& rhs, MultiFab& sigma,
+                       Geometry const& geom)
+{
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+    constexpr Real pi = std::numbers::pi_v<Real>;
+    constexpr Real a = pi;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(exact, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ex = exact.array(mfi);
+        Array4<Real> const rh = rhs.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const r = plo[0] + static_cast<Real>(i) * dx[0];
+            Real const z = plo[1] + static_cast<Real>(j) * dx[1];
+            Real const sr = std::sin(a*r);
+            Real const cr = std::cos(a*r);
+            Real const sz = std::sin(a*z);
+            ex(i,j,k) = sr * sz;
+            rh(i,j,k) = (a*cr - Real(2.0)*r*a*a*sr) * sz;
+        });
+    }
+
+    fill_rz_sigma(sigma, geom);
+}
+
+void fill_cartesian_mms (MultiFab& exact, MultiFab& rhs, MultiFab& sigma,
+                         Geometry const& geom)
+{
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+    constexpr Real pi = std::numbers::pi_v<Real>;
+    constexpr Real a = pi;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(exact, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ex = exact.array(mfi);
+        Array4<Real> const rh = rhs.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const x = plo[0] + static_cast<Real>(i) * dx[0];
+            Real const s = std::sin(a*x);
+            ex(i,j,k) = s;
+            rh(i,j,k) = -a*a*s;
+        });
+    }
+
+    sigma.setVal(1.0);
+}
+
+void fill_rz_eb_neumann_mms (MultiFab& exact, MultiFab& sigma,
+                             MultiFab& velocity, MultiFab& rhcc,
+                             MultiFab& eb_neumann,
+                             Geometry const& geom, Real eb_location)
+{
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+    constexpr Real pi = std::numbers::pi_v<Real>;
+    constexpr Real a = pi;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(exact, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ex = exact.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const r = plo[0] + static_cast<Real>(i) * dx[0];
+            Real const z = plo[1] + static_cast<Real>(j) * dx[1];
+            ex(i,j,k) = std::sin(a*r) * std::sin(a*z);
+        });
+    }
+
+    fill_rz_sigma(sigma, geom);
+
+    velocity.setVal(0.0);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(rhcc, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const rh = rhcc.array(mfi);
+        Array4<Real> const ebneu = eb_neumann.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const r = plo[0] + (static_cast<Real>(i) + Real(0.5)) * dx[0];
+            Real const z = plo[1] + (static_cast<Real>(j) + Real(0.5)) * dx[1];
+            Real const sr = std::sin(a*r);
+            Real const cr = std::cos(a*r);
+            Real const sz = std::sin(a*z);
+            rh(i,j,k) = (a*cr - Real(2.0)*r*a*a*sr) * sz;
+            ebneu(i,j,k) = eb_location * a * std::cos(a*eb_location) * sz;
+        });
+    }
+}
+
+#ifdef AMREX_USE_EB
+void fill_rz_eb_neumann_curved_mms (MultiFab& exact, MultiFab& sigma,
+                                    MultiFab& velocity, MultiFab& rhcc,
+                                    MultiFab& eb_neumann,
+                                    Geometry const& geom,
+                                    EBFArrayBoxFactory const& factory)
+{
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+    constexpr Real pi = std::numbers::pi_v<Real>;
+    constexpr Real a = pi;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(exact, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ex = exact.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const r = plo[0] + static_cast<Real>(i) * dx[0];
+            Real const z = plo[1] + static_cast<Real>(j) * dx[1];
+            ex(i,j,k) = std::sin(a*r) * std::sin(a*z);
+        });
+    }
+
+    fill_rz_sigma(sigma, geom);
+
+    velocity.setVal(0.0);
+    rhcc.setVal(0.0);
+    eb_neumann.setVal(0.0);
+
+    const auto& flags = factory.getMultiEBCellFlagFab();
+    const auto& bcent = factory.getBndryCent();
+    const auto& bnorm = factory.getBndryNormal();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(rhcc, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const rh = rhcc.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const r = plo[0] + (static_cast<Real>(i) + Real(0.5)) * dx[0];
+            Real const z = plo[1] + (static_cast<Real>(j) + Real(0.5)) * dx[1];
+            Real const sr = std::sin(a*r);
+            Real const cr = std::cos(a*r);
+            Real const sz = std::sin(a*z);
+            rh(i,j,k) = (a*cr - Real(2.0)*r*a*a*sr) * sz;
+        });
+    }
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(eb_neumann, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        if (!bcent.ok(mfi) || !bnorm.ok(mfi)) { continue; }
+
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ebneu = eb_neumann.array(mfi);
+        Array4<EBCellFlag const> const flag = flags.const_array(mfi);
+        Array4<Real const> const bc = bcent.const_array(mfi);
+        Array4<Real const> const bn = bnorm.const_array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            if (flag(i,j,k).isSingleValued()) {
+                Real const nx = bn(i,j,k,0);
+                Real const ny = bn(i,j,k,1);
+                Real const r = plo[0] + (static_cast<Real>(i) + Real(0.5) + bc(i,j,k,0)) * dx[0];
+                Real const z = plo[1] + (static_cast<Real>(j) + Real(0.5) + bc(i,j,k,1)) * dx[1];
+                Real const dphidr = a * std::cos(a*r) * std::sin(a*z);
+                Real const dphidz = a * std::sin(a*r) * std::cos(a*z);
+                ebneu(i,j,k) = r * (dphidr * nx + dphidz * ny);
+            }
+        });
+    }
+}
+
+void fill_rz_eb_inflow_velocity_curved_mms (MultiFab& eb_velocity,
+                                            Geometry const& geom,
+                                            EBFArrayBoxFactory const& factory)
+{
+    eb_velocity.setVal(0.0);
+
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+    constexpr Real pi = std::numbers::pi_v<Real>;
+    constexpr Real a = pi;
+
+    const auto& flags = factory.getMultiEBCellFlagFab();
+    const auto& bcent = factory.getBndryCent();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(eb_velocity, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        if (!bcent.ok(mfi)) { continue; }
+
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const vel = eb_velocity.array(mfi);
+        Array4<EBCellFlag const> const flag = flags.const_array(mfi);
+        Array4<Real const> const bc = bcent.const_array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            if (flag(i,j,k).isSingleValued()) {
+                Real const r = plo[0] + (static_cast<Real>(i) + Real(0.5) + bc(i,j,k,0)) * dx[0];
+                Real const z = plo[1] + (static_cast<Real>(j) + Real(0.5) + bc(i,j,k,1)) * dx[1];
+                vel(i,j,k,0) = -r * a * std::cos(a*r) * std::sin(a*z);
+                vel(i,j,k,1) = -r * a * std::sin(a*r) * std::cos(a*z);
+            }
+        });
+    }
+}
+
+void fill_rz_eb_neumann_physical_bc_mms (MultiFab& exact, MultiFab& sigma,
+                                         MultiFab& velocity, MultiFab& rhcc,
+                                         MultiFab& eb_neumann,
+                                         Geometry const& geom,
+                                         EBFArrayBoxFactory const& factory,
+                                         bool all_neumann)
+{
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+    constexpr Real pi = std::numbers::pi_v<Real>;
+    constexpr Real ar = Real(2.0) * pi;
+    Real const az = all_neumann ? Real(2.0) * pi : pi;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(exact, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ex = exact.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const r = plo[0] + static_cast<Real>(i) * dx[0];
+            Real const z = plo[1] + static_cast<Real>(j) * dx[1];
+            Real const zfac = all_neumann ? std::cos(az*z) : std::sin(az*z);
+            ex(i,j,k) = std::cos(ar*r) * zfac;
+        });
+    }
+
+    fill_rz_sigma(sigma, geom);
+
+    velocity.setVal(0.0);
+    rhcc.setVal(0.0);
+    eb_neumann.setVal(0.0);
+
+    const auto& flags = factory.getMultiEBCellFlagFab();
+    const auto& bcent = factory.getBndryCent();
+    const auto& bnorm = factory.getBndryNormal();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(rhcc, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const rh = rhcc.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const r = plo[0] + (static_cast<Real>(i) + Real(0.5)) * dx[0];
+            Real const z = plo[1] + (static_cast<Real>(j) + Real(0.5)) * dx[1];
+            Real const sr = std::sin(ar*r);
+            Real const cr = std::cos(ar*r);
+            Real const zfac = all_neumann ? std::cos(az*z) : std::sin(az*z);
+            rh(i,j,k) = -ar*sr*zfac - r*(ar*ar + az*az)*cr*zfac;
+        });
+    }
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(eb_neumann, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        if (!bcent.ok(mfi) || !bnorm.ok(mfi)) { continue; }
+
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ebneu = eb_neumann.array(mfi);
+        Array4<EBCellFlag const> const flag = flags.const_array(mfi);
+        Array4<Real const> const bc = bcent.const_array(mfi);
+        Array4<Real const> const bn = bnorm.const_array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            if (flag(i,j,k).isSingleValued()) {
+                Real const nx = bn(i,j,k,0);
+                Real const ny = bn(i,j,k,1);
+                Real const r = plo[0] + (static_cast<Real>(i) + Real(0.5) + bc(i,j,k,0)) * dx[0];
+                Real const z = plo[1] + (static_cast<Real>(j) + Real(0.5) + bc(i,j,k,1)) * dx[1];
+                Real const sr = std::sin(ar*r);
+                Real const cr = std::cos(ar*r);
+                Real const zfac = all_neumann ? std::cos(az*z) : std::sin(az*z);
+                Real const dzfac = all_neumann ? -az*std::sin(az*z) : az*std::cos(az*z);
+                Real const dphidr = -ar * sr * zfac;
+                Real const dphidz = cr * dzfac;
+                ebneu(i,j,k) = r * (dphidr * nx + dphidz * ny);
+            }
+        });
+    }
+}
+
+void fill_cartesian_eb_neumann_curved_mms (MultiFab& exact, MultiFab& sigma,
+                                           MultiFab& velocity, MultiFab& rhcc,
+                                           MultiFab& eb_neumann,
+                                           Geometry const& geom,
+                                           EBFArrayBoxFactory const& factory)
+{
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+    constexpr Real pi = std::numbers::pi_v<Real>;
+    constexpr Real a = pi;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(exact, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ex = exact.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const x = plo[0] + static_cast<Real>(i) * dx[0];
+            Real const y = plo[1] + static_cast<Real>(j) * dx[1];
+            ex(i,j,k) = std::sin(a*x) * std::sin(a*y);
+        });
+    }
+
+    sigma.setVal(1.0);
+    velocity.setVal(0.0);
+    rhcc.setVal(0.0);
+    eb_neumann.setVal(0.0);
+
+    const auto& flags = factory.getMultiEBCellFlagFab();
+    const auto& bcent = factory.getBndryCent();
+    const auto& bnorm = factory.getBndryNormal();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(rhcc, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const rh = rhcc.array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const x = plo[0] + (static_cast<Real>(i) + Real(0.5)) * dx[0];
+            Real const y = plo[1] + (static_cast<Real>(j) + Real(0.5)) * dx[1];
+            rh(i,j,k) = -Real(2.0)*a*a*std::sin(a*x)*std::sin(a*y);
+        });
+    }
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(eb_neumann, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        if (!bcent.ok(mfi) || !bnorm.ok(mfi)) { continue; }
+
+        Box const& bx = mfi.tilebox();
+        Array4<Real> const ebneu = eb_neumann.array(mfi);
+        Array4<EBCellFlag const> const flag = flags.const_array(mfi);
+        Array4<Real const> const bc = bcent.const_array(mfi);
+        Array4<Real const> const bn = bnorm.const_array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            if (flag(i,j,k).isSingleValued()) {
+                Real const nx = bn(i,j,k,0);
+                Real const ny = bn(i,j,k,1);
+                Real const x = plo[0] + (static_cast<Real>(i) + Real(0.5) + bc(i,j,k,0)) * dx[0];
+                Real const y = plo[1] + (static_cast<Real>(j) + Real(0.5) + bc(i,j,k,1)) * dx[1];
+                Real const dphidx = a * std::cos(a*x) * std::sin(a*y);
+                Real const dphidy = a * std::sin(a*x) * std::cos(a*y);
+                ebneu(i,j,k) = dphidx * nx + dphidy * ny;
+            }
+        });
+    }
+}
+#endif
+
+void initialize_dirichlet_guess (MultiFab& solution, MultiFab const& exact,
+                                 Geometry const& geom)
+{
+    MultiFab::Copy(solution, exact, 0, 0, 1, 0);
+    Box const interior = amrex::surroundingNodes(amrex::grow(geom.Domain(), -1));
+    solution.setVal(0.0, interior, 0, 1, 0);
+}
+
+std::pair<Real,Real> compute_error_norms (MultiFab& solution, MultiFab const& exact,
+                                          Geometry const& geom,
+                                          iMultiFab const* active_mask = nullptr,
+                                          bool remove_constant_offset = false)
+{
+    MultiFab error(solution.boxArray(), solution.DistributionMap(), 1, 0);
+    MultiFab::Copy(error, solution, 0, 0, 1, 0);
+    MultiFab::Subtract(error, exact, 0, 0, 1, 0);
+
+    auto mask = error.OwnerMask(geom.periodicity());
+    if (active_mask != nullptr) {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        for (MFIter mfi(*mask, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            Box const& bx = mfi.tilebox();
+            Array4<int> const owner = mask->array(mfi);
+            Array4<int const> const active = active_mask->const_array(mfi);
+            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            {
+                owner(i,j,k) *= active(i,j,k);
+            });
+        }
+    }
+
+    Long const npts = mask->sum(0);
+    if (npts <= 0) {
+        Abort("NodeRZEBBaseline: error norm mask has no active points");
+    }
+
+    if (remove_constant_offset) {
+        MultiFab ones(error.boxArray(), error.DistributionMap(), 1, 0);
+        ones.setVal(1.0);
+        Real const errsum = MultiFab::Dot(*mask, error, 0, ones, 0, 1, 0);
+        error.plus(-errsum / static_cast<Real>(npts), 0, 1, 0);
+    }
+
+    Real const linf = error.norm0(*mask, 0, 0);
+    Real const dot = MultiFab::Dot(*mask, error, 0, error, 0, 1, 0);
+    Real const l2 = std::sqrt(dot / static_cast<Real>(npts));
+    return {l2, linf};
+}
+
+#ifdef AMREX_USE_EB
+std::unique_ptr<iMultiFab>
+make_eb_active_node_mask (BoxArray const& nba, DistributionMapping const& dmap,
+                          Geometry const& geom, EBFArrayBoxFactory const& factory)
+{
+    auto active = std::make_unique<iMultiFab>(nba, dmap, 1, 0);
+    active->setVal(0);
+
+    Box const& ccdom = geom.Domain();
+    const auto domlo = amrex::lbound(ccdom);
+    const auto domhi = amrex::ubound(ccdom);
+    const auto& flags = factory.getMultiEBCellFlagFab();
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(*active, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<int> const act = active->array(mfi);
+        Array4<EBCellFlag const> const flag = flags.const_array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            int is_active = 0;
+            for (int jj = j-1; jj <= j; ++jj) {
+                for (int ii = i-1; ii <= i; ++ii) {
+                    bool const in_domain = (ii >= domlo.x && ii <= domhi.x &&
+                                            jj >= domlo.y && jj <= domhi.y);
+                    if (in_domain && !flag(ii,jj,k).isCovered()) {
+                        is_active = 1;
+                    }
+                }
+            }
+            act(i,j,k) = is_active;
+        });
+    }
+
+    return active;
+}
+
+std::unique_ptr<iMultiFab>
+make_sphere_fluid_node_mask (BoxArray const& nba, DistributionMapping const& dmap,
+                             Geometry const& geom, iMultiFab const& active_mask,
+                             Real radius, Real cx, Real cy)
+{
+    auto fluid = std::make_unique<iMultiFab>(nba, dmap, 1, 0);
+    fluid->setVal(0);
+    const auto dx = geom.CellSizeArray();
+    const auto plo = geom.ProbLoArray();
+    Real const r2 = radius * radius;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(*fluid, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Box const& bx = mfi.tilebox();
+        Array4<int> const fl = fluid->array(mfi);
+        Array4<int const> const act = active_mask.const_array(mfi);
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real const x = plo[0] + static_cast<Real>(i) * dx[0];
+            Real const y = plo[1] + static_cast<Real>(j) * dx[1];
+            Real const d2 = (x-cx)*(x-cx) + (y-cy)*(y-cy);
+            fl(i,j,k) = (act(i,j,k) && d2 >= r2) ? 1 : 0;
+        });
+    }
+
+    return fluid;
+}
+#endif
+
+LPInfo make_lp_info (Parameters const& p)
+{
+    LPInfo info;
+    info.setMaxCoarseningLevel(p.max_coarsening_level);
+    return info;
+}
+
+SolveResult run_rz_mms_case (Parameters const& p, int n_cell,
+                             MLNodeLaplacian::CoarseningStrategy strategy,
+                             bool full_mms)
+{
+    Real const t0 = second();
+
+    Geometry geom = make_rz_geometry(n_cell);
+    BoxArray grids(geom.Domain());
+    grids.maxSize(p.max_grid_size);
+    DistributionMapping dmap(grids);
+
+    BoxArray const nba = amrex::convert(grids, IntVect::TheNodeVector());
+    MultiFab solution(nba, dmap, 1, 0);
+    MultiFab exact(nba, dmap, 1, 0);
+    MultiFab rhs(nba, dmap, 1, 0);
+    MultiFab sigma(grids, dmap, 1, 0);
+
+    if (full_mms) {
+        fill_rz_full_mms(exact, rhs, sigma, geom);
+    } else {
+        fill_rz_radial_mms(exact, rhs, sigma, geom);
+    }
+    initialize_dirichlet_guess(solution, exact, geom);
+
+    LPInfo info = make_lp_info(p);
+    MLNodeLaplacian linop({geom}, {grids}, {dmap}, info);
+    linop.setCoarseningStrategy(strategy);
+    linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)},
+                      {AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)});
+    linop.setSigma(0, sigma);
+
+    MLMG mlmg(linop);
+    mlmg.setVerbose(p.verbose);
+    mlmg.setBottomVerbose(p.bottom_verbose);
+    mlmg.setMaxIter(p.max_iter);
+    mlmg.setMaxFmgIter(p.max_fmg_iter);
+
+    Real const t1 = second();
+    Vector<MultiFab*> sol{&solution};
+    Vector<MultiFab const*> rh{&rhs};
+    Real const residual = mlmg.solve(sol, rh, p.reltol, p.abstol);
+    Real const t2 = second();
+
+    auto const [l2, linf] = compute_error_norms(solution, exact, geom);
+    Real const t3 = second();
+
+    SolveResult r;
+    r.n_cell = n_cell;
+    r.nprocs = ParallelDescriptor::NProcs();
+    r.mg_levels = linop.NMGLevels(0);
+    r.iterations = mlmg.getNumIters();
+    r.residual = residual;
+    r.l2 = l2;
+    r.linf = linf;
+    r.setup_time = t1 - t0;
+    r.solve_time = t2 - t1;
+    r.total_time = t3 - t0;
+    return r;
+}
+
+SolveResult run_cartesian_mms_case (Parameters const& p, int n_cell)
+{
+    Real const t0 = second();
+
+    Geometry geom = make_cartesian_geometry(n_cell);
+    BoxArray grids(geom.Domain());
+    grids.maxSize(p.max_grid_size);
+    DistributionMapping dmap(grids);
+
+    BoxArray const nba = amrex::convert(grids, IntVect::TheNodeVector());
+    MultiFab solution(nba, dmap, 1, 0);
+    MultiFab exact(nba, dmap, 1, 0);
+    MultiFab rhs(nba, dmap, 1, 0);
+    MultiFab sigma(grids, dmap, 1, 0);
+
+    fill_cartesian_mms(exact, rhs, sigma, geom);
+    initialize_dirichlet_guess(solution, exact, geom);
+
+    LPInfo info = make_lp_info(p);
+    MLNodeLaplacian linop({geom}, {grids}, {dmap}, info);
+    linop.setCoarseningStrategy(MLNodeLaplacian::CoarseningStrategy::RAP);
+    linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)},
+                      {AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)});
+    linop.setSigma(0, sigma);
+
+    MLMG mlmg(linop);
+    mlmg.setVerbose(p.verbose);
+    mlmg.setBottomVerbose(p.bottom_verbose);
+    mlmg.setMaxIter(p.max_iter);
+    mlmg.setMaxFmgIter(p.max_fmg_iter);
+
+    Real const t1 = second();
+    Vector<MultiFab*> sol{&solution};
+    Vector<MultiFab const*> rh{&rhs};
+    Real const residual = mlmg.solve(sol, rh, p.reltol, p.abstol);
+    Real const t2 = second();
+
+    auto const [l2, linf] = compute_error_norms(solution, exact, geom);
+    Real const t3 = second();
+
+    SolveResult r;
+    r.n_cell = n_cell;
+    r.nprocs = ParallelDescriptor::NProcs();
+    r.mg_levels = linop.NMGLevels(0);
+    r.iterations = mlmg.getNumIters();
+    r.residual = residual;
+    r.l2 = l2;
+    r.linf = linf;
+    r.setup_time = t1 - t0;
+    r.solve_time = t2 - t1;
+    r.total_time = t3 - t0;
+    return r;
+}
+
+void report_result (char const* label, SolveResult const& r)
+{
+    Print() << label
+            << " n_cell=" << r.n_cell
+            << " mpi_ranks=" << r.nprocs
+            << " mg_levels=" << r.mg_levels
+            << " iterations=" << r.iterations
+            << " residual=" << r.residual
+            << " l2=" << r.l2
+            << " linf=" << r.linf
+            << " setup_s=" << r.setup_time
+            << " solve_s=" << r.solve_time
+            << " total_s=" << r.total_time
+            << "\n";
+}
+
+void assert_mms_results (Parameters const& p, std::vector<SolveResult> const& results,
+                         char const* label)
+{
+    if (results.empty()) {
+        Abort(std::string("NodeRZEBBaseline: no ") + label + " cases were run");
+    }
+    for (auto const& r : results) {
+        if (p.do_assert &&
+            (!std::isfinite(r.residual) || !std::isfinite(r.l2) || !std::isfinite(r.linf))) {
+            Abort(std::string("NodeRZEBBaseline: non-finite ") + label +
+                  " residual or error norm");
+        }
+        if (p.do_assert && (r.iterations <= 0 || r.iterations > p.max_iter)) {
+            Abort(std::string("NodeRZEBBaseline: invalid ") + label + " MLMG iteration count");
+        }
+        if (p.do_assert && r.mg_levels < p.min_mg_levels) {
+            Abort(std::string("NodeRZEBBaseline: ") + label +
+                  " MG level count below threshold");
+        }
+    }
+
+    for (std::size_t i = 1; i < results.size(); ++i) {
+        Real const ratio = static_cast<Real>(results[i].n_cell)
+            / static_cast<Real>(results[i-1].n_cell);
+        Real const l2_order = std::log(results[i-1].l2 / results[i].l2) / std::log(ratio);
+        Real const linf_order = std::log(results[i-1].linf / results[i].linf) / std::log(ratio);
+        Print() << label << "_ORDER"
+                << " n_cell_coarse=" << results[i-1].n_cell
+                << " n_cell_fine=" << results[i].n_cell
+                << " l2_order=" << l2_order
+                << " linf_order=" << linf_order
+                << "\n";
+        if (p.do_assert && (l2_order < p.min_l2_order || linf_order < p.min_linf_order)) {
+            Abort(std::string("NodeRZEBBaseline: ") + label +
+                  " convergence order below threshold");
+        }
+    }
+
+    SolveResult const& finest = results.back();
+    if (p.do_assert && (finest.l2 > p.max_finest_l2 || finest.linf > p.max_finest_linf)) {
+        Abort(std::string("NodeRZEBBaseline: finest-grid ") + label +
+              " error above threshold");
+    }
+}
+
+void run_rz_mms (Parameters const& p)
+{
+    std::vector<int> n_cells = p.n_cell;
+    std::sort(n_cells.begin(), n_cells.end());
+    n_cells.erase(std::unique(n_cells.begin(), n_cells.end()), n_cells.end());
+
+    std::vector<SolveResult> results;
+    results.reserve(n_cells.size());
+
+    for (int n : n_cells) {
+        if (n < 4) {
+            Abort("NodeRZEBBaseline: n_cell must be at least 4");
+        }
+        SolveResult r = run_rz_mms_case(p, n,
+                                        MLNodeLaplacian::CoarseningStrategy::Sigma,
+                                        false);
+        report_result("RZ_MMS", r);
+        results.push_back(r);
+    }
+
+    assert_mms_results(p, results, "RZ_MMS");
+    Print() << "RZ_MMS_PASS cases=" << results.size()
+            << " mpi_ranks=" << ParallelDescriptor::NProcs()
+            << "\n";
+}
+
+void run_rz_mms_rap (Parameters const& p)
+{
+    std::vector<int> n_cells = p.n_cell;
+    std::sort(n_cells.begin(), n_cells.end());
+    n_cells.erase(std::unique(n_cells.begin(), n_cells.end()), n_cells.end());
+
+    std::vector<SolveResult> results;
+    results.reserve(n_cells.size());
+
+    for (int n : n_cells) {
+        if (n < 4) {
+            Abort("NodeRZEBBaseline: n_cell must be at least 4");
+        }
+        SolveResult r = run_rz_mms_case(p, n,
+                                        MLNodeLaplacian::CoarseningStrategy::RAP,
+                                        true);
+        report_result("RZ_MMS_RAP", r);
+        results.push_back(r);
+    }
+
+    assert_mms_results(p, results, "RZ_MMS_RAP");
+    Print() << "RZ_MMS_RAP_PASS cases=" << results.size()
+            << " mpi_ranks=" << ParallelDescriptor::NProcs()
+            << "\n";
+}
+
+void run_cartesian_mms (Parameters const& p)
+{
+    std::vector<int> n_cells = p.n_cell;
+    std::sort(n_cells.begin(), n_cells.end());
+    n_cells.erase(std::unique(n_cells.begin(), n_cells.end()), n_cells.end());
+
+    std::vector<SolveResult> results;
+    results.reserve(n_cells.size());
+
+    for (int n : n_cells) {
+        if (n < 4) {
+            Abort("NodeRZEBBaseline: n_cell must be at least 4");
+        }
+        SolveResult r = run_cartesian_mms_case(p, n);
+        report_result("CART_MMS_RAP", r);
+        results.push_back(r);
+    }
+
+    assert_mms_results(p, results, "CART_MMS_RAP");
+    Print() << "CART_MMS_RAP_PASS cases=" << results.size()
+            << " mpi_ranks=" << ParallelDescriptor::NProcs()
+            << "\n";
+}
+
+SolveResult run_rz_eb_rap_zero_case (Parameters const& p, int n_cell)
+{
+#ifdef AMREX_USE_EB
+    Real const t0 = second();
+
+    Geometry geom = make_rz_geometry(n_cell);
+    BoxArray grids(geom.Domain());
+    grids.maxSize(p.max_grid_size);
+    DistributionMapping dmap(grids);
+
+    EB2::SphereIF sphere(0.20, {AMREX_D_DECL(0.55, 0.50, 0.0)}, false);
+    auto gshop = EB2::makeShop(sphere);
+    EB2::Build(gshop, geom, 0, p.max_coarsening_level);
+
+    EB2::IndexSpace const& eb_is = EB2::IndexSpace::top();
+    EB2::Level const& eb_level = eb_is.getLevel(geom);
+    Vector<int> ng_ebs = {2, 2, 2};
+    EBFArrayBoxFactory factory(eb_level, geom, grids, dmap, ng_ebs, EBSupport::full);
+
+    BoxArray const nba = amrex::convert(grids, IntVect::TheNodeVector());
+    MultiFab solution(nba, dmap, 1, 0);
+    MultiFab exact(nba, dmap, 1, 0);
+    MultiFab rhs(nba, dmap, 1, 0);
+    MultiFab sigma(grids, dmap, 1, 0, MFInfo(), factory);
+
+    solution.setVal(0.0);
+    exact.setVal(0.0);
+    rhs.setVal(0.0);
+    fill_rz_sigma(sigma, geom);
+
+    LPInfo info = make_lp_info(p);
+    MLNodeLaplacian linop({geom}, {grids}, {dmap}, info,
+                          Vector<EBFArrayBoxFactory const*>{&factory});
+    linop.setCoarseningStrategy(MLNodeLaplacian::CoarseningStrategy::RAP);
+    linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)},
+                      {AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)});
+    linop.setSigma(0, sigma);
+
+    MLMG mlmg(linop);
+    mlmg.setVerbose(p.verbose);
+    mlmg.setBottomVerbose(p.bottom_verbose);
+    mlmg.setMaxIter(p.max_iter);
+    mlmg.setMaxFmgIter(p.max_fmg_iter);
+
+    Real const t1 = second();
+    Vector<MultiFab*> sol{&solution};
+    Vector<MultiFab const*> rh{&rhs};
+    Real const residual = mlmg.solve(sol, rh, p.reltol, p.abstol);
+    Real const t2 = second();
+
+    auto const [l2, linf] = compute_error_norms(solution, exact, geom);
+    Real const t3 = second();
+
+    SolveResult r;
+    r.n_cell = n_cell;
+    r.nprocs = ParallelDescriptor::NProcs();
+    r.mg_levels = linop.NMGLevels(0);
+    r.iterations = mlmg.getNumIters();
+    r.residual = residual;
+    r.l2 = l2;
+    r.linf = linf;
+    r.setup_time = t1 - t0;
+    r.solve_time = t2 - t1;
+    r.total_time = t3 - t0;
+    return r;
+#else
+    amrex::ignore_unused(p);
+    amrex::ignore_unused(n_cell);
+    Abort("NodeRZEBBaseline: rz_eb_rap_zero requires AMREX_USE_EB");
+    return {};
+#endif
+}
+
+SolveResult run_rz_eb_neumann_plane_case (Parameters const& p, int n_cell)
+{
+#ifdef AMREX_USE_EB
+    Real const t0 = second();
+
+    Geometry geom = make_rz_geometry(n_cell);
+    BoxArray grids(geom.Domain());
+    grids.maxSize(p.max_grid_size);
+    DistributionMapping dmap(grids);
+
+    constexpr Real eb_location = Real(0.47);
+    EB2::PlaneIF plane({AMREX_D_DECL(eb_location, 0.0, 0.0)},
+                       {AMREX_D_DECL(1.0, 0.0, 0.0)}, true);
+    auto gshop = EB2::makeShop(plane);
+    EB2::Build(gshop, geom, 0, p.max_coarsening_level);
+
+    EB2::IndexSpace const& eb_is = EB2::IndexSpace::top();
+    EB2::Level const& eb_level = eb_is.getLevel(geom);
+    Vector<int> ng_ebs = {2, 2, 2};
+    EBFArrayBoxFactory factory(eb_level, geom, grids, dmap, ng_ebs, EBSupport::full);
+
+    BoxArray const nba = amrex::convert(grids, IntVect::TheNodeVector());
+    MultiFab solution(nba, dmap, 1, 0);
+    MultiFab exact(nba, dmap, 1, 0);
+    MultiFab rhs(nba, dmap, 1, 0);
+    MultiFab sigma(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab velocity(grids, dmap, AMREX_SPACEDIM, 1, MFInfo(), factory);
+    MultiFab rhcc(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab eb_neumann(grids, dmap, 1, 1, MFInfo(), factory);
+
+    fill_rz_eb_neumann_mms(exact, sigma, velocity, rhcc, eb_neumann, geom,
+                           eb_location);
+    initialize_dirichlet_guess(solution, exact, geom);
+    rhs.setVal(0.0);
+
+    LPInfo info = make_lp_info(p);
+    MLNodeLaplacian linop({geom}, {grids}, {dmap}, info,
+                          Vector<EBFArrayBoxFactory const*>{&factory});
+    linop.setCoarseningStrategy(MLNodeLaplacian::CoarseningStrategy::RAP);
+    linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)},
+                      {AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)});
+    linop.setSigma(0, sigma);
+    linop.setEBInhomogNeumannFlux(0, eb_neumann);
+    linop.compRHS(Vector<MultiFab*>{&rhs}, Vector<MultiFab*>{&velocity},
+                  Vector<const MultiFab*>(), Vector<MultiFab*>{&rhcc});
+
+    MLMG mlmg(linop);
+    mlmg.setVerbose(p.verbose);
+    mlmg.setBottomVerbose(p.bottom_verbose);
+    mlmg.setMaxIter(p.max_iter);
+    mlmg.setMaxFmgIter(p.max_fmg_iter);
+
+    Real const t1 = second();
+    Vector<MultiFab*> sol{&solution};
+    Vector<MultiFab const*> rh{&rhs};
+    Real const residual = mlmg.solve(sol, rh, p.reltol, p.abstol);
+    Real const t2 = second();
+
+    auto active_mask = make_eb_active_node_mask(nba, dmap, geom, factory);
+    auto const [l2, linf] = compute_error_norms(solution, exact, geom, active_mask.get());
+    Real const t3 = second();
+
+    SolveResult r;
+    r.n_cell = n_cell;
+    r.nprocs = ParallelDescriptor::NProcs();
+    r.mg_levels = linop.NMGLevels(0);
+    r.iterations = mlmg.getNumIters();
+    r.residual = residual;
+    r.l2 = l2;
+    r.linf = linf;
+    r.setup_time = t1 - t0;
+    r.solve_time = t2 - t1;
+    r.total_time = t3 - t0;
+    return r;
+#else
+    amrex::ignore_unused(p);
+    amrex::ignore_unused(n_cell);
+    Abort("NodeRZEBBaseline: rz_eb_neumann_plane requires AMREX_USE_EB");
+    return {};
+#endif
+}
+
+SolveResult run_rz_eb_neumann_sphere_case (Parameters const& p, int n_cell)
+{
+#ifdef AMREX_USE_EB
+    Real const t0 = second();
+
+    Geometry geom = make_rz_geometry(n_cell);
+    BoxArray grids(geom.Domain());
+    grids.maxSize(p.max_grid_size);
+    DistributionMapping dmap(grids);
+
+    EB2::SphereIF sphere(0.33, {AMREX_D_DECL(0.92, 0.50, 0.0)}, false);
+    auto gshop = EB2::makeShop(sphere);
+    EB2::Build(gshop, geom, 0, p.max_coarsening_level);
+
+    EB2::IndexSpace const& eb_is = EB2::IndexSpace::top();
+    EB2::Level const& eb_level = eb_is.getLevel(geom);
+    Vector<int> ng_ebs = {2, 2, 2};
+    EBFArrayBoxFactory factory(eb_level, geom, grids, dmap, ng_ebs, EBSupport::full);
+
+    BoxArray const nba = amrex::convert(grids, IntVect::TheNodeVector());
+    MultiFab solution(nba, dmap, 1, 0);
+    MultiFab exact(nba, dmap, 1, 0);
+    MultiFab rhs(nba, dmap, 1, 0);
+    MultiFab sigma(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab velocity(grids, dmap, AMREX_SPACEDIM, 1, MFInfo(), factory);
+    MultiFab rhcc(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab eb_neumann(grids, dmap, 1, 1, MFInfo(), factory);
+
+    fill_rz_eb_neumann_curved_mms(exact, sigma, velocity, rhcc, eb_neumann, geom, factory);
+    initialize_dirichlet_guess(solution, exact, geom);
+    rhs.setVal(0.0);
+
+    LPInfo info = make_lp_info(p);
+    MLNodeLaplacian linop({geom}, {grids}, {dmap}, info,
+                          Vector<EBFArrayBoxFactory const*>{&factory});
+    linop.setCoarseningStrategy(MLNodeLaplacian::CoarseningStrategy::RAP);
+    linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)},
+                      {AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)});
+    linop.setSigma(0, sigma);
+    linop.setEBInhomogNeumannFlux(0, eb_neumann);
+    linop.compRHS(Vector<MultiFab*>{&rhs}, Vector<MultiFab*>{&velocity},
+                  Vector<const MultiFab*>(), Vector<MultiFab*>{&rhcc});
+
+    MLMG mlmg(linop);
+    mlmg.setVerbose(p.verbose);
+    mlmg.setBottomVerbose(p.bottom_verbose);
+    mlmg.setMaxIter(p.max_iter);
+    mlmg.setMaxFmgIter(p.max_fmg_iter);
+
+    Real const t1 = second();
+    Vector<MultiFab*> sol{&solution};
+    Vector<MultiFab const*> rh{&rhs};
+    Real const residual = mlmg.solve(sol, rh, p.reltol, p.abstol);
+    Real const t2 = second();
+
+    auto active_mask = make_eb_active_node_mask(nba, dmap, geom, factory);
+    auto fluid_node_mask = make_sphere_fluid_node_mask(nba, dmap, geom, *active_mask,
+                                                       Real(0.33), Real(0.92), Real(0.50));
+    auto const [l2, linf] = compute_error_norms(solution, exact, geom, fluid_node_mask.get());
+    Real const t3 = second();
+
+    SolveResult r;
+    r.n_cell = n_cell;
+    r.nprocs = ParallelDescriptor::NProcs();
+    r.mg_levels = linop.NMGLevels(0);
+    r.iterations = mlmg.getNumIters();
+    r.residual = residual;
+    r.l2 = l2;
+    r.linf = linf;
+    r.setup_time = t1 - t0;
+    r.solve_time = t2 - t1;
+    r.total_time = t3 - t0;
+    return r;
+#else
+    amrex::ignore_unused(p);
+    amrex::ignore_unused(n_cell);
+    Abort("NodeRZEBBaseline: rz_eb_neumann_sphere requires AMREX_USE_EB");
+    return {};
+#endif
+}
+
+SolveResult run_rz_eb_inflow_sphere_case (Parameters const& p, int n_cell)
+{
+#ifdef AMREX_USE_EB
+    Real const t0 = second();
+
+    Geometry geom = make_rz_geometry(n_cell);
+    BoxArray grids(geom.Domain());
+    grids.maxSize(p.max_grid_size);
+    DistributionMapping dmap(grids);
+
+    EB2::SphereIF sphere(0.33, {AMREX_D_DECL(0.92, 0.50, 0.0)}, false);
+    auto gshop = EB2::makeShop(sphere);
+    EB2::Build(gshop, geom, 0, p.max_coarsening_level);
+
+    EB2::IndexSpace const& eb_is = EB2::IndexSpace::top();
+    EB2::Level const& eb_level = eb_is.getLevel(geom);
+    Vector<int> ng_ebs = {2, 2, 2};
+    EBFArrayBoxFactory factory(eb_level, geom, grids, dmap, ng_ebs, EBSupport::full);
+
+    BoxArray const nba = amrex::convert(grids, IntVect::TheNodeVector());
+    MultiFab solution(nba, dmap, 1, 0);
+    MultiFab exact(nba, dmap, 1, 0);
+    MultiFab rhs(nba, dmap, 1, 0);
+    MultiFab sigma(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab velocity(grids, dmap, AMREX_SPACEDIM, 1, MFInfo(), factory);
+    MultiFab eb_velocity(grids, dmap, AMREX_SPACEDIM, 1, MFInfo(), factory);
+    MultiFab rhcc(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab eb_neumann(grids, dmap, 1, 1, MFInfo(), factory);
+
+    fill_rz_eb_neumann_curved_mms(exact, sigma, velocity, rhcc, eb_neumann, geom, factory);
+    fill_rz_eb_inflow_velocity_curved_mms(eb_velocity, geom, factory);
+    initialize_dirichlet_guess(solution, exact, geom);
+    rhs.setVal(0.0);
+
+    LPInfo info = make_lp_info(p);
+    MLNodeLaplacian linop({geom}, {grids}, {dmap}, info,
+                          Vector<EBFArrayBoxFactory const*>{&factory});
+    linop.setCoarseningStrategy(MLNodeLaplacian::CoarseningStrategy::RAP);
+    linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)},
+                      {AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)});
+    linop.setSigma(0, sigma);
+    linop.setEBInflowVelocity(0, eb_velocity);
+    linop.compRHS(Vector<MultiFab*>{&rhs}, Vector<MultiFab*>{&velocity},
+                  Vector<const MultiFab*>(), Vector<MultiFab*>{&rhcc});
+
+    MLMG mlmg(linop);
+    mlmg.setVerbose(p.verbose);
+    mlmg.setBottomVerbose(p.bottom_verbose);
+    mlmg.setMaxIter(p.max_iter);
+    mlmg.setMaxFmgIter(p.max_fmg_iter);
+
+    Real const t1 = second();
+    Vector<MultiFab*> sol{&solution};
+    Vector<MultiFab const*> rh{&rhs};
+    Real const residual = mlmg.solve(sol, rh, p.reltol, p.abstol);
+    Real const t2 = second();
+
+    auto active_mask = make_eb_active_node_mask(nba, dmap, geom, factory);
+    auto fluid_node_mask = make_sphere_fluid_node_mask(nba, dmap, geom, *active_mask,
+                                                       Real(0.33), Real(0.92), Real(0.50));
+    auto const [l2, linf] = compute_error_norms(solution, exact, geom, fluid_node_mask.get());
+    Real const t3 = second();
+
+    SolveResult r;
+    r.n_cell = n_cell;
+    r.nprocs = ParallelDescriptor::NProcs();
+    r.mg_levels = linop.NMGLevels(0);
+    r.iterations = mlmg.getNumIters();
+    r.residual = residual;
+    r.l2 = l2;
+    r.linf = linf;
+    r.setup_time = t1 - t0;
+    r.solve_time = t2 - t1;
+    r.total_time = t3 - t0;
+    return r;
+#else
+    amrex::ignore_unused(p);
+    amrex::ignore_unused(n_cell);
+    Abort("NodeRZEBBaseline: rz_eb_inflow_sphere requires AMREX_USE_EB");
+    return {};
+#endif
+}
+
+SolveResult run_cartesian_eb_neumann_sphere_case (Parameters const& p, int n_cell)
+{
+#ifdef AMREX_USE_EB
+    Real const t0 = second();
+
+    Geometry geom = make_cartesian_geometry(n_cell);
+    BoxArray grids(geom.Domain());
+    grids.maxSize(p.max_grid_size);
+    DistributionMapping dmap(grids);
+
+    EB2::SphereIF sphere(0.33, {AMREX_D_DECL(0.92, 0.50, 0.0)}, false);
+    auto gshop = EB2::makeShop(sphere);
+    EB2::Build(gshop, geom, 0, p.max_coarsening_level);
+
+    EB2::IndexSpace const& eb_is = EB2::IndexSpace::top();
+    EB2::Level const& eb_level = eb_is.getLevel(geom);
+    Vector<int> ng_ebs = {2, 2, 2};
+    EBFArrayBoxFactory factory(eb_level, geom, grids, dmap, ng_ebs, EBSupport::full);
+
+    BoxArray const nba = amrex::convert(grids, IntVect::TheNodeVector());
+    MultiFab solution(nba, dmap, 1, 0);
+    MultiFab exact(nba, dmap, 1, 0);
+    MultiFab rhs(nba, dmap, 1, 0);
+    MultiFab sigma(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab velocity(grids, dmap, AMREX_SPACEDIM, 1, MFInfo(), factory);
+    MultiFab rhcc(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab eb_neumann(grids, dmap, 1, 1, MFInfo(), factory);
+
+    fill_cartesian_eb_neumann_curved_mms(exact, sigma, velocity, rhcc, eb_neumann, geom, factory);
+    initialize_dirichlet_guess(solution, exact, geom);
+    rhs.setVal(0.0);
+
+    LPInfo info = make_lp_info(p);
+    MLNodeLaplacian linop({geom}, {grids}, {dmap}, info,
+                          Vector<EBFArrayBoxFactory const*>{&factory});
+    linop.setCoarseningStrategy(MLNodeLaplacian::CoarseningStrategy::RAP);
+    linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)},
+                      {AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)});
+    linop.setSigma(0, sigma);
+    linop.setEBInhomogNeumannFlux(0, eb_neumann);
+    linop.compRHS(Vector<MultiFab*>{&rhs}, Vector<MultiFab*>{&velocity},
+                  Vector<const MultiFab*>(), Vector<MultiFab*>{&rhcc});
+
+    MLMG mlmg(linop);
+    mlmg.setVerbose(p.verbose);
+    mlmg.setBottomVerbose(p.bottom_verbose);
+    mlmg.setMaxIter(p.max_iter);
+    mlmg.setMaxFmgIter(p.max_fmg_iter);
+
+    Real const t1 = second();
+    Vector<MultiFab*> sol{&solution};
+    Vector<MultiFab const*> rh{&rhs};
+    Real const residual = mlmg.solve(sol, rh, p.reltol, p.abstol);
+    Real const t2 = second();
+
+    auto active_mask = make_eb_active_node_mask(nba, dmap, geom, factory);
+    auto fluid_node_mask = make_sphere_fluid_node_mask(nba, dmap, geom, *active_mask,
+                                                       Real(0.33), Real(0.92), Real(0.50));
+    auto const [l2, linf] = compute_error_norms(solution, exact, geom, fluid_node_mask.get());
+    Real const t3 = second();
+
+    SolveResult r;
+    r.n_cell = n_cell;
+    r.nprocs = ParallelDescriptor::NProcs();
+    r.mg_levels = linop.NMGLevels(0);
+    r.iterations = mlmg.getNumIters();
+    r.residual = residual;
+    r.l2 = l2;
+    r.linf = linf;
+    r.setup_time = t1 - t0;
+    r.solve_time = t2 - t1;
+    r.total_time = t3 - t0;
+    return r;
+#else
+    amrex::ignore_unused(p);
+    amrex::ignore_unused(n_cell);
+    Abort("NodeRZEBBaseline: cart_eb_neumann_sphere requires AMREX_USE_EB");
+    return {};
+#endif
+}
+
+SolveResult run_rz_eb_neumann_physical_bc_case (Parameters const& p, int n_cell,
+                                                bool all_neumann,
+                                                bool add_incompatible_offset)
+{
+#ifdef AMREX_USE_EB
+    Real const t0 = second();
+
+    Geometry geom = make_rz_geometry(n_cell);
+    BoxArray grids(geom.Domain());
+    grids.maxSize(p.max_grid_size);
+    DistributionMapping dmap(grids);
+
+    EB2::SphereIF sphere(0.33, {AMREX_D_DECL(0.92, 0.50, 0.0)}, false);
+    auto gshop = EB2::makeShop(sphere);
+    EB2::Build(gshop, geom, 0, p.max_coarsening_level);
+
+    EB2::IndexSpace const& eb_is = EB2::IndexSpace::top();
+    EB2::Level const& eb_level = eb_is.getLevel(geom);
+    Vector<int> ng_ebs = {2, 2, 2};
+    EBFArrayBoxFactory factory(eb_level, geom, grids, dmap, ng_ebs, EBSupport::full);
+
+    BoxArray const nba = amrex::convert(grids, IntVect::TheNodeVector());
+    MultiFab solution(nba, dmap, 1, 0);
+    MultiFab exact(nba, dmap, 1, 0);
+    MultiFab rhs(nba, dmap, 1, 0);
+    MultiFab sigma(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab velocity(grids, dmap, AMREX_SPACEDIM, 1, MFInfo(), factory);
+    MultiFab rhcc(grids, dmap, 1, 0, MFInfo(), factory);
+    MultiFab eb_neumann(grids, dmap, 1, 1, MFInfo(), factory);
+
+    fill_rz_eb_neumann_physical_bc_mms(exact, sigma, velocity, rhcc, eb_neumann,
+                                       geom, factory, all_neumann);
+    if (add_incompatible_offset) {
+        rhcc.plus(1.0, 0, 1);
+    }
+    if (all_neumann) {
+        solution.setVal(0.0);
+    } else {
+        initialize_dirichlet_guess(solution, exact, geom);
+    }
+    rhs.setVal(0.0);
+
+    LinOpBCType const y_bc = all_neumann ? LinOpBCType::Neumann : LinOpBCType::Dirichlet;
+    LPInfo info = make_lp_info(p);
+    MLNodeLaplacian linop({geom}, {grids}, {dmap}, info,
+                          Vector<EBFArrayBoxFactory const*>{&factory});
+    linop.setCoarseningStrategy(MLNodeLaplacian::CoarseningStrategy::RAP);
+    linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Neumann,
+                                    y_bc,
+                                    LinOpBCType::Neumann)},
+                      {AMREX_D_DECL(LinOpBCType::Neumann,
+                                    y_bc,
+                                    LinOpBCType::Neumann)});
+    linop.setSigma(0, sigma);
+    linop.setEBInhomogNeumannFlux(0, eb_neumann);
+    linop.compRHS(Vector<MultiFab*>{&rhs}, Vector<MultiFab*>{&velocity},
+                  Vector<const MultiFab*>(), Vector<MultiFab*>{&rhcc});
+
+    MLMG mlmg(linop);
+    mlmg.setVerbose(p.verbose);
+    mlmg.setBottomVerbose(p.bottom_verbose);
+    mlmg.setMaxIter(p.max_iter);
+    mlmg.setMaxFmgIter(p.max_fmg_iter);
+
+    Real const t1 = second();
+    Vector<MultiFab*> sol{&solution};
+    Vector<MultiFab const*> rh{&rhs};
+    Real const residual = mlmg.solve(sol, rh, p.reltol, p.abstol);
+    Real const t2 = second();
+
+    auto active_mask = make_eb_active_node_mask(nba, dmap, geom, factory);
+    auto fluid_node_mask = make_sphere_fluid_node_mask(nba, dmap, geom, *active_mask,
+                                                       Real(0.33), Real(0.92), Real(0.50));
+    auto const [l2, linf] = compute_error_norms(solution, exact, geom,
+                                                fluid_node_mask.get(), all_neumann);
+    Real const t3 = second();
+
+    SolveResult r;
+    r.n_cell = n_cell;
+    r.nprocs = ParallelDescriptor::NProcs();
+    r.mg_levels = linop.NMGLevels(0);
+    r.iterations = mlmg.getNumIters();
+    r.residual = residual;
+    r.l2 = l2;
+    r.linf = linf;
+    r.setup_time = t1 - t0;
+    r.solve_time = t2 - t1;
+    r.total_time = t3 - t0;
+    return r;
+#else
+    amrex::ignore_unused(p);
+    amrex::ignore_unused(n_cell);
+    amrex::ignore_unused(all_neumann);
+    amrex::ignore_unused(add_incompatible_offset);
+    Abort("NodeRZEBBaseline: rz_eb_neumann physical BC cases require AMREX_USE_EB");
+    return {};
+#endif
+}
+
+void run_rz_eb_rap_zero (Parameters const& p)
+{
+    int const n_cell = p.n_cell.empty() ? 32 : p.n_cell.front();
+    if (n_cell < 8) {
+        Abort("NodeRZEBBaseline: rz_eb_rap_zero n_cell must be at least 8");
+    }
+
+    SolveResult r = run_rz_eb_rap_zero_case(p, n_cell);
+    report_result("RZ_EB_RAP_ZERO", r);
+
+    if (p.do_assert &&
+        (!std::isfinite(r.residual) || !std::isfinite(r.l2) || !std::isfinite(r.linf))) {
+        Abort("NodeRZEBBaseline: non-finite RZ_EB_RAP_ZERO residual or error norm");
+    }
+    if (p.do_assert && r.iterations > p.max_iter) {
+        Abort("NodeRZEBBaseline: invalid RZ_EB_RAP_ZERO MLMG iteration count");
+    }
+    if (p.do_assert && r.mg_levels < p.min_mg_levels) {
+        Abort("NodeRZEBBaseline: RZ_EB_RAP_ZERO MG level count below threshold");
+    }
+    if (p.do_assert && (r.l2 > p.max_finest_l2 || r.linf > p.max_finest_linf)) {
+        Abort("NodeRZEBBaseline: RZ_EB_RAP_ZERO zero-solution error above threshold");
+    }
+
+    Print() << "RZ_EB_RAP_ZERO_PASS"
+            << " mpi_ranks=" << ParallelDescriptor::NProcs()
+            << " mg_levels=" << r.mg_levels
+            << "\n";
+}
+
+void run_rz_eb_neumann_plane (Parameters const& p)
+{
+    std::vector<int> n_cells = p.n_cell;
+    std::sort(n_cells.begin(), n_cells.end());
+    n_cells.erase(std::unique(n_cells.begin(), n_cells.end()), n_cells.end());
+
+    std::vector<SolveResult> results;
+    results.reserve(n_cells.size());
+
+    for (int n : n_cells) {
+        if (n < 8) {
+            Abort("NodeRZEBBaseline: rz_eb_neumann_plane n_cell must be at least 8");
+        }
+        SolveResult r = run_rz_eb_neumann_plane_case(p, n);
+        report_result("RZ_EB_NEUMANN_PLANE", r);
+        results.push_back(r);
+    }
+
+    assert_mms_results(p, results, "RZ_EB_NEUMANN_PLANE");
+    Print() << "RZ_EB_NEUMANN_PLANE_PASS cases=" << results.size()
+            << " mpi_ranks=" << ParallelDescriptor::NProcs()
+            << "\n";
+}
+
+void run_rz_eb_neumann_sphere (Parameters const& p)
+{
+    std::vector<int> n_cells = p.n_cell;
+    std::sort(n_cells.begin(), n_cells.end());
+    n_cells.erase(std::unique(n_cells.begin(), n_cells.end()), n_cells.end());
+
+    std::vector<SolveResult> results;
+    results.reserve(n_cells.size());
+
+    for (int n : n_cells) {
+        if (n < 16) {
+            Abort("NodeRZEBBaseline: rz_eb_neumann_sphere n_cell must be at least 16");
+        }
+        SolveResult r = run_rz_eb_neumann_sphere_case(p, n);
+        report_result("RZ_EB_NEUMANN_SPHERE", r);
+        results.push_back(r);
+    }
+
+    assert_mms_results(p, results, "RZ_EB_NEUMANN_SPHERE");
+    Print() << "RZ_EB_NEUMANN_SPHERE_PASS cases=" << results.size()
+            << " mpi_ranks=" << ParallelDescriptor::NProcs()
+            << "\n";
+}
+
+void run_rz_eb_inflow_sphere (Parameters const& p)
+{
+    std::vector<int> n_cells = p.n_cell;
+    std::sort(n_cells.begin(), n_cells.end());
+    n_cells.erase(std::unique(n_cells.begin(), n_cells.end()), n_cells.end());
+
+    std::vector<SolveResult> results;
+    results.reserve(n_cells.size());
+
+    for (int n : n_cells) {
+        if (n < 16) {
+            Abort("NodeRZEBBaseline: rz_eb_inflow_sphere n_cell must be at least 16");
+        }
+        SolveResult r = run_rz_eb_inflow_sphere_case(p, n);
+        report_result("RZ_EB_INFLOW_SPHERE", r);
+        results.push_back(r);
+    }
+
+    assert_mms_results(p, results, "RZ_EB_INFLOW_SPHERE");
+    Print() << "RZ_EB_INFLOW_SPHERE_PASS cases=" << results.size()
+            << " mpi_ranks=" << ParallelDescriptor::NProcs()
+            << "\n";
+}
+
+void run_cartesian_eb_neumann_sphere (Parameters const& p)
+{
+    std::vector<int> n_cells = p.n_cell;
+    std::sort(n_cells.begin(), n_cells.end());
+    n_cells.erase(std::unique(n_cells.begin(), n_cells.end()), n_cells.end());
+
+    std::vector<SolveResult> results;
+    results.reserve(n_cells.size());
+
+    for (int n : n_cells) {
+        if (n < 16) {
+            Abort("NodeRZEBBaseline: cart_eb_neumann_sphere n_cell must be at least 16");
+        }
+        SolveResult r = run_cartesian_eb_neumann_sphere_case(p, n);
+        report_result("CART_EB_NEUMANN_SPHERE", r);
+        results.push_back(r);
+    }
+
+    assert_mms_results(p, results, "CART_EB_NEUMANN_SPHERE");
+    Print() << "CART_EB_NEUMANN_SPHERE_PASS cases=" << results.size()
+            << " mpi_ranks=" << ParallelDescriptor::NProcs()
+            << "\n";
+}
+
+void run_rz_eb_neumann_physical_bc (Parameters const& p, bool all_neumann,
+                                    bool add_incompatible_offset = false)
+{
+    std::vector<int> n_cells = p.n_cell;
+    std::sort(n_cells.begin(), n_cells.end());
+    n_cells.erase(std::unique(n_cells.begin(), n_cells.end()), n_cells.end());
+
+    std::vector<SolveResult> results;
+    results.reserve(n_cells.size());
+
+    char const* label = add_incompatible_offset ? "RZ_EB_NEUMANN_ALL_NEUMANN_OFFSET"
+        : (all_neumann ? "RZ_EB_NEUMANN_ALL_NEUMANN"
+                       : "RZ_EB_NEUMANN_MIXED_BC");
+    for (int n : n_cells) {
+        if (n < 16) {
+            Abort(std::string("NodeRZEBBaseline: ") + label +
+                  " n_cell must be at least 16");
+        }
+        SolveResult r = run_rz_eb_neumann_physical_bc_case(p, n, all_neumann,
+                                                           add_incompatible_offset);
+        report_result(label, r);
+        results.push_back(r);
+    }
+
+    assert_mms_results(p, results, label);
+    Print() << label << "_PASS cases=" << results.size()
+            << " mpi_ranks=" << ParallelDescriptor::NProcs()
+            << "\n";
+}
+
+}
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+    {
+        BL_PROFILE("main");
+        Parameters const p = read_parameters();
+        if (p.mode == "rz_mms") {
+            run_rz_mms(p);
+        } else if (p.mode == "rz_mms_rap") {
+            run_rz_mms_rap(p);
+        } else if (p.mode == "cart_mms_rap") {
+            run_cartesian_mms(p);
+        } else if (p.mode == "rz_eb_rap_zero") {
+            run_rz_eb_rap_zero(p);
+        } else if (p.mode == "rz_eb_neumann_plane") {
+            run_rz_eb_neumann_plane(p);
+        } else if (p.mode == "rz_eb_neumann_sphere") {
+            run_rz_eb_neumann_sphere(p);
+        } else if (p.mode == "rz_eb_inflow_sphere") {
+            run_rz_eb_inflow_sphere(p);
+        } else if (p.mode == "cart_eb_neumann_sphere") {
+            run_cartesian_eb_neumann_sphere(p);
+        } else if (p.mode == "rz_eb_neumann_mixed_bc") {
+            run_rz_eb_neumann_physical_bc(p, false);
+        } else if (p.mode == "rz_eb_neumann_all_neumann") {
+            run_rz_eb_neumann_physical_bc(p, true);
+        } else if (p.mode == "rz_eb_neumann_all_neumann_offset") {
+            run_rz_eb_neumann_physical_bc(p, true, true);
+        } else {
+            Abort("NodeRZEBBaseline: unknown mode '" + p.mode + "'");
+        }
+    }
+    amrex::Finalize();
+}


### PR DESCRIPTION
  This adds a 2D-only `MLNodeLaplacian` API for embedded-boundary inhomogeneous Neumann flux data, documents the EB normal convention, enables RZ RAP stencils, and adds CPU/GPU regression tests covering Cartesian, RZ, EB Neumann, EB inflow, and physical Neumann boundary combinations. 3D EB Neumann support remains unsupported.

  ## Summary

This PR adds support for inhomogeneous Neumann data on embedded boundaries for 2D nodal `MLNodeLaplacian` solves.

The new API is:

```cpp
MLNodeLaplacian::setEBInhomogNeumannFlux(int amrlev, const MultiFab& eb_neumann_flux)
```

The first component of `eb_neumann_flux` contains cell-centered cut-cell values of `sigma * dphi/dn_EB` at the EB surface. 

The EB normal convention is documented as the AMReX convention: n_EB points from the valid/fluid region toward the covered/body region.

This PR also enables RAP coarsening for 2D RZ MLNodeLaplacian stencils, including EB stencil and sync-residual paths. The existing EB inflow velocity convention is preserved.

The implementation is limited to 2D. Calls to the new EB Neumann API in other dimensions abort.

## Additional background

This is intended for 2D nodal Poisson-type solves with EB natural flux data. The new EB Neumann path is separate from `setEBInflowVelocity`: EB inflow remains a velocity-divergence contribution, while the new API supplies the operator boundary flux `sigma * dphi/dn_EB`.

RZ support includes RAP coarsening so the multigrid hierarchy can remain deep for EB geometries.

A new small regression test directory is added:

```text
Tests/LinearSolvers/NodeRZEBBaseline
```

It covers Cartesian and RZ baselines, EB Neumann plane/sphere cases, EB inflow compatibility, mixed and all-Neumann physical boundary conditions, and all-Neumann solvability-offset handling.

CPU validation performed:
```
make -j4 DIM=2 USE_MPI=TRUE USE_OMP=FALSE USE_EB=TRUE COMP=gnu
mpiexec -n 1 ./main2d.gnu.TEST.MPI.ex inputs.rz_eb_inflow_sphere
mpiexec -n 1 ./main2d.gnu.TEST.MPI.ex inputs.rz_eb_neumann_sphere
mpiexec -n 1 ./main2d.gnu.TEST.MPI.ex inputs.rz_eb_neumann_mixed_bc
mpiexec -n 4 ./main2d.gnu.TEST.MPI.ex inputs.rz_eb_inflow_sphere
mpiexec -n 4 ./main2d.gnu.TEST.MPI.ex inputs.rz_eb_neumann_sphere
mpiexec -n 4 ./main2d.gnu.TEST.MPI.ex inputs.rz_eb_neumann_mixed_bc
```
GPU validation performed:
```
make -j4 DIM=2 USE_MPI=TRUE USE_OMP=FALSE USE_EB=TRUE USE_CUDA=TRUE COMP=gnu
mpiexec -n 1 ./main2d.gnu.TEST.MPI.CUDA.ex inputs.rz_eb_inflow_sphere
mpiexec -n 1 ./main2d.gnu.TEST.MPI.CUDA.ex inputs.rz_eb_neumann_sphere
mpiexec -n 1 ./main2d.gnu.TEST.MPI.CUDA.ex inputs.rz_eb_neumann_mixed_bc
```
A focused mpiexec -n 4 GPU smoke test was also run on a single shared GPU with reduced AMReX arena preallocation. All focused CPU/MPI and GPU tests passed.

## Checklist

The proposed changes:

- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate

