### PR TITLE
Detect Doxygen errors in CI; fix LaTeX formula rendering

### DIFF
--- a/Docs/build_docs.sh
+++ b/Docs/build_docs.sh
@@ -5,9 +5,14 @@ set -e # Exit with nonzero exit code if anything fails
 echo "Build the Doxygen documentation"
 cd Doxygen
 doxygen doxygen.conf &> doxygen.out
-if grep -q "warning:" doxygen.out; then
-    echo "Doxygen warnings detected! Failing..."
-    cat doxygen.out
+# Doxygen exits 0 even when it emits warnings or errors (e.g. LaTeX failures
+# while rendering \f$...\f$ formulas), so the exit status is not a reliable
+# gate; scan the log instead. Match both "warning:" (documentation problems)
+# and "error:" (e.g. "error: Problems running latex...").
+failures=$(grep -nE "warning:|error:" doxygen.out || true)
+if [ -n "$failures" ]; then
+    echo "Doxygen warnings/errors detected! Failing..."
+    echo "$failures"
     exit 1
 fi
 cd ..

--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -750,14 +750,14 @@ namespace amrex {
         /**
          * \brief Create a single-cell component accessor.
          *
-         * Returns a \c CellData<T> view for the cell \f$(i,j,k)\f$ in an
+         * Returns a \c CellData<T> view for the cell \c (i,j,k) in an
          * Array4. The returned object provides access to all components
          * without recomputing full \c (i,j,k,n) indexing.
          *
          * \param i Cell index in x.
          * \param j Cell index in y.
          * \param k Cell index in z.
-         * \return A \c CellData<T> accessor for cell \f$(i,j,k)\f$.
+         * \return A \c CellData<T> accessor for cell \c (i,j,k).
          *
          * \note This overload is enabled only for Array4.
          *

--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -827,7 +827,7 @@ public:
     */
     template <RunOn run_on AMREX_DEFAULT_RUNON>
     int maskLT (BaseFab<int>& mask, T const& val, int comp = 0) const noexcept;
-    /** \brief Mark cells with value \f$\le\f$ \p val. */
+    /** \brief Mark cells with value \c <= \p val. */
     template <RunOn run_on AMREX_DEFAULT_RUNON>
     int maskLE (BaseFab<int>& mask, T const& val, int comp = 0) const noexcept;
 

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -1677,7 +1677,7 @@ public:
      * \param nghost number of ghost-cell layers included in the iteration space.
      * \param f callable object returning \c Result_t for reduction. Its signature is
      *          \c Result_t(int,int,int,int), where the arguments correspond to the
-     *          local box index in \c mf and the \f$(i,j,k)\f$ cell indices.
+     *          local box index in \c mf and the \c (i,j,k) cell indices.
      */
     template <FabArrayType MF, typename F>
     requires (IsCallable<F, int, int, int, int>::value)
@@ -1705,7 +1705,7 @@ public:
      * \param ncomp number of components.
      * \param f callable object returning \c Result_t for reduction. Its signature is
      *          \c Result_t(int,int,int,int,int), where the arguments correspond to the
-     *          local box index in \c mf, the \f$(i,j,k)\f$ cell indices, and the
+     *          local box index in \c mf, the \c (i,j,k) cell indices, and the
      *          component index.
      */
     template <FabArrayType MF, typename F>

--- a/Src/FFT/AMReX_FFT_Stokes.H
+++ b/Src/FFT/AMReX_FFT_Stokes.H
@@ -93,7 +93,7 @@ public:
     /**
      * \brief Solve the generalized Stokes problem in spectral space.
      *
-     * Solves \f$(\alpha - \eta \nabla^2) \mathbf{u} + \nabla p = \mathbf{f}\f$
+     * Solves `(alpha - eta * nabla^2) u + nabla p = f`
      * with the divergence-free constraint enforced in Fourier space.
      * This solver is for 2D and 3D only.
      *

--- a/Src/LinearSolvers/AMReX_GMRES_MLMG.H
+++ b/Src/LinearSolvers/AMReX_GMRES_MLMG.H
@@ -109,7 +109,7 @@ public:
     static void assign (VEC& lhs, VEC const& rhs);
 
     /**
-     * \brief Add a scaled vector: \f$ \text{lhs} \mathrel{+}= a\,\text{rhs}\f$.
+     * \brief Add a scaled vector: `lhs += a * rhs`.
      *
      * \param lhs Accumulation target.
      * \param rhs Source vector.
@@ -118,7 +118,7 @@ public:
     static void increment (VEC& lhs, VEC const& rhs, RT a);
 
     /**
-     * \brief Form a linear combination: \f$ \text{lhs} = a\,\text{rhs}_a + b\,\text{rhs}_b\f$.
+     * \brief Form a linear combination: `lhs = a * rhs_a + b * rhs_b`.
      *
      * \param lhs    Destination vector written in place.
      * \param a      Scalar applied to \p rhs_a.
@@ -131,13 +131,13 @@ public:
     /**
      * \brief Apply the operator supplied to the constructor.
      *
-     * \param lhs Destination vector receiving \f$L(\text{rhs})\f$.
+     * \param lhs Destination vector receiving `L(rhs)`.
      * \param rhs Source vector.
      */
     void apply (VEC& lhs, VEC const& rhs) const;
 
     /**
-     * \brief Apply the MLMG-based preconditioner: \f$\text{lhs} = P^{-1}(\text{rhs})\f$.
+     * \brief Apply the MLMG-based preconditioner: `lhs = P^{-1}(rhs)`.
      *
      * \param lhs Destination vector, zeroed before solving when the preconditioner is enabled.
      * \param rhs Source vector passed to the preconditioner.

--- a/Src/LinearSolvers/AMReX_GMRES_MV.H
+++ b/Src/LinearSolvers/AMReX_GMRES_MV.H
@@ -87,7 +87,7 @@ public:
     static void assign (VEC& lhs, VEC const& rhs);
 
     /**
-     * \brief Accumulate \f$\text{lhs} \mathrel{+}= a\,\text{rhs}\f$.
+     * \brief Accumulate `lhs += a * rhs`.
      *
      * \param lhs Accumulation target.
      * \param rhs Source vector.
@@ -96,7 +96,7 @@ public:
     static void increment (VEC& lhs, VEC const& rhs, T a);
 
     /**
-     * \brief Form the linear combination \f$\text{lhs} = a\,\text{rhs}_a + b\,\text{rhs}_b\f$.
+     * \brief Form the linear combination `lhs = a * rhs_a + b * rhs_b`.
      *
      * \param lhs    Destination vector.
      * \param a      Scalar applied to \p rhs_a.

--- a/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.H
@@ -18,8 +18,8 @@ namespace amrex {
  * \brief curl (alpha curl E) + beta E = rhs
  *
  * Here E is an Array of 3 MultiFabs on the staggered grid.  The coefficient
- * \f$\alpha\f$ can be supplied either as a positive scalar (via setScalars)
- * or as a nodal MultiFab (via setAlpha), and \f$\beta\f$ can be either a
+ * \c alpha can be supplied either as a positive scalar (via setScalars)
+ * or as a nodal MultiFab (via setAlpha), and \c beta can be either a
  * non-negative scalar or an edge-centered MultiFab (via setBeta).
  *
  * It's the caller's responsibility to make sure rhs has consistent nodal


### PR DESCRIPTION
Docs/build_docs.sh only grepped for "warning:", and doxygen exits 0 even when it emits errors, so "error: Problems running latex..." from \f$...\f$ formula rendering slipped through CI. Extend the gate to also match "error:" and print only the offending lines instead of the full log.

Avoid \f$...\f$ formulas in Doxygen.