### PR TITLE
Add AMReX_TracerParticle_mod_K.H to CMakeLists.txt

### DIFF
--- a/Src/Particle/CMakeLists.txt
+++ b/Src/Particle/CMakeLists.txt
@@ -17,6 +17,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_ParGDB.H
        AMReX_Particle_mod_K.H
        AMReX_TracerParticles.H
+       AMReX_TracerParticle_mod_K.H
        AMReX_NeighborParticles.H
        AMReX_NeighborParticlesI.H
        AMReX_NeighborList.H


### PR DESCRIPTION
Works in a superbuild, but the header is missing when software is built against an already installed amrex (e.g. ERF with particle support in Spack).
