### PR TITLE
SIMD: Vectorized Particle Reductions (ParticleReduceSIMD)

### DIFF
--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -507,6 +507,105 @@ In this way, code can be written that is agnostic as to the data layout. For mor
 of pure SoA particles, please see the SOA tests in :cpp:`amrex/Tests/Particles/`, or refer
 to `WarpX <https://github.com/BLAST-WarpX/warpx>`_, `Hipace++ <https://github.com/Hi-PACE/hipace>`_, or `ImpactX <https://github.com/BLAST-ImpactX/impactx>`_, which use this type of particle container.
 
+.. _sec:Particles:Reductions:
+
+Particle Reductions
+===================
+
+AMReX provides functions to compute reductions (sums, minima, maxima, and
+logical and/or) over the particles in a :cpp:`ParticleContainer`, on CPUs and
+GPUs alike. The simple entry points :cpp:`amrex::ReduceSum`,
+:cpp:`amrex::ReduceMin`, :cpp:`amrex::ReduceMax`,
+:cpp:`amrex::ReduceLogicalAnd` and :cpp:`amrex::ReduceLogicalOr` reduce a
+single quantity computed per particle by a user-provided callable. The general
+:cpp:`amrex::ParticleReduce` computes many reductions in a single pass over
+the particles, combining :cpp:`amrex::ReduceOps` (e.g., several sums, minima
+and maxima at once) into one :cpp:`amrex::ReduceData` result tuple.
+
+The per-particle callable can take the particle in several forms; the most
+efficient one takes a :cpp:`ConstParticleTileData` and the particle index,
+which reads the particle components directly from the underlying (SoA) arrays:
+
+.. highlight:: c++
+
+::
+
+    using ConstPTDType = typename PC::ConstPTDType;
+    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real, int>> (
+                 pc, [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
+                               -> amrex::GpuTuple<amrex::Real, amrex::Real, int>
+             {
+                 const amrex::Real a = ptd.rdata(1)[i];
+                 const amrex::Real b = ptd.rdata(2)[i];
+                 const int c = ptd.idata(1)[i];
+                 return {a, b, c};
+             }, reduce_ops);
+
+Note that no MPI reduction is performed at the end of these operations; call
+the reductions in :cpp:`ParallelDescriptor` manually if you want that behavior.
+
+.. _sec:Particles:SIMDReductions:
+
+SIMD-Vectorized Particle Reductions
+-----------------------------------
+
+When AMReX is compiled with SIMD support (CMake option ``AMReX_SIMD=ON``, see
+:ref:`sec:build:cmake`), the entry points :cpp:`amrex::ParticleReduceSIMD`,
+:cpp:`amrex::ReduceSumSIMD`, :cpp:`amrex::ReduceMinSIMD` and
+:cpp:`amrex::ReduceMaxSIMD` evaluate the reduction vectorized over ``WIDTH``
+particles at a time, using SIMD registers as accumulators. The same user code
+compiles and runs unchanged in every configuration:
+
+* ``AMReX_SIMD=ON`` (CPU): vectorized main loop plus a scalar remainder loop,
+* ``AMReX_SIMD=OFF`` (CPU): a scalar loop, semantically identical to
+  :cpp:`amrex::ParticleReduce`,
+* GPU builds: the regular device reduction.
+
+The callable is invoked as :cpp:`f(ptd, si)` where ``si`` is an
+:cpp:`amrex::SIMDindex`. Write it generically over the index type and load
+particle components with :cpp:`amrex::simd::load_1d`, which returns a SIMD
+register in the vectorized main loop and a scalar value otherwise:
+
+.. highlight:: c++
+
+::
+
+    #include <AMReX_ParticleReduceSIMD.H>
+
+    using ConstPTDType = typename PC::ConstPTDType;
+    amrex::ReduceOps<ReduceOpSum, ReduceOpMin> reduce_ops;
+    auto r = amrex::ParticleReduceSIMD<ReduceData<amrex::ParticleReal, amrex::ParticleReal>> (
+                 pc, [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, auto si) noexcept
+             {
+                 auto const a = amrex::simd::load_1d(ptd.rdata(1), si);
+                 auto const w = amrex::simd::load_1d(ptd.rdata(2), si);
+                 return amrex::makeTuple(a * w, a);
+             }, reduce_ops);
+
+For CUDA builds, note that extended device lambdas have compiler-version
+dependent restrictions on generic (``auto``) parameters; a small functor with
+a templated :cpp:`operator()` is the most portable form of the kernel.
+
+The SIMD width can be chosen explicitly via the ``WIDTH`` template parameter
+(e.g., :cpp:`ParticleReduceSIMD<RD, 8>`); it defaults to the native SIMD
+register width for :cpp:`amrex::ParticleReal`, which is a good default in
+practice, in particular for kernels with many reduction components.
+
+Two differences from :cpp:`amrex::ParticleReduce` to be aware of:
+
+* Only :cpp:`ReduceOpSum`, :cpp:`ReduceOpMin` and :cpp:`ReduceOpMax` are
+  supported (enforced at compile time).
+* SIMD sum reductions reassociate floating-point additions (per-lane partial
+  sums plus a final horizontal fold), so results can differ from the scalar
+  evaluation order by rounding. In particular,
+  :cpp:`amrex::system::regtest_reduction` is not honored by the SIMD path;
+  use the scalar entry points when bitwise reproducible regression data is
+  required.
+
+For a complete example, including a benchmark against the scalar entry
+points, see ``Tests/Particles/ParticleReduceSIMD``.
+
 .. _sec:Particles:Interacting:
 
 Interacting with Mesh Data

--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -522,7 +522,7 @@ single quantity computed per particle by a user-provided callable. The general
 the particles, combining :cpp:`amrex::ReduceOps` (e.g., several sums, minima
 and maxima at once) into one :cpp:`amrex::ReduceData` result tuple.
 
-The per-particle callable can take the particle in several forms; the most
+The per-particle callable can take the particle in several forms: the most
 efficient one takes a :cpp:`ConstParticleTileData` and the particle index,
 which reads the particle components directly from the underlying (SoA) arrays:
 
@@ -531,8 +531,8 @@ which reads the particle components directly from the underlying (SoA) arrays:
 ::
 
     using ConstPTDType = typename PC::ConstPTDType;
-    amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
-    auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real, int>> (
+    amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpMin, amrex::ReduceOpMax> reduce_ops;
+    auto r = amrex::ParticleReduce<amrex::ReduceData<amrex::Real, amrex::Real, int>> (
                  pc, [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
                                -> amrex::GpuTuple<amrex::Real, amrex::Real, int>
              {
@@ -542,7 +542,7 @@ which reads the particle components directly from the underlying (SoA) arrays:
                  return {a, b, c};
              }, reduce_ops);
 
-Note that no MPI reduction is performed at the end of these operations; call
+Note that no MPI reduction is performed at the end of these operations. Call
 the reductions in :cpp:`ParallelDescriptor` manually if you want that behavior.
 
 .. _sec:Particles:SIMDReductions:
@@ -574,8 +574,8 @@ register in the vectorized main loop and a scalar value otherwise:
     #include <AMReX_ParticleReduceSIMD.H>
 
     using ConstPTDType = typename PC::ConstPTDType;
-    amrex::ReduceOps<ReduceOpSum, ReduceOpMin> reduce_ops;
-    auto r = amrex::ParticleReduceSIMD<ReduceData<amrex::ParticleReal, amrex::ParticleReal>> (
+    amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpMin> reduce_ops;
+    auto r = amrex::ParticleReduceSIMD<amrex::ReduceData<amrex::ParticleReal, amrex::ParticleReal>> (
                  pc, [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, auto si) noexcept
              {
                  auto const a = amrex::simd::load_1d(ptd.rdata(1), si);
@@ -583,12 +583,12 @@ register in the vectorized main loop and a scalar value otherwise:
                  return amrex::makeTuple(a * w, a);
              }, reduce_ops);
 
-For CUDA builds, note that extended device lambdas have compiler-version
-dependent restrictions on generic (``auto``) parameters; a small functor with
+For CUDA builds, note that extended device lambdas have nvcc-version
+dependent restrictions on generic (``auto``) parameters and a small functor with
 a templated :cpp:`operator()` is the most portable form of the kernel.
 
 The SIMD width can be chosen explicitly via the ``WIDTH`` template parameter
-(e.g., :cpp:`ParticleReduceSIMD<RD, 8>`); it defaults to the native SIMD
+(e.g., :cpp:`ParticleReduceSIMD<RD, 8>`). It defaults to the native SIMD
 register width for :cpp:`amrex::ParticleReal`, which is a good default in
 practice, in particular for kernels with many reduction components.
 
@@ -599,9 +599,17 @@ Two differences from :cpp:`amrex::ParticleReduce` to be aware of:
 * SIMD sum reductions reassociate floating-point additions (per-lane partial
   sums plus a final horizontal fold), so results can differ from the scalar
   evaluation order by rounding. In particular,
-  :cpp:`amrex::system::regtest_reduction` is not honored by the SIMD path;
+  :cpp:`amrex::system::regtest_reduction` is not honored by the SIMD path,
   use the scalar entry points when bitwise reproducible regression data is
   required.
+
+Under the hood, :cpp:`amrex::ParticleReduceSIMD` evaluates each particle tile
+with :cpp:`amrex::evalReduceSIMD<WIDTH>(n, reduce_data, f, reduce_ops)`, the
+SIMD analogue of the element loop in :cpp:`ReduceOps::eval`. This engine is
+not particle-specific: it can be used directly to reduce over any indexed
+range on the host, with the same single-source callable contract (``f(si)``
+with an :cpp:`amrex::SIMDindex`, provided by ``AMReX_ReduceSIMD.H``). See
+``Tests/SIMD`` for a small stand-alone example with a mixed-type tuple.
 
 For a complete example, including a benchmark against the scalar entry
 points, see ``Tests/Particles/ParticleReduceSIMD``.

--- a/Src/Base/AMReX_ReduceSIMD.H
+++ b/Src/Base/AMReX_ReduceSIMD.H
@@ -1,0 +1,220 @@
+#ifndef AMREX_REDUCE_SIMD_H_
+#define AMREX_REDUCE_SIMD_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_Extension.H>
+#include <AMReX_OpenMP.H>
+#include <AMReX_Reduce.H>  // provides amrex::SIMDindex via AMReX_Gpu.H
+#include <AMReX_SIMD.H>
+
+#include <concepts>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+namespace amrex {
+
+/// \cond DOXYGEN_IGNORE
+namespace Reduce::detail {
+
+    //! Reduce operations supported by the SIMD reduction path
+    template <typename P>
+    inline constexpr bool is_simd_reduce_op =
+        std::is_same_v<P, ReduceOpSum> ||
+        std::is_same_v<P, ReduceOpMin> ||
+        std::is_same_v<P, ReduceOpMax>;
+
+#if defined(AMREX_USE_SIMD) && !defined(AMREX_USE_GPU)
+
+    //! Transform a GpuTuple of scalars into a GpuTuple of SIMD registers of width W
+    template <int W, typename T>
+    struct MakeSIMDTuple;
+
+    template <int W, typename... Ts>
+    struct MakeSIMDTuple<W, GpuTuple<Ts...>>
+    {
+        using type = GpuTuple<amrex::simd::stdx::fixed_size_simd<Ts, W>...>;
+    };
+
+    //! Initialize a SIMD accumulator register with the identity element of the reduce operation
+    template <typename P, typename T>
+    AMREX_FORCE_INLINE
+    void simd_init (T& t)
+    {
+        using E = typename T::value_type;
+        if constexpr (std::is_same_v<P, ReduceOpSum>) {
+            t = T(E(0));
+        } else if constexpr (std::is_same_v<P, ReduceOpMin>) {
+            t = T(std::numeric_limits<E>::max());
+        } else if constexpr (std::is_same_v<P, ReduceOpMax>) {
+            t = T(std::numeric_limits<E>::lowest());
+        } else {
+            static_assert(is_simd_reduce_op<P>,
+                "SIMD reductions support only ReduceOpSum, ReduceOpMin and ReduceOpMax");
+        }
+    }
+
+    //! Element-wise (per SIMD lane) update of a SIMD accumulator register
+    template <typename P, typename T>
+    AMREX_FORCE_INLINE
+    void simd_local_update (T& d, T const& s)
+    {
+        namespace stdx = amrex::simd::stdx;
+        if constexpr (std::is_same_v<P, ReduceOpSum>) {
+            d += s;
+        } else if constexpr (std::is_same_v<P, ReduceOpMin>) {
+            d = stdx::min(d, s);
+        } else if constexpr (std::is_same_v<P, ReduceOpMax>) {
+            d = stdx::max(d, s);
+        } else {
+            static_assert(is_simd_reduce_op<P>,
+                "SIMD reductions support only ReduceOpSum, ReduceOpMin and ReduceOpMax");
+        }
+    }
+
+    //! Horizontal (across SIMD lanes) fold of a SIMD register into a scalar accumulator
+    template <typename P, typename T, typename S>
+    AMREX_FORCE_INLINE
+    void simd_horizontal_update (T& d, S const& s)
+    {
+        namespace stdx = amrex::simd::stdx;
+        if constexpr (std::is_same_v<P, ReduceOpSum>) {
+            d += stdx::reduce(s);
+        } else if constexpr (std::is_same_v<P, ReduceOpMin>) {
+            d = amrex::min(d, stdx::hmin(s));
+        } else if constexpr (std::is_same_v<P, ReduceOpMax>) {
+            d = amrex::max(d, stdx::hmax(s));
+        } else {
+            static_assert(is_simd_reduce_op<P>,
+                "SIMD reductions support only ReduceOpSum, ReduceOpMin and ReduceOpMax");
+        }
+    }
+
+    // The recursions below mirror for_each_local / for_each_init in AMReX_Reduce.H.
+
+    template <std::size_t I, typename T, typename P>
+    AMREX_FORCE_INLINE
+    void for_each_simd_init (T& t)
+    {
+        simd_init<P>(amrex::get<I>(t));
+    }
+
+    template <std::size_t I, typename T, typename P, typename P1, typename... Ps>
+    AMREX_FORCE_INLINE
+    void for_each_simd_init (T& t)
+    {
+        simd_init<P>(amrex::get<I>(t));
+        for_each_simd_init<I+1,T,P1,Ps...>(t);
+    }
+
+    template <std::size_t I, typename T, typename P>
+    AMREX_FORCE_INLINE
+    void for_each_simd_local (T& d, T const& s)
+    {
+        simd_local_update<P>(amrex::get<I>(d), amrex::get<I>(s));
+    }
+
+    template <std::size_t I, typename T, typename P, typename P1, typename... Ps>
+    AMREX_FORCE_INLINE
+    void for_each_simd_local (T& d, T const& s)
+    {
+        simd_local_update<P>(amrex::get<I>(d), amrex::get<I>(s));
+        for_each_simd_local<I+1,T,P1,Ps...>(d, s);
+    }
+
+    template <std::size_t I, typename TD, typename TS, typename P>
+    AMREX_FORCE_INLINE
+    void for_each_horizontal (TD& d, TS const& s)
+    {
+        simd_horizontal_update<P>(amrex::get<I>(d), amrex::get<I>(s));
+    }
+
+    template <std::size_t I, typename TD, typename TS, typename P, typename P1, typename... Ps>
+    AMREX_FORCE_INLINE
+    void for_each_horizontal (TD& d, TS const& s)
+    {
+        simd_horizontal_update<P>(amrex::get<I>(d), amrex::get<I>(s));
+        for_each_horizontal<I+1,TD,TS,P1,Ps...>(d, s);
+    }
+
+#endif // AMREX_USE_SIMD && !AMREX_USE_GPU
+}
+/// \endcond
+
+#ifndef AMREX_USE_GPU
+
+/**
+ * \brief SIMD-vectorized evaluation loop for host (CPU) reductions.
+ *
+ * This is the CPU/SIMD counterpart of the host \c ReduceOps::eval element loop.
+ * It processes \c n elements in chunks of \c WIDTH using per-lane SIMD accumulator
+ * registers, handles the remainder with scalar iterations, and folds the result
+ * into \c reduce_data exactly like the scalar evaluation loop.
+ *
+ * The callable \c f is invoked as \c f(amrex::SIMDindex<WIDTH>{i}) in the main loop
+ * and as \c f(amrex::SIMDindex<1>{i}) for the remainder. For \c SIMDindex<WIDTH> it
+ * must return the SIMD-widened form of the \c ReduceData tuple (each scalar component
+ * replaced by a \c fixed_size_simd register of the same element type and width);
+ * for \c SIMDindex<1> it must return the scalar \c ReduceData tuple. Kernels written
+ * with amrex::simd::load_1d satisfy both forms from a single source.
+ *
+ * Compiled without SIMD support (\c AMReX_SIMD=OFF), only the scalar loop remains
+ * and \c f is only ever called with \c SIMDindex<1>.
+ *
+ * Only \c ReduceOpSum, \c ReduceOpMin and \c ReduceOpMax are supported.
+ *
+ * \note SIMD sum reductions reassociate floating-point additions (per-lane partial
+ *       sums plus a final horizontal fold), so results can differ from the scalar
+ *       evaluation order by rounding.
+ *
+ * \tparam WIDTH SIMD width in elements
+ * \tparam N     index type (integer)
+ * \tparam D     the ReduceData type
+ * \tparam F     callable, see above
+ * \tparam Ps    the reduce operations of the ReduceOps
+ *
+ * \param n           number of elements to reduce over
+ * \param reduce_data where the result is accumulated
+ * \param f           callable, see above
+ */
+template <int WIDTH, std::integral N, typename D, typename F, typename... Ps>
+AMREX_ATTRIBUTE_FLATTEN_FOR
+void evalReduceSIMD (N n, D& reduce_data, F const& f, ReduceOps<Ps...>& /*reduce_ops*/)
+{
+    static_assert(WIDTH >= 1, "evalReduceSIMD: WIDTH must be at least 1");
+    static_assert((Reduce::detail::is_simd_reduce_op<Ps> && ...),
+        "evalReduceSIMD supports only ReduceOpSum, ReduceOpMin and ReduceOpMax");
+
+    using ReduceTuple = typename D::Type;
+    ReduceTuple rr;  // scalar accumulator (remainder and horizontal fold target)
+    Reduce::detail::for_each_init<0, ReduceTuple, Ps...>(rr);
+    N i = 0;
+#ifdef AMREX_USE_SIMD
+    if constexpr (WIDTH > 1) {
+        using SimdTuple = typename Reduce::detail::MakeSIMDTuple<WIDTH, ReduceTuple>::type;
+        static_assert(std::is_same_v<SimdTuple,
+                          std::decay_t<decltype(f(SIMDindex<WIDTH, N>{0}))>>,
+            "evalReduceSIMD: for SIMDindex<WIDTH> the callable must return the "
+            "SIMD-widened ReduceData tuple (fixed_size_simd of each component type). "
+            "Load particle/array data with amrex::simd::load_1d to get matching types.");
+        SimdTuple sr;
+        Reduce::detail::for_each_simd_init<0, SimdTuple, Ps...>(sr);
+        // vectorized main loop over full SIMD lanes
+        for (; i + WIDTH <= n; i += WIDTH) {
+            Reduce::detail::for_each_simd_local<0, SimdTuple, Ps...>(sr, f(SIMDindex<WIDTH, N>{i}));
+        }
+        Reduce::detail::for_each_horizontal<0, ReduceTuple, SimdTuple, Ps...>(rr, sr);
+    }
+#endif
+    // scalar handling of the remainder (or the whole range without SIMD)
+    for (; i < n; ++i) {
+        Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(rr, f(SIMDindex<1, N>{i}));
+    }
+    Reduce::detail::for_each_local<0, ReduceTuple, Ps...>(
+        reduce_data.reference(OpenMP::get_thread_num()), rr);
+}
+
+#endif // !AMREX_USE_GPU
+}
+
+#endif

--- a/Src/Base/AMReX_SIMD.H
+++ b/Src/Base/AMReX_SIMD.H
@@ -133,6 +133,63 @@ namespace amrex::simd
         {
             return mask ? true_val : false_val;
         }
+
+        /** Horizontal reduction over all elements (scalar identity fallback for simd reduce)
+         *
+         * For a scalar, the reduction over its single "element" is the value itself,
+         * independent of the (associative) binary operation.
+         *
+         * Example:
+         * ```cpp
+         * // Works for both simd<T> and scalar T:
+         * auto total = amrex::simd::stdx::reduce(v);  // sum of all elements
+         * ```
+         *
+         * @see https://en.cppreference.com/w/cpp/experimental/simd/reduce
+         */
+        template <typename T>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T reduce (T const& v) { return v; }
+
+        /** Horizontal reduction with an explicit binary operation (scalar identity fallback)
+         *
+         * @see reduce above
+         */
+        template <typename T, typename BinaryOperation>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T reduce (T const& v, BinaryOperation const&) { return v; }
+
+        /** Smallest element (scalar identity fallback for simd hmin)
+         *
+         * @see https://en.cppreference.com/w/cpp/experimental/simd/reduce_min_max
+         */
+        template <typename T>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T hmin (T const& v) { return v; }
+
+        /** Largest element (scalar identity fallback for simd hmax)
+         *
+         * @see https://en.cppreference.com/w/cpp/experimental/simd/reduce_min_max
+         */
+        template <typename T>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T hmax (T const& v) { return v; }
+
+        /** Element-wise minimum (scalar fallback for simd min)
+         *
+         * @see https://en.cppreference.com/w/cpp/experimental/simd/min
+         */
+        template <typename T>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T min (T const& a, T const& b) { return (b < a) ? b : a; }
+
+        /** Element-wise maximum (scalar fallback for simd max)
+         *
+         * @see https://en.cppreference.com/w/cpp/experimental/simd/max
+         */
+        template <typename T>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        T max (T const& a, T const& b) { return (a < b) ? b : a; }
 #endif
     }
 

--- a/Src/Base/CMakeLists.txt
+++ b/Src/Base/CMakeLists.txt
@@ -41,6 +41,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_FileSystem.cpp
        AMReX_ValLocPair.H
        AMReX_Reduce.H
+       AMReX_ReduceSIMD.H
        AMReX_Scan.H
        AMReX_Partition.H
        AMReX_Morton.H

--- a/Src/Base/Make.package
+++ b/Src/Base/Make.package
@@ -29,7 +29,7 @@ C$(AMREX_BASE)_sources += AMReX_String.cpp
 
 C$(AMREX_BASE)_sources += AMReX_ParmParse.cpp AMReX_parmparse_fi.cpp AMReX_Utility.cpp
 C$(AMREX_BASE)_headers += AMReX_ParmParse.H AMReX_Utility.H AMReX_BLassert.H AMReX_ArrayLim.H
-C$(AMREX_BASE)_headers += AMReX_Functional.H AMReX_Reduce.H AMReX_Scan.H AMReX_Partition.H
+C$(AMREX_BASE)_headers += AMReX_Functional.H AMReX_Reduce.H AMReX_ReduceSIMD.H AMReX_Scan.H AMReX_Partition.H
 C$(AMREX_BASE)_headers += AMReX_ValLocPair.H
 
 C$(AMREX_BASE)_headers += AMReX_FileSystem.H

--- a/Src/Particle/AMReX_ParticleReduceSIMD.H
+++ b/Src/Particle/AMReX_ParticleReduceSIMD.H
@@ -35,7 +35,8 @@ namespace particle_detail {
 
 /**
  * \brief A general SIMD-vectorized reduction method for the particles in a
- * ParticleContainer. This version operates from the specified lev_min to lev_max.
+ * ParticleContainer. This version operates from the specified lev_min to
+ * lev_max.
  *
  * This is the SIMD counterpart of amrex::ParticleReduce. When AMReX is compiled
  * with SIMD support (\c AMReX_SIMD=ON), the reduction runs vectorized over
@@ -53,9 +54,11 @@ namespace particle_detail {
  *    \code{.cpp}
  *       using ConstPTDType = typename PC::ConstPTDType;
  *       amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpMin> reduce_ops;
- *       auto r = amrex::ParticleReduceSIMD<amrex::ReduceData<amrex::ParticleReal, amrex::ParticleReal>>(
- *                    pc, lev_min, lev_max,
- *                    [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, auto si) noexcept
+ *       auto r =
+ * amrex::ParticleReduceSIMD<amrex::ReduceData<amrex::ParticleReal,
+ * amrex::ParticleReal>>( pc, lev_min, lev_max,
+ *                    [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, auto si)
+ * noexcept
  *                {
  *                    auto const a = amrex::simd::load_1d(ptd.rdata(1), si);
  *                    auto const w = amrex::simd::load_1d(ptd.rdata(2), si);
@@ -63,9 +66,9 @@ namespace particle_detail {
  *                }, reduce_ops);
  *    \endcode
  *
- * For CUDA builds, note that extended device lambdas have compiler-version
- * dependent restrictions on generic (auto) parameters; a small functor with a
- * templated \c operator() is the most portable form of the kernel.
+ * For CUDA builds, note that extended device lambdas have nvcc-version
+ * dependent restrictions on generic (auto) parameters and a small functor with
+ * a templated \c operator() is the most portable form of the kernel.
  *
  * Only \c ReduceOpSum, \c ReduceOpMin and \c ReduceOpMax are supported
  * (compile-time enforced). Note that there is no MPI reduction performed at
@@ -81,7 +84,7 @@ namespace particle_detail {
  *         width for amrex::ParticleReal (1 without SIMD support)
  * \tparam PC the ParticleContainer type
  * \tparam F a function object
- * \tparam ReduceOps_t the ReduceOps type
+ * \tparam Ps the reduce operations of the ReduceOps
  *
  * \param pc the ParticleContainer to operate on
  * \param lev_min the minimum level to include
@@ -89,24 +92,31 @@ namespace particle_detail {
  * \param f a callable that operates on WIDTH particles at a time, see above
  * \param reduce_ops the reduction operations, one per component of RD
  */
-template <class RD, int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
-          class PC, class F, class ReduceOps_t>
-requires (IsParticleContainer<PC>::value)
-typename RD::Type
-ParticleReduceSIMD (PC const& pc, int lev_min, int lev_max, F const& f, ReduceOps_t& reduce_ops)
-{
-    RD reduce_data(reduce_ops);
-    for (int lev = lev_min; lev <= lev_max; ++lev) {
-        const auto& plev = pc.GetParticles(lev);
-        Vector<std::pair<int, int> > grid_tile_ids;
-        Vector<const typename PC::ParticleTileType*> ptile_ptrs;
-        for (auto& kv : plev)
-        {
-            grid_tile_ids.push_back(kv.first);
-            ptile_ptrs.push_back(&(kv.second));
-        }
+template <class RD,
+          int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F, typename... Ps>
+  requires(IsParticleContainer<PC>::value)
+typename RD::Type ParticleReduceSIMD(PC const &pc, int lev_min, int lev_max,
+                                     F const &f, ReduceOps<Ps...> &reduce_ops) {
+  // enforce the documented contract in every configuration (CPU with and
+  // without SIMD support, GPU), not just where evalReduceSIMD is called
+  static_assert(WIDTH >= 1, "ParticleReduceSIMD: WIDTH must be at least 1");
+  static_assert((Reduce::detail::is_simd_reduce_op<Ps> && ...),
+                "ParticleReduceSIMD supports only ReduceOpSum, ReduceOpMin and "
+                "ReduceOpMax");
 
-        // We avoid ParIter here to allow reductions after grids change but prior to calling Redistribute()
+  RD reduce_data(reduce_ops);
+  for (int lev = lev_min; lev <= lev_max; ++lev) {
+    const auto &plev = pc.GetParticles(lev);
+    Vector<std::pair<int, int>> grid_tile_ids;
+    Vector<const typename PC::ParticleTileType *> ptile_ptrs;
+    for (auto &kv : plev) {
+      grid_tile_ids.push_back(kv.first);
+      ptile_ptrs.push_back(&(kv.second));
+    }
+
+    // We avoid ParIter here to allow reductions after grids change but prior to
+    // calling Redistribute()
 #if !defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP)
 #pragma omp parallel for
 #endif
@@ -150,13 +160,13 @@ ParticleReduceSIMD (PC const& pc, int lev_min, int lev_max, F const& f, ReduceOp
  * \param f a callable that operates on WIDTH particles at a time
  * \param reduce_ops the reduction operations, one per component of RD
  */
-template <class RD, int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
-          class PC, class F, class ReduceOps_t>
-requires (IsParticleContainer<PC>::value)
-typename RD::Type
-ParticleReduceSIMD (PC const& pc, int lev, F const& f, ReduceOps_t& reduce_ops)
-{
-    return ParticleReduceSIMD<RD, WIDTH>(pc, lev, lev, f, reduce_ops);
+template <class RD,
+          int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F, typename... Ps>
+  requires(IsParticleContainer<PC>::value)
+typename RD::Type ParticleReduceSIMD(PC const &pc, int lev, F const &f,
+                                     ReduceOps<Ps...> &reduce_ops) {
+  return ParticleReduceSIMD<RD, WIDTH>(pc, lev, lev, f, reduce_ops);
 }
 
 /**
@@ -170,13 +180,13 @@ ParticleReduceSIMD (PC const& pc, int lev, F const& f, ReduceOps_t& reduce_ops)
  * \param f a callable that operates on WIDTH particles at a time
  * \param reduce_ops the reduction operations, one per component of RD
  */
-template <class RD, int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
-          class PC, class F, class ReduceOps_t>
-requires (IsParticleContainer<PC>::value)
-typename RD::Type
-ParticleReduceSIMD (PC const& pc, F const& f, ReduceOps_t& reduce_ops)
-{
-    return ParticleReduceSIMD<RD, WIDTH>(pc, 0, pc.finestLevel(), f, reduce_ops);
+template <class RD,
+          int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F, typename... Ps>
+  requires(IsParticleContainer<PC>::value)
+typename RD::Type ParticleReduceSIMD(PC const &pc, F const &f,
+                                     ReduceOps<Ps...> &reduce_ops) {
+  return ParticleReduceSIMD<RD, WIDTH>(pc, 0, pc.finestLevel(), f, reduce_ops);
 }
 
 /**

--- a/Src/Particle/AMReX_ParticleReduceSIMD.H
+++ b/Src/Particle/AMReX_ParticleReduceSIMD.H
@@ -1,0 +1,411 @@
+#ifndef AMREX_PARTICLEREDUCE_SIMD_H_
+#define AMREX_PARTICLEREDUCE_SIMD_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_ParticleReduce.H>  // provides amrex::SIMDindex via AMReX_Gpu.H
+#include <AMReX_ReduceSIMD.H>
+#include <AMReX_SIMD.H>
+#include <AMReX_Tuple.H>
+#include <AMReX_TypeTraits.H>
+#include <AMReX_Vector.H>
+
+#include <type_traits>
+#include <utility>
+
+namespace amrex {
+
+/// \cond DOXYGEN_IGNORE
+namespace particle_detail {
+
+    //! Wraps a callable that returns a single value into one that returns a 1-element tuple
+    template <typename F>
+    struct SIMDTupleWrapper
+    {
+        F m_f;
+
+        template <typename PTD, typename SI>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        auto operator() (PTD const& ptd, SI const si) const noexcept
+        {
+            return amrex::makeTuple(m_f(ptd, si));
+        }
+    };
+}
+/// \endcond
+
+/**
+ * \brief A general SIMD-vectorized reduction method for the particles in a
+ * ParticleContainer. This version operates from the specified lev_min to lev_max.
+ *
+ * This is the SIMD counterpart of amrex::ParticleReduce. When AMReX is compiled
+ * with SIMD support (\c AMReX_SIMD=ON), the reduction runs vectorized over
+ * \c WIDTH particles at a time (with a scalar remainder loop). The same user
+ * code compiles and runs unchanged in all other configurations:
+ *   - \c AMReX_SIMD=OFF (CPU): a scalar loop, identical in semantics to
+ *     amrex::ParticleReduce.
+ *   - GPU builds: the regular device reduction, like amrex::ParticleReduce.
+ *
+ * The callable \c f is invoked as \c f(ptd,si) with a \c ConstParticleTileData
+ * and an amrex::SIMDindex. Write it generically over the index and load
+ * components with amrex::simd::load_1d so that a single source supports the
+ * vectorized main loop, the scalar remainder and GPUs:
+ *
+ *    \code{.cpp}
+ *       using ConstPTDType = typename PC::ConstPTDType;
+ *       amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpMin> reduce_ops;
+ *       auto r = amrex::ParticleReduceSIMD<amrex::ReduceData<amrex::ParticleReal, amrex::ParticleReal>>(
+ *                    pc, lev_min, lev_max,
+ *                    [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, auto si) noexcept
+ *                {
+ *                    auto const a = amrex::simd::load_1d(ptd.rdata(1), si);
+ *                    auto const w = amrex::simd::load_1d(ptd.rdata(2), si);
+ *                    return amrex::makeTuple(a * w, a);
+ *                }, reduce_ops);
+ *    \endcode
+ *
+ * For CUDA builds, note that extended device lambdas have compiler-version
+ * dependent restrictions on generic (auto) parameters; a small functor with a
+ * templated \c operator() is the most portable form of the kernel.
+ *
+ * Only \c ReduceOpSum, \c ReduceOpMin and \c ReduceOpMax are supported
+ * (compile-time enforced). Note that there is no MPI reduction performed at
+ * the end of this operation, just like for amrex::ParticleReduce.
+ *
+ * \note With SIMD enabled, sum reductions reassociate floating-point additions
+ *       (per-lane partial sums plus a final horizontal fold), so results can
+ *       differ from the scalar evaluation order by rounding. In particular,
+ *       \c amrex::system::regtest_reduction is not honored by the SIMD path.
+ *
+ * \tparam RD the ReduceData type
+ * \tparam WIDTH SIMD width in elements; defaults to the native SIMD register
+ *         width for amrex::ParticleReal (1 without SIMD support)
+ * \tparam PC the ParticleContainer type
+ * \tparam F a function object
+ * \tparam ReduceOps_t the ReduceOps type
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param lev_min the minimum level to include
+ * \param lev_max the maximum level to include
+ * \param f a callable that operates on WIDTH particles at a time, see above
+ * \param reduce_ops the reduction operations, one per component of RD
+ */
+template <class RD, int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F, class ReduceOps_t>
+requires (IsParticleContainer<PC>::value)
+typename RD::Type
+ParticleReduceSIMD (PC const& pc, int lev_min, int lev_max, F const& f, ReduceOps_t& reduce_ops)
+{
+    RD reduce_data(reduce_ops);
+    for (int lev = lev_min; lev <= lev_max; ++lev) {
+        const auto& plev = pc.GetParticles(lev);
+        Vector<std::pair<int, int> > grid_tile_ids;
+        Vector<const typename PC::ParticleTileType*> ptile_ptrs;
+        for (auto& kv : plev)
+        {
+            grid_tile_ids.push_back(kv.first);
+            ptile_ptrs.push_back(&(kv.second));
+        }
+
+        // We avoid ParIter here to allow reductions after grids change but prior to calling Redistribute()
+#if !defined(AMREX_USE_GPU) && defined(AMREX_USE_OMP)
+#pragma omp parallel for
+#endif
+        for (int pmap_it = 0; pmap_it < std::ssize(ptile_ptrs); ++pmap_it)
+        {
+            const auto& tile = plev.at(grid_tile_ids[pmap_it]);
+            const auto np = tile.numParticles();
+            const auto& ptd = tile.getConstParticleTileData();
+#ifdef AMREX_USE_GPU
+            reduce_ops.eval(np, reduce_data,
+                            [=] AMREX_GPU_DEVICE (const int i) noexcept
+                            {
+                                return f(ptd, SIMDindex<1, int>{i});
+                            });
+#else
+#ifdef AMREX_USE_SIMD
+            constexpr int EffWidth = WIDTH;
+#else
+            constexpr int EffWidth = 1;  // explicit WIDTH > 1 still compiles, scalar
+#endif
+            evalReduceSIMD<EffWidth>(np, reduce_data,
+                            [=] (auto si) noexcept
+                            {
+                                return f(ptd, si);
+                            }, reduce_ops);
+#endif
+        }
+    }
+    return reduce_data.value(reduce_ops);
+}
+
+/**
+ * \brief A general SIMD-vectorized reduction method for the particles in a
+ * ParticleContainer. This version operates only on the specified level.
+ *
+ * See the lev_min/lev_max overload of amrex::ParticleReduceSIMD for the
+ * kernel contract, an example, and the supported reduce operations.
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param lev the level to operate on
+ * \param f a callable that operates on WIDTH particles at a time
+ * \param reduce_ops the reduction operations, one per component of RD
+ */
+template <class RD, int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F, class ReduceOps_t>
+requires (IsParticleContainer<PC>::value)
+typename RD::Type
+ParticleReduceSIMD (PC const& pc, int lev, F const& f, ReduceOps_t& reduce_ops)
+{
+    return ParticleReduceSIMD<RD, WIDTH>(pc, lev, lev, f, reduce_ops);
+}
+
+/**
+ * \brief A general SIMD-vectorized reduction method for the particles in a
+ * ParticleContainer. This version operates over all particles on all levels.
+ *
+ * See the lev_min/lev_max overload of amrex::ParticleReduceSIMD for the
+ * kernel contract, an example, and the supported reduce operations.
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param f a callable that operates on WIDTH particles at a time
+ * \param reduce_ops the reduction operations, one per component of RD
+ */
+template <class RD, int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F, class ReduceOps_t>
+requires (IsParticleContainer<PC>::value)
+typename RD::Type
+ParticleReduceSIMD (PC const& pc, F const& f, ReduceOps_t& reduce_ops)
+{
+    return ParticleReduceSIMD<RD, WIDTH>(pc, 0, pc.finestLevel(), f, reduce_ops);
+}
+
+/**
+ * \brief A SIMD-vectorized sum reduction over the particles in a ParticleContainer.
+ * This version operates from the specified lev_min to lev_max.
+ *
+ * This is the SIMD counterpart of the \c (ptd,i) form of amrex::ReduceSum. The
+ * callable is invoked as \c f(ptd,si) with an amrex::SIMDindex and must return
+ * one value (a SIMD register of \c WIDTH values in the vectorized main loop, a
+ * scalar in the remainder loop and on GPUs). Load particle components with
+ * amrex::simd::load_1d so a single source supports all configurations:
+ *
+ *    \code{.cpp}
+ *       using ConstPTDType = typename PC::ConstPTDType;
+ *       auto sm = amrex::ReduceSumSIMD(pc, lev_min, lev_max,
+ *                 [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, auto si) noexcept
+ *                 {
+ *                     return amrex::simd::load_1d(ptd.rdata(0), si);
+ *                 });
+ *    \endcode
+ *
+ * Note that there is no MPI reduction performed at the end of this operation.
+ * On GPU builds this always runs on the device (like amrex::ParticleReduce and
+ * unlike amrex::ReduceSum, which checks the launch region).
+ *
+ * \note With SIMD enabled, sum reductions reassociate floating-point additions,
+ *       so results can differ from the scalar evaluation order by rounding.
+ *
+ * \tparam WIDTH SIMD width in elements; defaults to the native SIMD register
+ *         width for amrex::ParticleReal (1 without SIMD support)
+ * \tparam PC the ParticleContainer type
+ * \tparam F a function object
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param lev_min the minimum level to include
+ * \param lev_max the maximum level to include
+ * \param f a callable that operates on WIDTH particles at a time, see above
+ */
+template <int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F>
+requires (IsParticleContainer<PC>::value)
+auto
+ReduceSumSIMD (PC const& pc, int lev_min, int lev_max, F const& f)
+{
+    using ConstPTDType = typename PC::ConstPTDType;
+    using T = std::decay_t<std::invoke_result_t<F, ConstPTDType const&, SIMDindex<1, int>>>;
+    ReduceOps<ReduceOpSum> reduce_ops;
+    auto r = ParticleReduceSIMD<ReduceData<T>, WIDTH>(
+        pc, lev_min, lev_max, particle_detail::SIMDTupleWrapper<F>{f}, reduce_ops);
+    return amrex::get<0>(r);
+}
+
+/**
+ * \brief A SIMD-vectorized sum reduction over the particles in a ParticleContainer.
+ * This version operates only on the specified level.
+ *
+ * See the lev_min/lev_max overload of amrex::ReduceSumSIMD for the kernel
+ * contract and an example.
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param lev the level to operate on
+ * \param f a callable that operates on WIDTH particles at a time
+ */
+template <int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F>
+requires (IsParticleContainer<PC>::value)
+auto
+ReduceSumSIMD (PC const& pc, int lev, F const& f)
+{
+    return ReduceSumSIMD<WIDTH>(pc, lev, lev, f);
+}
+
+/**
+ * \brief A SIMD-vectorized sum reduction over the particles in a ParticleContainer.
+ * This version operates over all particles on all levels.
+ *
+ * See the lev_min/lev_max overload of amrex::ReduceSumSIMD for the kernel
+ * contract and an example.
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param f a callable that operates on WIDTH particles at a time
+ */
+template <int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F>
+requires (IsParticleContainer<PC>::value)
+auto
+ReduceSumSIMD (PC const& pc, F const& f)
+{
+    return ReduceSumSIMD<WIDTH>(pc, 0, pc.finestLevel(), f);
+}
+
+/**
+ * \brief A SIMD-vectorized min reduction over the particles in a ParticleContainer.
+ * This version operates from the specified lev_min to lev_max.
+ *
+ * See amrex::ReduceSumSIMD for the kernel contract and an example; this
+ * version uses "min" as the reduction operation (exact, no floating-point
+ * reassociation concerns).
+ *
+ * \tparam WIDTH SIMD width in elements; defaults to the native SIMD register
+ *         width for amrex::ParticleReal (1 without SIMD support)
+ * \tparam PC the ParticleContainer type
+ * \tparam F a function object
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param lev_min the minimum level to include
+ * \param lev_max the maximum level to include
+ * \param f a callable that operates on WIDTH particles at a time
+ */
+template <int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F>
+requires (IsParticleContainer<PC>::value)
+auto
+ReduceMinSIMD (PC const& pc, int lev_min, int lev_max, F const& f)
+{
+    using ConstPTDType = typename PC::ConstPTDType;
+    using T = std::decay_t<std::invoke_result_t<F, ConstPTDType const&, SIMDindex<1, int>>>;
+    ReduceOps<ReduceOpMin> reduce_ops;
+    auto r = ParticleReduceSIMD<ReduceData<T>, WIDTH>(
+        pc, lev_min, lev_max, particle_detail::SIMDTupleWrapper<F>{f}, reduce_ops);
+    return amrex::get<0>(r);
+}
+
+/**
+ * \brief A SIMD-vectorized min reduction over the particles in a ParticleContainer.
+ * This version operates only on the specified level.
+ *
+ * See amrex::ReduceSumSIMD for the kernel contract and an example.
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param lev the level to operate on
+ * \param f a callable that operates on WIDTH particles at a time
+ */
+template <int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F>
+requires (IsParticleContainer<PC>::value)
+auto
+ReduceMinSIMD (PC const& pc, int lev, F const& f)
+{
+    return ReduceMinSIMD<WIDTH>(pc, lev, lev, f);
+}
+
+/**
+ * \brief A SIMD-vectorized min reduction over the particles in a ParticleContainer.
+ * This version operates over all particles on all levels.
+ *
+ * See amrex::ReduceSumSIMD for the kernel contract and an example.
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param f a callable that operates on WIDTH particles at a time
+ */
+template <int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F>
+requires (IsParticleContainer<PC>::value)
+auto
+ReduceMinSIMD (PC const& pc, F const& f)
+{
+    return ReduceMinSIMD<WIDTH>(pc, 0, pc.finestLevel(), f);
+}
+
+/**
+ * \brief A SIMD-vectorized max reduction over the particles in a ParticleContainer.
+ * This version operates from the specified lev_min to lev_max.
+ *
+ * See amrex::ReduceSumSIMD for the kernel contract and an example; this
+ * version uses "max" as the reduction operation (exact, no floating-point
+ * reassociation concerns).
+ *
+ * \tparam WIDTH SIMD width in elements; defaults to the native SIMD register
+ *         width for amrex::ParticleReal (1 without SIMD support)
+ * \tparam PC the ParticleContainer type
+ * \tparam F a function object
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param lev_min the minimum level to include
+ * \param lev_max the maximum level to include
+ * \param f a callable that operates on WIDTH particles at a time
+ */
+template <int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F>
+requires (IsParticleContainer<PC>::value)
+auto
+ReduceMaxSIMD (PC const& pc, int lev_min, int lev_max, F const& f)
+{
+    using ConstPTDType = typename PC::ConstPTDType;
+    using T = std::decay_t<std::invoke_result_t<F, ConstPTDType const&, SIMDindex<1, int>>>;
+    ReduceOps<ReduceOpMax> reduce_ops;
+    auto r = ParticleReduceSIMD<ReduceData<T>, WIDTH>(
+        pc, lev_min, lev_max, particle_detail::SIMDTupleWrapper<F>{f}, reduce_ops);
+    return amrex::get<0>(r);
+}
+
+/**
+ * \brief A SIMD-vectorized max reduction over the particles in a ParticleContainer.
+ * This version operates only on the specified level.
+ *
+ * See amrex::ReduceSumSIMD for the kernel contract and an example.
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param lev the level to operate on
+ * \param f a callable that operates on WIDTH particles at a time
+ */
+template <int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F>
+requires (IsParticleContainer<PC>::value)
+auto
+ReduceMaxSIMD (PC const& pc, int lev, F const& f)
+{
+    return ReduceMaxSIMD<WIDTH>(pc, lev, lev, f);
+}
+
+/**
+ * \brief A SIMD-vectorized max reduction over the particles in a ParticleContainer.
+ * This version operates over all particles on all levels.
+ *
+ * See amrex::ReduceSumSIMD for the kernel contract and an example.
+ *
+ * \param pc the ParticleContainer to operate on
+ * \param f a callable that operates on WIDTH particles at a time
+ */
+template <int WIDTH = static_cast<int>(simd::native_simd_size_particlereal),
+          class PC, class F>
+requires (IsParticleContainer<PC>::value)
+auto
+ReduceMaxSIMD (PC const& pc, F const& f)
+{
+    return ReduceMaxSIMD<WIDTH>(pc, 0, pc.finestLevel(), f);
+}
+
+}
+
+#endif

--- a/Src/Particle/AMReX_ParticleReduceSIMD.H
+++ b/Src/Particle/AMReX_ParticleReduceSIMD.H
@@ -41,7 +41,7 @@ namespace particle_detail {
     template <typename F, typename PTD>
     struct SIMDKernelBinder
     {
-        F const& m_f;
+        F m_f;
         PTD m_ptd;
 
         template <typename SI>

--- a/Src/Particle/AMReX_ParticleReduceSIMD.H
+++ b/Src/Particle/AMReX_ParticleReduceSIMD.H
@@ -30,6 +30,27 @@ namespace particle_detail {
             return amrex::makeTuple(m_f(ptd, si));
         }
     };
+
+    /** Binds the tile data as the first argument of a reduction kernel.
+     *
+     * The force-inlined \c operator() makes the kernel invocation fold into
+     * the evalReduceSIMD accumulation loop instead of remaining an
+     * out-of-line call, which would spill all SIMD accumulator registers
+     * (caller-saved) around it on every iteration.
+     */
+    template <typename F, typename PTD>
+    struct SIMDKernelBinder
+    {
+        F const& m_f;
+        PTD m_ptd;
+
+        template <typename SI>
+        AMREX_FORCE_INLINE
+        auto operator() (SI const si) const noexcept
+        {
+            return m_f(m_ptd, si);
+        }
+    };
 }
 /// \endcond
 
@@ -137,11 +158,10 @@ typename RD::Type ParticleReduceSIMD(PC const &pc, int lev_min, int lev_max,
 #else
             constexpr int EffWidth = 1;  // explicit WIDTH > 1 still compiles, scalar
 #endif
+            using PTDType = std::decay_t<decltype(ptd)>;
             evalReduceSIMD<EffWidth>(np, reduce_data,
-                            [=] (auto si) noexcept
-                            {
-                                return f(ptd, si);
-                            }, reduce_ops);
+                            particle_detail::SIMDKernelBinder<F, PTDType>{f, ptd},
+                            reduce_ops);
 #endif
         }
     }

--- a/Src/Particle/CMakeLists.txt
+++ b/Src/Particle/CMakeLists.txt
@@ -41,6 +41,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        AMReX_ParticleCommunication.cpp
        AMReX_ParticleInterpolators.H
        AMReX_ParticleReduce.H
+       AMReX_ParticleReduceSIMD.H
        AMReX_ParticleMesh.H
        AMReX_ParticleLocator.H
        AMReX_ParticleIO.H

--- a/Src/Particle/Make.package
+++ b/Src/Particle/Make.package
@@ -39,6 +39,7 @@ CEXE_headers += AMReX_ParticleCommunication.H
 CEXE_sources += AMReX_ParticleCommunication.cpp
 
 CEXE_headers += AMReX_ParticleReduce.H
+CEXE_headers += AMReX_ParticleReduceSIMD.H
 
 CEXE_headers += AMReX_ParticleLocator.H
 CEXE_headers += AMReX_ParticleArray.H

--- a/Tests/Particles/ParticleReduceSIMD/CMakeLists.txt
+++ b/Tests/Particles/ParticleReduceSIMD/CMakeLists.txt
@@ -1,0 +1,9 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources     main.cpp)
+    set(_input_files inputs  )
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Particles/ParticleReduceSIMD/GNUmakefile
+++ b/Tests/Particles/ParticleReduceSIMD/GNUmakefile
@@ -1,0 +1,24 @@
+AMREX_HOME = ../../../
+
+DEBUG	= FALSE
+
+DIM	= 3
+
+COMP    = gcc
+
+USE_MPI   = FALSE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+
+TINY_PROFILE = FALSE
+USE_PARTICLES = TRUE
+
+CXXSTD = c++20
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+include $(AMREX_HOME)/Src/Particle/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Particles/ParticleReduceSIMD/Make.package
+++ b/Tests/Particles/ParticleReduceSIMD/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Particles/ParticleReduceSIMD/inputs
+++ b/Tests/Particles/ParticleReduceSIMD/inputs
@@ -1,0 +1,7 @@
+# defaults keep CI/ctest runs fast; override on the command line for real
+# benchmark runs, e.g.:
+#   benchmark.sizes="1000 10000 100000 1000000 10000000" benchmark.target_evals=200000000
+benchmark.enabled = 1
+benchmark.sizes = 1000
+benchmark.target_evals = 2000000
+benchmark.warmup_reps = 3

--- a/Tests/Particles/ParticleReduceSIMD/main.cpp
+++ b/Tests/Particles/ParticleReduceSIMD/main.cpp
@@ -1,0 +1,424 @@
+// Test and benchmark for SIMD-vectorized particle reductions:
+//   amrex::ParticleReduceSIMD, amrex::ReduceSumSIMD,
+//   amrex::ReduceMinSIMD, amrex::ReduceMaxSIMD
+//
+// The reduction kernel reproduces the "reduced beam characteristics"
+// diagnostic of ImpactX: one fused reduction with 34 sums (weight +
+// 9 weighted first moments + 24 weighted second moments), 6 mins and
+// 6 maxes over a pure-SoA particle container with 11 real components.
+//
+// Three kernel variants are compared for correctness and speed:
+//   A: amrex::ParticleReduce with a SuperParticle lambda (per-particle copy)
+//   B: amrex::ParticleReduce with a (ConstParticleTileData, int) lambda
+//   C: amrex::ParticleReduceSIMD with a single-source load_1d functor
+//
+// Compiles and runs with AMReX_SIMD=OFF (scalar fallback, GPU) and ON (CPU SIMD).
+
+#include <AMReX.H>
+#include <AMReX_BLassert.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_ParticleReduceSIMD.H>
+#include <AMReX_Particles.H>
+#include <AMReX_Print.H>
+#include <AMReX_Reduce.H>
+#include <AMReX_SIMD.H>
+#include <AMReX_Tuple.H>
+#include <AMReX_TypeList.H>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace amrex;
+
+// SoA layout mimicking ImpactX (x, y, t double as the positions in 3D)
+struct RealSoA
+{
+    enum { x = 0, y, t, px, py, pt, sx, sy, sz, qm, w, nattribs };
+};
+
+static constexpr int NReal = RealSoA::nattribs;  // 11
+static constexpr int NInt = 0;
+
+using PC = ParticleContainerPureSoA<NReal, NInt>;
+using ConstPTDType = typename PC::ConstPTDType;
+using SPType = typename PC::SuperParticleType;
+
+// 34 sums + 6 mins + 6 maxes, exactly as in ImpactX ReducedBeamCharacteristics
+static constexpr std::size_t num_sum = 34;
+static constexpr std::size_t num_min = 6;
+static constexpr std::size_t num_max = 6;
+static constexpr std::size_t num_red = num_sum + num_min + num_max;
+
+using ReduceOpsT = TypeMultiplier<ReduceOps,
+    ReduceOpSum[num_sum], ReduceOpMin[num_min], ReduceOpMax[num_max]>;
+using ReduceDataT = TypeMultiplier<ReduceData, ParticleReal[num_red]>;
+using ReduceTupleT = typename ReduceDataT::Type;
+
+//! Constant shifts subtracted before forming moments (well-conditioned squares)
+struct Shifts
+{
+    ParticleReal x, y, t, px, py, pt, sx, sy, sz;
+};
+
+/** The per-particle moments, shared by all kernel variants.
+ *
+ * T is amrex::ParticleReal in the scalar variants and remainder loop,
+ * and a SIMD register of WIDTH values in the vectorized main loop.
+ */
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+auto beam_moments (T const& p_w,
+                   T const& p_x, T const& p_y, T const& p_t,
+                   T const& p_px, T const& p_py, T const& p_pt,
+                   T const& p_sx, T const& p_sy, T const& p_sz,
+                   Shifts const& s) noexcept
+{
+    T const dx  = p_x  - s.x;
+    T const dy  = p_y  - s.y;
+    T const dt  = p_t  - s.t;
+    T const dpx = p_px - s.px;
+    T const dpy = p_py - s.py;
+    T const dpt = p_pt - s.pt;
+    T const dsx = p_sx - s.sx;
+    T const dsy = p_sy - s.sy;
+    T const dsz = p_sz - s.sz;
+
+    return amrex::makeTuple(
+        // Sum(w)
+        p_w,
+        // weighted first moments (shifted): x, y, t, px, py, pt, sx, sy, sz
+        dx*p_w, dy*p_w, dt*p_w, dpx*p_w, dpy*p_w, dpt*p_w,
+        dsx*p_w, dsy*p_w, dsz*p_w,
+        // weighted second moments (shifted): diagonal x, y, t, px, py, pt
+        dx*dx*p_w, dy*dy*p_w, dt*dt*p_w, dpx*dpx*p_w, dpy*dpy*p_w, dpt*dpt*p_w,
+        // same-plane correlations: xpx, ypy, tpt
+        dx*dpx*p_w, dy*dpy*p_w, dt*dpt*p_w,
+        // dispersive correlations: xpt, pxpt, ypt, pypt
+        dx*dpt*p_w, dpx*dpt*p_w, dy*dpt*p_w, dpy*dpt*p_w,
+        // cross-plane correlations: xy, xpy, xt, pxy, pxpy, pxt, yt, pyt
+        dx*dy*p_w, dx*dpy*p_w, dx*dt*p_w, dpx*dy*p_w,
+        dpx*dpy*p_w, dpx*dt*p_w, dy*dt*p_w, dpy*dt*p_w,
+        // spin second moments (diagonal): sx, sy, sz
+        dsx*dsx*p_w, dsy*dsy*p_w, dsz*dsz*p_w,
+        // min of x, y, t, px, py, pt
+        p_x, p_y, p_t, p_px, p_py, p_pt,
+        // max of x, y, t, px, py, pt
+        p_x, p_y, p_t, p_px, p_py, p_pt
+    );
+}
+
+//! Variant C: single-source kernel for ParticleReduceSIMD (scalar, SIMD and GPU)
+struct BeamMomentsKernel
+{
+    Shifts s;
+
+    template <typename PTD, typename SI>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    auto operator() (PTD const& ptd, SI const si) const noexcept
+    {
+        auto const p_w  = simd::load_1d(ptd.rdata(RealSoA::w), si);
+        auto const p_x  = simd::load_1d(ptd.rdata(RealSoA::x), si);
+        auto const p_y  = simd::load_1d(ptd.rdata(RealSoA::y), si);
+        auto const p_t  = simd::load_1d(ptd.rdata(RealSoA::t), si);
+        auto const p_px = simd::load_1d(ptd.rdata(RealSoA::px), si);
+        auto const p_py = simd::load_1d(ptd.rdata(RealSoA::py), si);
+        auto const p_pt = simd::load_1d(ptd.rdata(RealSoA::pt), si);
+        auto const p_sx = simd::load_1d(ptd.rdata(RealSoA::sx), si);
+        auto const p_sy = simd::load_1d(ptd.rdata(RealSoA::sy), si);
+        auto const p_sz = simd::load_1d(ptd.rdata(RealSoA::sz), si);
+
+        return beam_moments(p_w, p_x, p_y, p_t, p_px, p_py, p_pt,
+                            p_sx, p_sy, p_sz, s);
+    }
+};
+
+//! Kernel loading a single component, for the Reduce{Sum,Min,Max}SIMD tests
+template <int Comp>
+struct LoadCompKernel
+{
+    template <typename PTD, typename SI>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    auto operator() (PTD const& ptd, SI const si) const noexcept
+    {
+        return simd::load_1d(ptd.rdata(Comp), si);
+    }
+};
+
+//! Deterministic pseudo-random number in [0, 1) from an integer (splitmix64 finalizer)
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+ParticleReal hash01 (std::uint64_t z) noexcept
+{
+    z ^= z >> 33; z *= 0xff51afd7ed558ccdULL;
+    z ^= z >> 33; z *= 0xc4ceb9fe1a85ec53ULL;
+    z ^= z >> 33;
+    return static_cast<ParticleReal>(static_cast<double>(z >> 11) * 0x1.0p-53);
+}
+
+//! Fill one tile with np particles with deterministic pseudo-random data
+void init_particles (PC& pc, int np)
+{
+    const int myproc = ParallelDescriptor::MyProc();
+
+    // only the rank that owns grid 0 holds particles
+    if (pc.ParticleDistributionMap(0)[0] != myproc) { return; }
+
+    auto& ptile = pc.DefineAndReturnParticleTile(0, 0, 0);
+    ptile.resize(np);
+    auto ptd = ptile.getParticleTileData();
+
+    ParallelFor(np, [=] AMREX_GPU_DEVICE (int i) noexcept
+    {
+        for (int k = 0; k < NReal; ++k) {
+            // values in [-1, 1); positions (comps 0..AMREX_SPACEDIM-1) lie
+            // inside the [-2, 2] domain
+            ptd.rdata(k)[i] = ParticleReal(2.)*hash01(std::uint64_t(i)*NReal + std::uint64_t(k))
+                            - ParticleReal(1.);
+        }
+        // positive weight in (0, 1]
+        ptd.rdata(RealSoA::w)[i] = ParticleReal(1.)
+            - hash01(std::uint64_t(i)*NReal + std::uint64_t(RealSoA::w));
+        ptd.idcpu(i) = SetParticleIDandCPU(i+1, myproc);
+    });
+    Gpu::streamSynchronize();
+}
+
+ReduceTupleT run_variant_a (PC const& pc, Shifts const& s)
+{
+    ReduceOpsT reduce_ops;
+    return ParticleReduce<ReduceDataT>(pc,
+        [=] AMREX_GPU_DEVICE (const SPType& p) noexcept
+        {
+            return beam_moments(p.rdata(RealSoA::w),
+                                p.rdata(RealSoA::x), p.rdata(RealSoA::y), p.rdata(RealSoA::t),
+                                p.rdata(RealSoA::px), p.rdata(RealSoA::py), p.rdata(RealSoA::pt),
+                                p.rdata(RealSoA::sx), p.rdata(RealSoA::sy), p.rdata(RealSoA::sz),
+                                s);
+        }, reduce_ops);
+}
+
+ReduceTupleT run_variant_b (PC const& pc, Shifts const& s)
+{
+    ReduceOpsT reduce_ops;
+    return ParticleReduce<ReduceDataT>(pc,
+        [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
+        {
+            return beam_moments(ptd.rdata(RealSoA::w)[i],
+                                ptd.rdata(RealSoA::x)[i], ptd.rdata(RealSoA::y)[i], ptd.rdata(RealSoA::t)[i],
+                                ptd.rdata(RealSoA::px)[i], ptd.rdata(RealSoA::py)[i], ptd.rdata(RealSoA::pt)[i],
+                                ptd.rdata(RealSoA::sx)[i], ptd.rdata(RealSoA::sy)[i], ptd.rdata(RealSoA::sz)[i],
+                                s);
+        }, reduce_ops);
+}
+
+ReduceTupleT run_variant_c (PC const& pc, Shifts const& s)
+{
+    ReduceOpsT reduce_ops;
+    return ParticleReduceSIMD<ReduceDataT>(pc, BeamMomentsKernel{s}, reduce_ops);
+}
+
+//! like run_variant_c, but with twice the native SIMD width (more ILP)
+ReduceTupleT run_variant_c2 (PC const& pc, Shifts const& s)
+{
+    constexpr int w2 = 2 * static_cast<int>(simd::native_simd_size_particlereal);
+    ReduceOpsT reduce_ops;
+    return ParticleReduceSIMD<ReduceDataT, w2>(pc, BeamMomentsKernel{s}, reduce_ops);
+}
+
+/** Compare two reduction results component-wise.
+ *
+ * Sums are compared with an absolute tolerance of
+ * tol_scale * epsilon * max(np, 1) (the summands are O(1));
+ * pass tol_scale = 0 to require bitwise identical sums.
+ * Mins and maxes must always match exactly.
+ */
+void compare_results (ReduceTupleT const& a, ReduceTupleT const& b,
+                      int np, Real tol_scale, std::string const& what)
+{
+    auto const ta = tupleToArray(a);
+    auto const tb = tupleToArray(b);
+
+    const auto tol = static_cast<ParticleReal>(tol_scale)
+        * std::numeric_limits<ParticleReal>::epsilon()
+        * static_cast<ParticleReal>(std::max(np, 1));
+
+    for (int k = 0; k < static_cast<int>(num_red); ++k) {
+        const bool is_sum = (k < static_cast<int>(num_sum));
+        const auto diff = std::abs(ta[k] - tb[k]);
+        if ((is_sum && diff > tol) || (!is_sum && diff != ParticleReal(0.))) {
+            amrex::AllPrint() << "  mismatch (" << what << "): np=" << np
+                              << " comp=" << k << " a=" << ta[k] << " b=" << tb[k]
+                              << " diff=" << diff << " tol=" << tol << "\n";
+            amrex::Abort("ParticleReduceSIMD result mismatch: " + what);
+        }
+    }
+}
+
+void correctness_tests (Geometry const& geom, DistributionMapping const& dm,
+                        BoxArray const& ba, Shifts const& shifts)
+{
+    constexpr int W = static_cast<int>(simd::native_simd_size_particlereal);
+    std::vector<int> sizes{0, 1, 3, W-1, W, W+1, 2*W+3, 1003};
+
+    for (int np : sizes) {
+        if (np < 0) { continue; }
+
+        PC pc(geom, dm, ba);
+        init_particles(pc, np);
+
+        auto const ra = run_variant_a(pc, shifts);
+        auto const rb = run_variant_b(pc, shifts);
+        auto const rc = run_variant_c(pc, shifts);
+
+        // A and B evaluate identical arithmetic in identical order
+        compare_results(ra, rb, np, Real(0.), "A (SuperParticle) vs B (ptd,i)");
+        // C reassociates the sums across SIMD lanes
+        compare_results(rc, rb, np, Real(100.), "C (SIMD) vs B (ptd,i)");
+        // non-native (2x) SIMD width
+        auto const rc2 = run_variant_c2(pc, shifts);
+        compare_results(rc2, rb, np, Real(100.), "C2 (SIMD 2x width) vs B (ptd,i)");
+
+        // value helpers vs the established scalar entry points
+        auto sum_simd = ReduceSumSIMD(pc, LoadCompKernel<RealSoA::w>{});
+        auto sum_ref = ReduceSum(pc,
+            [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
+            { return ptd.rdata(RealSoA::w)[i]; });
+        const auto sum_tol = ParticleReal(100.)
+            * std::numeric_limits<ParticleReal>::epsilon()
+            * static_cast<ParticleReal>(std::max(np, 1));
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::abs(sum_simd - sum_ref) <= sum_tol,
+            "ReduceSumSIMD does not match ReduceSum");
+
+        auto min_simd = ReduceMinSIMD(pc, LoadCompKernel<RealSoA::x>{});
+        auto min_ref = ReduceMin(pc,
+            [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
+            { return ptd.rdata(RealSoA::x)[i]; });
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(min_simd == min_ref,
+            "ReduceMinSIMD does not match ReduceMin");
+
+        auto max_simd = ReduceMaxSIMD(pc, LoadCompKernel<RealSoA::x>{});
+        auto max_ref = ReduceMax(pc,
+            [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
+            { return ptd.rdata(RealSoA::x)[i]; });
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(max_simd == max_ref,
+            "ReduceMaxSIMD does not match ReduceMax");
+
+        Print() << "correctness: np=" << np << " PASSED\n";
+    }
+}
+
+template <typename FRun>
+void bench_variant (std::string const& name, int np, long reps_per_batch,
+                    int nbatch, int warmup_reps, FRun const& run, double& checksum)
+{
+    for (int i = 0; i < warmup_reps; ++i) {
+        checksum += static_cast<double>(amrex::get<0>(run()));
+    }
+
+    double best = std::numeric_limits<double>::max();
+    double total = 0.;
+    for (int b = 0; b < nbatch; ++b) {
+        const auto t0 = amrex::second();
+        for (long r = 0; r < reps_per_batch; ++r) {
+            checksum += static_cast<double>(amrex::get<0>(run()));
+        }
+        const auto dt = amrex::second() - t0;
+        best = std::min(best, dt);
+        total += dt;
+    }
+
+    const auto npd = static_cast<double>(std::max(np, 1));
+    const double best_eval = best / static_cast<double>(reps_per_batch);
+    const double mean_eval = total / static_cast<double>(nbatch)
+                                   / static_cast<double>(reps_per_batch);
+    Print() << "benchmark: np=" << np
+            << " variant=" << name
+            << " reps=" << reps_per_batch << "x" << nbatch
+            << " best=" << best_eval / npd * 1.e9 << " ns/particle"
+            << " (" << npd / best_eval / 1.e6 << " Mp/s)"
+            << " mean=" << mean_eval / npd * 1.e9 << " ns/particle\n";
+}
+
+void run_benchmark (Geometry const& geom, DistributionMapping const& dm,
+                    BoxArray const& ba, Shifts const& shifts)
+{
+    ParmParse pp("benchmark");
+
+    int enabled = 1;
+    pp.query("enabled", enabled);
+    if (enabled == 0) { return; }
+
+    std::vector<int> sizes{1000};
+    if (pp.contains("sizes")) {
+        sizes.clear();
+        pp.queryarr("sizes", sizes);
+    }
+    double target_evals = 2.e6;  // total particle evaluations per measurement
+    pp.query("target_evals", target_evals);
+    int warmup_reps = 3;
+    pp.query("warmup_reps", warmup_reps);
+    const int nbatch = 5;
+
+    Print() << "\nbenchmark setup: SIMD width=" << simd::native_simd_size_particlereal
+            << " sizeof(ParticleReal)=" << sizeof(ParticleReal)
+            << " OMP threads=" << OpenMP::get_max_threads()
+            << " MPI ranks=" << ParallelDescriptor::NProcs() << "\n";
+
+    double checksum = 0.;
+    for (int np : sizes) {
+        PC pc(geom, dm, ba);
+        init_particles(pc, np);
+
+        const long nrep = std::max(5L,
+            static_cast<long>(target_evals / static_cast<double>(std::max(np, 1))));
+        const long reps_per_batch = std::max(1L, nrep / nbatch);
+
+        bench_variant("A(SuperParticle)", np, reps_per_batch, nbatch, warmup_reps,
+                      [&] () { return run_variant_a(pc, shifts); }, checksum);
+        bench_variant("B(ptd,i)        ", np, reps_per_batch, nbatch, warmup_reps,
+                      [&] () { return run_variant_b(pc, shifts); }, checksum);
+        bench_variant("C(SIMD)         ", np, reps_per_batch, nbatch, warmup_reps,
+                      [&] () { return run_variant_c(pc, shifts); }, checksum);
+        bench_variant("C2(SIMD 2x)     ", np, reps_per_batch, nbatch, warmup_reps,
+                      [&] () { return run_variant_c2(pc, shifts); }, checksum);
+    }
+    Print() << "benchmark checksum: " << checksum << "\n";
+}
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+    {
+        int is_per[AMREX_SPACEDIM];
+        for (int& d : is_per) { d = 1; }
+
+        RealBox real_box;
+        for (int n = 0; n < AMREX_SPACEDIM; n++) {
+            real_box.setLo(n, -2.0);
+            real_box.setHi(n,  2.0);
+        }
+
+        IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
+        IntVect domain_hi(AMREX_D_DECL(63, 63, 63));
+        const Box domain(domain_lo, domain_hi);
+
+        Geometry geom(domain, &real_box, CoordSys::cartesian, is_per);
+        BoxArray ba(domain);
+        ba.maxSize(64);  // one box, one tile
+        DistributionMapping dm(ba);
+
+        const Shifts shifts{
+            ParticleReal(0.1), ParticleReal(-0.2), ParticleReal(0.05),
+            ParticleReal(0.3), ParticleReal(-0.15), ParticleReal(0.25),
+            ParticleReal(0.01), ParticleReal(-0.02), ParticleReal(0.03)};
+
+        correctness_tests(geom, dm, ba, shifts);
+        Print() << "\nAll ParticleReduceSIMD tests PASSED.\n";
+
+        run_benchmark(geom, dm, ba, shifts);
+    }
+    amrex::Finalize();
+}

--- a/Tests/Particles/ParticleReduceSIMD/main.cpp
+++ b/Tests/Particles/ParticleReduceSIMD/main.cpp
@@ -48,10 +48,10 @@ using ConstPTDType = typename PC::ConstPTDType;
 using SPType = typename PC::SuperParticleType;
 
 // 34 sums + 6 mins + 6 maxes, exactly as in ImpactX ReducedBeamCharacteristics
-static constexpr std::size_t num_sum = 34;
-static constexpr std::size_t num_min = 6;
-static constexpr std::size_t num_max = 6;
-static constexpr std::size_t num_red = num_sum + num_min + num_max;
+static constexpr int num_sum = 34;
+static constexpr int num_min = 6;
+static constexpr int num_max = 6;
+static constexpr int num_red = num_sum + num_min + num_max;
 
 using ReduceOpsT = TypeMultiplier<ReduceOps,
     ReduceOpSum[num_sum], ReduceOpMin[num_min], ReduceOpMax[num_max]>;
@@ -200,18 +200,45 @@ ReduceTupleT run_variant_a (PC const& pc, Shifts const& s)
         }, reduce_ops);
 }
 
-ReduceTupleT run_variant_b (PC const& pc, Shifts const& s)
-{
-    ReduceOpsT reduce_ops;
-    return ParticleReduce<ReduceDataT>(pc,
-        [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
-        {
-            return beam_moments(ptd.rdata(RealSoA::w)[i],
-                                ptd.rdata(RealSoA::x)[i], ptd.rdata(RealSoA::y)[i], ptd.rdata(RealSoA::t)[i],
-                                ptd.rdata(RealSoA::px)[i], ptd.rdata(RealSoA::py)[i], ptd.rdata(RealSoA::pt)[i],
-                                ptd.rdata(RealSoA::sx)[i], ptd.rdata(RealSoA::sy)[i], ptd.rdata(RealSoA::sz)[i],
-                                s);
-        }, reduce_ops);
+//! reads each component into a local value upfront, like variant C does via
+//! load_1d (like-for-like comparison)
+ReduceTupleT run_variant_b(PC const &pc, Shifts const &s) {
+  ReduceOpsT reduce_ops;
+  return ParticleReduce<ReduceDataT>(
+      pc,
+      [=] AMREX_GPU_DEVICE(const ConstPTDType &ptd, const int i) noexcept {
+        auto const p_w = ptd.rdata(RealSoA::w)[i];
+        auto const p_x = ptd.rdata(RealSoA::x)[i];
+        auto const p_y = ptd.rdata(RealSoA::y)[i];
+        auto const p_t = ptd.rdata(RealSoA::t)[i];
+        auto const p_px = ptd.rdata(RealSoA::px)[i];
+        auto const p_py = ptd.rdata(RealSoA::py)[i];
+        auto const p_pt = ptd.rdata(RealSoA::pt)[i];
+        auto const p_sx = ptd.rdata(RealSoA::sx)[i];
+        auto const p_sy = ptd.rdata(RealSoA::sy)[i];
+        auto const p_sz = ptd.rdata(RealSoA::sz)[i];
+
+        return beam_moments(p_w, p_x, p_y, p_t, p_px, p_py, p_pt, p_sx, p_sy,
+                            p_sz, s);
+      },
+      reduce_ops);
+}
+
+//! like run_variant_b, but binds the components by reference into the SoA
+//! arrays instead of copying them into locals (measures whether that matters)
+ReduceTupleT run_variant_b2(PC const &pc, Shifts const &s) {
+  ReduceOpsT reduce_ops;
+  return ParticleReduce<ReduceDataT>(
+      pc,
+      [=] AMREX_GPU_DEVICE(const ConstPTDType &ptd, const int i) noexcept {
+        return beam_moments(
+            ptd.rdata(RealSoA::w)[i], ptd.rdata(RealSoA::x)[i],
+            ptd.rdata(RealSoA::y)[i], ptd.rdata(RealSoA::t)[i],
+            ptd.rdata(RealSoA::px)[i], ptd.rdata(RealSoA::py)[i],
+            ptd.rdata(RealSoA::pt)[i], ptd.rdata(RealSoA::sx)[i],
+            ptd.rdata(RealSoA::sy)[i], ptd.rdata(RealSoA::sz)[i], s);
+      },
+      reduce_ops);
 }
 
 ReduceTupleT run_variant_c (PC const& pc, Shifts const& s)
@@ -245,15 +272,15 @@ void compare_results (ReduceTupleT const& a, ReduceTupleT const& b,
         * std::numeric_limits<ParticleReal>::epsilon()
         * static_cast<ParticleReal>(std::max(np, 1));
 
-    for (int k = 0; k < static_cast<int>(num_red); ++k) {
-        const bool is_sum = (k < static_cast<int>(num_sum));
-        const auto diff = std::abs(ta[k] - tb[k]);
-        if ((is_sum && diff > tol) || (!is_sum && diff != ParticleReal(0.))) {
-            amrex::AllPrint() << "  mismatch (" << what << "): np=" << np
-                              << " comp=" << k << " a=" << ta[k] << " b=" << tb[k]
-                              << " diff=" << diff << " tol=" << tol << "\n";
-            amrex::Abort("ParticleReduceSIMD result mismatch: " + what);
-        }
+    for (int k = 0; k < num_red; ++k) {
+      const bool is_sum = (k < num_sum);
+      const auto diff = std::abs(ta[k] - tb[k]);
+      if ((is_sum && diff > tol) || (!is_sum && diff != ParticleReal(0.))) {
+        amrex::AllPrint() << "  mismatch (" << what << "): np=" << np
+                          << " comp=" << k << " a=" << ta[k] << " b=" << tb[k]
+                          << " diff=" << diff << " tol=" << tol << "\n";
+        amrex::Abort("ParticleReduceSIMD result mismatch: " + what);
+      }
     }
 }
 
@@ -273,8 +300,11 @@ void correctness_tests (Geometry const& geom, DistributionMapping const& dm,
         auto const rb = run_variant_b(pc, shifts);
         auto const rc = run_variant_c(pc, shifts);
 
-        // A and B evaluate identical arithmetic in identical order
+        // A, B and B2 evaluate identical arithmetic in identical order
         compare_results(ra, rb, np, Real(0.), "A (SuperParticle) vs B (ptd,i)");
+        auto const rb2 = run_variant_b2(pc, shifts);
+        compare_results(rb2, rb, np, Real(0.),
+                        "B2 (ptd,i by-ref) vs B (ptd,i)");
         // C reassociates the sums across SIMD lanes
         compare_results(rc, rb, np, Real(100.), "C (SIMD) vs B (ptd,i)");
         // non-native (2x) SIMD width
@@ -283,9 +313,10 @@ void correctness_tests (Geometry const& geom, DistributionMapping const& dm,
 
         // value helpers vs the established scalar entry points
         auto sum_simd = ReduceSumSIMD(pc, LoadCompKernel<RealSoA::w>{});
-        auto sum_ref = ReduceSum(pc,
-            [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
-            { return ptd.rdata(RealSoA::w)[i]; });
+        auto sum_ref =
+            ReduceSum(pc, [=] AMREX_GPU_HOST_DEVICE(const ConstPTDType &ptd,
+                                                    const int i) noexcept { return ptd.rdata(RealSoA::w)[i];
+            });
         const auto sum_tol = ParticleReal(100.)
             * std::numeric_limits<ParticleReal>::epsilon()
             * static_cast<ParticleReal>(std::max(np, 1));
@@ -293,16 +324,18 @@ void correctness_tests (Geometry const& geom, DistributionMapping const& dm,
             "ReduceSumSIMD does not match ReduceSum");
 
         auto min_simd = ReduceMinSIMD(pc, LoadCompKernel<RealSoA::x>{});
-        auto min_ref = ReduceMin(pc,
-            [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
-            { return ptd.rdata(RealSoA::x)[i]; });
+        auto min_ref =
+            ReduceMin(pc, [=] AMREX_GPU_HOST_DEVICE(const ConstPTDType &ptd,
+                                                    const int i) noexcept { return ptd.rdata(RealSoA::x)[i];
+            });
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(min_simd == min_ref,
             "ReduceMinSIMD does not match ReduceMin");
 
         auto max_simd = ReduceMaxSIMD(pc, LoadCompKernel<RealSoA::x>{});
-        auto max_ref = ReduceMax(pc,
-            [=] AMREX_GPU_DEVICE (const ConstPTDType& ptd, const int i) noexcept
-            { return ptd.rdata(RealSoA::x)[i]; });
+        auto max_ref =
+            ReduceMax(pc, [=] AMREX_GPU_HOST_DEVICE(const ConstPTDType &ptd,
+                                                    const int i) noexcept { return ptd.rdata(RealSoA::x)[i];
+            });
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(max_simd == max_ref,
             "ReduceMaxSIMD does not match ReduceMax");
 
@@ -380,6 +413,9 @@ void run_benchmark (Geometry const& geom, DistributionMapping const& dm,
                       [&] () { return run_variant_a(pc, shifts); }, checksum);
         bench_variant("B(ptd,i)        ", np, reps_per_batch, nbatch, warmup_reps,
                       [&] () { return run_variant_b(pc, shifts); }, checksum);
+        bench_variant(
+            "B2(ptd,i by-ref)", np, reps_per_batch, nbatch, warmup_reps,
+            [&]() { return run_variant_b2(pc, shifts); }, checksum);
         bench_variant("C(SIMD)         ", np, reps_per_batch, nbatch, warmup_reps,
                       [&] () { return run_variant_c(pc, shifts); }, checksum);
         bench_variant("C2(SIMD 2x)     ", np, reps_per_batch, nbatch, warmup_reps,
@@ -410,10 +446,15 @@ int main (int argc, char* argv[])
         ba.maxSize(64);  // one box, one tile
         DistributionMapping dm(ba);
 
-        const Shifts shifts{
-            ParticleReal(0.1), ParticleReal(-0.2), ParticleReal(0.05),
-            ParticleReal(0.3), ParticleReal(-0.15), ParticleReal(0.25),
-            ParticleReal(0.01), ParticleReal(-0.02), ParticleReal(0.03)};
+        const Shifts shifts{.x = ParticleReal(0.1),
+                            .y = ParticleReal(-0.2),
+                            .t = ParticleReal(0.05),
+                            .px = ParticleReal(0.3),
+                            .py = ParticleReal(-0.15),
+                            .pt = ParticleReal(0.25),
+                            .sx = ParticleReal(0.01),
+                            .sy = ParticleReal(-0.02),
+                            .sz = ParticleReal(0.03)};
 
         correctness_tests(geom, dm, ba, shifts);
         Print() << "\nAll ParticleReduceSIMD tests PASSED.\n";

--- a/Tests/SIMD/main.cpp
+++ b/Tests/SIMD/main.cpp
@@ -7,6 +7,7 @@
 #include <AMReX.H>
 #include <AMReX_GpuLaunch.H>
 #include <AMReX_Print.H>
+#include <AMReX_ReduceSIMD.H>
 #include <AMReX_SIMD.H>
 #include <AMReX_Vector.H>
 
@@ -469,6 +470,49 @@ int main (int argc, char* argv[])
             Print() << "any_of + where + select (portable): "
                     << (err == 0 ? "PASSED" : "FAILED") << "\n";
         }
+
+#ifndef AMREX_USE_GPU
+        // ================================================================
+        // Test 15: evalReduceSIMD with a mixed-type tuple
+        //   Sum(Real), Min(int), Max(Real) over the same index range.
+        //   With AMReX_SIMD=ON the main loop runs vectorized (native width);
+        //   without, the same code runs the scalar loop.
+        // ================================================================
+        {
+            constexpr int n = 67;  // prime, stresses SIMD remainder handling
+            Vector<Real> rdata(n);
+            Vector<int> idata(n);
+            for (int i = 0; i < n; ++i) {
+                rdata[i] = static_cast<Real>(i + 1);  // 1 .. n
+                idata[i] = (i * 7) % 23 + 1;          // in [1, 23]
+            }
+            auto const* rp = rdata.data();
+            auto const* ip = idata.data();
+
+            ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
+            ReduceData<Real, int, Real> reduce_data(reduce_ops);
+            constexpr int W = static_cast<int>(simd::native_simd_size_real);
+
+            evalReduceSIMD<W>(n, reduce_data,
+                [=] (auto si)
+                {
+                    auto const a = simd::load_1d(rp, si);
+                    auto const b = simd::load_1d(ip, si);
+                    return amrex::makeTuple(a, b, a);
+                }, reduce_ops);
+            auto const r = reduce_data.value(reduce_ops);
+
+            int err = 0;
+            constexpr int expected_sum = n*(n+1)/2;  // sum 1..n
+            if (amrex::get<0>(r) != static_cast<Real>(expected_sum)) { ++err; }
+            if (amrex::get<1>(r) != 1) { ++err; }
+            if (amrex::get<2>(r) != static_cast<Real>(n)) { ++err; }
+
+            nerrors += err;
+            Print() << "evalReduceSIMD (mixed-type tuple): "
+                    << (err == 0 ? "PASSED" : "FAILED") << "\n";
+        }
+#endif // !AMREX_USE_GPU
 
         // ================================================================
         // Final report


### PR DESCRIPTION
## Summary

Add a SIMD-vectorized CPU path for particle reductions, following the single-source SIMD design (`SIMDindex`, `load_1d`, `AMReX_SIMD=ON`):

- `Src/Base/AMReX_ReduceSIMD.H`: generic host reduction engine evalReduceSIMD<WIDTH>` that accumulates in SIMD registers over full lanes, handles the remainder scalar, and folds into `ReduceData` like the scalar `ReduceOps::eval`. Supports `ReduceOpSum/Min/Max` (enforced at compile time), any `GpuTuple` element types (`MakeSIMDTuple`).
- Src/Particle/AMReX_ParticleReduceSIMD.H: ParticleReduceSIMD (generic ReduceOps/ReduceData form) and `ReduceSumSIMD/ReduceMinSIMD/ReduceMaxSIMD` value helpers, mirroring `ParallelForSIMD` conventions:
  explicit `WIDTH` template parameter (default: native width), same user source compiles to a scalar loop with `AMReX_SIMD=OFF` and to the regular device path on GPUs. The kernel invocation is force-inlined into the accumulation loop (`particle_detail::SIMDKernelBinder`), which keeps the SIMD accumulators out of caller-saved spill/reload traffic, lets loads lower to single `vmovupd`s, and fuses multiply+accumulate into FMAs.
- `Src/Base/AMReX_SIMD.H`: scalar fallbacks for `stdx::reduce/hmin/hmax/min/max` so portable kernels compile with `AMReX_SIMD=OFF`.
- `Tests/Particles/ParticleReduceSIMD`: correctness test + benchmark reproducing the ImpactX `ReducedBeamCharacteristics` kernel (fused 34 sums + 6 mins + 6 maxes over a pure-SoA container, 11 real  components). Compares `SuperParticle`-lambda and `(ptd,i)`-lambda `ParticleReduce` against `ParticleReduceSIMD` at native and 2x width. (2×-native width loses in both precisions (W=16 in SP is 55–60% slower than W=8). Register pressure for the 46-operand kernel; native width as the default confirmed.)
- `Tests/SIMD`: `evalReduceSIMD` unit test with a mixed-type tuple.
- Docs: new "Particle Reductions" section in Particle.rst.

Benchmark (i9-12900H P-core, AVX2+FMA, pinned, 1 thread, GCC 13.3 `-O3 -march=native`, best of 5 batches, ~2e8 particle evaluations per measurement), ns/particle:

### Double precision (native SIMD width 4):
```
  N     ParticleReduce  ParticleReduce  ParticleReduceSIMD  speedup
        (SuperParticle) (ptd,i)         (W=4)               vs (ptd,i)
  1k    7.09            9.62            3.58                2.7x
  10k   7.42            9.45            3.57                2.6x
  100k  7.58            9.58            3.51                2.7x
  1M    7.86            10.69           4.52                2.4x
  10M   7.96            10.77           4.55                2.4x
```
### Single precision (native SIMD width 8):
```
  N     ParticleReduce  ParticleReduce  ParticleReduceSIMD  speedup
        (SuperParticle) (ptd,i)         (W=8)               vs (ptd,i)
  1k    7.27            8.96            1.88                4.8x
  10k   7.64            9.35            1.90                4.9x
  100k  7.78            9.35            1.83                5.1x
  1M    8.08            9.75            2.11                4.6x
  10M   8.13            9.90            2.20                4.5x
```

Peak throughput: ~545 Mp/s in SP, ~285 Mp/s in DP. Twice-native `WIDTH` is consistently slower than native width for this 46-operand kernel (register pressure); native is the right default. With `AMReX_SIMD=OFF`, the same single-source kernel is SLP-auto-vectorized by GCC thanks to the force-inlined invocation chain and, at 7.0-7.4 ns/particle (DP), is now the *fastest* scalar form — faster than both classic `ParticleReduce` lambda styles. Single-source kernels win in every build configuration.

## Additional background

ImpactX is in some of our science cases spending 50% of its runtime in those AMReX reduces: https://github.com/BLAST-ImpactX/impactx/issues/1102

Assembly-level analysis of the kernel variants (SLP vectorization of the SuperParticle form, call-boundary accumulator spills before the force-inline fix): https://github.com/AMReX-Codes/amrex/pull/5562#discussion_r3592507831

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
