### PR TITLE
Fix modulo bias in device Random_int rejection sampling

### DIFF
--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -223,7 +223,7 @@ namespace amrex
                 do {
                 AMREX_HIP_OR_CUDA( rand = hiprand(random_engine.rand_state);,
                                 rand =  curand(random_engine.rand_state) );
-                } while (rand > (RAND_M - RAND_M % n));
+                } while (rand >= (RAND_M - RAND_M % n));
                 return rand % n;
         ))
         AMREX_IF_ON_HOST((


### PR DESCRIPTION
The CUDA/HIP device path of Random_int used `rand > (RAND_M - RAND_M % n)` as its rejection bound, which accepts L+1 values where L is the largest multiple of n ≤ RAND_M.  The extra value L maps to residue 0, biasing the output toward 0 — up to ~2× for large n (e.g., n = 2^31).

Change `>` to `>=` so the accepted set is exactly {0, …, L-1}, a perfect multiple of n, giving a uniform distribution.
