### PR TITLE
placementNew/placementDelete: simplify with if constexpr and trivially_copyable

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -94,48 +94,51 @@ makeArray4 (T* p, Box const& bx, int ncomp) noexcept
     return Array4<T>{p, amrex::begin(bx), amrex::end(bx), ncomp};
 }
 
+/**
+ * \brief Start the lifetime of objects in a preallocated buffer.
+ *
+ * Trivially copyable types (including arithmetic types and simple aggregates)
+ * need no construction — their lifetime begins implicitly once storage is
+ * allocated.  For non-trivially-copyable types, placement-new is called on
+ * each element via AMReX host/device loops so both CPU and GPU resident
+ * buffers are initialized correctly.
+ *
+ * \note In C++23, \c std::is_implicit_lifetime could replace
+ * \c std::is_trivially_copyable for an even more precise condition.
+ */
 template <typename T>
-requires (std::is_arithmetic_v<T>)
-void
-placementNew (T* const /*ptr*/, Long /*n*/)
-{}
-
-template <typename T>
-requires (std::is_trivially_default_constructible_v<T> && !std::is_arithmetic_v<T>)
 void
 placementNew (T* const ptr, Long n)
 {
-    for (Long i = 0; i < n; ++i) {
-        new (ptr+i) T;
+    amrex::ignore_unused(ptr,n);
+    // In C++23, we could switch to std::is_implicit_lifetime_v
+    if constexpr (!std::is_trivially_copyable_v<T>) {
+        AMREX_HOST_DEVICE_FOR_1D ( n, i,
+        {
+            new (ptr+i) T;
+        });
     }
 }
 
+/**
+ * \brief Destroy objects previously constructed via placementNew.
+ *
+ * Trivially destructible types need no destruction — their lifetime ends
+ * implicitly when storage is released.  For non-trivially-destructible types,
+ * the destructor is called on each element via AMReX host/device loops so
+ * both CPU and GPU resident buffers are finalized correctly.
+ */
 template <typename T>
-requires (!std::is_trivially_default_constructible_v<T>)
-void
-placementNew (T* const ptr, Long n)
-{
-    AMREX_HOST_DEVICE_FOR_1D ( n, i,
-    {
-        new (ptr+i) T;
-    });
-}
-
-template <typename T>
-requires (std::is_trivially_destructible_v<T>)
-void
-placementDelete (T* const /*ptr*/, Long /*n*/)
-{}
-
-template <typename T>
-requires (!std::is_trivially_destructible_v<T>)
 void
 placementDelete (T* const ptr, Long n)
 {
-    AMREX_HOST_DEVICE_FOR_1D (n, i,
-    {
-        (ptr+i)->~T();
-    });
+    amrex::ignore_unused(ptr,n);
+    if constexpr (!std::is_trivially_destructible_v<T>) {
+        AMREX_HOST_DEVICE_FOR_1D (n, i,
+        {
+            (ptr+i)->~T();
+        });
+    }
 }
 
 /**


### PR DESCRIPTION
Replace the three requires-overloads of placementNew with a single function using if constexpr.  Use std::is_trivially_copyable instead of std::is_trivially_default_constructible — trivially copyable types (including arithmetic and POD types) begin their lifetime implicitly once storage is allocated and need no placement-new.  Add matching Doxygen comments for both functions.

Breaking change: BaseFab<T> no longer default-constructs trivially copyable element types. Code that relied on BaseFab<T> allocation/resize to initialize values, including BaseFab<GpuComplex<T>> zero-initialization, must explicitly fill or write the data before reading it. This is consistent with the existing behavior for arithmetic types, which are not initialized on allocation; in that sense, the new behavior is arguably the less surprising one for BaseFab storage.
