### PR TITLE
CMake Config: NOMPI

### DIFF
--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -727,6 +727,8 @@ A list of AMReX component names and related configure options are shown in the t
    +------------------------------+-----------------+
    | AMReX_MPI                    | MPI             |
    +------------------------------+-----------------+
+   | AMReX_NOMPI                  | No MPI          |
+   +------------------------------+-----------------+
    | AMReX_SIMD                   | SIMD            |
    +------------------------------+-----------------+
    | AMReX_OMP                    | OMP             |

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -725,7 +725,7 @@ A list of AMReX component names and related configure options are shown in the t
    +------------------------------+-----------------+
    | AMReX_PIC                    | PIC             |
    +------------------------------+-----------------+
-   | AMReX_MPI                    | MPI, NOMPI       |
+   | AMReX_MPI                    | MPI, NOMPI      |
    +------------------------------+-----------------+
    | AMReX_SIMD                   | SIMD            |
    +------------------------------+-----------------+

--- a/Docs/sphinx_documentation/source/BuildingAMReX.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX.rst
@@ -725,9 +725,7 @@ A list of AMReX component names and related configure options are shown in the t
    +------------------------------+-----------------+
    | AMReX_PIC                    | PIC             |
    +------------------------------+-----------------+
-   | AMReX_MPI                    | MPI             |
-   +------------------------------+-----------------+
-   | AMReX_NOMPI                  | No MPI          |
+   | AMReX_MPI                    | MPI, NOMPI       |
    +------------------------------+-----------------+
    | AMReX_SIMD                   | SIMD            |
    +------------------------------+-----------------+

--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -61,6 +61,11 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${AMReX_MODULE_PATH})
 
 # General options
 set(AMReX_MPI_FOUND                 @AMReX_MPI@)
+if(AMReX_MPI_FOUND)  # ensure users can request a no-MPI variant
+  set(AMReX_NOMPI_FOUND             FALSE)
+else()
+  set(AMReX_NOMPI_FOUND             TRUE)
+endif()
 set(AMReX_MPI_THREAD_MULTIPLE_FOUND @AMReX_MPI_THREAD_MULTIPLE@)
 set(AMReX_SIMD_FOUND                @AMReX_SIMD@)
 set(AMReX_OMP_FOUND                 @AMReX_OMP@)


### PR DESCRIPTION
## Summary

CMake package variants are opt-in. Since AMReX MPI and no-MPI builds are binary incompatible, users might want to `REQUIRE` to select a no-MPI build. This adds the respective option for them to use in `find_package(AMReX COMPONENTS ...)`.

## Additional background

This is useful when both an MPI and no-MPI variant are in the users install path.
While generally useful for other binary build options as well, MPI is the most critical and common option where we need to provide this.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
