### PR TITLE
PC_local_gpu: fix narrowing conversion, brittle init, and deterministic handling

### DIFF
--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -536,7 +536,8 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion())
         {
-            PC_local_gpu(thecpc, src, scomp, dcomp, ncomp, op, deterministic);
+            PC_local_gpu(thecpc, src, scomp, dcomp, ncomp, op,
+                         deterministic && (op == FabArrayBase::ADD));
         }
         else
 #endif
@@ -638,7 +639,8 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
 #ifdef AMREX_USE_GPU
             if (Gpu::inLaunchRegion())
             {
-                PC_local_gpu(thecpc, src, SC, DC, NC, op, deterministic);
+                PC_local_gpu(thecpc, src, SC, DC, NC, op,
+                             deterministic && (op == FabArrayBase::ADD));
             }
             else
 #endif

--- a/Src/Base/AMReX_PCI.H
+++ b/Src/Base/AMReX_PCI.H
@@ -91,9 +91,12 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
                              int scomp, int dcomp, int ncomp, CpOp op,
                              bool deterministic)
 {
-    int N_locs = thecpc.m_LocTags->size();
+    auto const N_locs = static_cast<int>(thecpc.m_LocTags->size());
     if (N_locs == 0) { return; }
     bool is_thread_safe = thecpc.m_threadsafe_loc;
+
+    // Deterministic handling is only implemented for ADD.
+    if (deterministic) { AMREX_ALWAYS_ASSERT(op == FabArrayBase::ADD); }
 
     using TagType = Array4CopyTag<value_type>;
     Vector<TagType> loc_copy_tags;
@@ -119,11 +122,12 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
         const CopyComTag& tag = (*thecpc.m_LocTags)[i];
         if (this != &src || tag.dstIndex != tag.srcIndex || tag.sbox != tag.dbox) {
             int li = this->localindex(tag.dstIndex);
-            loc_copy_tags.push_back
-                ({this->atLocalIdx(li).array(), tag.dstIndex,
-                  src.fabPtr(tag.srcIndex)->const_array(),
-                  tag.dbox,
-                  (tag.sbox.smallEnd()-tag.dbox.smallEnd()).dim3()});
+            loc_copy_tags.push_back(
+                TagType{.dfab   = this->atLocalIdx(li).array(),
+                        .dindex = tag.dstIndex,
+                        .sfab   = src.fabPtr(tag.srcIndex)->const_array(),
+                        .dbox   = tag.dbox,
+                        .offset = (tag.sbox.smallEnd()-tag.dbox.smallEnd()).dim3()});
 
             if (maskfabs.size() > 0) {
                 if (!maskfabs[li].isAllocated()) {
@@ -155,15 +159,17 @@ FabArray<FAB>::PC_local_gpu (const CPC& thecpc, FabArray<FAB> const& src,
     }
     else
     {
-        if (deterministic) {
+        if (is_thread_safe) {
+            // Non-overlapping destinations: a plain add is already bitwise
+            // reproducible, so no need for the heavier deterministic kernel.
+            detail::fab_to_fab<value_type, value_type>(loc_copy_tags, scomp,
+                dcomp, ncomp, detail::CellAdd<value_type, value_type>());
+        } else if (deterministic) {
             // Use deterministic_fab_to_fab for ADD operations to ensure bitwise
             // reproducibility. The atomic add operations (fab_to_fab_atomic_add) are
             // non-deterministic because the order of atomic additions is not guaranteed.
             detail::deterministic_fab_to_fab<value_type, value_type>(
                 loc_copy_tags, scomp, dcomp, ncomp, detail::CellAdd<value_type, value_type>());
-        } else if (is_thread_safe) {
-            detail::fab_to_fab<value_type, value_type>(loc_copy_tags, scomp,
-                dcomp, ncomp, detail::CellAdd<value_type, value_type>());
         } else {
             detail::fab_to_fab_atomic_add<value_type, value_type>(
                 loc_copy_tags, scomp, dcomp, ncomp, masks);


### PR DESCRIPTION
- Use explicit static_cast<int> for N_locs, matching PC_local_cpu.
- Replace positional aggregate init of Array4CopyTag with designated initializers, matching the mask tags in the same function and the FillBoundary sibling.
- Assert that deterministic implies ADD inside PC_local_gpu, and mask the flag at both call sites to match the MPI path.  Previously a deterministic COPY request was silently ignored with no diagnostic.
- In the ADD branch, check is_thread_safe before deterministic so that non-overlapping destinations take the cheap plain-add path instead of the heavier deterministic kernel.
