### PR TITLE
Make the "local" and "nGrow" arguments IntVects instead of ints for Redistribute

### DIFF
--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -259,6 +259,12 @@ be moved to their proper places in the container, and all invalid particles
 (particles with id set to :cpp:`-1`) will be removed. All the MPI communication
 needed to do this happens automatically.
 
+For short-range particle motion, :cpp:`Redistribute` can use a local communication
+algorithm. Set the local flag to :cpp:`true` only when every particle has moved no
+more than the supplied :cpp:`IntVect` number of cells in each direction since the
+last :cpp:`Redistribute()` call. Use the global algorithm after initialization,
+regridding, load balancing, or any update that may send particles arbitrarily far.
+
 Application codes will likely want to create their own derived
 ParticleContainer class that specializes the template parameters and adds
 additional functionality, like setting the initial conditions, moving the

--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -260,10 +260,12 @@ be moved to their proper places in the container, and all invalid particles
 needed to do this happens automatically.
 
 For short-range particle motion, :cpp:`Redistribute` can use a local communication
-algorithm. Set the local flag to :cpp:`true` only when every particle has moved no
-more than the supplied :cpp:`IntVect` number of cells in each direction since the
-last :cpp:`Redistribute()` call. Use the global algorithm after initialization,
-regridding, load balancing, or any update that may send particles arbitrarily far.
+algorithm. The overload with a boolean local flag accepts :cpp:`IntVect` values
+for both :cpp:`nGrow` and the maximum number of cells a particle may have moved.
+Set the local flag to :cpp:`true` only when every particle has moved no more than
+the supplied cell count in each direction since the last :cpp:`Redistribute()`
+call. Use the global algorithm after initialization, regridding, load balancing,
+or any update that may send particles arbitrarily far.
 
 Application codes will likely want to create their own derived
 ParticleContainer class that specializes the template parameters and adds

--- a/Src/Extern/HDF5/AMReX_ParticleHDF5.H
+++ b/Src/Extern/HDF5/AMReX_ParticleHDF5.H
@@ -1509,7 +1509,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             ++rptr;
         }
 
-        locateParticle(ptemp, pld, 0, finestLevel(), 0);
+        locateParticle(ptemp, pld, 0, finestLevel(), IntVect(0));
 
         std::pair<int, int> ind(grd, pld.m_tile);
 

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -350,16 +350,17 @@ public:
     }
 
     void Redistribute (int lev_min=0, int lev_max=-1, int nGrow=0,
-                       IntVect local=IntVect(0), bool remove_negative=true)
+                       int local=0, bool remove_negative=true)
     {
         clearNeighbors();
         ParticleContainerType::Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
     }
 
-    void Redistribute (int lev_min, int lev_max, int nGrow, int local,
-                       bool remove_negative=true)
+    void Redistribute (int lev_min, int lev_max, int nGrow,
+                       IntVect local, bool remove_negative=true)
     {
-        Redistribute(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
+        clearNeighbors();
+        ParticleContainerType::Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
     }
 
     void RedistributeLocal (bool remove_negative=true)

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -357,10 +357,12 @@ public:
     }
 
     void Redistribute (int lev_min, int lev_max, int nGrow,
-                       IntVect local, bool remove_negative=true)
+                       bool local, IntVect local_redistribute_ngrow,
+                       bool remove_negative=true)
     {
         clearNeighbors();
-        ParticleContainerType::Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
+        ParticleContainerType::Redistribute(lev_min, lev_max, nGrow, local,
+                                            local_redistribute_ngrow, remove_negative);
     }
 
     void RedistributeLocal (bool remove_negative=true)
@@ -370,7 +372,7 @@ public:
         const int nGrow = 0;
         const IntVect local(1);
         clearNeighbors();
-        this->Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
+        this->Redistribute(lev_min, lev_max, nGrow, true, local, remove_negative);
     }
 
 #ifdef AMREX_USE_GPU

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -349,11 +349,17 @@ public:
         calcCommSize();
     }
 
-    void Redistribute (int lev_min=0, int lev_max=-1, int nGrow=0, int local=0,
-                       bool remove_negative=true)
+    void Redistribute (int lev_min=0, int lev_max=-1, int nGrow=0,
+                       IntVect local=IntVect(0), bool remove_negative=true)
     {
         clearNeighbors();
         ParticleContainerType::Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
+    }
+
+    void Redistribute (int lev_min, int lev_max, int nGrow, int local,
+                       bool remove_negative=true)
+    {
+        Redistribute(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
     }
 
     void RedistributeLocal (bool remove_negative=true)
@@ -361,7 +367,7 @@ public:
         const int lev_min = 0;
         const int lev_max = 0;
         const int nGrow = 0;
-        const int local = 1;
+        const IntVect local(1);
         clearNeighbors();
         this->Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
     }

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -356,7 +356,7 @@ public:
         ParticleContainerType::Redistribute(lev_min, lev_max, nGrow, local, remove_negative);
     }
 
-    void Redistribute (int lev_min, int lev_max, int nGrow,
+    void Redistribute (int lev_min, int lev_max, IntVect nGrow,
                        bool local, IntVect max_cells_moved,
                        bool remove_negative=true)
     {
@@ -369,7 +369,7 @@ public:
     {
         const int lev_min = 0;
         const int lev_max = 0;
-        const int nGrow = 0;
+        const IntVect nGrow(0);
         const IntVect local(1);
         clearNeighbors();
         this->Redistribute(lev_min, lev_max, nGrow, true, local, remove_negative);

--- a/Src/Particle/AMReX_NeighborParticles.H
+++ b/Src/Particle/AMReX_NeighborParticles.H
@@ -357,12 +357,12 @@ public:
     }
 
     void Redistribute (int lev_min, int lev_max, int nGrow,
-                       bool local, IntVect local_redistribute_ngrow,
+                       bool local, IntVect max_cells_moved,
                        bool remove_negative=true)
     {
         clearNeighbors();
         ParticleContainerType::Redistribute(lev_min, lev_max, nGrow, local,
-                                            local_redistribute_ngrow, remove_negative);
+                                            max_cells_moved, remove_negative);
     }
 
     void RedistributeLocal (bool remove_negative=true)

--- a/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesGPUImpl.H
@@ -334,7 +334,7 @@ fillNeighborsGPU ()
     neighbor_copy_plan.clear();
     buildNeighborCopyOp();
     neighbor_copy_plan.build(*this, neighbor_copy_op, ghost_int_comp,
-                             ghost_real_comp, true);
+                             ghost_real_comp, true, IntVect(m_num_neighbor_cells));
     updateNeighborsGPU(false);
 }
 
@@ -351,7 +351,7 @@ updateNeighborsGPU (bool boundary_neighbors_only)
         neighbor_copy_plan.clear();
         buildNeighborCopyOp(true);
         neighbor_copy_plan.build(*this, neighbor_copy_op, ghost_int_comp,
-                                 ghost_real_comp, true);
+                                 ghost_real_comp, true, IntVect(m_num_neighbor_cells));
     }
 
     clearNeighbors();

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -508,29 +508,6 @@ public:
         buildMPIStart(pc, pc.BufferMap(), m_superparticle_size);
     }
 
-    template <class PC>
-    requires (IsParticleContainer<PC>::value)
-    void build (const PC& pc,
-                const ParticleCopyOp& op,
-                const Vector<int>& int_comp_mask,
-                const Vector<int>& real_comp_mask,
-                IntVect max_cells_moved)
-    {
-        build(pc, op, int_comp_mask, real_comp_mask,
-              max_cells_moved.allGT(0), max_cells_moved);
-    }
-
-    template <class PC>
-    requires (IsParticleContainer<PC>::value)
-    void build (const PC& pc,
-                const ParticleCopyOp& op,
-                const Vector<int>& int_comp_mask,
-                const Vector<int>& real_comp_mask,
-                int local)
-    {
-        build(pc, op, int_comp_mask, real_comp_mask, local > 0, IntVect(local));
-    }
-
     void clear ();
 
     void buildMPIFinish (const ParticleBufferMap& map);

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -410,7 +410,7 @@ public:
                 const ParticleCopyOp& op,
                 const Vector<int>& int_comp_mask,
                 const Vector<int>& real_comp_mask,
-                int local)
+                IntVect local)
     {
         BL_PROFILE("ParticleCopyPlan::build");
 
@@ -418,8 +418,8 @@ public:
         pp.query("do_one_sided_comms", m_do_one_sided_comms);
           const int num_buckets = pc.BufferMap().numBuckets();
 
-        m_local = local;
-        if (local)
+        m_local = local.allGT(0);
+        if (m_local)
         {
             m_neighbor_procs = pc.NeighborProcs(local);
         }
@@ -505,6 +505,17 @@ public:
                               + num_int_comm_comp  * sizeof(int);
 
         buildMPIStart(pc, pc.BufferMap(), m_superparticle_size);
+    }
+
+    template <class PC>
+    requires (IsParticleContainer<PC>::value)
+    void build (const PC& pc,
+                const ParticleCopyOp& op,
+                const Vector<int>& int_comp_mask,
+                const Vector<int>& real_comp_mask,
+                int local)
+    {
+        build(pc, op, int_comp_mask, real_comp_mask, IntVect(local));
     }
 
     void clear ();

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -410,7 +410,7 @@ public:
                 const ParticleCopyOp& op,
                 const Vector<int>& int_comp_mask,
                 const Vector<int>& real_comp_mask,
-                bool local, IntVect local_redistribute_ngrow)
+                bool local, IntVect max_cells_moved)
     {
         BL_PROFILE("ParticleCopyPlan::build");
 
@@ -418,11 +418,11 @@ public:
         pp.query("do_one_sided_comms", m_do_one_sided_comms);
           const int num_buckets = pc.BufferMap().numBuckets();
 
-        AMREX_ASSERT(!local || local_redistribute_ngrow.allGE(0));
+        AMREX_ASSERT(!local || max_cells_moved.allGE(0));
         m_local = local;
         if (m_local)
         {
-            m_neighbor_procs = pc.NeighborProcs(local_redistribute_ngrow);
+            m_neighbor_procs = pc.NeighborProcs(max_cells_moved);
         }
         else
         {
@@ -514,10 +514,10 @@ public:
                 const ParticleCopyOp& op,
                 const Vector<int>& int_comp_mask,
                 const Vector<int>& real_comp_mask,
-                IntVect local_redistribute_ngrow)
+                IntVect max_cells_moved)
     {
         build(pc, op, int_comp_mask, real_comp_mask,
-              local_redistribute_ngrow.allGT(0), local_redistribute_ngrow);
+              max_cells_moved.allGT(0), max_cells_moved);
     }
 
     template <class PC>

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -410,7 +410,7 @@ public:
                 const ParticleCopyOp& op,
                 const Vector<int>& int_comp_mask,
                 const Vector<int>& real_comp_mask,
-                IntVect local)
+                bool local, IntVect local_redistribute_ngrow)
     {
         BL_PROFILE("ParticleCopyPlan::build");
 
@@ -418,10 +418,11 @@ public:
         pp.query("do_one_sided_comms", m_do_one_sided_comms);
           const int num_buckets = pc.BufferMap().numBuckets();
 
-        m_local = local.allGT(0);
+        AMREX_ASSERT(!local || local_redistribute_ngrow.allGE(0));
+        m_local = local;
         if (m_local)
         {
-            m_neighbor_procs = pc.NeighborProcs(local);
+            m_neighbor_procs = pc.NeighborProcs(local_redistribute_ngrow);
         }
         else
         {
@@ -513,9 +514,21 @@ public:
                 const ParticleCopyOp& op,
                 const Vector<int>& int_comp_mask,
                 const Vector<int>& real_comp_mask,
+                IntVect local_redistribute_ngrow)
+    {
+        build(pc, op, int_comp_mask, real_comp_mask,
+              local_redistribute_ngrow.allGT(0), local_redistribute_ngrow);
+    }
+
+    template <class PC>
+    requires (IsParticleContainer<PC>::value)
+    void build (const PC& pc,
+                const ParticleCopyOp& op,
+                const Vector<int>& int_comp_mask,
+                const Vector<int>& real_comp_mask,
                 int local)
     {
-        build(pc, op, int_comp_mask, real_comp_mask, IntVect(local));
+        build(pc, op, int_comp_mask, real_comp_mask, local > 0, IntVect(local));
     }
 
     void clear ();

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -519,9 +519,14 @@ public:
 
     //! Like Redistribute(int, int, int, int, bool) but separates the local/global
     //! algorithm choice from the per-direction local distance.
+    //! \param lev_min The minimum level to consider.
+    //! \param lev_max The maximum level to consider.
+    //! \param nGrow If particles are within nGrow cells of their current box,
+    //!        they will not be moved.
     //! \param local If true, use the local Redistribute algorithm.
     //! \param local_redistribute_ngrow The maximum number of cells a particle can
     //!        have moved since the last Redistribute() call in each direction.
+    //! \param remove_negative If true, remove particles with a negative ID.
     void Redistribute (int lev_min, int lev_max, int nGrow,
                        bool local, IntVect local_redistribute_ngrow,
                        bool remove_negative=true);

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -1288,15 +1288,6 @@ public:
       return doUnlink;
     }
 
-    void RedistributeCPU (int lev_min = 0, int lev_max = -1, int nGrow = 0,
-                          int local = 0, bool remove_negative=true)
-    {
-        RedistributeCPU(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
-    }
-
-    void RedistributeCPU (int lev_min, int lev_max, int nGrow,
-                          IntVect local, bool remove_negative=true);
-
     void Redistribute_impl (int lev_min = 0, int lev_max = -1, int nGrow = 0,
                             int local = 0, bool remove_negative=true)
     {

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -524,11 +524,11 @@ public:
     //! \param nGrow If particles are within nGrow cells of their current box,
     //!        they will not be moved.
     //! \param local If true, use the local Redistribute algorithm.
-    //! \param local_redistribute_ngrow The maximum number of cells a particle can
+    //! \param max_cells_moved The maximum number of cells a particle can
     //!        have moved since the last Redistribute() call in each direction.
     //! \param remove_negative If true, remove particles with a negative ID.
     void Redistribute (int lev_min, int lev_max, int nGrow,
-                       bool local, IntVect local_redistribute_ngrow,
+                       bool local, IntVect max_cells_moved,
                        bool remove_negative=true);
 
 
@@ -1304,7 +1304,7 @@ public:
     }
 
     void Redistribute_impl (int lev_min, int lev_max, int nGrow,
-                            bool local, IntVect local_redistribute_ngrow,
+                            bool local, IntVect max_cells_moved,
                             bool remove_negative=true);
 
     void ReserveForRedistribute (ParticleCopyPlan const& plan);

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -504,21 +504,23 @@ public:
     *              redistributed but are not necessarily at the same time as those on the coarse
     *              level.
     *              Default: 0
-    * \param local If all components are 0, this will be a non-local redistribute, meaning that
-    *              particles can potentially go to any other box in the simulation. Otherwise,
-    *              each component is the maximum number of cells a particle can have moved in
-    *              that direction since the last Redistribute() call. Knowing this allows an
-    *              optimized MPI communication pattern to be used.
+    * \param local If 0, this will be a non-local redistribute, meaning that particles can
+    *              potentially go to any other box in the simulation. Otherwise, it is the
+    *              maximum number of cells a particle can have moved since the last
+    *              Redistribute() call, applied uniformly in all directions. Knowing this
+    *              allows an optimized MPI communication pattern to be used.
     * \param remove_negative If true, remove particles with a negative ID. Default: true.
     */
     void Redistribute (int lev_min = 0, int lev_max = -1, int nGrow = 0,
-                       IntVect local=IntVect(0), bool remove_negative=true);
-
-    void Redistribute (int lev_min, int lev_max, int nGrow, int local,
-                       bool remove_negative=true)
+                       int local = 0, bool remove_negative=true)
     {
         Redistribute(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
     }
+
+    //! Like Redistribute(int, int, int, int, bool) but allows specifying a different
+    //! local distance per direction.
+    void Redistribute (int lev_min, int lev_max, int nGrow,
+                       IntVect local, bool remove_negative=true);
 
 
     /**
@@ -1287,22 +1289,22 @@ public:
     }
 
     void RedistributeCPU (int lev_min = 0, int lev_max = -1, int nGrow = 0,
-                          IntVect local=IntVect(0), bool remove_negative=true);
-
-    void RedistributeCPU (int lev_min, int lev_max, int nGrow, int local,
-                          bool remove_negative=true)
+                          int local = 0, bool remove_negative=true)
     {
         RedistributeCPU(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
     }
 
-    void Redistribute_impl (int lev_min = 0, int lev_max = -1, int nGrow = 0,
-                            IntVect local=IntVect(0), bool remove_negative=true);
+    void RedistributeCPU (int lev_min, int lev_max, int nGrow,
+                          IntVect local, bool remove_negative=true);
 
-    void Redistribute_impl (int lev_min, int lev_max, int nGrow, int local,
-                            bool remove_negative=true)
+    void Redistribute_impl (int lev_min = 0, int lev_max = -1, int nGrow = 0,
+                            int local = 0, bool remove_negative=true)
     {
         Redistribute_impl(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
     }
+
+    void Redistribute_impl (int lev_min, int lev_max, int nGrow,
+                            IntVect local, bool remove_negative=true);
 
     void ReserveForRedistribute (ParticleCopyPlan const& plan);
 

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -504,8 +504,8 @@ public:
     *              redistributed but are not necessarily at the same time as those on the coarse
     *              level.
     *              Default: 0
-    * \param local If 0, this will be a non-local redistribute, meaning that particles can
-    *              potentially go to any other box in the simulation. Otherwise, it is the
+    * \param local If not positive, this will be a non-local redistribute, meaning that particles
+    *              can potentially go to any other box in the simulation. Otherwise, it is the
     *              maximum number of cells a particle can have moved since the last
     *              Redistribute() call, applied uniformly in all directions. Knowing this
     *              allows an optimized MPI communication pattern to be used.
@@ -514,13 +514,17 @@ public:
     void Redistribute (int lev_min = 0, int lev_max = -1, int nGrow = 0,
                        int local = 0, bool remove_negative=true)
     {
-        Redistribute(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
+        Redistribute(lev_min, lev_max, nGrow, local > 0, IntVect(local), remove_negative);
     }
 
-    //! Like Redistribute(int, int, int, int, bool) but allows specifying a different
-    //! local distance per direction.
+    //! Like Redistribute(int, int, int, int, bool) but separates the local/global
+    //! algorithm choice from the per-direction local distance.
+    //! \param local If true, use the local Redistribute algorithm.
+    //! \param local_redistribute_ngrow The maximum number of cells a particle can
+    //!        have moved since the last Redistribute() call in each direction.
     void Redistribute (int lev_min, int lev_max, int nGrow,
-                       IntVect local, bool remove_negative=true);
+                       bool local, IntVect local_redistribute_ngrow,
+                       bool remove_negative=true);
 
 
     /**
@@ -1291,11 +1295,12 @@ public:
     void Redistribute_impl (int lev_min = 0, int lev_max = -1, int nGrow = 0,
                             int local = 0, bool remove_negative=true)
     {
-        Redistribute_impl(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
+        Redistribute_impl(lev_min, lev_max, nGrow, local > 0, IntVect(local), remove_negative);
     }
 
     void Redistribute_impl (int lev_min, int lev_max, int nGrow,
-                            IntVect local, bool remove_negative=true);
+                            bool local, IntVect local_redistribute_ngrow,
+                            bool remove_negative=true);
 
     void ReserveForRedistribute (ParticleCopyPlan const& plan);
 
@@ -1560,7 +1565,7 @@ private:
     AMREX_FORCE_INLINE
     int hostPartitionTile (ParticleTileType& src_tile,
                            int lev, int gid, int tid,
-                           int lev_min, int lev_max, int nGrow, IntVect local,
+                           int lev_min, int lev_max, int nGrow, bool local,
                            bool remove_negative, int myproc,
                            Gpu::DeviceVector<int>& boxes,
                            Gpu::DeviceVector<int>& levels,
@@ -1580,7 +1585,7 @@ private:
                            Gpu::DeviceVector<IntVect>& periodic_shift)
     {
         return hostPartitionTile(src_tile, lev, gid, tid,
-                                 lev_min, lev_max, nGrow, IntVect(local),
+                                 lev_min, lev_max, nGrow, local > 0,
                                  remove_negative, myproc,
                                  boxes, levels, tiles, src_indices, periodic_shift);
     }

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -514,20 +514,21 @@ public:
     void Redistribute (int lev_min = 0, int lev_max = -1, int nGrow = 0,
                        int local = 0, bool remove_negative=true)
     {
-        Redistribute(lev_min, lev_max, nGrow, local > 0, IntVect(local), remove_negative);
+        Redistribute(lev_min, lev_max, IntVect(nGrow),
+                     local > 0, IntVect(local), remove_negative);
     }
 
     //! Like Redistribute(int, int, int, int, bool) but separates the local/global
     //! algorithm choice from the per-direction local distance.
     //! \param lev_min The minimum level to consider.
     //! \param lev_max The maximum level to consider.
-    //! \param nGrow If particles are within nGrow cells of their current box,
-    //!        they will not be moved.
+    //! \param nGrow If particles are within nGrow cells of their current box
+    //!        in each direction, they will not be moved.
     //! \param local If true, use the local Redistribute algorithm.
     //! \param max_cells_moved The maximum number of cells a particle can
     //!        have moved since the last Redistribute() call in each direction.
     //! \param remove_negative If true, remove particles with a negative ID.
-    void Redistribute (int lev_min, int lev_max, int nGrow,
+    void Redistribute (int lev_min, int lev_max, IntVect nGrow,
                        bool local, IntVect max_cells_moved,
                        bool remove_negative=true);
 
@@ -1300,10 +1301,11 @@ public:
     void Redistribute_impl (int lev_min = 0, int lev_max = -1, int nGrow = 0,
                             int local = 0, bool remove_negative=true)
     {
-        Redistribute_impl(lev_min, lev_max, nGrow, local > 0, IntVect(local), remove_negative);
+        Redistribute_impl(lev_min, lev_max, IntVect(nGrow),
+                          local > 0, IntVect(local), remove_negative);
     }
 
-    void Redistribute_impl (int lev_min, int lev_max, int nGrow,
+    void Redistribute_impl (int lev_min, int lev_max, IntVect nGrow,
                             bool local, IntVect max_cells_moved,
                             bool remove_negative=true);
 
@@ -1465,7 +1467,7 @@ protected:
     /**
     * \brief Checks a particle's location on levels lev_min and higher.
     * Returns false if the particle does not exist on that level.
-    * Only if lev_min == lev_max, nGrow can be \> 0 (i.e., including
+    * Only if lev_min == lev_max, nGrow can be nonzero (i.e., including
     * nGrow ghost cells).
     *
     * \param prt
@@ -1477,7 +1479,8 @@ protected:
     */
     template <typename P>
     bool Where (const P& prt, ParticleLocData& pld,
-                int lev_min = 0, int lev_max = -1, int nGrow=0, int local_grid=-1) const;
+                int lev_min = 0, int lev_max = -1, IntVect nGrow=IntVect(0),
+                int local_grid=-1) const;
 
 
     /**
@@ -1570,7 +1573,7 @@ private:
     AMREX_FORCE_INLINE
     int hostPartitionTile (ParticleTileType& src_tile,
                            int lev, int gid, int tid,
-                           int lev_min, int lev_max, int nGrow, bool local,
+                           int lev_min, int lev_max, IntVect nGrow, bool local,
                            bool remove_negative, int myproc,
                            Gpu::DeviceVector<int>& boxes,
                            Gpu::DeviceVector<int>& levels,
@@ -1590,14 +1593,14 @@ private:
                            Gpu::DeviceVector<IntVect>& periodic_shift)
     {
         return hostPartitionTile(src_tile, lev, gid, tid,
-                                 lev_min, lev_max, nGrow, local > 0,
+                                 lev_min, lev_max, IntVect(nGrow), local > 0,
                                  remove_negative, myproc,
                                  boxes, levels, tiles, src_indices, periodic_shift);
     }
 
     template <typename P>
     void locateParticle (P& p, ParticleLocData& pld,
-                         int lev_min, int lev_max, int nGrow, int local_grid=-1) const;
+                         int lev_min, int lev_max, IntVect nGrow, int local_grid=-1) const;
 
     void Initialize ();
 

--- a/Src/Particle/AMReX_ParticleContainer.H
+++ b/Src/Particle/AMReX_ParticleContainer.H
@@ -504,14 +504,21 @@ public:
     *              redistributed but are not necessarily at the same time as those on the coarse
     *              level.
     *              Default: 0
-    * \param local If 0, this will be a non-local redistribute, meaning that particle can potentially
-    *              go to any other box in the simulation. If > 0, this is the maximum number of cells
-    *              a particle can have moved since the last Redistribute() call. Knowing this number
-    *              allows an optimized MPI communication pattern to be used.
+    * \param local If all components are 0, this will be a non-local redistribute, meaning that
+    *              particles can potentially go to any other box in the simulation. Otherwise,
+    *              each component is the maximum number of cells a particle can have moved in
+    *              that direction since the last Redistribute() call. Knowing this allows an
+    *              optimized MPI communication pattern to be used.
     * \param remove_negative If true, remove particles with a negative ID. Default: true.
     */
-    void Redistribute (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
-                       bool remove_negative=true);
+    void Redistribute (int lev_min = 0, int lev_max = -1, int nGrow = 0,
+                       IntVect local=IntVect(0), bool remove_negative=true);
+
+    void Redistribute (int lev_min, int lev_max, int nGrow, int local,
+                       bool remove_negative=true)
+    {
+        Redistribute(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
+    }
 
 
     /**
@@ -1279,11 +1286,23 @@ public:
       return doUnlink;
     }
 
-    void RedistributeCPU (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
-                          bool remove_negative=true);
+    void RedistributeCPU (int lev_min = 0, int lev_max = -1, int nGrow = 0,
+                          IntVect local=IntVect(0), bool remove_negative=true);
 
-    void Redistribute_impl (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
-                            bool remove_negative=true);
+    void RedistributeCPU (int lev_min, int lev_max, int nGrow, int local,
+                          bool remove_negative=true)
+    {
+        RedistributeCPU(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
+    }
+
+    void Redistribute_impl (int lev_min = 0, int lev_max = -1, int nGrow = 0,
+                            IntVect local=IntVect(0), bool remove_negative=true);
+
+    void Redistribute_impl (int lev_min, int lev_max, int nGrow, int local,
+                            bool remove_negative=true)
+    {
+        Redistribute_impl(lev_min, lev_max, nGrow, IntVect(local), remove_negative);
+    }
 
     void ReserveForRedistribute (ParticleCopyPlan const& plan);
 
@@ -1548,13 +1567,30 @@ private:
     AMREX_FORCE_INLINE
     int hostPartitionTile (ParticleTileType& src_tile,
                            int lev, int gid, int tid,
-                           int lev_min, int lev_max, int nGrow, int local,
+                           int lev_min, int lev_max, int nGrow, IntVect local,
                            bool remove_negative, int myproc,
                            Gpu::DeviceVector<int>& boxes,
                            Gpu::DeviceVector<int>& levels,
                            Gpu::DeviceVector<int>& tiles,
                            Gpu::DeviceVector<int>& src_indices,
                            Gpu::DeviceVector<IntVect>& periodic_shift);
+
+    AMREX_FORCE_INLINE
+    int hostPartitionTile (ParticleTileType& src_tile,
+                           int lev, int gid, int tid,
+                           int lev_min, int lev_max, int nGrow, int local,
+                           bool remove_negative, int myproc,
+                           Gpu::DeviceVector<int>& boxes,
+                           Gpu::DeviceVector<int>& levels,
+                           Gpu::DeviceVector<int>& tiles,
+                           Gpu::DeviceVector<int>& src_indices,
+                           Gpu::DeviceVector<IntVect>& periodic_shift)
+    {
+        return hostPartitionTile(src_tile, lev, gid, tid,
+                                 lev_min, lev_max, nGrow, IntVect(local),
+                                 remove_negative, myproc,
+                                 boxes, levels, tiles, src_indices, periodic_shift);
+    }
 
     template <typename P>
     void locateParticle (P& p, ParticleLocData& pld,

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -265,9 +265,14 @@ public:
         { return m_particle_handshake_window ? m_particle_handshake_window->win : MPI_WIN_NULL; }
 #endif
 
-    Vector<int> NeighborProcs(int ngrow) const
+    Vector<int> NeighborProcs(IntVect ngrow) const
     {
         return computeNeighborProcs(this->GetParGDB(), ngrow);
+    }
+
+    Vector<int> NeighborProcs(int ngrow) const
+    {
+        return NeighborProcs(IntVect(ngrow));
     }
 
     template <class MF>
@@ -297,7 +302,12 @@ public:
 
 protected:
 
-    void BuildRedistributeMask (int lev, int nghost=1) const;
+    void BuildRedistributeMask (int lev, IntVect nghost) const;
+
+    void BuildRedistributeMask (int lev, int nghost=1) const
+    {
+        BuildRedistributeMask(lev, IntVect(nghost));
+    }
     void defineBufferMap () const;
 
     int         m_verbose{0};
@@ -308,7 +318,7 @@ protected:
     Arena* m_arena = nullptr;
 
     mutable std::unique_ptr<iMultiFab> redistribute_mask_ptr;
-    mutable int redistribute_mask_nghost = std::numeric_limits<int>::min();
+    mutable IntVect redistribute_mask_nghost = IntVect(std::numeric_limits<int>::min());
     mutable amrex::Vector<int> neighbor_procs;
     mutable ParticleBufferMap m_buffer_map;
 

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -329,13 +329,13 @@ int ParticleContainerBase::AggregationBuffer ()
     return aggregation_buffer;
 }
 
-void ParticleContainerBase::BuildRedistributeMask (int lev, int nghost) const
+void ParticleContainerBase::BuildRedistributeMask (int lev, IntVect nghost) const
 {
     BL_PROFILE("ParticleContainer::BuildRedistributeMask");
     AMREX_ASSERT(lev == 0);
 
     if (redistribute_mask_ptr == nullptr ||
-        redistribute_mask_nghost < nghost ||
+        ! redistribute_mask_nghost.allGE(nghost) ||
         ! BoxArray::SameRefs(redistribute_mask_ptr->boxArray(), this->ParticleBoxArray(lev)) ||
         ! DistributionMapping::SameRefs(redistribute_mask_ptr->DistributionMap(), this->ParticleDistributionMap(lev)))
     {

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1236,7 +1236,8 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::Redistribute (int lev_min, int lev_max, int nGrow, IntVect local, bool remove_negative)
+::Redistribute (int lev_min, int lev_max, int nGrow,
+                bool local, IntVect local_redistribute_ngrow, bool remove_negative)
 {
     BL_PROFILE_SYNC_START_TIMED("SyncBeforeComms: Redist");
 
@@ -1246,7 +1247,8 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         "runtime real components for positions"
     );
 
-    Redistribute_impl(lev_min, lev_max, nGrow, local, remove_negative);
+    Redistribute_impl(lev_min, lev_max, nGrow, local, local_redistribute_ngrow,
+                      remove_negative);
 
     BL_PROFILE_SYNC_STOP();
 }
@@ -1353,7 +1355,7 @@ int
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::hostPartitionTile (ParticleTileType& src_tile,
                      int lev, int gid, int tid,
-                     int lev_min, int lev_max, int nGrow, IntVect local,
+                     int lev_min, int lev_max, int nGrow, bool local,
                      bool remove_negative, int myproc,
                      Gpu::DeviceVector<int>& boxes,
                      Gpu::DeviceVector<int>& levels,
@@ -1395,7 +1397,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         }
 
         // full locate
-        locateParticle(p, pld, lev_min, lev_max, nGrow, local.allGT(0) ? gid : -1);
+        locateParticle(p, pld, lev_min, lev_max, nGrow, local ? gid : -1);
         particlePostLocate(p, pld, lev);
 
         // particle may have been invalidated, so check if we need to remove again.
@@ -1440,9 +1442,14 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::Redistribute_impl (int lev_min, int lev_max, int nGrow, IntVect local, bool remove_negative)
+::Redistribute_impl (int lev_min, int lev_max, int nGrow,
+                     bool local, IntVect local_redistribute_ngrow, bool remove_negative)
 {
-    if (local.allGT(0)) { AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max, local) == 0); }
+    if (local) {
+        AMREX_ASSERT(local_redistribute_ngrow.allGE(0));
+        AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max,
+                                            local_redistribute_ngrow) == 0);
+    }
 
     BL_PROFILE("ParticleContainer::Redistribute_impl()");
     BL_PROFILE_VAR_NS("Redistribute_partition", blp_partition);
@@ -1474,7 +1481,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     this->defineBufferMap();
 
 #ifndef AMREX_USE_GPU
-    if (local.allGT(0)) { BuildRedistributeMask(0, local); }
+    if (local) { BuildRedistributeMask(0, local_redistribute_ngrow); }
 #else
     if (! m_particle_locator.isValid(GetParGDB(), do_tiling, tile_size)) { m_particle_locator.build(GetParGDB(), do_tiling, tile_size); }
     m_particle_locator.setGeometry(GetParGDB());
@@ -1661,7 +1668,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     ParticleCopyPlan plan;
 
     plan.build(*this, op, h_redistribute_int_comp,
-               h_redistribute_real_comp, local);
+               h_redistribute_real_comp, local, local_redistribute_ngrow);
 
     // by default, this uses The_Arena();
     amrex::PODVector<char, PolymorphicArenaAllocator<char> > snd_buffer;

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1236,7 +1236,7 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::Redistribute (int lev_min, int lev_max, int nGrow, int local, bool remove_negative)
+::Redistribute (int lev_min, int lev_max, int nGrow, IntVect local, bool remove_negative)
 {
     BL_PROFILE_SYNC_START_TIMED("SyncBeforeComms: Redist");
 
@@ -1353,7 +1353,7 @@ int
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::hostPartitionTile (ParticleTileType& src_tile,
                      int lev, int gid, int tid,
-                     int lev_min, int lev_max, int nGrow, int local,
+                     int lev_min, int lev_max, int nGrow, IntVect local,
                      bool remove_negative, int myproc,
                      Gpu::DeviceVector<int>& boxes,
                      Gpu::DeviceVector<int>& levels,
@@ -1395,7 +1395,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         }
 
         // full locate
-        locateParticle(p, pld, lev_min, lev_max, nGrow, local ? gid : -1);
+        locateParticle(p, pld, lev_min, lev_max, nGrow, local.allGT(0) ? gid : -1);
         particlePostLocate(p, pld, lev);
 
         // particle may have been invalidated, so check if we need to remove again.
@@ -1440,9 +1440,9 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::Redistribute_impl (int lev_min, int lev_max, int nGrow, int local, bool remove_negative)
+::Redistribute_impl (int lev_min, int lev_max, int nGrow, IntVect local, bool remove_negative)
 {
-    if (local) { AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max, local) == 0); }
+    if (local.allGT(0)) { AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max, local) == 0); }
 
     BL_PROFILE("ParticleContainer::Redistribute_impl()");
     BL_PROFILE_VAR_NS("Redistribute_partition", blp_partition);
@@ -1474,7 +1474,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     this->defineBufferMap();
 
 #ifndef AMREX_USE_GPU
-    if (local > 0) { BuildRedistributeMask(0, local); }
+    if (local.allGT(0)) { BuildRedistributeMask(0, local); }
 #else
     if (! m_particle_locator.isValid(GetParGDB(), do_tiling, tile_size)) { m_particle_locator.build(GetParGDB(), do_tiling, tile_size); }
     m_particle_locator.setGeometry(GetParGDB());

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -218,7 +218,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
          ParticleLocData&    pld,
          int                 lev_min,
          int                 lev_max,
-         int                 nGrow,
+         IntVect             nGrow,
          int                 local_grid) const
 {
 
@@ -230,7 +230,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
   AMREX_ASSERT(lev_max <= finestLevel());
 
-  AMREX_ASSERT(nGrow == 0 || (nGrow >= 0 && lev_min == lev_max));
+  AMREX_ASSERT(nGrow == 0 || (nGrow.allGE(0) && lev_min == lev_max));
 
   std::vector< std::pair<int, Box> > isects;
 
@@ -257,13 +257,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
           bool findfirst = (nGrow == 0) ? true : false;
           ba.intersections(Box(iv, iv), isects, findfirst, nGrow);
           grid = isects.empty() ? -1 : isects[0].first;
-          if (nGrow > 0 && std::ssize(isects) > 1) {
+          if (nGrow != 0 && std::ssize(isects) > 1) {
              for (auto & isect : isects) {
                  Box bx = ba.getCellCenteredBox(isect.first);
                  for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
                      Box gbx = bx;
                      IntVect gr(IntVect::TheZeroVector());
-                     gr[dir] = nGrow;
+                     gr[dir] = nGrow[dir];
                      gbx.grow(gr);
                      if (gbx.contains(iv)) {
                         grid = isect.first;
@@ -445,7 +445,7 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
 template <typename P>
 void
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>::locateParticle (P& p, ParticleLocData& pld,
-                                                                                        int lev_min, int lev_max, int nGrow, int local_grid) const
+                                                                                        int lev_min, int lev_max, IntVect nGrow, int local_grid) const
 {
     bool success;
     if (Geom(0).outsideRoundoffDomain(AMREX_D_DECL(p.pos(0), p.pos(1), p.pos(2))))
@@ -461,12 +461,12 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     }
     else
     {
-        success = Where(p, pld, lev_min, lev_max, 0, local_grid);
+        success = Where(p, pld, lev_min, lev_max, IntVect(0), local_grid);
     }
 
     if (!success)
     {
-        success = (nGrow > 0) && Where(p, pld, lev_min, lev_min, nGrow);
+        success = (nGrow != 0) && Where(p, pld, lev_min, lev_min, nGrow);
         pld.m_grown_gridbox = pld.m_gridbox; // reset grown box for subsequent calls.
     }
 
@@ -1236,7 +1236,7 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::Redistribute (int lev_min, int lev_max, int nGrow,
+::Redistribute (int lev_min, int lev_max, IntVect nGrow,
                 bool local, IntVect max_cells_moved, bool remove_negative)
 {
     BL_PROFILE_SYNC_START_TIMED("SyncBeforeComms: Redist");
@@ -1355,7 +1355,7 @@ int
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::hostPartitionTile (ParticleTileType& src_tile,
                      int lev, int gid, int tid,
-                     int lev_min, int lev_max, int nGrow, bool local,
+                     int lev_min, int lev_max, IntVect nGrow, bool local,
                      bool remove_negative, int myproc,
                      Gpu::DeviceVector<int>& boxes,
                      Gpu::DeviceVector<int>& levels,
@@ -1442,7 +1442,7 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
           template<class> class Allocator, class CellAssignor>
 void
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
-::Redistribute_impl (int lev_min, int lev_max, int nGrow,
+::Redistribute_impl (int lev_min, int lev_max, IntVect nGrow,
                      bool local, IntVect max_cells_moved, bool remove_negative)
 {
     if (local) {

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1237,7 +1237,7 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
 void
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::Redistribute (int lev_min, int lev_max, int nGrow,
-                bool local, IntVect local_redistribute_ngrow, bool remove_negative)
+                bool local, IntVect max_cells_moved, bool remove_negative)
 {
     BL_PROFILE_SYNC_START_TIMED("SyncBeforeComms: Redist");
 
@@ -1247,7 +1247,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         "runtime real components for positions"
     );
 
-    Redistribute_impl(lev_min, lev_max, nGrow, local, local_redistribute_ngrow,
+    Redistribute_impl(lev_min, lev_max, nGrow, local, max_cells_moved,
                       remove_negative);
 
     BL_PROFILE_SYNC_STOP();
@@ -1443,12 +1443,12 @@ template <typename ParticleType, int NArrayReal, int NArrayInt,
 void
 ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssignor>
 ::Redistribute_impl (int lev_min, int lev_max, int nGrow,
-                     bool local, IntVect local_redistribute_ngrow, bool remove_negative)
+                     bool local, IntVect max_cells_moved, bool remove_negative)
 {
     if (local) {
-        AMREX_ASSERT(local_redistribute_ngrow.allGE(0));
+        AMREX_ASSERT(max_cells_moved.allGE(0));
         AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max,
-                                            local_redistribute_ngrow) == 0);
+                                            max_cells_moved) == 0);
     }
 
     BL_PROFILE("ParticleContainer::Redistribute_impl()");
@@ -1481,7 +1481,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     this->defineBufferMap();
 
 #ifndef AMREX_USE_GPU
-    if (local) { BuildRedistributeMask(0, local_redistribute_ngrow); }
+    if (local) { BuildRedistributeMask(0, max_cells_moved); }
 #else
     if (! m_particle_locator.isValid(GetParGDB(), do_tiling, tile_size)) { m_particle_locator.build(GetParGDB(), do_tiling, tile_size); }
     m_particle_locator.setGeometry(GetParGDB());
@@ -1668,7 +1668,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     ParticleCopyPlan plan;
 
     plan.build(*this, op, h_redistribute_int_comp,
-               h_redistribute_real_comp, local, local_redistribute_ngrow);
+               h_redistribute_real_comp, local, max_cells_moved);
 
     // by default, this uses The_Arena();
     amrex::PODVector<char, PolymorphicArenaAllocator<char> > snd_buffer;

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -924,7 +924,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             ++rptr;
         }
 
-        locateParticle(ptemp, pld, 0, finestLevel(), 0);
+        locateParticle(ptemp, pld, 0, finestLevel(), IntVect(0));
 
         std::pair<int, int> ind(grd, pld.m_tile);
 

--- a/Src/Particle/AMReX_ParticleLocator.H
+++ b/Src/Particle/AMReX_ParticleLocator.H
@@ -61,7 +61,14 @@ struct AssignGrid
 
     template <typename P, typename Assignor = DefaultAssignor>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    std::pair<int, int> operator() (const P& p, int nGrow=0, Assignor const& assignor = Assignor{}) const noexcept
+    std::pair<int, int> operator() (const P& p, int nGrow, Assignor const& assignor = Assignor{}) const noexcept
+    {
+        return this->operator()(p, IntVect(nGrow), assignor);
+    }
+
+    template <typename P, typename Assignor = DefaultAssignor>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    std::pair<int, int> operator() (const P& p, IntVect nGrow=IntVect(0), Assignor const& assignor = Assignor{}) const noexcept
     {
         const auto iv = assignor(p, m_plo, m_dxi, m_domain);
         return this->operator()(iv, nGrow);
@@ -70,17 +77,24 @@ struct AssignGrid
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     std::pair<int, int> operator() (const IntVect& iv, int nGrow=0) const noexcept
     {
+        return this->operator()(iv, IntVect(nGrow));
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    std::pair<int, int> operator() (const IntVect& iv, IntVect nGrow) const noexcept
+    {
         if (AMREX_D_TERM((m_num_bins.x == 0), && (m_num_bins.y == 0), && (m_num_bins.z == 0))) {
             return {-1, -1};
         }
         const auto lo = iv.dim3();
-        int ix_lo = amrex::max((lo.x - nGrow - m_lo.x) / m_bin_size.x - 1, 0);
-        int iy_lo = amrex::max((lo.y - nGrow - m_lo.y) / m_bin_size.y - 1, 0);
-        int iz_lo = amrex::max((lo.z - nGrow - m_lo.z) / m_bin_size.z - 1, 0);
+        const auto ng = nGrow.dim3(0);
+        int ix_lo = amrex::max((lo.x - ng.x - m_lo.x) / m_bin_size.x - 1, 0);
+        int iy_lo = amrex::max((lo.y - ng.y - m_lo.y) / m_bin_size.y - 1, 0);
+        int iz_lo = amrex::max((lo.z - ng.z - m_lo.z) / m_bin_size.z - 1, 0);
 
-        int ix_hi = amrex::min((lo.x + nGrow - m_lo.x) / m_bin_size.x, m_num_bins.x-1);
-        int iy_hi = amrex::min((lo.y + nGrow - m_lo.y) / m_bin_size.y, m_num_bins.y-1);
-        int iz_hi = amrex::min((lo.z + nGrow - m_lo.z) / m_bin_size.z, m_num_bins.z-1);
+        int ix_hi = amrex::min((lo.x + ng.x - m_lo.x) / m_bin_size.x, m_num_bins.x-1);
+        int iy_hi = amrex::min((lo.y + ng.y - m_lo.y) / m_bin_size.y, m_num_bins.y-1);
+        int iz_hi = amrex::min((lo.z + ng.z - m_lo.z) / m_bin_size.z, m_num_bins.z-1);
         int loc_gid = -1;
         int loc_tid = -1;
         for (int kk = iz_lo; kk <= iz_hi; ++kk) {
@@ -103,7 +117,7 @@ struct AssignGrid
                             // Prefer particle not in corner ghost cells
                             for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
                                 Box gdbx = bx;
-                                gdbx.grow(dir, nGrow);
+                                gdbx.grow(dir, nGrow[dir]);
                                 if (gdbx.contains(iv)) {
                                     loc_gid = nbor.first;
                                     loc_tid = tile;
@@ -256,6 +270,14 @@ struct AmrAssignGrid
     template <typename P, typename Assignor = DefaultAssignor>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     GpuTuple<int, int, int> operator() (const P& p, int lev_min=-1, int lev_max=-1, int nGrow=0,
+                                        Assignor const& assignor = {}) const noexcept
+    {
+        return this->operator()(p, lev_min, lev_max, IntVect(nGrow), assignor);
+    }
+
+    template <typename P, typename Assignor = DefaultAssignor>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    GpuTuple<int, int, int> operator() (const P& p, int lev_min, int lev_max, IntVect nGrow,
                                         Assignor const& assignor = {}) const noexcept
     {
         lev_min = (lev_min == -1) ? 0 : lev_min;

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -659,7 +659,7 @@ partitionParticlesByDest (PTile& ptile, const PLocator& ploc, CellAssignor const
                           const GpuArray<ParticleReal,AMREX_SPACEDIM>& rhi,
                           const GpuArray<int ,AMREX_SPACEDIM>& is_per,
                           int lev, int gid, int tid,
-                          int lev_min, int lev_max, int nGrow, bool remove_negative)
+                          int lev_min, int lev_max, IntVect nGrow, bool remove_negative)
 {
     auto getPID = pmap.getPIDFunctor();
     int pid = ParallelContext::MyProcSub();

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -747,6 +747,8 @@ IntVect computeRefFac (const ParGDBBase* a_gdb, int src_lev, int lev);
 
 Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, int ngrow);
 
+Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, IntVect ngrow);
+
 /// \cond DOXYGEN_IGNORE
 namespace particle_detail
 {

--- a/Src/Particle/AMReX_ParticleUtil.cpp
+++ b/Src/Particle/AMReX_ParticleUtil.cpp
@@ -19,7 +19,7 @@ IntVect computeRefFac (const ParGDBBase* a_gdb, int src_lev, int lev)
     return ref_fac;
 }
 
-Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, int ngrow)
+Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, IntVect ngrow)
 {
     BL_PROFILE("amrex::computeNeighborProcs");
 
@@ -63,6 +63,11 @@ Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, int ngrow)
 
     RemoveDuplicates(neighbor_procs);
     return neighbor_procs;
+}
+
+Vector<int> computeNeighborProcs (const ParGDBBase* a_gdb, int ngrow)
+{
+    return computeNeighborProcs(a_gdb, IntVect(ngrow));
 }
 }
 

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -64,7 +64,7 @@ public:
     {
         const int lev_min = 0;
         const int lev_max = finestLevel();
-        const int nGrow = 0;
+        const IntVect nGrow(0);
         const bool local = true;
         const IntVect max_cells_moved(1);
         Redistribute(lev_min, lev_max, nGrow, local, max_cells_moved, remove_neg);

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -66,8 +66,8 @@ public:
         const int lev_max = finestLevel();
         const int nGrow = 0;
         const bool local = true;
-        const IntVect local_redistribute_ngrow(1);
-        Redistribute(lev_min, lev_max, nGrow, local, local_redistribute_ngrow, remove_neg);
+        const IntVect max_cells_moved(1);
+        Redistribute(lev_min, lev_max, nGrow, local, max_cells_moved, remove_neg);
     }
 
     void RedistributeGlobal (bool remove_neg=true)

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -65,8 +65,9 @@ public:
         const int lev_min = 0;
         const int lev_max = finestLevel();
         const int nGrow = 0;
-        const int local = 1;
-        Redistribute(lev_min, lev_max, nGrow, local, remove_neg);
+        const bool local = true;
+        const IntVect local_redistribute_ngrow(1);
+        Redistribute(lev_min, lev_max, nGrow, local, local_redistribute_ngrow, remove_neg);
     }
 
     void RedistributeGlobal (bool remove_neg=true)


### PR DESCRIPTION
This could be useful for cases where the particle motion is anisotropic. 

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
