### PR TITLE
Add N <= 0 guard to FillRandom for consistency with FillRandomNormal

### DIFF
--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -262,6 +262,8 @@ DeallocateRandomSeedDevArray ()
 
 void FillRandom (Real* p, Long N)
 {
+    if (N <= 0) { return; }
+
 #ifdef AMREX_USE_CUDA
 
 #  ifdef BL_USE_FLOAT


### PR DESCRIPTION
On GPU paths, passing N <= 0 to curand/hiprand/SYCL library calls can cause an abort (N == 0) or an out-of-bounds write (N < 0 converted to huge size_t).  FillRandomNormal already has this guard; add the same one to FillRandom for safety and consistency.
