### PR TITLE
TimeIntegrator::integrate: fix swap guard for start_step != 0

### DIFF
--- a/Src/Base/AMReX_TimeIntegrator.H
+++ b/Src/Base/AMReX_TimeIntegrator.H
@@ -230,7 +230,7 @@ public:
                 stop = true;
             }
 
-            if (m_step_number > 0) {
+            if (m_step_number > start_step) {
                 std::swap(S_old, S_new);
             }
 


### PR DESCRIPTION
The swap guard used `m_step_number > 0`, but the loop counter starts from `start_step`. When `start_step > 0` (e.g. restarting from a checkpoint), the first iteration would incorrectly swap S_old/S_new before advancing, causing advance() to read from the uninitialized S_new buffer instead of the actual initial condition in S_old. Change the guard to `m_step_number > start_step` so the first step of each integrate() call never swaps, matching the intent.
