### PR TITLE
VisMF::Header ctor: use IOProcessorNumber(comm) instead of hardcoded 0

### DIFF
--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -738,7 +738,7 @@ VisMF::Header::Header (const FabArray<FArrayBox>& mf,
     }
 
     if(calcMinMax) {
-      CalculateMinMax(mf,0, comm);
+      CalculateMinMax(mf, ParallelDescriptor::IOProcessorNumber(comm), comm);
     }
 }
 


### PR DESCRIPTION
Replace the literal 0 with ParallelDescriptor::IOProcessorNumber(comm) in the convenience constructor's CalculateMinMax call, matching the convention used in VisMF::Write. Functionally a no-op (both resolve to 0), but removes a magic number and makes the intent consistent with the rest of the write path.
