### PR TITLE
Avoid FPE in fcompare when a plot variable is all zeros

### DIFF
--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -257,7 +257,14 @@ int main_main()
                 }
 
                 if (norm == 0) {
-                    rerror[icomp_a] /= rerror_denom[icomp_a];
+                    if (rerror_denom[icomp_a] != 0.0) {
+                        rerror[icomp_a] /= rerror_denom[icomp_a];
+                    } else {
+                        // A is identically zero; relative error is undefined.
+                        // If there is no absolute error either, report 0.
+                        rerror[icomp_a] = (rerror[icomp_a] == 0.0) ? 0.0
+                            : std::numeric_limits<Real>::infinity();
+                    }
                 } else {
                     const auto& dx = pf_a.cellSize(ilev);
                     Real dv = 1.0;
@@ -265,7 +272,12 @@ int main_main()
                         dv *= dx[idim];
                     }
                     aerror[icomp_a] *= std::pow(dv,Real(1.)/static_cast<Real>(norm));
-                    rerror[icomp_a] = rerror[icomp_a]/rerror_denom[icomp_a];
+                    if (rerror_denom[icomp_a] != 0.0) {
+                        rerror[icomp_a] = rerror[icomp_a]/rerror_denom[icomp_a];
+                    } else {
+                        rerror[icomp_a] = (rerror[icomp_a] == 0.0) ? 0.0
+                            : std::numeric_limits<Real>::infinity();
+                    }
                 }
 
                 if (icomp_a == save_var_a || icomp_a == zone_info_var_a) {

--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -262,7 +262,7 @@ int main_main()
                     } else {
                         // A is identically zero; relative error is undefined.
                         // If there is no absolute error either, report 0.
-                        rerror[icomp_a] = (rerror[icomp_a] == 0.0) ? 0.0
+                        rerror[icomp_a] = (rerror[icomp_a] == Real(0.0)) ? Real(0.0)
                             : std::numeric_limits<Real>::infinity();
                     }
                 } else {
@@ -275,7 +275,7 @@ int main_main()
                     if (rerror_denom[icomp_a] != 0.0) {
                         rerror[icomp_a] = rerror[icomp_a]/rerror_denom[icomp_a];
                     } else {
-                        rerror[icomp_a] = (rerror[icomp_a] == 0.0) ? 0.0
+                        rerror[icomp_a] = (rerror[icomp_a] == Real(0.0)) ? Real(0.0)
                             : std::numeric_limits<Real>::infinity();
                     }
                 }


### PR DESCRIPTION
## Summary

An FPE is possible when a variable in each plot file is all zeros. This avoids the divide by 0 FPE.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
