### PR TITLE
MLNodeLaplacian: update cached state after setSigma

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -1611,6 +1611,17 @@ MLMGT<MF>::prepareLinOp ()
         linop_prepared = true;
     } else if (linop.needsUpdate()) {
         linop.update();
+
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
+        hypre_solver.reset();
+        hypre_bndry.reset();
+        hypre_node_solver.reset();
+#endif
+
+#if defined(AMREX_USE_PETSC) && (AMREX_SPACEDIM > 1)
+        petsc_solver.reset();
+        petsc_bndry.reset();
+#endif
     }
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -43,8 +43,8 @@ public :
      * \param a_dmap        Distribution mappings.
      * \param a_info        LPInfo overrides.
      * \param a_factory     Optional nodal factories per level.
-     * \param a_const_sigma Uniform conductivity.  Zero means variable
-     *                      conductivity and setSigma() must be called.
+     * \param a_const_sigma Uniform conductivity.  Zero selects variable
+     *                      conductivity; setSigma() must then supply nonzero coefficients.
      */
     MLNodeLaplacian (const Vector<Geometry>& a_geom,
                      const Vector<BoxArray>& a_grids,
@@ -76,8 +76,8 @@ public :
      * \param a_dmap        Distribution mappings.
      * \param a_info        LPInfo overrides.
      * \param a_factory     Optional nodal factories per level.
-     * \param a_const_sigma Uniform conductivity.  Zero means variable
-     *                      conductivity and setSigma() must be called.
+     * \param a_const_sigma Uniform conductivity.  Zero selects variable
+     *                      conductivity; setSigma() must then supply nonzero coefficients.
      */
     void define (const Vector<Geometry>& a_geom,
                  const Vector<BoxArray>& a_grids,
@@ -109,14 +109,19 @@ public :
      *
      * \param t Minimum average magnitude allowed before rescaling.
      */
-    void setNormalizationThreshold (Real t) noexcept { m_normalization_threshold = t; }
+    void setNormalizationThreshold (Real t) noexcept {
+        if (m_normalization_threshold != t) {
+            m_normalization_threshold = t;
+            m_needs_update = true;
+        }
+    }
 
     /**
      * \brief Provide per-level conductivity (cell-centered MultiFab).
      * A multi-component input also triggers mapped-coordinate mode.
      *
      * \param amrlev AMR level receiving the coefficients.
-     * \param a_sigma Cell-centered conductivity MultiFab.
+     * \param a_sigma Cell-centered MultiFab containing nonzero conductivity coefficients.
      */
     void setSigma (int amrlev, const MultiFab& a_sigma);
 
@@ -151,14 +156,24 @@ public :
      *
      * \param flag True enables harmonic averaging.
      */
-    void setHarmonicAverage (bool flag) noexcept { m_use_harmonic_average = flag; }
+    void setHarmonicAverage (bool flag) noexcept {
+        if (m_use_harmonic_average != flag) {
+            m_use_harmonic_average = flag;
+            m_needs_update = true;
+        }
+    }
 
     /**
      * \brief Enable mapped-coordinate metrics (non-orthogonal grids).
      *
      * \param flag True enables mapped-coordinate support.
      */
-    void setMapped (bool flag) noexcept { m_use_mapped = flag; }
+    void setMapped (bool flag) noexcept {
+        if (m_use_mapped != flag) {
+            m_use_mapped = flag;
+            m_needs_update = true;
+        }
+    }
 
     /**
      * \brief Pick between sigma-weighted or RAP coarsening (ignored if `sigma` constant).
@@ -166,7 +181,12 @@ public :
      * \param cs Desired coarsening strategy enum.
      */
     void setCoarseningStrategy (CoarseningStrategy cs) noexcept {
-        if (m_const_sigma == Real(0.0)) { m_coarsening_strategy = cs; }
+        if (m_const_sigma == Real(0.0) && m_coarsening_strategy != cs) {
+            m_coarsening_strategy = cs;
+            m_masks_built = false;
+            m_precond_weight_mask.clear();
+            m_needs_update = true;
+        }
     }
 
     BottomSolver getDefaultBottomSolver () const final {
@@ -192,6 +212,10 @@ public :
 
     //! Finalize metric terms, sigma averages, and BC caches before solving.
     void prepareForSolve () final;
+    //! True if sigma-derived data need to be refreshed before reuse.
+    [[nodiscard]] bool needsUpdate () const final { return m_needs_update; }
+    //! Refresh sigma averages/stencils and clear the dirty flag.
+    void update () final;
     //! Apply the nodal Laplacian to \p in at (\p amrlev,\p mglev).
     void Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) const final;
     /**
@@ -339,6 +363,7 @@ private:
     bool m_use_gauss_seidel     = true;
     bool m_use_harmonic_average = false;
     bool m_use_mapped           = false;
+    bool m_needs_update         = true;
 
     void checkPoint (std::string const& file_name) const final;
 };

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -98,6 +98,8 @@ MLNodeLaplacian::define (const Vector<Geometry>& a_geom,
 #if (AMREX_SPACEDIM == 2)
     m_is_rz = m_geom[0][0].IsRZ();
 #endif
+
+    m_needs_update = true;
 }
 
 #ifdef AMREX_USE_EB
@@ -399,6 +401,8 @@ MLNodeLaplacian::setSigma (int amrlev, const MultiFab& a_sigma)
     } else {
         MultiFab::Copy(*m_sigma[amrlev][0][0], a_sigma, 0, 0, 1, 0);
     }
+
+    m_needs_update = true;
 }
 
 void
@@ -466,6 +470,19 @@ MLNodeLaplacian::prepareForSolve ()
 #endif
 
     buildStencil();
+
+    m_needs_update = false;
+}
+
+void
+MLNodeLaplacian::update ()
+{
+    BL_PROFILE("MLNodeLaplacian::update()");
+    // prepareForSolve rebuilds the sigma-dependent masks, averaged coefficients,
+    // and stencil.  The EB integrals are not rebuilt: buildIntegral() and
+    // buildSurfaceIntegral() self-guard (m_integral_built / m_surface_integral_built)
+    // and are no-ops once they have already been built.
+    prepareForSolve();
 }
 
 void

--- a/Tests/LinearSolvers/NodalPoisson/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodalPoisson/CMakeLists.txt
@@ -13,6 +13,11 @@ foreach(D IN LISTS AMReX_SPACEDIM)
 
     setup_test(${D} _sources _input_files)
 
+    set(_input_files inputs-sigma-update)
+
+    setup_test(${D} _sources _input_files
+       BASE_NAME LinearSolvers_NodalPoisson_SigmaUpdate)
+
     unset(_sources)
     unset(_input_files)
 endforeach()

--- a/Tests/LinearSolvers/NodalPoisson/MyTest.H
+++ b/Tests/LinearSolvers/NodalPoisson/MyTest.H
@@ -26,6 +26,7 @@ public:
 private:
 
     void readParameters ();
+    void testSigmaUpdate ();
 
     int max_level = 1;
     int ref_ratio = 2;
@@ -55,6 +56,7 @@ private:
     bool use_hypre = false;
     bool do_plots = true;
     int num_trials = 1;
+    bool test_sigma_update = false;
 
 #ifdef AMREX_USE_HYPRE
     int hypre_interface_i = 1;  // 1. structed, 2. semi-structed, 3. ij

--- a/Tests/LinearSolvers/NodalPoisson/MyTest.cpp
+++ b/Tests/LinearSolvers/NodalPoisson/MyTest.cpp
@@ -6,6 +6,8 @@
 #include <AMReX_FillPatchUtil.H>
 #include <AMReX_PlotFileUtil.H>
 
+#include <algorithm>
+#include <cmath>
 #include <numbers>
 
 using namespace amrex;
@@ -20,6 +22,12 @@ void
 MyTest::solve ()
 {
     BL_PROFILE("NodalPoisson::solve()");
+
+    if (test_sigma_update) {
+        testSigmaUpdate();
+        return;
+    }
+
     LPInfo info;
     info.setAgglomeration(agglomeration);
     info.setConsolidation(consolidation);
@@ -135,6 +143,8 @@ MyTest::solve ()
 void
 MyTest::compute_norms () const
 {
+    if (test_sigma_update) { return; }
+
     for (int ilev = 0; ilev <= max_level; ++ilev) {
         amrex::Print() << "Level " << ilev << "\n";
         MultiFab error(solution[ilev].boxArray(), solution[ilev].DistributionMap(), 1, 0);
@@ -183,6 +193,8 @@ MyTest::readParameters ()
 
     pp.query("do_plots", do_plots);
     pp.query("num_trials", num_trials);
+    pp.query("test_sigma_update", test_sigma_update);
+    if (test_sigma_update) { do_plots = false; }
 
 #ifdef AMREX_USE_HYPRE
     pp.query("use_hypre", use_hypre);
@@ -280,4 +292,63 @@ MyTest::initData ()
 
         sigma[ilev].setVal(1.0);
     }
+}
+
+void
+MyTest::testSigmaUpdate ()
+{
+#if (AMREX_SPACEDIM == 1)
+    amrex::Abort("NodalPoisson::testSigmaUpdate: RAP coarsening is not supported in 1D");
+#else
+    LPInfo info;
+    info.setAgglomeration(agglomeration);
+    info.setConsolidation(consolidation);
+    info.setSemicoarsening(semicoarsening);
+    info.setMaxCoarseningLevel(max_coarsening_level);
+    info.setMaxSemicoarseningLevel(max_semicoarsening_level);
+
+    MLNodeLaplacian linop({geom[0]}, {grids[0]}, {dmap[0]}, info);
+    linop.setDomainBC({AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)},
+                      {AMREX_D_DECL(LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet,
+                                    LinOpBCType::Dirichlet)});
+    linop.setCoarseningStrategy(MLNodeLaplacian::CoarseningStrategy::RAP);
+
+    sigma[0].setVal(Real(1.0));
+    linop.setSigma(0, sigma[0]);
+
+    MLMG mlmg(linop);
+    mlmg.setVerbose(verbose);
+    mlmg.setBottomVerbose(bottom_verbose);
+
+    MultiFab lhs1(exact_solution[0].boxArray(), exact_solution[0].DistributionMap(), 1, 0);
+    MultiFab lhs2(exact_solution[0].boxArray(), exact_solution[0].DistributionMap(), 1, 0);
+    mlmg.apply({&lhs1}, {exact_solution.data()});
+
+    sigma[0].setVal(Real(2.0));
+    linop.setSigma(0, sigma[0]);
+    mlmg.apply({&lhs2}, {exact_solution.data()});
+
+    MultiFab diff(exact_solution[0].boxArray(), exact_solution[0].DistributionMap(), 1, 0);
+    MultiFab::LinComb(diff, Real(1.0), lhs2, 0, Real(-2.0), lhs1, 0, 0, 1, 0);
+
+    auto mask = diff.OwnerMask(geom[0].periodicity());
+    const Real err = diff.norm0(*mask, 0, 0);
+    const Real scale = std::max(Real(1.0), lhs2.norm0(*mask, 0, 0));
+#ifdef AMREX_USE_FLOAT
+    constexpr Real reltol_update = Real(1.e-4);
+#else
+    constexpr Real reltol_update = Real(1.e-12);
+#endif
+    const Real tol = reltol_update * scale;
+
+    amrex::Print() << "NodalPoisson sigma update check: max error = "
+                   << err << ", tolerance = " << tol << "\n";
+
+    if (err > tol || std::isnan(err)) {
+        amrex::Abort("NodalPoisson sigma update check failed");
+    }
+#endif
 }

--- a/Tests/LinearSolvers/NodalPoisson/inputs-sigma-update
+++ b/Tests/LinearSolvers/NodalPoisson/inputs-sigma-update
@@ -1,0 +1,9 @@
+max_level = 0
+n_cell = 32
+max_grid_size = 16
+
+test_sigma_update = 1
+
+verbose = 0
+bottom_verbose = 0
+do_plots = 0


### PR DESCRIPTION
Mark MLNodeLaplacian dirty when sigma or sigma-dependent options change, and add an update path that rebuilds averaged coefficients and stencils before a reused MLMG applies or solves with new coefficients.

Add a NodalPoisson regression that reuses MLMG, changes sigma, and checks that the operator application reflects the updated coefficient state.
