### PR TITLE
Arena: add largest free block query

### DIFF
--- a/Src/Base/AMReX_Arena.H
+++ b/Src/Base/AMReX_Arena.H
@@ -191,6 +191,13 @@ public:
     */
     virtual std::size_t freeUnused () { return 0; }
 
+    /**
+    * \brief Return the largest free memory block already held by this Arena.
+    *
+    * A return value of 0 means this query is not applicable or unknown.
+    */
+    [[nodiscard]] virtual std::size_t largestFreeBlock () const { return 0; }
+
     //! Check whether the memory is accessible on the device. Note that
     //! isDeviceAccessible and isHostAccessible can both be true.
     [[nodiscard]] virtual bool isDeviceAccessible () const;

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -101,6 +101,9 @@ public:
     //! Return the amount of memory that can be freed
     [[nodiscard]] std::size_t freeableMemory () const;
 
+    //! Return the largest free memory block already held by this CArena.
+    [[nodiscard]] std::size_t largestFreeBlock () const final;
+
     /**
      * \brief Does the device have enough free memory for allocating this
      * much memory?  For CPU builds, this always return true.  This is not a
@@ -256,7 +259,7 @@ protected:
     //! The max amount of memory given out via alloc().
     std::size_t m_max_actually_used{0};
 
-    std::mutex carena_mutex;
+    mutable std::mutex carena_mutex;
 
     friend std::ostream& operator<< (std::ostream& os, const CArena& arena);
 };

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -404,6 +404,17 @@ CArena::freeableMemory () const
 }
 
 std::size_t
+CArena::largestFreeBlock () const
+{
+    std::scoped_lock lock(carena_mutex);
+    std::size_t nbytes = 0;
+    for (auto const& free_block : m_freelist) {
+        nbytes = std::max(nbytes, free_block.size());
+    }
+    return nbytes;
+}
+
+std::size_t
 CArena::freeUnused_protected ()
 {
     std::size_t nbytes = 0;


### PR DESCRIPTION
Add a virtual Arena::largestFreeBlock() query with a default return value of 0 for arenas where the value is not available. Override it in CArena to report the largest currently free block already held in the arena without triggering a new allocation.
