### PR TITLE
GNUMake:  add VERBOSE=QUIET option to suppress per-file build messages

### DIFF
--- a/Tools/GNUMake/Make.rules
+++ b/Tools/GNUMake/Make.rules
@@ -16,12 +16,20 @@ vpath AMReX_Version.H $(srcTempDir)
 
 FCPPFLAGS := $(addprefix $(CPP_PREFIX), $(CPPFLAGS))
 
-# Suppress display of executed commands.  Default verbose
+# Suppress display of executed commands.  Default verbose.
+#   VERBOSE=FALSE (or OFF) hides the full command lines but keeps the
+#   per-file "Compiling foo.cpp ..." / "Depending ..." progress lines.
+#   VERBOSE=QUIET additionally suppresses those per-file progress lines.
+
 SILENT =
+ECHO = echo
 ifeq ($(VERBOSE),OFF)
   SILENT = @
 else ifeq ($(VERBOSE),FALSE)
   SILENT = @
+else ifeq ($(VERBOSE),QUIET)
+  SILENT = @
+  ECHO = true
 endif
 
 ifndef LINKFLAGS
@@ -257,7 +265,7 @@ FORCE:
 # Rules for objects.
 #
 $(objEXETempDir)/%.o: %.cpp $(srcTempDir)/AMReX_Config.H $(srcTempDir)/AMReX_Version.H $(AUTO_BUILD_SOURCES)
-	@echo Compiling $*.cpp ...
+	@$(ECHO) Compiling $*.cpp ...
 	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
@@ -274,7 +282,7 @@ ifeq ($(LOG_BUILD_TIME),TRUE)
 endif
 
 $(objEXETempDir)/%.o: %.c $(srcTempDir)/AMReX_Config.H $(srcTempDir)/AMReX_Version.H $(AUTO_BUILD_SOURCES)
-	@echo Compiling $*.c ...
+	@$(ECHO) Compiling $*.c ...
 	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
@@ -286,7 +294,7 @@ ifeq ($(LOG_BUILD_TIME),TRUE)
 endif
 
 $(objEXETempDir)/%.o: %.f
-	@echo Compiling $*.f ...
+	@$(ECHO) Compiling $*.f ...
 	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
@@ -298,7 +306,7 @@ ifeq ($(LOG_BUILD_TIME),TRUE)
 endif
 
 $(objEXETempDir)/%.o: %.F $(srcTempDir)/AMReX_Config.H $(srcTempDir)/AMReX_Version.H $(AUTO_BUILD_SOURCES)
-	@echo Compiling $*.F ...
+	@$(ECHO) Compiling $*.F ...
 	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 	@if [ ! -d $(f77EXETempDir) ]; then mkdir -p $(f77EXETempDir); fi
 ifeq ($(LOG_BUILD_TIME),TRUE)
@@ -312,7 +320,7 @@ ifeq ($(LOG_BUILD_TIME),TRUE)
 endif
 
 $(objEXETempDir)/%.o: %.f90
-	@echo Compiling $*.f90 ...
+	@$(ECHO) Compiling $*.f90 ...
 	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
@@ -324,7 +332,7 @@ ifeq ($(LOG_BUILD_TIME),TRUE)
 endif
 
 $(objEXETempDir)/%.o: %.F90 $(srcTempDir)/AMReX_Config.H $(srcTempDir)/AMReX_Version.H $(AUTO_BUILD_SOURCES)
-	@echo Compiling $*.F90 ...
+	@$(ECHO) Compiling $*.F90 ...
 	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 ifeq ($(LOG_BUILD_TIME),TRUE)
 	@if [ ! -d $(tmpEXETempDir) ]; then mkdir -p $(tmpEXETempDir); fi
@@ -340,7 +348,7 @@ endif
 #
 
 $(depEXETempDir)/%.d: %.cpp $(srcTempDir)/AMReX_Config.H $(srcTempDir)/AMReX_Version.H $(AUTO_BUILD_SOURCES)
-	@echo Depending $< ...
+	@$(ECHO) Depending $< ...
 	@if [ ! -d $(depEXETempDir) ]; then mkdir -p $(depEXETempDir); fi
 ifeq ($(USE_SYCL),TRUE)
         # Use > $@2 to filter out unnecessary messages
@@ -353,7 +361,7 @@ endif
 	@$(SHELL) -ec 'sed -i -e '\''s,$*\.o,$(objEXETempDir)/& $@,g'\'' $@'
 
 $(depEXETempDir)/%.d: %.c $(srcTempDir)/AMReX_Config.H $(srcTempDir)/AMReX_Version.H $(AUTO_BUILD_SOURCES)
-	@echo Depending $< ...
+	@$(ECHO) Depending $< ...
 	@if [ ! -d $(depEXETempDir) ]; then mkdir -p $(depEXETempDir); fi
 ifeq ($(USE_SYCL),TRUE)
 	$(CC) $(CDEPFLAGS) $< -o $@
@@ -397,14 +405,14 @@ endif
 #
 
 $(depEXETempDir)/%.d: %.F $(srcTempDir)/AMReX_Config.H $(srcTempDir)/AMReX_Version.H $(AUTO_BUILD_SOURCES)
-	@echo Depending $< ...
+	@$(ECHO) Depending $< ...
 	@if [ ! -d $(depEXETempDir) ]; then mkdir -p $(depEXETempDir); fi
 	@$(SHELL) -ec '$(MKDEP) -fortran $(fincludes) $< | \
 		sed -e '\''s,^[^:]*\/,,'\'' | \
 		sed -e '\''s,$*\.o,$(objEXETempDir)/& $@,'\'' > $@'
 
 $(depEXETempDir)/%.d: %.f $(srcTempDir)/AMReX_Config.H $(srcTempDir)/AMReX_Version.H $(AUTO_BUILD_SOURCES)
-	@echo Depending $< ...
+	@$(ECHO) Depending $< ...
 	@if [ ! -d $(depEXETempDir) ]; then mkdir -p $(depEXETempDir); fi
 	@$(SHELL) -ec '$(MKDEP) -fortran $(fincludes) $< | \
 		sed -e '\''s,^[^:]*\/,,'\'' | \

--- a/Tools/GNUMake/README.md
+++ b/Tools/GNUMake/README.md
@@ -34,6 +34,15 @@ commands include:
 * `make file_locations` shows the path of each file.
 * `make tags` and `make TAGS` generate tag files using `ctags` and `etags`, respectively.
 
+Build output verbosity is controlled by the `VERBOSE` make variable:
+
+* `VERBOSE=TRUE` (the default) echoes each compiler and linker command in full.
+* `VERBOSE=FALSE` (or `VERBOSE=OFF`) hides the full command lines but keeps the
+  per-file `Compiling foo.cpp ...` and `Depending ...` progress lines.
+* `VERBOSE=QUIET` additionally suppresses the per-file progress lines, leaving
+  only build milestones (e.g. `Linking`) and any warnings or errors.  This is
+  useful for continuous integration logs.
+
 The `Make.defs` includes the following files in the listed order:
 
 * `Make.machines`: This file defines three variables, `which_site`,


### PR DESCRIPTION
## Summary
Adds a new `VERBOSE=QUIET` value to the GNU Make build system that suppresses the per-file `Compiling foo.cpp` ... and `Depending` ... progress lines, in addition to the command-hiding that `VERBOSE=FALSE` already provides.

## Additional background
`Make.rules`: introduce an `ECHO` variable (default echo) and a third `VERBOSE` value. `VERBOSE=QUIET` sets `SILENT = @` (same as `FALSE`) and additionally` ECHO = true`, turning the per-file progress echoes into no-ops.

The per-file` @echo Compiling ...` and `@echo Depending ...` recipes now use `@$(ECHO) ....`

`Tools/GNUMake/README.md`: document all three `VERBOSE` values (the existing `TRUE/FALSE/OFF` behavior was previously undocumented).

All changes are backward-compatible.

Unchanged: the `make help` output (where the echo is the target's output), clean/uninstall targets, and once-per-build milestone lines such as Linking and Building libamrex.a, which are low volume and informative.

The per-file progress lines are emitted by unguarded `@echo` recipes in Make.rules, so they are printed regardless of the VERBOSE setting, and make -s does not suppress them either (it silences make's own command echoing, not echo commands inside a recipe). For a build with hundreds of source files this is the dominant source of CI log volume, which makes actual compiler errors harder to find.

VERBOSE=FALSE already removes the full command lines (the long g++ ... invocations); this new VERBOSE=QUIET option lets a user go one step further and remove the per-file messages too.

Verified all three values on a real GNU Make build (serial CPU, gnu comp):
VERBOSE=TRUE/default and VERBOSE=FALSE produce identical output to
before the change; VERBOSE=QUIET additionally drops the per-file `Compiling`
`/Depending` lines, leaving config generation, Linking, and the final link
command. Confirmed the error path is unaffected: a deliberate compile error
under `VERBOSE=QUIET` still prints the full compiler diagnostic and fails the
build with a nonzero exit.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate



