### PR TITLE
Add clear() to YAFluxRegister and EBFluxRegister; call it in define()

### DIFF
--- a/Src/Boundary/AMReX_YAFluxRegister.H
+++ b/Src/Boundary/AMReX_YAFluxRegister.H
@@ -66,6 +66,9 @@ public:
     //! Reset stored fluxes and flags before a coarse advance.
     void reset ();
 
+    //! Deallocate all data and reset to default-constructed state.
+    void clear ();
+
     /**
      * \brief Add coarse-level fluxes for the tile indicated by \p mfi.
      *
@@ -205,6 +208,7 @@ YAFluxRegisterT<MF>::define (const BoxArray& fba, const BoxArray& cba,
                              const Geometry& fgeom, const Geometry& cgeom,
                              const IntVect& ref_ratio, int fine_lev, int nvar)
 {
+    clear();
     m_fine_geom = fgeom;
     m_crse_geom = cgeom;
     m_ratio = ref_ratio;
@@ -414,6 +418,32 @@ YAFluxRegisterT<MF>::reset ()
 {
     m_crse_data.setVal(T(0.0));
     m_cfpatch.setVal(T(0.0));
+}
+
+template <typename MF>
+void
+YAFluxRegisterT<MF>::clear ()
+{
+    // Keep m_deterministic — it is a behavioral preference (how GPU
+    // reductions are done), not tied to the geometry or BoxArrays being
+    // defined.  Preserving it avoids surprising the user who set it once.
+    //
+    // m_deterministic is not reset here.
+
+    m_cvol = nullptr;
+    m_ncomp = 0;
+    m_fine_level = 0;
+    m_ratio = IntVect(1);
+    m_crse_geom = Geometry();
+    m_fine_geom = Geometry();
+
+    m_cfp_localindex.clear();
+    m_cfp_fab.clear();
+    m_cfp_mask.clear();
+    m_cfpatch.clear();
+    m_crse_fab_flag.clear();
+    m_crse_flag.clear();
+    m_crse_data.clear();
 }
 
 template <typename MF>

--- a/Src/EB/AMReX_EBFluxRegister.H
+++ b/Src/EB/AMReX_EBFluxRegister.H
@@ -94,6 +94,9 @@ public:
                  const Geometry& fgeom, const Geometry& cgeom,
                  const IntVect& ref_ratio, int fine_lev, int nvar);
 
+    //! Deallocate all data and reset to default-constructed state.
+    void clear ();
+
     using YAFluxRegister::CrseAdd;
     /**
      * \brief Add coarse fluxes for tiles containing cut cells (all components).

--- a/Src/EB/AMReX_EBFluxRegister.cpp
+++ b/Src/EB/AMReX_EBFluxRegister.cpp
@@ -73,6 +73,13 @@ EBFluxRegister::defineExtra (const BoxArray& fba, const DistributionMapping& fdm
 }
 
 void
+EBFluxRegister::clear ()
+{
+    m_cfp_inside_mask.clear();
+    YAFluxRegister::clear();
+}
+
+void
 EBFluxRegister::CrseAdd (const MFIter& mfi,
                          const std::array<FArrayBox const*, AMREX_SPACEDIM>& flux,
                          const Real* dx, Real dt,


### PR DESCRIPTION
YAFluxRegisterT::define() and EBFluxRegister::define() did not clear existing data before reinitializing.  While the internal MultiFab members handle redefinition safely via their own define() calls, two Vector members (m_cfp_localindex and the inner vectors of m_cfp_fab) are populated using push_back without being cleared first.  Calling define() on an already-defined object would accumulate stale entries, with m_cfp_fab holding dangling FAB* pointers into the old m_cfpatch.

Add a clear() method to both classes that releases all memory and resets geometry/ratio/level/ncomp to defaults.  call clear() at the start of YAFluxRegisterT::define() so redefinition is always safe.  preserve m_deterministic across clear() since it is a behavioral GPU flag, not geometry-dependent state.

EBFluxRegister::define() needs no extra change — the base define() clears, and defineExtra() already redefines m_cfp_inside_mask safely
