### PR TITLE
Fix latent ODR violation: drop inline from SetGrowthFactor declaration

### DIFF
--- a/Src/Base/AMReX_PODVector.H
+++ b/Src/Base/AMReX_PODVector.H
@@ -253,7 +253,7 @@ namespace amrex
     {
         extern AMREX_EXPORT Real growth_factor;
         inline Real GetGrowthFactor () { return growth_factor; }
-        inline void SetGrowthFactor (Real a_factor);
+        void SetGrowthFactor (Real a_factor);
 
         /// \cond DOXYGEN_IGNORE
         namespace detail


### PR DESCRIPTION
SetGrowthFactor was declared inline in the header but defined only in the .cpp.  Any external caller sees no body, cannot inline, and emits an unresolved reference.  It survived only because nothing outside PODVector calls it yet.

See also https://en.cppreference.com/w/cpp/language/inline: "The definition of an inline function or variable must be reachable in the translation unit where it is accessed."
