### PR TITLE
Scan: drop C++17 feature-detection guards and std::partial_sum fallbacks

### DIFF
--- a/Src/Base/AMReX_Scan.H
+++ b/Src/Base/AMReX_Scan.H
@@ -1134,12 +1134,7 @@ T PrefixSum (N n, FIN const& fin, FOUT const& fout, TYPE, RetSum = retSum)
 template <std::integral N, typename T >
 T InclusiveSum (N n, T const* in, T * out, RetSum /*a_ret_sum*/ = retSum)
 {
-#if (__cplusplus >= 201703L) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 10)
-    // GCC's __cplusplus is not a reliable indication for C++17 support
     std::inclusive_scan(in, in+n, out);
-#else
-    std::partial_sum(in, in+n, out);
-#endif
     return (n > 0) ? out[n-1] : T(0);
 }
 
@@ -1150,13 +1145,7 @@ T ExclusiveSum (N n, T const* in, T * out, RetSum /*a_ret_sum*/ = retSum)
     if (n <= 0) { return 0; }
 
     auto in_last = in[n-1];
-#if (__cplusplus >= 201703L) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 10)
-    // GCC's __cplusplus is not a reliable indication for C++17 support
     std::exclusive_scan(in, in+n, out, 0);
-#else
-    out[0] = 0;
-    std::partial_sum(in, in+n-1, out+1);
-#endif
     return in_last + out[n-1];
 }
 
@@ -1177,11 +1166,8 @@ namespace Gpu
         OutIter result_end = result;
         std::advance(result_end, N);
         return result_end;
-#elif (__cplusplus >= 201703L) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 10)
-        // GCC's __cplusplus is not a reliable indication for C++17 support
-        return std::inclusive_scan(begin, end, result);
 #else
-        return std::partial_sum(begin, end, result);
+        return std::inclusive_scan(begin, end, result);
 #endif
     }
 
@@ -1196,20 +1182,8 @@ namespace Gpu
         OutIter result_end = result;
         std::advance(result_end, N);
         return result_end;
-#elif (__cplusplus >= 201703L) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 10)
-        // GCC's __cplusplus is not a reliable indication for C++17 support
-        return std::exclusive_scan(begin, end, result, 0);
 #else
-        if (begin == end) { return result; }
-
-        typename std::iterator_traits<InIter>::value_type sum = *begin;
-        *result++ = sum - *begin;
-
-        while (++begin != end) {
-            sum = std::move(sum) + *begin;
-            *result++ = sum - *begin;
-        }
-        return ++result;
+        return std::exclusive_scan(begin, end, result, 0);
 #endif
     }
 

--- a/Src/Extern/HYPRE/AMReX_HypreMLABecLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreMLABecLap.cpp
@@ -491,18 +491,8 @@ void HypreMLABecLap::addNonStencilEntriesToGraph ()
         if (!nentries.empty()) {
             auto& offset = m_f2c_offset[clev];
             offset.resize(nentries.size());
-#if (__cplusplus >= 201703L) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE >= 10)
-            // GCC's __cplusplus is not a reliable indication for C++17 support
             std::exclusive_scan(nentries.begin(), nentries.end(), offset.begin(),
                                 std::size_t(0), std::plus<std::size_t>{});
-#else
-            offset[0] = 0;
-            auto const offset_size = offset.size();
-            if (offset_size > 1) {
-                auto const* pin = nentries.data();
-                std::partial_sum(pin, pin+offset_size-1, offset.data()+1, std::plus<std::size_t>{});
-            }
-#endif
             auto nvalues = std::size_t(nentries.back()) + offset.back();
             m_f2c_values[clev].resize(nvalues,Real(0.0));
         }


### PR DESCRIPTION
We require C++20, so std::inclusive_scan / std::exclusive_scan are always available. Remove the _GLIBCXX_RELEASE / __cplusplus preprocessor guards and their std::partial_sum fallbacks in all four functions: Scan::{Inclusive,Exclusive}Sum and Gpu::{inclusive,exclusive}_scan.
