### PR TITLE
Make LayoutData::define() safe for repeated calls; fix BndryDataT redefine

### DIFF
--- a/Src/Base/AMReX_LayoutData.H
+++ b/Src/Base/AMReX_LayoutData.H
@@ -7,29 +7,37 @@
 
 namespace amrex
 {
-  //! a one-thingy-per-box distributed object
-  template <class T>
-  class LayoutData: public FabArrayBase
-  {
-  public:
+//! a one-thingy-per-box distributed object
+template <class T>
+class LayoutData: public FabArrayBase
+{
+public:
 
-    //!
     LayoutData() = default;
 
     LayoutData(const BoxArray            & a_grids,
                const DistributionMapping & a_dm)
-      {
+    {
         define(a_grids, a_dm);
-      }
+    }
 
     void define(const BoxArray           & a_grids,
                 const DistributionMapping & a_dm)
-      {
+    {
+        clear();
         FabArrayBase::define(a_grids, a_dm, 1, 0);
         m_need_to_clear_bd = true;
         addThisBD();
         m_data.resize(local_size());
-      }
+    }
+
+    void clear ()
+    {
+        m_data.clear();
+        if (m_need_to_clear_bd) { clearThisBD(); }
+        m_need_to_clear_bd = false;
+        FabArrayBase::clear();
+    }
 
     ~LayoutData () { if (m_need_to_clear_bd) { clearThisBD(); } }
 
@@ -82,43 +90,43 @@ namespace amrex
     }
 
     T& operator[](const MFIter& a_mfi) noexcept
-      {
+    {
         int local_index = a_mfi.LocalIndex();
         BL_ASSERT(local_index >= 0 && local_index < m_data.size() &&
                   DistributionMap() == a_mfi.DistributionMap());
         return m_data[local_index];
-      }
+    }
 
 
     const T& operator[](const MFIter& a_mfi) const noexcept
-      {
+    {
         int local_index = a_mfi.LocalIndex();
         BL_ASSERT(local_index >= 0 && local_index < m_data.size() &&
                   DistributionMap() == a_mfi.DistributionMap());
         return m_data[local_index];
-      }
+    }
 
     T& operator[](int a_box_index) noexcept
-      {
+    {
         int local_index = this->localindex(a_box_index);
         BL_ASSERT(local_index >= 0 && local_index < m_data.size());
         return m_data[local_index];
-      }
-
+    }
 
     const T& operator[](int a_box_index) const noexcept
-      {
+    {
         int local_index = this->localindex(a_box_index);
         BL_ASSERT(local_index >= 0 && local_index < m_data.size());
         return m_data[local_index];
-      }
+    }
 
     const T* data () const noexcept { return m_data.data(); }
     T*       data ()       noexcept { return m_data.data(); }
 
-  private:
-      Vector<T> m_data;
-      bool m_need_to_clear_bd = false;
-  };
+private:
+    Vector<T> m_data;
+    bool m_need_to_clear_bd = false;
+};
+
 }
 #endif

--- a/Src/Boundary/AMReX_BndryData.H
+++ b/Src/Boundary/AMReX_BndryData.H
@@ -270,20 +270,25 @@ BndryDataT<MF>::define (const BoxArray& _grids,
 
     if (m_defined) {
         if (m_ncomp == _ncomp && _geom.Domain() == geom.Domain() &&
+            amrex::AlmostEqual(_geom.ProbDomain(), geom.ProbDomain()) &&
+            _geom.Coord() == geom.Coord() &&
             _geom.periodicity() == geom.periodicity() &&
             _grids == this->boxes() && _dmap == this->DistributionMap()) {
             // We want to allow reuse of BndryDataT objects that were define()d exactly as a previous call.
             return;
         }
-        // Otherwise we'll just abort.  We could make this work but it's just as easy to start with a fresh Bndrydata object.
-        amrex::Abort("BndryDataT<MF>::define(): object already built");
+        // Parameters differ; clear and redefine.
+        BndryRegisterT<MF>::clear();
+        bcond.clear();
+        bcloc.clear();
+        masks.clear();
+        m_defined = false;
     }
     geom    = _geom;
     m_ncomp = _ncomp;
 
     BndryRegisterT<MF>::setBoxes(_grids);
 
-    masks.clear();
     masks.resize(2*AMREX_SPACEDIM);
 
     for (OrientationIter fi; fi; ++fi) {


### PR DESCRIPTION
LayoutData:
- Add a clear() method that properly cleans up data, BD registration, and FabArrayBase state.
- define() now calls clear() first, making it safe to call define() multiple times without an explicit clear between calls.

BndryDataT::define():
- Also compare ProbDomain() and Coord() in the early-return guard so that changing only the physical domain triggers re-definition instead of silently keeping stale geometry.
- When parameters differ, clear the object and redefine rather than aborting.
