### PR TITLE
Fix AnyOf CPU signature mismatch with declaration

### DIFF
--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -1463,9 +1463,9 @@ std::pair<T,T> MinMax (N n, T const* v)
 }
 
 template <typename T, std::integral N, typename P>
-bool AnyOf (N n, T const* v, P&& pred)
+bool AnyOf (N n, T const* v, P const& pred)
 {
-    return std::any_of(v, v+n, std::forward<P>(pred));
+    return std::any_of(v, v+n, pred);
 }
 
 template <typename P, int dim>


### PR DESCRIPTION
Reduce::AnyOf(N, T const*, P const&) is declared and GPU-defined with the predicate taken by const lvalue reference, but the CPU definition used a forwarding reference (P&&). This created two distinct overloads in CPU builds, where the P const& overload (declared but undefined in CPU builds) was a better match for const-lvalue predicates, causing a link error.

Change the CPU definition to match the declaration and GPU definition, consistent with all other Reduce:: functions.
