### PR TITLE
Guard InterpBndryDataT order-3 path against refinement ratio > 4

### DIFF
--- a/Src/Boundary/AMReX_InterpBndryData.H
+++ b/Src/Boundary/AMReX_InterpBndryData.H
@@ -94,6 +94,12 @@ public:
      * \param ratio     refinement ratio
      * \param max_order interpolation order
      * \param max_width max width of the interpolation stencil
+     *
+     * \note Order-3 interpolation reads the boundary mask at tangential offsets
+     *       of `±ratio`, and the masks are allocated with a fixed tangential
+     *       half-width (see `BndryDataT::NTangHalfWidth`).  Consequently
+     *       `max_order == 3` requires `ratio <= 4` in every dimension; this is
+     *       enforced at runtime.  `max_order == 1` has no such restriction.
      */
     void setBndryValues (BndryRegisterT<MF> const& crse, int c_start, const MF& fine, int f_start,
                          int bnd_start, int num_comp, const IntVect& ratio,
@@ -172,6 +178,15 @@ InterpBndryDataT<MF>::setBndryValues (BndryRegisterT<MF> const& crse, int c_star
     AMREX_ASSERT(this->grids == fine.boxArray());
 
     const Box& fine_domain = this->geom.Domain();
+
+    // Order-3 interpolation reads the boundary mask at tangential offsets of
+    // ±ratio.  The masks are built with a fixed tangential half-width
+    // (BndryDataT::NTangHalfWidth == 5, i.e. ref_ratio + 1), so ratios above 4
+    // would walk past the allocated mask halo.  Order-1 does not touch the mask.
+    if (max_order == 3) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ratio.allLE(4),
+            "InterpBndryDataT<MF>::setBndryValues: max_order=3 requires refinement ratio <= 4");
+    }
 
     if (max_order==3 || max_order==1)
     {


### PR DESCRIPTION
InterpBndryDataT::setBndryValues() forwarded the caller-supplied refinement ratio into the order-3 interpolation kernels without validation.  Those kernels read the boundary mask at unguarded tangential offsets of +/-ratio (e.g. mask(i,j-r.y,0) in the 2D kernel), but the masks are allocated with a fixed tangential half-width (BndryDataT::NTangHalfWidth == 5, i.e. ref_ratio + 1), so refinement ratios above 4 walk past the allocated mask halo.  The limitation was documented only in the mask-allocation comment, not enforced at the API.

Order-3 is the default (IBD_max_order_DEF == 3) and the offending reads happen inside GPU/OMP kernels, so a too-large ratio produced silent corruption or hard-to-reproduce crashes in optimized builds rather than a clear error.  Order-1 does not touch the mask and is unaffected.

Add an AMREX_ALWAYS_ASSERT_WITH_MESSAGE in setBndryValues() that rejects ratio > 4 when max_order == 3 (active in both debug and release builds), and document the constraint in the function's Doxygen.  updateBndryValues() delegates to setBndryValues() and needs no separate change.  This is a behavior change for any caller using max_order=3 with ratio > 4: previously silent out-of-bounds access, now an abort.
