### PR TITLE
Fix mkpkgconfig.py: generated amrex.pc had an empty Version field

### DIFF
--- a/Tools/libamrex/mkpkgconfig.py
+++ b/Tools/libamrex/mkpkgconfig.py
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 
 import argparse
+import re
+
+def pkg_version(git_version):
+    """Extract a clean MAJOR.MINOR[.PATCH] from git describe output.
+
+    git describe produces strings like 25.06, 25.06.1, 25.06-3-g1a2b3c4, or
+    25.06.1-3-g1a2b3c4-dirty.  We take the leading numeric tag as the
+    pkg-config version so that version comparisons work.
+    """
+    m = re.match(r'^(\d+\.\d+(?:\.\d+)?)', git_version)
+    return m.group(1) if m else git_version
 
 def doit(prefix, version, cflags, libs, libpriv, fflags):
+    pkg_ver = pkg_version(version)
     print("# AMReX Version: "+version)
     print("")
     print("prefix="+prefix)
@@ -14,7 +26,7 @@ def doit(prefix, version, cflags, libs, libpriv, fflags):
     print("")
     print("Name: amrex")
     print("Description: Software Framework for Block Structured AMR")
-    print("Version:")
+    print("Version: "+pkg_ver)
     print("URL: https://github.com/AMReX-Codes/amrex")
     print("Requires:")
     print("Cflags: -I${includedir}", cflags)


### PR DESCRIPTION
The `version` argument was passed through from git describe but only used in a comment; the pkg-config Version field was left blank.  This broke `pkg-config --modversion amrex` and any version constraints after `make install`.

Parse the git describe string (e.g. 25.06-3-g1a2b3c4-dirty) to extract the leading MAJOR.MINOR[.PATCH] tag, matching what CMake already computes as AMREX_PKG_VERSION.  Falls back to raw input for non-git sources.
