### PR TITLE
Fix two mkconfig/mkversionheader argument-parsing bugs

### DIFF
--- a/Tools/libamrex/mkconfig.py
+++ b/Tools/libamrex/mkconfig.py
@@ -14,7 +14,7 @@ def doit(defines, undefines, comp, allow_diff_comp):
     for d in defs:
         dd = d.strip()
         if dd:
-            v = dd.split("=")
+            v = dd.split("=", 1)
             print("#ifndef",v[0])
             if len(v) == 2:
                 print("#define",v[0],v[1])
@@ -22,7 +22,7 @@ def doit(defines, undefines, comp, allow_diff_comp):
                 print("#define",v[0],1)
             print("#endif")
 
-    for ud in undefines:
+    for ud in undefines.split():
         print("#undef",ud)
 
     print("#ifdef __cplusplus");

--- a/Tools/libamrex/mkversionheader.py
+++ b/Tools/libamrex/mkversionheader.py
@@ -14,7 +14,7 @@ def doit(code, defines):
     for d in defs:
         dd = d.strip()
         if dd:
-            v = dd.split("=")
+            v = dd.split("=", 1)
             print("#ifndef",v[0])
             if len(v) == 2:
                 print("#define",v[0],v[1])


### PR DESCRIPTION
- --undefines iterated over string characters instead of tokens because the raw str from argparse wasn't split on whitespace. Use .split().
- A -D value containing '=' (e.g. -DMY_EXPR=a==b) was silently replaced with 1 because split("=") broke on every '='. Use split("=", 1) to split only on the first '=', preserving the value.

Both bugs were dormant (--undefines always passed empty; = in values is rare), but would silently corrupt the generated header if triggered.
