### PR TITLE
Remove amrex::is_integer(const char*)

### DIFF
--- a/Src/Base/AMReX_Utility.H
+++ b/Src/Base/AMReX_Utility.H
@@ -40,9 +40,6 @@ namespace amrex
 * \brief Useful C++ Utility Functions
 */
 
-    //! Return true if argument is a non-zero length string of digits.
-    bool is_integer (const char* str);
-
     //! Return true and store value in v if string s is type T.
     template <typename T> bool is_it (std::string const& s, T& v);
 

--- a/Src/Base/AMReX_Utility.cpp
+++ b/Src/Base/AMReX_Utility.cpp
@@ -27,27 +27,6 @@
 #include <random>
 #include <thread>
 
-//
-// Return true if argument is a non-zero length string of digits.
-//
-
-bool
-amrex::is_integer (const char* str)
-{
-    if (str == nullptr) { return false; }
-
-    int len = static_cast<int>(std::strlen(str));
-    if (len == 0) { return false; }
-
-    for (int i = 0; i < len; i++) {
-        if (!std::isdigit(str[i])) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
 namespace {
     bool tokenize_initialized = false;
     char* line = nullptr;


### PR DESCRIPTION
The function is not used anywhere and it contains an undefined behavior of using std::isdigit on signed char.
