### PR TITLE
CMake: ROCm/HIP `find_dependency()`

### DIFF
--- a/Tools/CMake/AMReXConfig.cmake.in
+++ b/Tools/CMake/AMReXConfig.cmake.in
@@ -268,6 +268,25 @@ if (@AMReX_CUDA@)
     endif ()
 endif ()
 
+#
+# HIP
+#
+if (@AMReX_HIP@)
+    find_dependency(hip REQUIRED CONFIG)
+    find_dependency(hiprand REQUIRED CONFIG)
+    find_dependency(rocrand REQUIRED CONFIG)
+    find_dependency(rocprim REQUIRED CONFIG)
+    if (@AMReX_LINEAR_SOLVERS@)
+        find_dependency(rocsparse REQUIRED CONFIG)
+    endif ()
+    if (@AMReX_FFT@)
+        find_dependency(rocfft REQUIRED CONFIG)
+    endif ()
+    if (@AMReX_ROCTX@)
+        find_dependency(rocprofiler-sdk-roctx REQUIRED CONFIG)
+    endif ()
+endif ()
+
 # CMake targets
 include( "${CMAKE_CURRENT_LIST_DIR}/AMReXTargets.cmake" )
 


### PR DESCRIPTION
## Summary

Add corresponding `find_dependency()` calls for ROCm/HIP `find_package()` calls that populate public CMake targets that we expose to downstream users.

## Additional background

Fix #5491

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
