### PR TITLE
Add support for RZ + EB with sigma MF in `MLEBNodeFDLaplacian`

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
@@ -467,6 +467,71 @@ void mlebndfdlap_sig_gsrb (int i, int j, int k, Array4<Real> const& x,
     }
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_sig_adotx_rz (int i, int j, int k, Array4<Real> const& y,
+                                Array4<Real const> const& x,
+                                Array4<int const> const& dmsk,
+                                Array4<Real const> const& sig,
+                                Real dr, Real dz, Real rlo, Real alpha) noexcept
+{
+    Real const r = rlo + Real(i)*dr;
+    if (dmsk(i,j,k) || (r == Real(0.0) && alpha != Real(0.0))) {
+        y(i,j,k) = Real(0.0);
+    } else {
+        Real const rp = r + Real(0.5)*dr;
+        Real const rm = (r >= Real(0.5)*dr) ? (r - Real(0.5)*dr) : (Real(0.5)*dr - r);
+        Real const sigyp = (sig(i-1,j  ,k)*rm + sig(i,j  ,k)*rp) / (rm+rp);
+        Real const sigym = (sig(i-1,j-1,k)*rm + sig(i,j-1,k)*rp) / (rm+rp);
+        Real Ax = (sigyp*(x(i,j+1,k)-x(i,j,k)) + sigym*(x(i,j-1,k)-x(i,j,k))) / (dz*dz);
+        if (r == Real(0.0)) {
+            Real const sigxp = Real(0.5)*(sig(i,j-1,k)+sig(i,j,k));
+            Ax += Real(4.0) * sigxp * (x(i+1,j,k)-x(i,j,k)) / (dr*dr);
+        } else {
+            Real const sigxp = Real(0.5)*(sig(i,  j-1,k)+sig(i,  j,k));
+            Real const sigxm = Real(0.5)*(sig(i-1,j-1,k)+sig(i-1,j,k));
+            Ax += (sigxp*rp*(x(i+1,j,k)-x(i,j,k)) + sigxm*rm*(x(i-1,j,k)-x(i,j,k))) / (r*dr*dr);
+            Ax -= alpha/(r*r) * x(i,j,k);
+        }
+        y(i,j,k) = Ax;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_sig_gsrb_rz (int i, int j, int k, Array4<Real> const& x,
+                               Array4<Real const> const& rhs,
+                               Array4<int const> const& dmsk,
+                               Array4<Real const> const& sig,
+                               Real dr, Real dz, Real rlo, int redblack, Real alpha) noexcept
+{
+    if ((i+j+k+redblack)%2 == 0) {
+        Real const r = rlo + Real(i)*dr;
+        if (dmsk(i,j,k) || (r == Real(0.0) && alpha != Real(0.0))) {
+            x(i,j,k) = Real(0.);
+        } else {
+            Real const rp = r + Real(0.5)*dr;
+            Real const rm = (r >= Real(0.5)*dr) ? (r - Real(0.5)*dr) : (Real(0.5)*dr - r);
+            Real const sigyp = (sig(i-1,j  ,k)*rm + sig(i,j  ,k)*rp) / (rm+rp);
+            Real const sigym = (sig(i-1,j-1,k)*rm + sig(i,j-1,k)*rp) / (rm+rp);
+            Real Ax = (sigyp*(x(i,j+1,k)-x(i,j,k)) + sigym*(x(i,j-1,k)-x(i,j,k))) / (dz*dz);
+            Real gamma = -(sigyp+sigym) / (dz*dz);
+            if (r == Real(0.0)) {
+                Real const sigxp = Real(0.5)*(sig(i,j-1,k)+sig(i,j,k));
+                Ax += (Real(4.0)*sigxp/(dr*dr)) * (x(i+1,j,k)-x(i,j,k));
+                gamma += -(Real(4.0)*sigxp/(dr*dr));
+            } else {
+                Real const sigxp = Real(0.5)*(sig(i,  j-1,k)+sig(i,  j,k));
+                Real const sigxm = Real(0.5)*(sig(i-1,j-1,k)+sig(i-1,j,k));
+                Ax += (sigxp*rp*(x(i+1,j,k)-x(i,j,k)) + sigxm*rm*(x(i-1,j,k)-x(i,j,k))) / (r*dr*dr);
+                gamma += -(sigxp*rp+sigxm*rm) / (r*dr*dr);
+                Ax -= alpha/(r*r) * x(i,j,k);
+                gamma -= alpha/(r*r);
+            }
+            constexpr Real omega = Real(1.25);
+            x(i,j,k) += (rhs(i,j,k) - Ax) * (omega / gamma);
+        }
+    }
+}
+
 template <typename F>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_sig_adotx_eb_doit (int i, int j, int k, Array4<Real> const& y,

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_2D_K.H
@@ -555,6 +555,118 @@ void mlebndfdlap_sig_adotx_eb (int i, int j, int k, Array4<Real> const& y,
                                   bx, by);
 }
 
+template <typename F>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_sig_adotx_rz_eb_doit (int i, int j, int k, Array4<Real> const& y,
+                                        Array4<Real const> const& x, Array4<Real const> const& levset,
+                                        Array4<int const> const& dmsk,
+                                        Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                                        Array4<Real const> const& sig, Array4<Real const> const& vfrc,
+                                        F const& xeb, Real dr, Real dz, Real rlo, Real alpha) noexcept
+{
+    Real const r = rlo + Real(i) * dr;
+    if (dmsk(i,j,k) || (r == Real(0.0) && alpha != Real(0.0))) {
+        y(i,j,k) = Real(0.0);
+    } else {
+        Real tmp, sigma;
+        Real hp, hm, scale, out;
+
+        if (r == Real(0.0)) {
+            sigma = (sig(i,j-1,k)*vfrc(i,j-1,k) + sig(i,j,k)*vfrc(i,j,k))
+                /  (vfrc(i,j-1,k)              + vfrc(i,j,k));
+            if (levset(i+1,j,k) < Real(0.0)) { // regular
+                out = Real(4.0) * sigma * (x(i+1,j,k)-x(i,j,k)) / (dr*dr);
+                scale = Real(1.0);
+            } else {
+                hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+                out = Real(4.0) * sigma * (xeb(i+1,j,k)-x(i,j,k)) / (dr*dr*hp*hp);
+                scale = hp;
+            }
+        } else {
+            sigma = (sig(i,j-1,k)*vfrc(i,j-1,k) + sig(i,j,k)*vfrc(i,j,k))
+                /  (vfrc(i,j-1,k)              + vfrc(i,j,k));
+            hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+            if (levset(i+1,j,k) < Real(0.0)) { // regular
+                tmp = sigma * (x(i+1,j,k) - x(i,j,k)) * (r + Real(0.5) * dr);
+            } else {
+                tmp = sigma * (xeb(i+1,j,k) - x(i,j,k)) / hp * (r + Real(0.5) * hp * dr);
+            }
+
+            sigma = (sig(i-1,j-1,k)*vfrc(i-1,j-1,k) + sig(i-1,j,k)*vfrc(i-1,j,k))
+                /  (vfrc(i-1,j-1,k)                + vfrc(i-1,j,k));
+            hm = (ecx(i-1,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecx(i-1,j,k));
+            if (levset(i-1,j,k) < Real(0.0)) {
+                tmp += sigma * (x(i-1,j,k) - x(i,j,k)) * (r - Real(0.5) * dr);
+            } else {
+                tmp += sigma * (xeb(i-1,j,k) - x(i,j,k)) / hm * (r - Real(0.5) * hm * dr);
+            }
+
+            out = tmp * Real(2.0) / ((hp+hm) * r * dr * dr);
+            scale = amrex::min(hm, hp);
+        }
+
+        // Cell-centre radii for cells at i and i-1; abs handles the axis (r=0) where
+        // the cell at i-1 is the reflected image at the same physical radius as i.
+        Real const rp = r + Real(0.5) * dr;
+        Real const rm = (r >= Real(0.5) * dr) ? (r - Real(0.5) * dr) : (Real(0.5) * dr - r);
+
+        sigma = (sig(i-1,j,k)*vfrc(i-1,j,k)*rm + sig(i,j,k)*vfrc(i,j,k)*rp)
+            /  (vfrc(i-1,j,k)*rm              + vfrc(i,j,k)*rp);
+        hp = (ecy(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecy(i,j,k));
+        if (levset(i,j+1,k) < Real(0.0)) {
+            tmp = sigma * (x(i,j+1,k) - x(i,j,k));
+        } else {
+            tmp = sigma * ((xeb(i,j+1,k) - x(i,j,k)) / hp);
+        }
+
+        sigma = (sig(i-1,j-1,k)*vfrc(i-1,j-1,k)*rm + sig(i,j-1,k)*vfrc(i,j-1,k)*rp)
+            /  (vfrc(i-1,j-1,k)*rm                + vfrc(i,j-1,k)*rp);
+        hm = (ecy(i,j-1,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecy(i,j-1,k));
+        if (levset(i,j-1,k) < Real(0.0)) {
+            tmp += sigma * (x(i,j-1,k) - x(i,j,k));
+        } else {
+            tmp += sigma * ((xeb(i,j-1,k) - x(i,j,k)) / hm);
+        }
+
+        out += tmp * Real(2.0) / ((hp+hm) * dz * dz);
+        scale = amrex::min(scale, hm, hp);
+
+        if (r != Real(0.0)) {
+            out -= alpha/(r*r) * x(i,j,k);
+        }
+
+        y(i,j,k) = out*scale;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_sig_adotx_rz_eb (int i, int j, int k, Array4<Real> const& y,
+                                   Array4<Real const> const& x, Array4<Real const> const& levset,
+                                   Array4<int const> const& dmsk,
+                                   Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                                   Array4<Real const> const& sig, Array4<Real const> const& vfrc,
+                                   Real xeb, Real dr, Real dz, Real rlo, Real alpha) noexcept
+{
+    mlebndfdlap_sig_adotx_rz_eb_doit(i, j, k, y, x, levset, dmsk, ecx, ecy, sig, vfrc,
+                                      [=] (int, int, int) -> Real { return xeb; },
+                                      dr, dz, rlo, alpha);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_sig_adotx_rz_eb (int i, int j, int k, Array4<Real> const& y,
+                                   Array4<Real const> const& x, Array4<Real const> const& levset,
+                                   Array4<int const> const& dmsk,
+                                   Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                                   Array4<Real const> const& sig, Array4<Real const> const& vfrc,
+                                   Array4<Real const> const& xeb, Real dr, Real dz, Real rlo,
+                                   Real alpha) noexcept
+{
+    mlebndfdlap_sig_adotx_rz_eb_doit(i, j, k, y, x, levset, dmsk, ecx, ecy, sig, vfrc,
+                                      [=] (int i1, int i2, int i3) -> Real {
+                                          return xeb(i1,i2,i3); },
+                                      dr, dz, rlo, alpha);
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlebndfdlap_sig_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
                               Array4<Real const> const& rhs,
@@ -624,6 +736,101 @@ void mlebndfdlap_sig_gsrb_eb (int i, int j, int k, Array4<Real> const& x,
             scale = amrex::min(scale, hm, hp);
 
             Real Ax = rho + gamma*x(i,j,k);
+            constexpr Real omega = Real(1.25);
+            x(i,j,k) += (rhs(i,j,k) - Ax*scale) * (omega / (gamma*scale));
+        }
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mlebndfdlap_sig_gsrb_rz_eb (int i, int j, int k, Array4<Real> const& x,
+                                  Array4<Real const> const& rhs, Array4<Real const> const& levset,
+                                  Array4<int const> const& dmsk,
+                                  Array4<Real const> const& ecx, Array4<Real const> const& ecy,
+                                  Array4<Real const> const& sig, Array4<Real const> const& vfrc,
+                                  Real dr, Real dz, Real rlo, int redblack, Real alpha) noexcept
+{
+    if ((i+j+k+redblack)%2 == 0) {
+        Real const r = rlo + Real(i) * dr;
+        if (dmsk(i,j,k) || (r == Real(0.0) && alpha != Real(0.0))) {
+            x(i,j,k) = Real(0.);
+        } else {
+            Real tmp0, tmp1, sigma;
+            Real hp, hm, scale, Ax, gamma;
+
+            if (r == Real(0.0)) {
+                sigma = (sig(i,j-1,k)*vfrc(i,j-1,k) + sig(i,j,k)*vfrc(i,j,k))
+                    /  (vfrc(i,j-1,k)              + vfrc(i,j,k));
+                if (levset(i+1,j,k) < Real(0.0)) { // regular
+                    Ax = (Real(4.0) * sigma / (dr*dr)) * (x(i+1,j,k)-x(i,j,k));
+                    gamma = -(Real(4.0) * sigma / (dr*dr));
+                    scale = Real(1.0);
+                } else {
+                    hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+                    gamma = -(Real(4.0) * sigma / (dr*dr*hp*hp));
+                    Ax = gamma * x(i,j,k);
+                    scale = hp;
+                }
+            } else {
+                sigma = (sig(i,j-1,k)*vfrc(i,j-1,k) + sig(i,j,k)*vfrc(i,j,k))
+                    /  (vfrc(i,j-1,k)              + vfrc(i,j,k));
+                hp = (ecx(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecx(i,j,k));
+                if (levset(i+1,j,k) < Real(0.0)) { // regular
+                    tmp1 = sigma * x(i+1,j,k) * (r + Real(0.5) * dr);
+                    tmp0 = sigma * (-(r + Real(0.5) * dr));
+                } else {
+                    tmp0 = sigma * Real(-1.0) / hp * (r + Real(0.5) * hp * dr);
+                    tmp1 = Real(0.0);
+                }
+
+                sigma = (sig(i-1,j-1,k)*vfrc(i-1,j-1,k) + sig(i-1,j,k)*vfrc(i-1,j,k))
+                    /  (vfrc(i-1,j-1,k)                + vfrc(i-1,j,k));
+                hm = (ecx(i-1,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecx(i-1,j,k));
+                if (levset(i-1,j,k) < Real(0.0)) {
+                    tmp1 += sigma * x(i-1,j,k) * (r - Real(0.5) * dr);
+                    tmp0 += sigma * (-(r - Real(0.5) * dr));
+                } else {
+                    tmp0 += sigma * Real(-1.0) / hm * (r - Real(0.5) * hm * dr);
+                }
+
+                Ax = (tmp1 + tmp0*x(i,j,k)) * Real(2.0) / ((hp+hm) * r * dr * dr);
+                gamma = tmp0 * Real(2.0) / ((hp+hm) * r * dr * dr);
+                scale = amrex::min(hm, hp);
+            }
+
+            Real const rp = r + Real(0.5) * dr;
+            Real const rm = (r >= Real(0.5) * dr) ? (r - Real(0.5) * dr) : (Real(0.5) * dr - r);
+
+            sigma = (sig(i-1,j,k)*vfrc(i-1,j,k)*rm + sig(i,j,k)*vfrc(i,j,k)*rp)
+                /  (vfrc(i-1,j,k)*rm              + vfrc(i,j,k)*rp);
+            hp = (ecy(i,j,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)+Real(2.)*ecy(i,j,k));
+            if (levset(i,j+1,k) < Real(0.0)) {
+                tmp0 = sigma * Real(-1.0);
+                tmp1 = sigma * x(i,j+1,k);
+            } else {
+                tmp0 = sigma * Real(-1.0) / hp;
+                tmp1 = Real(0.0);
+            }
+
+            sigma = (sig(i-1,j-1,k)*vfrc(i-1,j-1,k)*rm + sig(i,j-1,k)*vfrc(i,j-1,k)*rp)
+                /  (vfrc(i-1,j-1,k)*rm                + vfrc(i,j-1,k)*rp);
+            hm = (ecy(i,j-1,k) == Real(1.0)) ? Real(1.0) : (Real(1.0)-Real(2.)*ecy(i,j-1,k));
+            if (levset(i,j-1,k) < Real(0.0)) {
+                tmp0 += sigma * Real(-1.0);
+                tmp1 += sigma * x(i,j-1,k);
+            } else {
+                tmp0 += sigma * Real(-1.0) / hm;
+            }
+
+            Ax += (tmp1 + tmp0*x(i,j,k)) * Real(2.0) / ((hp+hm) * dz * dz);
+            gamma += tmp0 * Real(2.0) / ((hp+hm) * dz * dz);
+            scale = amrex::min(scale, hm, hp);
+
+            if (r != Real(0.0)) {
+                Ax -= alpha/(r*r) * x(i,j,k);
+                gamma -= alpha/(r*r);
+            }
+
             constexpr Real omega = Real(1.25);
             x(i,j,k) += (rhs(i,j,k) - Ax*scale) * (omega / (gamma*scale));
         }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -21,8 +21,8 @@ namespace amrex {
 // del dot (sigma grad phi) - alpha/r^2 phi = rhs, for RZ where alpha is a
 // scalar constant that is zero by default.
 //
-// New feature: for non-RZ, sigma can also be a single-component
-// cell-centered multifab.
+// New feature: sigma can also be a single-component cell-centered multifab
+// (except for RZ + non-EB builds).
 
 /// \ingroup amrex_eb
 class MLEBNodeFDLaplacian

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -21,8 +21,7 @@ namespace amrex {
 // del dot (sigma grad phi) - alpha/r^2 phi = rhs, for RZ where alpha is a
 // scalar constant that is zero by default.
 //
-// New feature: sigma can also be a single-component cell-centered multifab
-// (except for RZ + non-EB builds).
+// New feature: sigma can also be a single-component cell-centered multifab.
 
 /// \ingroup amrex_eb
 class MLEBNodeFDLaplacian

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -316,7 +316,6 @@ MLEBNodeFDLaplacian::prepareForSolve ()
         if (m_sigma[0] == 0._rt) {
             m_sigma[0] = 1._rt; // For backward compatibility
         }
-        AMREX_ASSERT(!m_has_sigma_mf);
     }
 #endif
 
@@ -410,11 +409,21 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
                 auto const& phiebarr = m_phi_eb[amrlev].const_array(mfi);
 #if (AMREX_SPACEDIM == 2)
                 if (m_rz) {
-                    AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
-                    {
-                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,levset,dmarr,ecx,ecy,
-                                                phiebarr, sig0, dx0, dx1, xlo, alpha);
-                    });
+                    if (m_has_sigma_mf) {
+                        auto const& sigarr = m_sigma_mf[amrlev][mglev]->const_array(mfi);
+                        auto const& vfrc = factory->getVolFrac().const_array(mfi);
+                        AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                        {
+                            mlebndfdlap_sig_adotx_rz_eb(i,j,k,yarr,xarr,levset,dmarr,ecx,ecy,
+                                                        sigarr, vfrc, phiebarr, dx0, dx1, xlo, alpha);
+                        });
+                    } else {
+                        AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                        {
+                            mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,levset,dmarr,ecx,ecy,
+                                                    phiebarr, sig0, dx0, dx1, xlo, alpha);
+                        });
+                    }
                 } else
 #endif
                 if (m_has_sigma_mf) {
@@ -435,11 +444,21 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
             } else {
 #if (AMREX_SPACEDIM == 2)
                 if (m_rz) {
-                    AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
-                    {
-                        mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,levset,dmarr,ecx,ecy,
-                                                phieb, sig0, dx0, dx1, xlo, alpha);
-                    });
+                    if (m_has_sigma_mf) {
+                        auto const& sigarr = m_sigma_mf[amrlev][mglev]->const_array(mfi);
+                        auto const& vfrc = factory->getVolFrac().const_array(mfi);
+                        AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                        {
+                            mlebndfdlap_sig_adotx_rz_eb(i,j,k,yarr,xarr,levset,dmarr,ecx,ecy,
+                                                        sigarr, vfrc, phieb, dx0, dx1, xlo, alpha);
+                        });
+                    } else {
+                        AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                        {
+                            mlebndfdlap_adotx_rz_eb(i,j,k,yarr,xarr,levset,dmarr,ecx,ecy,
+                                                    phieb, sig0, dx0, dx1, xlo, alpha);
+                        });
+                    }
                 } else
 #endif
                 if (m_has_sigma_mf) {
@@ -535,11 +554,21 @@ MLEBNodeFDLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
                 auto const& levset = factory->getLevelSet().const_array(mfi);
 #if (AMREX_SPACEDIM == 2)
                 if (m_rz) {
-                    AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
-                    {
-                        mlebndfdlap_gsrb_rz_eb(i,j,k,solarr,rhsarr,levset,dmskarr,ecx,ecy,
-                                               sig0, dx0, dx1, xlo, redblack, alpha);
-                    });
+                    if (m_has_sigma_mf) {
+                        auto const& sigarr = m_sigma_mf[amrlev][mglev]->const_array(mfi);
+                        auto const& vfrc = factory->getVolFrac().const_array(mfi);
+                        AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                        {
+                            mlebndfdlap_sig_gsrb_rz_eb(i,j,k,solarr,rhsarr,levset,dmskarr,ecx,ecy,
+                                                       sigarr, vfrc, dx0, dx1, xlo, redblack, alpha);
+                        });
+                    } else {
+                        AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                        {
+                            mlebndfdlap_gsrb_rz_eb(i,j,k,solarr,rhsarr,levset,dmskarr,ecx,ecy,
+                                                   sig0, dx0, dx1, xlo, redblack, alpha);
+                        });
+                    }
                 } else
 #endif
                 if (m_has_sigma_mf) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -316,6 +316,9 @@ MLEBNodeFDLaplacian::prepareForSolve ()
         if (m_sigma[0] == 0._rt) {
             m_sigma[0] = 1._rt; // For backward compatibility
         }
+#ifndef AMREX_USE_EB
+        AMREX_ASSERT(!m_has_sigma_mf);
+#endif
     }
 #endif
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -316,9 +316,6 @@ MLEBNodeFDLaplacian::prepareForSolve ()
         if (m_sigma[0] == 0._rt) {
             m_sigma[0] = 1._rt; // For backward compatibility
         }
-#ifndef AMREX_USE_EB
-        AMREX_ASSERT(!m_has_sigma_mf);
-#endif
     }
 #endif
 
@@ -485,10 +482,18 @@ MLEBNodeFDLaplacian::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFa
         {
 #if (AMREX_SPACEDIM == 2)
             if (m_rz) {
-                AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
-                {
-                    mlebndfdlap_adotx_rz(i,j,k,yarr,xarr,dmarr,sig0,dx0,dx1,xlo,alpha);
-                });
+                if (m_has_sigma_mf) {
+                    auto const& sigarr = m_sigma_mf[amrlev][mglev]->const_array(mfi);
+                    AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                    {
+                        mlebndfdlap_sig_adotx_rz(i,j,k,yarr,xarr,dmarr,sigarr,dx0,dx1,xlo,alpha);
+                    });
+                } else {
+                    AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                    {
+                        mlebndfdlap_adotx_rz(i,j,k,yarr,xarr,dmarr,sig0,dx0,dx1,xlo,alpha);
+                    });
+                }
             } else
 #endif
             if (m_has_sigma_mf) {
@@ -594,11 +599,20 @@ MLEBNodeFDLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
             {
 #if (AMREX_SPACEDIM == 2)
                 if (m_rz) {
-                    AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
-                    {
-                        mlebndfdlap_gsrb_rz(i,j,k,solarr,rhsarr,dmskarr,
-                                            sig0, dx0, dx1, xlo, redblack, alpha);
-                    });
+                    if (m_has_sigma_mf) {
+                        auto const& sigarr = m_sigma_mf[amrlev][mglev]->const_array(mfi);
+                        AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                        {
+                            mlebndfdlap_sig_gsrb_rz(i,j,k,solarr,rhsarr,dmskarr,sigarr,
+                                                    dx0, dx1, xlo, redblack, alpha);
+                        });
+                    } else {
+                        AMREX_HOST_DEVICE_FOR_3D(box, i, j, k,
+                        {
+                            mlebndfdlap_gsrb_rz(i,j,k,solarr,rhsarr,dmskarr,
+                                                sig0, dx0, dx1, xlo, redblack, alpha);
+                        });
+                    }
                 } else
 #endif
                 if (m_has_sigma_mf) {


### PR DESCRIPTION
## Summary

Currently the `MLEBNodeFDLaplacian` does not support a spatially varying sigma for RZ simulations. This PR adds functionality for this when compiled with EB support. Specifically, this is needed for an extension to the WarpX effective potential solver (see https://github.com/BLAST-WarpX/warpx/pull/6961).

## Additional background

I tested the new functionality by comparing the electrostatic solution in WarpX from using the "lab frame" electrostatic solver (uses constant sigma values) and the "effective potential" solver (which uses a sigma MF). The sigma MF was set to 1 everywhere to get the same system as with the constant sigma.

Result from this PR:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/4063773e-0b72-4c75-b995-b63781c30b59" />

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
