### PR TITLE
Tests/FortranInterface: fix Advection_F 3D particle crash and precision

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -158,7 +158,8 @@ else()
       list(APPEND AMREX_TESTS_SUBDIRS HDF5Benchmark)
    endif ()
 
-   if (AMReX_FORTRAN_INTERFACES)
+   # The Fortran interface tests do not work on GPU, so only build them on CPU.
+   if (AMReX_FORTRAN_INTERFACES AND AMReX_GPU_BACKEND STREQUAL NONE)
       list(APPEND AMREX_TESTS_SUBDIRS FortranInterface)
    endif ()
 

--- a/Tests/FortranInterface/Advection_F/CMakeLists.txt
+++ b/Tests/FortranInterface/Advection_F/CMakeLists.txt
@@ -3,9 +3,10 @@ foreach(D IN LISTS AMReX_SPACEDIM)
        continue()
     endif ()
 
-    if (AMReX_PARTICLES) # Particle currently does not work. Remove this block once the issue is resolved.
+    # This test always advects particles and therefore requires AMReX_PARTICLES.
+    if (NOT AMReX_PARTICLES)
        continue()
-    endif()
+    endif ()
 
     set(_sources advect_${D}d_mod.F90 compute_flux_${D}d.f90 slope_${D}d.f90 )
     list(TRANSFORM _sources PREPEND Src_${D}d/ )

--- a/Tests/FortranInterface/Advection_F/Exec/SingleVortex/Prob_2d.f90
+++ b/Tests/FortranInterface/Advection_F/Exec/SingleVortex/Prob_2d.f90
@@ -28,17 +28,17 @@ contains
     !$omp parallel do private(i,j,k,x,y,z,r2) collapse(2)
     do k=lo(3),hi(3)
        do j=lo(2),hi(2)
-          z = prob_lo(3) + (dble(k)+0.5d0) * dx(3)
-          y = prob_lo(2) + (dble(j)+0.5d0) * dx(2)
+          z = prob_lo(3) + (real(k,amrex_real)+0.5_amrex_real) * dx(3)
+          y = prob_lo(2) + (real(j,amrex_real)+0.5_amrex_real) * dx(2)
           do i=lo(1),hi(1)
-             x = prob_lo(1) + (dble(i)+0.5d0) * dx(1)
+             x = prob_lo(1) + (real(i,amrex_real)+0.5_amrex_real) * dx(1)
 
              if ( amrex_spacedim .eq. 2) then
-                r2 = ((x-0.5d0)**2 + (y-0.75d0)**2) / 0.01d0
-                phi(i,j,k) = 1.d0 + exp(-r2)
+                r2 = ((x-0.5_amrex_real)**2 + (y-0.75_amrex_real)**2) / 0.01_amrex_real
+                phi(i,j,k) = 1.0_amrex_real + exp(-r2)
              else
-                r2 = ((x-0.5d0)**2 + (y-0.75d0)**2 + (z-0.5d0)**2) / 0.01d0
-                phi(i,j,k) = 1.d0 + exp(-r2)
+                r2 = ((x-0.5_amrex_real)**2 + (y-0.75_amrex_real)**2 + (z-0.5_amrex_real)**2) / 0.01_amrex_real
+                phi(i,j,k) = 1.0_amrex_real + exp(-r2)
              end if
           end do
        end do
@@ -49,7 +49,7 @@ contains
 
   subroutine init_part_data(pc, lev, mfi, lo, hi, dx, prob_lo)
 
-    use amrex_fort_module, only : amrex_spacedim, amrex_real
+    use amrex_fort_module, only : amrex_spacedim, amrex_real, amrex_particle_real
     use amrex_particlecontainer_module, only: amrex_particlecontainer, amrex_particle, &
          amrex_get_next_particle_id, amrex_get_cpu, amrex_set_particle_id, amrex_set_particle_cpu
     use amrex_multifab_module, only : amrex_mfiter
@@ -61,19 +61,19 @@ contains
     integer, intent(in) :: lo(2), hi(2)
     real(amrex_real), intent(in) :: dx(2), prob_lo(2)
 
-    integer          :: i,j
-    real(amrex_real) :: x,y
+    integer                  :: i,j
+    real(amrex_particle_real) :: x,y
     type(amrex_particle) :: p
 
     do j=lo(2),hi(2)
-       y = prob_lo(2) + (dble(j)+0.5d0) * dx(2)
+       y = prob_lo(2) + (real(j,amrex_real)+0.5_amrex_real) * dx(2)
        do i=lo(1),hi(1)
-          x = prob_lo(1) + (dble(i)+0.5d0) * dx(1)
+          x = prob_lo(1) + (real(i,amrex_real)+0.5_amrex_real) * dx(1)
 
           p%pos(1) = x
           p%pos(2) = y
 
-          p%vel = 0.d0
+          p%vel = 0.0_amrex_particle_real
 
           call amrex_set_particle_id(amrex_get_next_particle_id(), p)
           call amrex_set_particle_cpu(amrex_get_cpu(), p)

--- a/Tests/FortranInterface/Advection_F/Exec/SingleVortex/Prob_3d.f90
+++ b/Tests/FortranInterface/Advection_F/Exec/SingleVortex/Prob_3d.f90
@@ -10,11 +10,12 @@ contains
 
 subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
+  use amrex_fort_module, only : amrex_real
   implicit none
 
   integer, intent(in) :: init, namlen
   integer, intent(in) :: name(namlen)
-  double precision, intent(in) :: problo(*), probhi(*)
+  real(amrex_real), intent(in) :: problo(*), probhi(*)
 
   ! nothing needs to be done here
 
@@ -25,17 +26,18 @@ subroutine init_prob_data(level, time, lo, hi, &
      phi, phi_lo, phi_hi, &
      dx, prob_lo) bind(C, name="initdata")
 
+  use amrex_fort_module, only : amrex_real
   implicit none
   integer, intent(in) :: level, lo(3), hi(3), phi_lo(3), phi_hi(3)
-  double precision, intent(in) :: time
-  double precision, intent(inout) :: phi(phi_lo(1):phi_hi(1), &
+  real(amrex_real), intent(in) :: time
+  real(amrex_real), intent(inout) :: phi(phi_lo(1):phi_hi(1), &
        &                                 phi_lo(2):phi_hi(2), &
        &                                 phi_lo(3):phi_hi(3))
-  double precision, intent(in) :: dx(3), prob_lo(3)
+  real(amrex_real), intent(in) :: dx(3), prob_lo(3)
 
   integer          :: dm
   integer          :: i,j,k
-  double precision :: x,y,z,r2
+  real(amrex_real) :: x,y,z,r2
 
   if (phi_lo(3) .eq. 0 .and. phi_hi(3) .eq. 0) then
      dm = 2
@@ -46,17 +48,17 @@ subroutine init_prob_data(level, time, lo, hi, &
   !$omp parallel do private(i,j,k,x,y,z,r2) collapse(2)
   do k=lo(3),hi(3)
      do j=lo(2),hi(2)
-        z = prob_lo(3) + (dble(k)+0.5d0) * dx(3)
-        y = prob_lo(2) + (dble(j)+0.5d0) * dx(2)
+        z = prob_lo(3) + (real(k,amrex_real)+0.5_amrex_real) * dx(3)
+        y = prob_lo(2) + (real(j,amrex_real)+0.5_amrex_real) * dx(2)
         do i=lo(1),hi(1)
-           x = prob_lo(1) + (dble(i)+0.5d0) * dx(1)
+           x = prob_lo(1) + (real(i,amrex_real)+0.5_amrex_real) * dx(1)
 
            if ( dm.eq. 2) then
-              r2 = ((x-0.5d0)**2 + (y-0.75d0)**2) / 0.01d0
-              phi(i,j,k) = 1.d0 + exp(-r2)
+              r2 = ((x-0.5_amrex_real)**2 + (y-0.75_amrex_real)**2) / 0.01_amrex_real
+              phi(i,j,k) = 1.0_amrex_real + exp(-r2)
            else
-              r2 = ((x-0.5d0)**2 + (y-0.75d0)**2 + (z-0.5d0)**2) / 0.01d0
-              phi(i,j,k) = 1.d0 + exp(-r2)
+              r2 = ((x-0.5_amrex_real)**2 + (y-0.75_amrex_real)**2 + (z-0.5_amrex_real)**2) / 0.01_amrex_real
+              phi(i,j,k) = 1.0_amrex_real + exp(-r2)
            end if
         end do
      end do
@@ -67,7 +69,7 @@ end subroutine init_prob_data
 
   subroutine init_part_data(pc, lev, mfi, lo, hi, dx, prob_lo)
 
-    use amrex_fort_module, only : amrex_spacedim, amrex_real
+    use amrex_fort_module, only : amrex_spacedim, amrex_real, amrex_particle_real
     use amrex_particlecontainer_module, only: amrex_particlecontainer, amrex_particle, &
          amrex_get_next_particle_id, amrex_get_cpu, amrex_set_particle_id, amrex_set_particle_cpu
     use amrex_multifab_module, only : amrex_mfiter
@@ -79,22 +81,22 @@ end subroutine init_prob_data
     integer, intent(in) :: lo(3), hi(3)
     real(amrex_real), intent(in) :: dx(3), prob_lo(3)
 
-    integer          :: i,j,k
-    real(amrex_real) :: x,y,z
+    integer                  :: i,j,k
+    real(amrex_particle_real) :: x,y,z
     type(amrex_particle) :: p
 
     do k=lo(3),hi(3)
        do j=lo(2),hi(2)
-          z = prob_lo(3) + (dble(k)+0.5d0) * dx(3)
-          y = prob_lo(2) + (dble(j)+0.5d0) * dx(2)
+          z = prob_lo(3) + (real(k,amrex_real)+0.5_amrex_real) * dx(3)
+          y = prob_lo(2) + (real(j,amrex_real)+0.5_amrex_real) * dx(2)
           do i=lo(1),hi(1)
-             x = prob_lo(1) + (dble(i)+0.5d0) * dx(1)
+             x = prob_lo(1) + (real(i,amrex_real)+0.5_amrex_real) * dx(1)
 
              p%pos(1) = x
              p%pos(2) = y
-             p%pos(3) = x
+             p%pos(3) = z
 
-             p%vel = 0.d0
+             p%vel = 0.0_amrex_particle_real
 
              call amrex_set_particle_id(amrex_get_next_particle_id(), p)
              call amrex_set_particle_cpu(amrex_get_cpu(), p)

--- a/Tests/FortranInterface/Advection_F/Exec/SingleVortex/face_velocity_2d.F90
+++ b/Tests/FortranInterface/Advection_F/Exec/SingleVortex/face_velocity_2d.F90
@@ -22,7 +22,7 @@ contains
     integer :: i, j, plo(2), phi(2)
     real(amrex_real) :: x, y
     real(amrex_real), pointer, contiguous :: psi(:,:)
-    real(amrex_real), parameter :: M_PI = 3.141592653589793238462643383279502884197d0
+    real(amrex_real), parameter :: M_PI = 3.141592653589793238462643383279502884197_amrex_real
 
     plo(1) = min(vxlo(1)-1, vylo(1)-1)
     plo(2) = min(vxlo(2)-1, vylo(2)-1)
@@ -33,28 +33,28 @@ contains
 
     ! streamfunction psi
     do j = plo(2), phi(2)
-       y = (dble(j)+0.5d0)*dx(2) + prob_lo(2)
+       y = (real(j,amrex_real)+0.5_amrex_real)*dx(2) + prob_lo(2)
        do i = plo(1), phi(1)
-          x = (dble(i)+0.5d0)*dx(1) + prob_lo(1)
-          psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.d0) * (1.d0 / M_PI)
+          x = (real(i,amrex_real)+0.5_amrex_real)*dx(1) + prob_lo(1)
+          psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.0_amrex_real) * (1.0_amrex_real / M_PI)
        end do
     end do
 
     ! x velocity
     do j = vxlo(2), vxhi(2)
-       y = (dble(j)+0.5d0) * dx(2) + prob_lo(2)
+       y = (real(j,amrex_real)+0.5_amrex_real) * dx(2) + prob_lo(2)
        do i = vxlo(1), vxhi(1)
-          x = dble(i) * dx(1) + prob_lo(1)
-          vx(i,j) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25d0/dx(2))
+          x = real(i,amrex_real) * dx(1) + prob_lo(1)
+          vx(i,j) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25_amrex_real/dx(2))
        end do
     end do
 
     ! y velocity
     do j = vylo(2), vyhi(2)
-       y = dble(j) * dx(2) + prob_lo(2)
+       y = real(j,amrex_real) * dx(2) + prob_lo(2)
        do i = vylo(1), vyhi(1)
-          x = (dble(i)+0.5d0) * dx(1) + prob_lo(1)
-          vy(i,j) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25d0/dx(1))
+          x = (real(i,amrex_real)+0.5_amrex_real) * dx(1) + prob_lo(1)
+          vy(i,j) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25_amrex_real/dx(1))
        end do
     end do
 

--- a/Tests/FortranInterface/Advection_F/Exec/SingleVortex/face_velocity_3d.F90
+++ b/Tests/FortranInterface/Advection_F/Exec/SingleVortex/face_velocity_3d.F90
@@ -18,19 +18,19 @@ use amrex_base_module
   implicit none
 
   !integer, intent(in) :: level
-  double precision, intent(in) :: time
+  real(amrex_real), intent(in) :: time
   integer, intent(in) :: vxlo(3),vxhi(3)
   integer, intent(in) :: vylo(3),vyhi(3)
   integer, intent(in) :: vzlo(3),vzhi(3)
-  double precision, intent(out) :: vx(vxlo(1):vxhi(1),vxlo(2):vxhi(2),vxlo(3):vxhi(3))
-  double precision, intent(out) :: vy(vylo(1):vyhi(1),vylo(2):vyhi(2),vylo(3):vyhi(3))
-  double precision, intent(out) :: vz(vzlo(1):vzhi(1),vzlo(2):vzhi(2),vzlo(3):vzhi(3))
-  double precision, intent(in) :: dx(3), prob_lo(3)
+  real(amrex_real), intent(out) :: vx(vxlo(1):vxhi(1),vxlo(2):vxhi(2),vxlo(3):vxhi(3))
+  real(amrex_real), intent(out) :: vy(vylo(1):vyhi(1),vylo(2):vyhi(2),vylo(3):vyhi(3))
+  real(amrex_real), intent(out) :: vz(vzlo(1):vzhi(1),vzlo(2):vzhi(2),vzlo(3):vzhi(3))
+  real(amrex_real), intent(in) :: dx(3), prob_lo(3)
 
   integer :: i, j, k, plo(2), phi(2)
-  double precision :: x, y, z
-  double precision, pointer, contiguous :: psi(:,:)
-  double precision, parameter :: M_PI = 3.141592653589793238462643383279502884197d0
+  real(amrex_real) :: x, y, z
+  real(amrex_real), pointer, contiguous :: psi(:,:)
+  real(amrex_real), parameter :: M_PI = 3.141592653589793238462643383279502884197_amrex_real
   integer :: vx_l1,vx_l2,vx_l3,vy_l1,vy_l2,vy_l3,vz_l1,vz_l2,vz_l3
   integer :: vx_h1,vx_h2,vx_h3,vy_h1,vy_h2,vy_h3,vz_h1,vz_h2,vz_h3
 
@@ -50,20 +50,20 @@ use amrex_base_module
 
   ! streamfunction psi
   do j = plo(2), phi(2)
-     y = (dble(j)+0.5d0)*dx(2) + prob_lo(2)
+     y = (real(j,amrex_real)+0.5_amrex_real)*dx(2) + prob_lo(2)
      do i = plo(1), phi(1)
-        x = (dble(i)+0.5d0)*dx(1) + prob_lo(1)
-        psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.d0) * (1.d0 / M_PI)
+        x = (real(i,amrex_real)+0.5_amrex_real)*dx(1) + prob_lo(1)
+        psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.0_amrex_real) * (1.0_amrex_real / M_PI)
      end do
   end do
 
   ! x velocity
   do k = vx_l3, vx_h3
   do j = vx_l2, vx_h2
-     y = (dble(j)+0.5d0) * dx(2) + prob_lo(2)
+     y = (real(j,amrex_real)+0.5_amrex_real) * dx(2) + prob_lo(2)
      do i = vx_l1, vx_h1
-        x = dble(i) * dx(1) + prob_lo(1)
-        vx(i,j,k) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25d0/dx(2))
+        x = real(i,amrex_real) * dx(1) + prob_lo(1)
+        vx(i,j,k) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25_amrex_real/dx(2))
      end do
   end do
   end do
@@ -71,15 +71,15 @@ use amrex_base_module
   ! y velocity
   do k = vy_l3, vy_h3
   do j = vy_l2, vy_h2
-     y = dble(j) * dx(2) + prob_lo(2)
+     y = real(j,amrex_real) * dx(2) + prob_lo(2)
      do i = vy_l1, vy_h1
-        x = (dble(i)+0.5d0) * dx(1) + prob_lo(1)
-        vy(i,j,k) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25d0/dx(1))
+        x = (real(i,amrex_real)+0.5_amrex_real) * dx(1) + prob_lo(1)
+        vy(i,j,k) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25_amrex_real/dx(1))
      end do
   end do
   end do
 
-  vz = 1.d0
+  vz = 1.0_amrex_real
 
   call bl_deallocate(psi)
 

--- a/Tests/FortranInterface/Advection_F/Source/Src_2d/advect_2d_mod.F90
+++ b/Tests/FortranInterface/Advection_F/Source/Src_2d/advect_2d_mod.F90
@@ -151,7 +151,7 @@ contains
     velocity(1)%p => ux
     velocity(2)%p => uy
 
-    inv_dx = 1.0d0/dx
+    inv_dx = 1.0_amrex_real/dx
 
     do ipass = 1, 2
        do n = 1, np
@@ -159,10 +159,10 @@ contains
           length = (particles(n)%pos - plo)*inv_dx
 
           cc_cell = floor(length)
-          cell    = floor(length + 0.5d0)
+          cell    = floor(length + 0.5_amrex_real)
 
-          w_hi = length + 0.5d0 - cell
-          w_lo = 1.d0 - w_hi
+          w_hi = length + 0.5_amrex_real - cell
+          w_lo = 1.0_amrex_real - w_hi
 
           do d = 1, 2
              e_cell = cell
@@ -172,8 +172,8 @@ contains
              e_lo = w_lo
              e_hi(d) = length(d) - cc_cell(d)
 
-             e_hi = max(0.d0,min(1.d0,e_hi))
-             e_lo(d) = 1.d0 - e_hi(d)
+             e_hi = max(0.0_amrex_real,min(1.0_amrex_real,e_hi))
+             e_lo(d) = 1.0_amrex_real - e_hi(d)
 
              vel = e_lo(1)*e_lo(2)*velocity(d)%p(e_cell(1)-1, e_cell(2)-1) + &
                    e_lo(1)*e_hi(2)*velocity(d)%p(e_cell(1)-1, e_cell(2)  ) + &
@@ -182,7 +182,7 @@ contains
 
              if (ipass == 1) then
                 particles(n)%vel(d) = particles(n)%pos(d)
-                particles(n)%pos(d) = particles(n)%pos(d) + 0.5d0*dt*vel
+                particles(n)%pos(d) = particles(n)%pos(d) + 0.5_amrex_real*dt*vel
              else
                 particles(n)%pos(d) = particles(n)%vel(d) + dt*vel
                 particles(n)%vel(d) = vel

--- a/Tests/FortranInterface/Advection_F/Source/Src_2d/compute_flux_2d.f90
+++ b/Tests/FortranInterface/Advection_F/Source/Src_2d/compute_flux_2d.f90
@@ -48,10 +48,10 @@ contains
     do    j = lo(2)-1, hi(2)+1
        do i = lo(1)  , hi(1)+1
 
-          if (umac(i,j) .lt. 0.d0) then
-             phix_1d(i,j) = phi(i  ,j) - (0.5d0 + hdtdx(1)*umac(i,j))*slope(i  ,j)
+          if (umac(i,j) .lt. 0.0_amrex_real) then
+             phix_1d(i,j) = phi(i  ,j) - (0.5_amrex_real + hdtdx(1)*umac(i,j))*slope(i  ,j)
           else
-             phix_1d(i,j) = phi(i-1,j) + (0.5d0 - hdtdx(1)*umac(i,j))*slope(i-1,j)
+             phix_1d(i,j) = phi(i-1,j) + (0.5_amrex_real - hdtdx(1)*umac(i,j))*slope(i-1,j)
           end if
 
        end do
@@ -65,10 +65,10 @@ contains
     do    j = lo(2)  , hi(2)+1
        do i = lo(1)-1, hi(1)+1
 
-          if (vmac(i,j) .lt. 0.d0) then
-             phiy_1d(i,j) = phi(i,j  ) - (0.5d0 + hdtdx(2)*vmac(i,j))*slope(i,j  )
+          if (vmac(i,j) .lt. 0.0_amrex_real) then
+             phiy_1d(i,j) = phi(i,j  ) - (0.5_amrex_real + hdtdx(2)*vmac(i,j))*slope(i,j  )
           else
-             phiy_1d(i,j) = phi(i,j-1) + (0.5d0 - hdtdx(2)*vmac(i,j))*slope(i,j-1)
+             phiy_1d(i,j) = phi(i,j-1) + (0.5_amrex_real - hdtdx(2)*vmac(i,j))*slope(i,j-1)
           end if
 
        end do
@@ -78,12 +78,12 @@ contains
     do    j = lo(2), hi(2)
        do i = lo(1), hi(1)+1
 
-          if (umac(i,j) .lt. 0.d0) then
+          if (umac(i,j) .lt. 0.0_amrex_real) then
              phix(i,j) = phix_1d(i,j) &
-                  - hdtdx(2)*( 0.5d0*(vmac(i  ,j+1)+vmac(i  ,j)) * (phiy_1d(i  ,j+1)-phiy_1d(i  ,j)) )
+                  - hdtdx(2)*( 0.5_amrex_real*(vmac(i  ,j+1)+vmac(i  ,j)) * (phiy_1d(i  ,j+1)-phiy_1d(i  ,j)) )
           else
              phix(i,j) = phix_1d(i,j) &
-                  - hdtdx(2)*( 0.5d0*(vmac(i-1,j+1)+vmac(i-1,j)) * (phiy_1d(i-1,j+1)-phiy_1d(i-1,j)) )
+                  - hdtdx(2)*( 0.5_amrex_real*(vmac(i-1,j+1)+vmac(i-1,j)) * (phiy_1d(i-1,j+1)-phiy_1d(i-1,j)) )
           end if
 
           ! compute final x-fluxes
@@ -96,12 +96,12 @@ contains
     do    j = lo(2), hi(2)+1
        do i = lo(1), hi(1)
 
-          if (vmac(i,j) .lt. 0.d0) then
+          if (vmac(i,j) .lt. 0.0_amrex_real) then
              phiy(i,j) = phiy_1d(i,j) &
-                  - hdtdx(1)*( 0.5d0*(umac(i+1,j  )+umac(i,j  )) * (phix_1d(i+1,j  )-phix_1d(i,j  )) )
+                  - hdtdx(1)*( 0.5_amrex_real*(umac(i+1,j  )+umac(i,j  )) * (phix_1d(i+1,j  )-phix_1d(i,j  )) )
           else
              phiy(i,j) = phiy_1d(i,j) &
-                  - hdtdx(1)*( 0.5d0*(umac(i+1,j-1)+umac(i,j-1)) * (phix_1d(i+1,j-1)-phix_1d(i,j-1)) )
+                  - hdtdx(1)*( 0.5_amrex_real*(umac(i+1,j-1)+umac(i,j-1)) * (phix_1d(i+1,j-1)-phix_1d(i,j-1)) )
           end if
 
           ! compute final y-fluxes

--- a/Tests/FortranInterface/Advection_F/Source/Src_2d/slope_2d.f90
+++ b/Tests/FortranInterface/Advection_F/Source/Src_2d/slope_2d.f90
@@ -33,12 +33,12 @@ contains
        do i = lo(1)-1, hi(1)+1
           dlft = q(i  ,j) - q(i-1,j)
           drgt = q(i+1,j) - q(i  ,j)
-          dcen(i) = .5d0 * (dlft+drgt)
-          dsgn(i) = sign(1.d0, dcen(i))
-          if (dlft*drgt .ge. 0.d0) then
-             dlim(i) = 2.d0 * min( abs(dlft), abs(drgt) )
+          dcen(i) = .5_amrex_real * (dlft+drgt)
+          dsgn(i) = sign(1.0_amrex_real, dcen(i))
+          if (dlft*drgt .ge. 0.0_amrex_real) then
+             dlim(i) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
           else
-             dlim(i) = 0.d0
+             dlim(i) = 0.0_amrex_real
           endif
           df(i) = dsgn(i)*min( dlim(i), abs(dcen(i)) )
        end do
@@ -102,12 +102,12 @@ contains
        do i = lo(1)  , hi(1)
           dlft = q(i,j  ) - q(i,j-1)
           drgt = q(i,j+1) - q(i,j  )
-          dcen(i,j) = .5d0 * (dlft+drgt)
-          dsgn(i,j) = sign( 1.d0, dcen(i,j) )
-          if (dlft*drgt .ge. 0.d0) then
-             dlim(i,j) = 2.d0 * min( abs(dlft), abs(drgt) )
+          dcen(i,j) = .5_amrex_real * (dlft+drgt)
+          dsgn(i,j) = sign( 1.0_amrex_real, dcen(i,j) )
+          if (dlft*drgt .ge. 0.0_amrex_real) then
+             dlim(i,j) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
           else
-             dlim(i,j) = 0.d0
+             dlim(i,j) = 0.0_amrex_real
           endif
           df(i,j) = dsgn(i,j)*min( dlim(i,j),abs(dcen(i,j)) )
        end do

--- a/Tests/FortranInterface/Advection_F/Source/Src_3d/advect_3d_mod.F90
+++ b/Tests/FortranInterface/Advection_F/Source/Src_3d/advect_3d_mod.F90
@@ -26,7 +26,7 @@ subroutine advect(time, lo, hi, &
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
-  double precision, intent(in) :: dx(3), dt, time
+  real(amrex_real), intent(in) :: dx(3), dt, time
   integer, intent(in) :: ui_lo(3), ui_hi(3)
   integer, intent(in) :: uo_lo(3), uo_hi(3)
   integer, intent(in) :: vx_lo(3), vx_hi(3)
@@ -35,21 +35,21 @@ subroutine advect(time, lo, hi, &
   integer, intent(in) :: fx_lo(3), fx_hi(3)
   integer, intent(in) :: fy_lo(3), fy_hi(3)
   integer, intent(in) :: fz_lo(3), fz_hi(3)
-  double precision, intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2),ui_lo(3):ui_hi(3))
-  double precision, intent(inout) :: uout(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3))
-  double precision, intent(in   ) :: vx  (vx_lo(1):vx_hi(1),vx_lo(2):vx_hi(2),vx_lo(3):vx_hi(3))
-  double precision, intent(in   ) :: vy  (vy_lo(1):vy_hi(1),vy_lo(2):vy_hi(2),vy_lo(3):vy_hi(3))
-  double precision, intent(in   ) :: vz  (vz_lo(1):vz_hi(1),vz_lo(2):vz_hi(2),vz_lo(3):vz_hi(3))
-  double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
-  double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
-  double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
+  real(amrex_real), intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2),ui_lo(3):ui_hi(3))
+  real(amrex_real), intent(inout) :: uout(uo_lo(1):uo_hi(1),uo_lo(2):uo_hi(2),uo_lo(3):uo_hi(3))
+  real(amrex_real), intent(in   ) :: vx  (vx_lo(1):vx_hi(1),vx_lo(2):vx_hi(2),vx_lo(3):vx_hi(3))
+  real(amrex_real), intent(in   ) :: vy  (vy_lo(1):vy_hi(1),vy_lo(2):vy_hi(2),vy_lo(3):vy_hi(3))
+  real(amrex_real), intent(in   ) :: vz  (vz_lo(1):vz_hi(1),vz_lo(2):vz_hi(2),vz_lo(3):vz_hi(3))
+  real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
+  real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
+  real(amrex_real), intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
 
   integer :: i, j, k
   integer :: glo(3), ghi(3)
-  double precision :: dtdx(3), umax, vmax, wmax
+  real(amrex_real) :: dtdx(3), umax, vmax, wmax
 
   ! Some compiler may not support 'contiguous'.  Remove it in that case.
-  double precision, dimension(:,:,:), pointer, contiguous :: &
+  real(amrex_real), dimension(:,:,:), pointer, contiguous :: &
        phix, phix_y, phix_z, phiy, phiy_x, phiy_z, phiz, phiz_x, phiz_y, slope
 
   dtdx = dt/dx
@@ -162,8 +162,8 @@ subroutine advect_particles(particles, np, &
   integer,                    intent(in)            :: uylo(3), uyhi(3)
   integer,                    intent(in)            :: uzlo(3), uzhi(3)
   real(amrex_real), target,   intent(in)     :: ux(uxlo(1):uxhi(1),uxlo(2):uxhi(2),uxlo(3):uxhi(3))
-  real(amrex_real), target,   intent(in)     :: uy(uylo(1):uyhi(1),uylo(2):uyhi(2),uxlo(3):uxhi(3))
-  real(amrex_real), target,   intent(in)     :: uz(uzlo(1):uzhi(1),uzlo(2):uzhi(2),uxlo(3):uxhi(3))
+  real(amrex_real), target,   intent(in)     :: uy(uylo(1):uyhi(1),uylo(2):uyhi(2),uylo(3):uyhi(3))
+  real(amrex_real), target,   intent(in)     :: uz(uzlo(1):uzhi(1),uzlo(2):uzhi(2),uzlo(3):uzhi(3))
   real(amrex_real),           intent(in)            :: dt
   real(amrex_real),           intent(in)            :: plo(3)
   real(amrex_real),           intent(in)            :: dx(3)
@@ -191,9 +191,9 @@ subroutine advect_particles(particles, np, &
 
   velocity(1)%p => ux
   velocity(2)%p => uy
-  velocity(3)%p => uy
+  velocity(3)%p => uz
 
-  inv_dx = 1.0d0/dx
+  inv_dx = 1.0_amrex_real/dx
 
   do ipass = 1, 2
      do n = 1, np
@@ -201,10 +201,10 @@ subroutine advect_particles(particles, np, &
         length = (particles(n)%pos - plo)*inv_dx
 
         cc_cell = floor(length)
-        cell    = floor(length + 0.5d0)
+        cell    = floor(length + 0.5_amrex_real)
 
-        w_hi = length + 0.5d0 - cell
-        w_lo = 1.d0 - w_hi
+        w_hi = length + 0.5_amrex_real - cell
+        w_lo = 1.0_amrex_real - w_hi
 
         ! x direction
         do d = 1, 3
@@ -215,8 +215,8 @@ subroutine advect_particles(particles, np, &
            e_lo = w_lo
            e_hi(d) = length(d) - cc_cell(d)
 
-           e_hi = max(0.d0,min(1.d0,e_hi))
-           e_lo(d) = 1.d0 - e_hi(d)
+           e_hi = max(0.0_amrex_real,min(1.0_amrex_real,e_hi))
+           e_lo(d) = 1.0_amrex_real - e_hi(d)
 
            vel = e_lo(1)*e_lo(2)*e_lo(3)*velocity(d)%p(e_cell(1)-1, e_cell(2)-1, e_cell(3)-1) + &
                  e_lo(1)*e_lo(2)*e_hi(3)*velocity(d)%p(e_cell(1)-1, e_cell(2)-1, e_cell(3)  ) + &
@@ -229,7 +229,7 @@ subroutine advect_particles(particles, np, &
 
            if (ipass == 1) then
               particles(n)%vel(d) = particles(n)%pos(d)
-              particles(n)%pos(d) = particles(n)%pos(d) + 0.5d0*dt*vel
+              particles(n)%pos(d) = particles(n)%pos(d) + 0.5_amrex_real*dt*vel
            else
               particles(n)%pos(d) = particles(n)%vel(d) + dt*vel
               particles(n)%vel(d) = vel

--- a/Tests/FortranInterface/Advection_F/Source/Src_3d/compute_flux_3d.f90
+++ b/Tests/FortranInterface/Advection_F/Source/Src_3d/compute_flux_3d.f90
@@ -1,5 +1,7 @@
 module compute_flux_module
 
+  use amrex_base_module
+
   implicit none
 
   private
@@ -24,7 +26,7 @@ contains
     use slope_module, only: slopex, slopey, slopez
 
     integer, intent(in) :: lo(3), hi(3), glo(3), ghi(3)
-    double precision, intent(in) :: dt, dx(3)
+    real(amrex_real), intent(in) :: dt, dx(3)
     integer, intent(in) :: ph_lo(3), ph_hi(3)
     integer, intent(in) ::  u_lo(3),  u_hi(3)
     integer, intent(in) ::  v_lo(3),  v_hi(3)
@@ -32,21 +34,21 @@ contains
     integer, intent(in) :: fx_lo(3), fx_hi(3)
     integer, intent(in) :: fy_lo(3), fy_hi(3)
     integer, intent(in) :: fz_lo(3), fz_hi(3)
-    double precision, intent(in   ) :: phi (ph_lo(1):ph_hi(1),ph_lo(2):ph_hi(2),ph_lo(3):ph_hi(3))
-    double precision, intent(in   ) :: umac( u_lo(1): u_hi(1), u_lo(2): u_hi(2), u_lo(3): u_hi(3))
-    double precision, intent(in   ) :: vmac( v_lo(1): v_hi(1), v_lo(2): v_hi(2), v_lo(3): v_hi(3))
-    double precision, intent(in   ) :: wmac( w_lo(1): w_hi(1), w_lo(2): w_hi(2), w_lo(3): w_hi(3))
-    double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
-    double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
-    double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
-    double precision, dimension(glo(1):ghi(1),glo(2):ghi(2),glo(3):ghi(3)) :: &
+    real(amrex_real), intent(in   ) :: phi (ph_lo(1):ph_hi(1),ph_lo(2):ph_hi(2),ph_lo(3):ph_hi(3))
+    real(amrex_real), intent(in   ) :: umac( u_lo(1): u_hi(1), u_lo(2): u_hi(2), u_lo(3): u_hi(3))
+    real(amrex_real), intent(in   ) :: vmac( v_lo(1): v_hi(1), v_lo(2): v_hi(2), v_lo(3): v_hi(3))
+    real(amrex_real), intent(in   ) :: wmac( w_lo(1): w_hi(1), w_lo(2): w_hi(2), w_lo(3): w_hi(3))
+    real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
+    real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
+    real(amrex_real), intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
+    real(amrex_real), dimension(glo(1):ghi(1),glo(2):ghi(2),glo(3):ghi(3)) :: &
          phix, phix_y, phix_z, phiy, phiy_x, phiy_z, phiz, phiz_x, phiz_y, slope
 
     integer :: i, j, k
-    double precision :: hdtdx(3), tdtdx(3)
+    real(amrex_real) :: hdtdx(3), tdtdx(3)
 
     hdtdx = 0.5*(dt/dx)
-    tdtdx = (1.d0/3.d0)*(dt/dx)
+    tdtdx = (1.0_amrex_real/3.0_amrex_real)*(dt/dx)
 
     call slopex(glo, ghi, &
                 phi, ph_lo, ph_hi, &
@@ -57,10 +59,10 @@ contains
        do    j = lo(2)-1, hi(2)+1
           do i = lo(1)  , hi(1)+1
 
-             if (umac(i,j,k) .lt. 0.d0) then
-                phix(i,j,k) = phi(i  ,j,k) - (0.5d0 + hdtdx(1)*umac(i,j,k))*slope(i  ,j,k)
+             if (umac(i,j,k) .lt. 0.0_amrex_real) then
+                phix(i,j,k) = phi(i  ,j,k) - (0.5_amrex_real + hdtdx(1)*umac(i,j,k))*slope(i  ,j,k)
              else
-                phix(i,j,k) = phi(i-1,j,k) + (0.5d0 - hdtdx(1)*umac(i,j,k))*slope(i-1,j,k)
+                phix(i,j,k) = phi(i-1,j,k) + (0.5_amrex_real - hdtdx(1)*umac(i,j,k))*slope(i-1,j,k)
              end if
 
           end do
@@ -76,10 +78,10 @@ contains
        do    j = lo(2)  , hi(2)+1
           do i = lo(1)-1, hi(1)+1
 
-             if (vmac(i,j,k) .lt. 0.d0) then
-                phiy(i,j,k) = phi(i,j  ,k) - (0.5d0 + hdtdx(2)*vmac(i,j,k))*slope(i,j  ,k)
+             if (vmac(i,j,k) .lt. 0.0_amrex_real) then
+                phiy(i,j,k) = phi(i,j  ,k) - (0.5_amrex_real + hdtdx(2)*vmac(i,j,k))*slope(i,j  ,k)
              else
-                phiy(i,j,k) = phi(i,j-1,k) + (0.5d0 - hdtdx(2)*vmac(i,j,k))*slope(i,j-1,k)
+                phiy(i,j,k) = phi(i,j-1,k) + (0.5_amrex_real - hdtdx(2)*vmac(i,j,k))*slope(i,j-1,k)
              end if
 
           end do
@@ -95,10 +97,10 @@ contains
        do    j = lo(2)-1, hi(2)+1
           do i = lo(1)-1, hi(1)+1
 
-             if (wmac(i,j,k) .lt. 0.d0) then
-                phiz(i,j,k) = phi(i,j,k  ) - (0.5d0 + hdtdx(3)*wmac(i,j,k))*slope(i,j,k  )
+             if (wmac(i,j,k) .lt. 0.0_amrex_real) then
+                phiz(i,j,k) = phi(i,j,k  ) - (0.5_amrex_real + hdtdx(3)*wmac(i,j,k))*slope(i,j,k  )
              else
-                phiz(i,j,k) = phi(i,j,k-1) + (0.5d0 - hdtdx(3)*wmac(i,j,k))*slope(i,j,k-1)
+                phiz(i,j,k) = phi(i,j,k-1) + (0.5_amrex_real - hdtdx(3)*wmac(i,j,k))*slope(i,j,k-1)
              end if
 
           end do
@@ -114,12 +116,12 @@ contains
        do    j=lo(2)  , hi(2)
           do i=lo(1)  , hi(1)+1
 
-             if (umac(i,j,k) .lt. 0.d0) then
+             if (umac(i,j,k) .lt. 0.0_amrex_real) then
                 phix_y(i,j,k) = phix(i,j,k) &
-                     - tdtdx(2) * (0.5d0*(vmac(i  ,j+1,k)+vmac(i  ,j,k)) * (phiy(i  ,j+1,k)-phiy(i  ,j,k)) )
+                     - tdtdx(2) * (0.5_amrex_real*(vmac(i  ,j+1,k)+vmac(i  ,j,k)) * (phiy(i  ,j+1,k)-phiy(i  ,j,k)) )
              else
                 phix_y(i,j,k) = phix(i,j,k) &
-                     - tdtdx(2) * (0.5d0*(vmac(i-1,j+1,k)+vmac(i-1,j,k)) * (phiy(i-1,j+1,k)-phiy(i-1,j,k)) )
+                     - tdtdx(2) * (0.5_amrex_real*(vmac(i-1,j+1,k)+vmac(i-1,j,k)) * (phiy(i-1,j+1,k)-phiy(i-1,j,k)) )
              end if
 
           end do
@@ -131,12 +133,12 @@ contains
        do    j=lo(2)-1, hi(2)+1
           do i=lo(1)  , hi(1)+1
 
-             if (umac(i,j,k) .lt. 0.d0) then
+             if (umac(i,j,k) .lt. 0.0_amrex_real) then
                 phix_z(i,j,k) = phix(i,j,k) &
-                     - tdtdx(3) * (0.5d0*(wmac(i  ,j,k+1)+wmac(i  ,j,k)) * (phiz(i  ,j,k+1)-phiz(i  ,j,k)) )
+                     - tdtdx(3) * (0.5_amrex_real*(wmac(i  ,j,k+1)+wmac(i  ,j,k)) * (phiz(i  ,j,k+1)-phiz(i  ,j,k)) )
              else
                 phix_z(i,j,k) = phix(i,j,k) &
-                     - tdtdx(3) * (0.5d0*(wmac(i-1,j,k+1)+wmac(i-1,j,k)) * (phiz(i-1,j,k+1)-phiz(i-1,j,k)) )
+                     - tdtdx(3) * (0.5_amrex_real*(wmac(i-1,j,k+1)+wmac(i-1,j,k)) * (phiz(i-1,j,k+1)-phiz(i-1,j,k)) )
              end if
 
           end do
@@ -148,12 +150,12 @@ contains
        do    j = lo(2)  , hi(2)+1
           do i = lo(1)  , hi(1)
 
-             if (vmac(i,j,k) .lt. 0.d0) then
+             if (vmac(i,j,k) .lt. 0.0_amrex_real) then
                 phiy_x(i,j,k) = phiy(i,j,k) &
-                     - tdtdx(1) * (0.5d0*(umac(i+1,j  ,k)+umac(i,j  ,k)) * (phix(i+1,j  ,k)-phix(i,j  ,k)) )
+                     - tdtdx(1) * (0.5_amrex_real*(umac(i+1,j  ,k)+umac(i,j  ,k)) * (phix(i+1,j  ,k)-phix(i,j  ,k)) )
              else
                 phiy_x(i,j,k) = phiy(i,j,k) &
-                     - tdtdx(1) * (0.5d0*(umac(i+1,j-1,k)+umac(i,j-1,k)) * (phix(i+1,j-1,k)-phix(i,j-1,k)) )
+                     - tdtdx(1) * (0.5_amrex_real*(umac(i+1,j-1,k)+umac(i,j-1,k)) * (phix(i+1,j-1,k)-phix(i,j-1,k)) )
              end if
 
           end do
@@ -165,12 +167,12 @@ contains
        do    j = lo(2)  , hi(2)+1
           do i = lo(1)-1, hi(1)+1
 
-             if (vmac(i,j,k) .lt. 0.d0) then
+             if (vmac(i,j,k) .lt. 0.0_amrex_real) then
                 phiy_z(i,j,k) = phiy(i,j,k) &
-                     - tdtdx(3) * (0.5d0*(wmac(i,j  ,k+1)+wmac(i,j  ,k)) * (phiz(i,j  ,k+1)-phiz(i,j  ,k)) )
+                     - tdtdx(3) * (0.5_amrex_real*(wmac(i,j  ,k+1)+wmac(i,j  ,k)) * (phiz(i,j  ,k+1)-phiz(i,j  ,k)) )
              else
                 phiy_z(i,j,k) = phiy(i,j,k) &
-                     - tdtdx(3) * (0.5d0*(wmac(i,j-1,k+1)+wmac(i,j-1,k)) * (phiz(i,j-1,k+1)-phiz(i,j-1,k)) )
+                     - tdtdx(3) * (0.5_amrex_real*(wmac(i,j-1,k+1)+wmac(i,j-1,k)) * (phiz(i,j-1,k+1)-phiz(i,j-1,k)) )
              end if
 
           end do
@@ -182,12 +184,12 @@ contains
        do    j = lo(2)-1, hi(2)+1
           do i = lo(1)  , hi(1)
 
-             if (wmac(i,j,k) .lt. 0.d0) then
+             if (wmac(i,j,k) .lt. 0.0_amrex_real) then
                 phiz_x(i,j,k) = phiz(i,j,k) &
-                     - tdtdx(1) * (0.5d0*(umac(i+1,j,k  )+umac(i,j,k  )) * (phix(i+1,j,k  )-phix(i,j,k  )) )
+                     - tdtdx(1) * (0.5_amrex_real*(umac(i+1,j,k  )+umac(i,j,k  )) * (phix(i+1,j,k  )-phix(i,j,k  )) )
              else
                 phiz_x(i,j,k) = phiz(i,j,k) &
-                     - tdtdx(1) * (0.5d0*(umac(i+1,j,k-1)+umac(i,j,k-1)) * (phix(i+1,j,k-1)-phix(i,j,k-1)) )
+                     - tdtdx(1) * (0.5_amrex_real*(umac(i+1,j,k-1)+umac(i,j,k-1)) * (phix(i+1,j,k-1)-phix(i,j,k-1)) )
              end if
 
           end do
@@ -199,12 +201,12 @@ contains
        do    j = lo(2)  , hi(2)
           do i = lo(1)-1, hi(1)+1
 
-             if (wmac(i,j,k) .lt. 0.d0) then
+             if (wmac(i,j,k) .lt. 0.0_amrex_real) then
                 phiz_y(i,j,k) = phiz(i,j,k) &
-                     - tdtdx(2) * (0.5d0*(vmac(i,j+1,k  )+vmac(i,j,k  )) * (phiy(i,j+1,k  )-phiy(i,j,k  )) )
+                     - tdtdx(2) * (0.5_amrex_real*(vmac(i,j+1,k  )+vmac(i,j,k  )) * (phiy(i,j+1,k  )-phiy(i,j,k  )) )
              else
                 phiz_y(i,j,k) = phiz(i,j,k) &
-                     - tdtdx(2) * (0.5d0*(vmac(i,j+1,k-1)+vmac(i,j,k-1)) * (phiy(i,j+1,k-1)-phiy(i,j,k-1)) )
+                     - tdtdx(2) * (0.5_amrex_real*(vmac(i,j+1,k-1)+vmac(i,j,k-1)) * (phiy(i,j+1,k-1)-phiy(i,j,k-1)) )
              end if
 
           end do
@@ -220,14 +222,14 @@ contains
        do    j = lo(2), hi(2)
           do i = lo(1), hi(1)+1
 
-             if (umac(i,j,k) .lt. 0.d0) then
+             if (umac(i,j,k) .lt. 0.0_amrex_real) then
                 phix(i,j,k) = phix(i,j,k) &
-                     - hdtdx(2)*( 0.5d0*(vmac(i  ,j+1,k  )+vmac(i  ,j,k)) * (phiy_z(i  ,j+1,k  )-phiy_z(i  ,j,k)) ) &
-                     - hdtdx(3)*( 0.5d0*(wmac(i  ,j  ,k+1)+wmac(i  ,j,k)) * (phiz_y(i  ,j  ,k+1)-phiz_y(i  ,j,k)) )
+                     - hdtdx(2)*( 0.5_amrex_real*(vmac(i  ,j+1,k  )+vmac(i  ,j,k)) * (phiy_z(i  ,j+1,k  )-phiy_z(i  ,j,k)) ) &
+                     - hdtdx(3)*( 0.5_amrex_real*(wmac(i  ,j  ,k+1)+wmac(i  ,j,k)) * (phiz_y(i  ,j  ,k+1)-phiz_y(i  ,j,k)) )
              else
                 phix(i,j,k) = phix(i,j,k) &
-                     - hdtdx(2)*( 0.5d0*(vmac(i-1,j+1,k  )+vmac(i-1,j,k)) * (phiy_z(i-1,j+1,k  )-phiy_z(i-1,j,k)) ) &
-                     - hdtdx(3)*( 0.5d0*(wmac(i-1,j  ,k+1)+wmac(i-1,j,k)) * (phiz_y(i-1,j  ,k+1)-phiz_y(i-1,j,k)) )
+                     - hdtdx(2)*( 0.5_amrex_real*(vmac(i-1,j+1,k  )+vmac(i-1,j,k)) * (phiy_z(i-1,j+1,k  )-phiy_z(i-1,j,k)) ) &
+                     - hdtdx(3)*( 0.5_amrex_real*(wmac(i-1,j  ,k+1)+wmac(i-1,j,k)) * (phiz_y(i-1,j  ,k+1)-phiz_y(i-1,j,k)) )
              end if
 
              ! compute final x-fluxes
@@ -242,14 +244,14 @@ contains
        do    j = lo(2), hi(2)+1
           do i = lo(1), hi(1)
 
-             if (vmac(i,j,k) .lt. 0.d0) then
+             if (vmac(i,j,k) .lt. 0.0_amrex_real) then
                 phiy(i,j,k) = phiy(i,j,k) &
-                     - hdtdx(1)*( 0.5d0*(umac(i+1,j  ,k  )+umac(i,j  ,k)) * (phix_z(i+1,j  ,k  )-phix_z(i,j  ,k)) ) &
-                     - hdtdx(3)*( 0.5d0*(wmac(i  ,j  ,k+1)+wmac(i,j  ,k)) * (phiz_x(i  ,j  ,k+1)-phiz_x(i,j  ,k)) )
+                     - hdtdx(1)*( 0.5_amrex_real*(umac(i+1,j  ,k  )+umac(i,j  ,k)) * (phix_z(i+1,j  ,k  )-phix_z(i,j  ,k)) ) &
+                     - hdtdx(3)*( 0.5_amrex_real*(wmac(i  ,j  ,k+1)+wmac(i,j  ,k)) * (phiz_x(i  ,j  ,k+1)-phiz_x(i,j  ,k)) )
              else
                 phiy(i,j,k) = phiy(i,j,k) &
-                     - hdtdx(1)*( 0.5d0*(umac(i+1,j-1,k  )+umac(i,j-1,k)) * (phix_z(i+1,j-1,k  )-phix_z(i,j-1,k)) ) &
-                     - hdtdx(3)*( 0.5d0*(wmac(i  ,j-1,k+1)+wmac(i,j-1,k)) * (phiz_x(i  ,j-1,k+1)-phiz_x(i,j-1,k)) )
+                     - hdtdx(1)*( 0.5_amrex_real*(umac(i+1,j-1,k  )+umac(i,j-1,k)) * (phix_z(i+1,j-1,k  )-phix_z(i,j-1,k)) ) &
+                     - hdtdx(3)*( 0.5_amrex_real*(wmac(i  ,j-1,k+1)+wmac(i,j-1,k)) * (phiz_x(i  ,j-1,k+1)-phiz_x(i,j-1,k)) )
              end if
 
              ! compute final y-fluxes
@@ -264,14 +266,14 @@ contains
        do    j = lo(2), hi(2)
           do i = lo(1), hi(1)
 
-             if (wmac(i,j,k) .lt. 0.d0) then
+             if (wmac(i,j,k) .lt. 0.0_amrex_real) then
                 phiz(i,j,k) = phiz(i,j,k) &
-                     - hdtdx(1)*( 0.5d0*(umac(i+1,j  ,k  )+umac(i  ,j,k)) * (phix_y(i+1,j  ,k  )-phix_y(i,j,k  )) ) &
-                     - hdtdx(2)*( 0.5d0*(vmac(i  ,j+1,k  )+vmac(i  ,j,k)) * (phiy_x(i  ,j+1,k  )-phiy_x(i,j,k  )) )
+                     - hdtdx(1)*( 0.5_amrex_real*(umac(i+1,j  ,k  )+umac(i  ,j,k)) * (phix_y(i+1,j  ,k  )-phix_y(i,j,k  )) ) &
+                     - hdtdx(2)*( 0.5_amrex_real*(vmac(i  ,j+1,k  )+vmac(i  ,j,k)) * (phiy_x(i  ,j+1,k  )-phiy_x(i,j,k  )) )
              else
                 phiz(i,j,k) = phiz(i,j,k) &
-                     - hdtdx(1)*( 0.5d0*(umac(i+1,j  ,k-1)+umac(i,j,k-1)) * (phix_y(i+1,j  ,k-1)-phix_y(i,j,k-1)) ) &
-                     - hdtdx(2)*( 0.5d0*(vmac(i  ,j+1,k-1)+vmac(i,j,k-1)) * (phiy_x(i  ,j+1,k-1)-phiy_x(i,j,k-1)) )
+                     - hdtdx(1)*( 0.5_amrex_real*(umac(i+1,j  ,k-1)+umac(i,j,k-1)) * (phix_y(i+1,j  ,k-1)-phix_y(i,j,k-1)) ) &
+                     - hdtdx(2)*( 0.5_amrex_real*(vmac(i  ,j+1,k-1)+vmac(i,j,k-1)) * (phiy_x(i  ,j+1,k-1)-phiy_x(i,j,k-1)) )
              end if
 
              ! compute final z-fluxes

--- a/Tests/FortranInterface/Advection_F/Source/Src_3d/slope_3d.f90
+++ b/Tests/FortranInterface/Advection_F/Source/Src_3d/slope_3d.f90
@@ -1,8 +1,10 @@
 module slope_module
 
+  use amrex_base_module
+
   implicit none
 
-  double precision, parameter:: four3rd=4.d0/3.d0, sixth=1.d0/6.d0
+  real(amrex_real), parameter:: four3rd=4.0_amrex_real/3.0_amrex_real, sixth=1.0_amrex_real/6.0_amrex_real
 
   private
 
@@ -17,12 +19,12 @@ contains
     implicit none
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3)
-    double precision, intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real), intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
 
     integer :: i, j, k
-    double precision, dimension(lo(1)-1:hi(1)+1) :: dsgn, dlim, df, dcen
-    double precision :: dlft, drgt, dq1
+    real(amrex_real), dimension(lo(1)-1:hi(1)+1) :: dsgn, dlim, df, dcen
+    real(amrex_real) :: dlft, drgt, dq1
 
     do    k = lo(3), hi(3)
        do j = lo(2), hi(2)
@@ -31,12 +33,12 @@ contains
           do i = lo(1)-1, hi(1)+1
              dlft = q(i  ,j,k) - q(i-1,j,k)
              drgt = q(i+1,j,k) - q(i  ,j,k)
-             dcen(i) = .5d0 * (dlft+drgt)
-             dsgn(i) = sign(1.d0, dcen(i))
-             if (dlft*drgt .ge. 0.d0) then
-                dlim(i) = 2.d0 * min( abs(dlft), abs(drgt) )
+             dcen(i) = .5_amrex_real * (dlft+drgt)
+             dsgn(i) = sign(1.0_amrex_real, dcen(i))
+             if (dlft*drgt .ge. 0.0_amrex_real) then
+                dlim(i) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
              else
-                dlim(i) = 0.d0
+                dlim(i) = 0.0_amrex_real
              endif
              df(i) = dsgn(i)*min( dlim(i), abs(dcen(i)) )
           end do
@@ -59,11 +61,11 @@ contains
     use amrex_mempool_module, only : bl_allocate, bl_deallocate
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3)
-    double precision, intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real), intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
 
     ! Some compiler may not support 'contiguous'.  Remove it in that case.
-    double precision, dimension(:,:), pointer, contiguous :: dsgn, dlim, df, dcen
+    real(amrex_real), dimension(:,:), pointer, contiguous :: dsgn, dlim, df, dcen
 
     call bl_allocate(dsgn, lo(1), hi(1), lo(2)-1, hi(2)+1)
     call bl_allocate(dlim, lo(1), hi(1), lo(2)-1, hi(2)+1)
@@ -89,15 +91,15 @@ contains
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3), &
          ddlo(2), ddhi(2)
-    double precision, intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
-    double precision              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
-    double precision              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
-    double precision              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2))
-    double precision              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real), intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real)              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real)              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real)              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real)              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
 
     integer :: i, j, k
-    double precision :: dlft, drgt, dq1
+    real(amrex_real) :: dlft, drgt, dq1
 
     do k = lo(3), hi(3)
 
@@ -106,12 +108,12 @@ contains
           do i = lo(1)  , hi(1)
              dlft = q(i,j  ,k) - q(i,j-1,k)
              drgt = q(i,j+1,k) - q(i,j  ,k)
-             dcen(i,j) = .5d0 * (dlft+drgt)
-             dsgn(i,j) = sign( 1.d0, dcen(i,j) )
-             if (dlft*drgt .ge. 0.d0) then
-                dlim(i,j) = 2.d0 * min( abs(dlft), abs(drgt) )
+             dcen(i,j) = .5_amrex_real * (dlft+drgt)
+             dsgn(i,j) = sign( 1.0_amrex_real, dcen(i,j) )
+             if (dlft*drgt .ge. 0.0_amrex_real) then
+                dlim(i,j) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
              else
-                dlim(i,j) = 0.d0
+                dlim(i,j) = 0.0_amrex_real
              endif
              df(i,j) = dsgn(i,j)*min( dlim(i,j),abs(dcen(i,j)) )
           end do
@@ -137,11 +139,11 @@ contains
     use amrex_mempool_module, only : bl_allocate, bl_deallocate
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3)
-    double precision, intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real), intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
 
     ! Some compiler may not support 'contiguous'.  Remove it in that case.
-    double precision, dimension(:,:,:), pointer, contiguous :: dsgn, dlim, df, dcen
+    real(amrex_real), dimension(:,:,:), pointer, contiguous :: dsgn, dlim, df, dcen
 
     call bl_allocate(dsgn, lo(1), hi(1), lo(2), hi(2), lo(3)-1, hi(3)+1)
     call bl_allocate(dlim, lo(1), hi(1), lo(2), hi(2), lo(3)-1, hi(3)+1)
@@ -168,15 +170,15 @@ contains
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3), &
          ddlo(3), ddhi(3)
-    double precision, intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
-    double precision              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
-    double precision              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
-    double precision              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
-    double precision              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    real(amrex_real), intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real)              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    real(amrex_real)              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    real(amrex_real)              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    real(amrex_real)              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
 
     integer :: i, j, k
-    double precision :: dlft, drgt, dq1
+    real(amrex_real) :: dlft, drgt, dq1
 
     ! first compute Fromm slopes
     do k       = lo(3)-1, hi(3)+1
@@ -184,12 +186,12 @@ contains
           do i = lo(1)  , hi(1)
              dlft = q(i,j,k  ) - q(i,j,k-1)
              drgt = q(i,j,k+1) - q(i,j,k  )
-             dcen(i,j,k) = .5d0 * (dlft+drgt)
-             dsgn(i,j,k) = sign( 1.d0, dcen(i,j,k) )
-             if (dlft*drgt .ge. 0.d0) then
-                dlim(i,j,k) = 2.d0 * min( abs(dlft), abs(drgt) )
+             dcen(i,j,k) = .5_amrex_real * (dlft+drgt)
+             dsgn(i,j,k) = sign( 1.0_amrex_real, dcen(i,j,k) )
+             if (dlft*drgt .ge. 0.0_amrex_real) then
+                dlim(i,j,k) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
              else
-                dlim(i,j,k) = 0.d0
+                dlim(i,j,k) = 0.0_amrex_real
              endif
              df(i,j,k) = dsgn(i,j,k)*min( dlim(i,j,k),abs(dcen(i,j,k)) )
           end do

--- a/Tests/FortranInterface/Advection_F/Source/amr_data_mod.F90
+++ b/Tests/FortranInterface/Advection_F/Source/amr_data_mod.F90
@@ -30,7 +30,7 @@ contains
     t_new = 0.0_rt
 
     allocate(t_old(0:amrex_max_level))
-    t_old = -1.0e100_rt
+    t_old = -1.0e30_rt
 
     allocate(phi_new(0:amrex_max_level))
     allocate(phi_old(0:amrex_max_level))

--- a/Tests/FortranInterface/Advection_F/Source/evolve_mod.F90
+++ b/Tests/FortranInterface/Advection_F/Source/evolve_mod.F90
@@ -182,7 +182,12 @@ contains
        call uface(idim)%reset_omp_private()
        call flux(idim)%reset_omp_private()
     end do
-    call amrex_mfiter_build(mfi, phi_new(lev), tiling=.true.)
+    ! MFIter tiling must match the ParticleContainer's tiling.  Particle
+    ! containers are un-tiled by default (particles.do_tiling = false), so we
+    ! disable MFIter tiling here to stay consistent.  Because it is hard-coded
+    ! off here, do NOT enable particle tiling via the particles.do_tiling
+    ! ParmParse parameter -- the two must stay consistent.
+    call amrex_mfiter_build(mfi, phi_new(lev), tiling=.false.)
     do while(mfi%next())
        bx = mfi%tilebox()
 

--- a/Tests/FortranInterface/Advection_F/Source/my_amr_mod.F90
+++ b/Tests/FortranInterface/Advection_F/Source/my_amr_mod.F90
@@ -121,7 +121,7 @@ contains
     dm = pdm
 
     t_new(lev) = time
-    t_old(lev) = time - 1.e200_amrex_real
+    t_old(lev) = time - 1.e30_amrex_real
 
     call my_clear_level(lev)
 
@@ -161,7 +161,7 @@ contains
     call my_clear_level(lev)
 
     t_new(lev) = time
-    t_old(lev) = time - 1.e200_amrex_real
+    t_old(lev) = time - 1.e30_amrex_real
 
     call amrex_multifab_build(phi_new(lev), ba, dm, ncomp, nghost)
     call amrex_multifab_build(phi_old(lev), ba, dm, ncomp, nghost)
@@ -193,7 +193,7 @@ contains
     call my_clear_level(lev)
 
     t_new(lev) = time
-    t_old(lev) = time - 1.e200_amrex_real
+    t_old(lev) = time - 1.e30_amrex_real
 
     call amrex_multifab_build(phi_new(lev), ba, dm, ncomp, nghost)
     call amrex_multifab_build(phi_old(lev), ba, dm, ncomp, nghost)

--- a/Tests/FortranInterface/Advection_F_RK/Exec/SingleVortex/Prob_2d.f90
+++ b/Tests/FortranInterface/Advection_F_RK/Exec/SingleVortex/Prob_2d.f90
@@ -28,17 +28,17 @@ contains
     !$omp parallel do private(i,j,k,x,y,z,r2) collapse(2)
     do k=lo(3),hi(3)
        do j=lo(2),hi(2)
-          z = prob_lo(3) + (dble(k)+0.5d0) * dx(3)
-          y = prob_lo(2) + (dble(j)+0.5d0) * dx(2)
+          z = prob_lo(3) + (real(k,amrex_real)+0.5_amrex_real) * dx(3)
+          y = prob_lo(2) + (real(j,amrex_real)+0.5_amrex_real) * dx(2)
           do i=lo(1),hi(1)
-             x = prob_lo(1) + (dble(i)+0.5d0) * dx(1)
+             x = prob_lo(1) + (real(i,amrex_real)+0.5_amrex_real) * dx(1)
 
              if ( amrex_spacedim .eq. 2) then
-                r2 = ((x-0.5d0)**2 + (y-0.75d0)**2) / 0.01d0
-                phi(i,j,k) = 1.d0 + exp(-r2)
+                r2 = ((x-0.5_amrex_real)**2 + (y-0.75_amrex_real)**2) / 0.01_amrex_real
+                phi(i,j,k) = 1.0_amrex_real + exp(-r2)
              else
-                r2 = ((x-0.5d0)**2 + (y-0.75d0)**2 + (z-0.5d0)**2) / 0.01d0
-                phi(i,j,k) = 1.d0 + exp(-r2)
+                r2 = ((x-0.5_amrex_real)**2 + (y-0.75_amrex_real)**2 + (z-0.5_amrex_real)**2) / 0.01_amrex_real
+                phi(i,j,k) = 1.0_amrex_real + exp(-r2)
              end if
           end do
        end do

--- a/Tests/FortranInterface/Advection_F_RK/Exec/SingleVortex/Prob_3d.f90
+++ b/Tests/FortranInterface/Advection_F_RK/Exec/SingleVortex/Prob_3d.f90
@@ -10,11 +10,12 @@ contains
 
 subroutine amrex_probinit (init,name,namlen,problo,probhi) bind(c)
 
+  use amrex_fort_module, only : amrex_real
   implicit none
 
   integer, intent(in) :: init, namlen
   integer, intent(in) :: name(namlen)
-  double precision, intent(in) :: problo(*), probhi(*)
+  real(amrex_real), intent(in) :: problo(*), probhi(*)
 
   ! nothing needs to be done here
 
@@ -25,17 +26,18 @@ subroutine init_prob_data(level, time, lo, hi, &
      phi, phi_lo, phi_hi, &
      dx, prob_lo) bind(C, name="initdata")
 
+  use amrex_fort_module, only : amrex_real
   implicit none
   integer, intent(in) :: level, lo(3), hi(3), phi_lo(3), phi_hi(3)
-  double precision, intent(in) :: time
-  double precision, intent(inout) :: phi(phi_lo(1):phi_hi(1), &
+  real(amrex_real), intent(in) :: time
+  real(amrex_real), intent(inout) :: phi(phi_lo(1):phi_hi(1), &
        &                                 phi_lo(2):phi_hi(2), &
        &                                 phi_lo(3):phi_hi(3))
-  double precision, intent(in) :: dx(3), prob_lo(3)
+  real(amrex_real), intent(in) :: dx(3), prob_lo(3)
 
   integer          :: dm
   integer          :: i,j,k
-  double precision :: x,y,z,r2
+  real(amrex_real) :: x,y,z,r2
 
   if (phi_lo(3) .eq. 0 .and. phi_hi(3) .eq. 0) then
      dm = 2
@@ -46,17 +48,17 @@ subroutine init_prob_data(level, time, lo, hi, &
   !$omp parallel do private(i,j,k,x,y,z,r2) collapse(2)
   do k=lo(3),hi(3)
      do j=lo(2),hi(2)
-        z = prob_lo(3) + (dble(k)+0.5d0) * dx(3)
-        y = prob_lo(2) + (dble(j)+0.5d0) * dx(2)
+        z = prob_lo(3) + (real(k,amrex_real)+0.5_amrex_real) * dx(3)
+        y = prob_lo(2) + (real(j,amrex_real)+0.5_amrex_real) * dx(2)
         do i=lo(1),hi(1)
-           x = prob_lo(1) + (dble(i)+0.5d0) * dx(1)
+           x = prob_lo(1) + (real(i,amrex_real)+0.5_amrex_real) * dx(1)
 
            if ( dm.eq. 2) then
-              r2 = ((x-0.5d0)**2 + (y-0.75d0)**2) / 0.01d0
-              phi(i,j,k) = 1.d0 + exp(-r2)
+              r2 = ((x-0.5_amrex_real)**2 + (y-0.75_amrex_real)**2) / 0.01_amrex_real
+              phi(i,j,k) = 1.0_amrex_real + exp(-r2)
            else
-              r2 = ((x-0.5d0)**2 + (y-0.75d0)**2 + (z-0.5d0)**2) / 0.01d0
-              phi(i,j,k) = 1.d0 + exp(-r2)
+              r2 = ((x-0.5_amrex_real)**2 + (y-0.75_amrex_real)**2 + (z-0.5_amrex_real)**2) / 0.01_amrex_real
+              phi(i,j,k) = 1.0_amrex_real + exp(-r2)
            end if
         end do
      end do

--- a/Tests/FortranInterface/Advection_F_RK/Exec/SingleVortex/face_velocity_2d.F90
+++ b/Tests/FortranInterface/Advection_F_RK/Exec/SingleVortex/face_velocity_2d.F90
@@ -22,7 +22,7 @@ contains
     integer :: i, j, plo(2), phi(2)
     real(amrex_real) :: x, y
     real(amrex_real), pointer, contiguous :: psi(:,:)
-    real(amrex_real), parameter :: M_PI = 3.141592653589793238462643383279502884197d0
+    real(amrex_real), parameter :: M_PI = 3.141592653589793238462643383279502884197_amrex_real
 
     plo(1) = min(vxlo(1)-1, vylo(1)-1)
     plo(2) = min(vxlo(2)-1, vylo(2)-1)
@@ -33,28 +33,28 @@ contains
 
     ! streamfunction psi
     do j = plo(2), phi(2)
-       y = (dble(j)+0.5d0)*dx(2) + prob_lo(2)
+       y = (real(j,amrex_real)+0.5_amrex_real)*dx(2) + prob_lo(2)
        do i = plo(1), phi(1)
-          x = (dble(i)+0.5d0)*dx(1) + prob_lo(1)
-          psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.d0) * (1.d0 / M_PI)
+          x = (real(i,amrex_real)+0.5_amrex_real)*dx(1) + prob_lo(1)
+          psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.0_amrex_real) * (1.0_amrex_real / M_PI)
        end do
     end do
 
     ! x velocity
     do j = vxlo(2), vxhi(2)
-       y = (dble(j)+0.5d0) * dx(2) + prob_lo(2)
+       y = (real(j,amrex_real)+0.5_amrex_real) * dx(2) + prob_lo(2)
        do i = vxlo(1), vxhi(1)
-          x = dble(i) * dx(1) + prob_lo(1)
-          vx(i,j) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25d0/dx(2))
+          x = real(i,amrex_real) * dx(1) + prob_lo(1)
+          vx(i,j) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25_amrex_real/dx(2))
        end do
     end do
 
     ! y velocity
     do j = vylo(2), vyhi(2)
-       y = dble(j) * dx(2) + prob_lo(2)
+       y = real(j,amrex_real) * dx(2) + prob_lo(2)
        do i = vylo(1), vyhi(1)
-          x = (dble(i)+0.5d0) * dx(1) + prob_lo(1)
-          vy(i,j) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25d0/dx(1))
+          x = (real(i,amrex_real)+0.5_amrex_real) * dx(1) + prob_lo(1)
+          vy(i,j) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25_amrex_real/dx(1))
        end do
     end do
 

--- a/Tests/FortranInterface/Advection_F_RK/Exec/SingleVortex/face_velocity_3d.F90
+++ b/Tests/FortranInterface/Advection_F_RK/Exec/SingleVortex/face_velocity_3d.F90
@@ -18,19 +18,19 @@ use amrex_base_module
   implicit none
 
   !integer, intent(in) :: level
-  double precision, intent(in) :: time
+  real(amrex_real), intent(in) :: time
   integer, intent(in) :: vxlo(3),vxhi(3)
   integer, intent(in) :: vylo(3),vyhi(3)
   integer, intent(in) :: vzlo(3),vzhi(3)
-  double precision, intent(out) :: vx(vxlo(1):vxhi(1),vxlo(2):vxhi(2),vxlo(3):vxhi(3))
-  double precision, intent(out) :: vy(vylo(1):vyhi(1),vylo(2):vyhi(2),vylo(3):vyhi(3))
-  double precision, intent(out) :: vz(vzlo(1):vzhi(1),vzlo(2):vzhi(2),vzlo(3):vzhi(3))
-  double precision, intent(in) :: dx(3), prob_lo(3)
+  real(amrex_real), intent(out) :: vx(vxlo(1):vxhi(1),vxlo(2):vxhi(2),vxlo(3):vxhi(3))
+  real(amrex_real), intent(out) :: vy(vylo(1):vyhi(1),vylo(2):vyhi(2),vylo(3):vyhi(3))
+  real(amrex_real), intent(out) :: vz(vzlo(1):vzhi(1),vzlo(2):vzhi(2),vzlo(3):vzhi(3))
+  real(amrex_real), intent(in) :: dx(3), prob_lo(3)
 
   integer :: i, j, k, plo(2), phi(2)
-  double precision :: x, y, z
-  double precision, pointer, contiguous :: psi(:,:)
-  double precision, parameter :: M_PI = 3.141592653589793238462643383279502884197d0
+  real(amrex_real) :: x, y, z
+  real(amrex_real), pointer, contiguous :: psi(:,:)
+  real(amrex_real), parameter :: M_PI = 3.141592653589793238462643383279502884197_amrex_real
   integer :: vx_l1,vx_l2,vx_l3,vy_l1,vy_l2,vy_l3,vz_l1,vz_l2,vz_l3
   integer :: vx_h1,vx_h2,vx_h3,vy_h1,vy_h2,vy_h3,vz_h1,vz_h2,vz_h3
 
@@ -50,20 +50,20 @@ use amrex_base_module
 
   ! streamfunction psi
   do j = plo(2), phi(2)
-     y = (dble(j)+0.5d0)*dx(2) + prob_lo(2)
+     y = (real(j,amrex_real)+0.5_amrex_real)*dx(2) + prob_lo(2)
      do i = plo(1), phi(1)
-        x = (dble(i)+0.5d0)*dx(1) + prob_lo(1)
-        psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.d0) * (1.d0 / M_PI)
+        x = (real(i,amrex_real)+0.5_amrex_real)*dx(1) + prob_lo(1)
+        psi(i,j) =  sin(M_PI*x)**2 * sin(M_PI*y)**2 * cos (M_PI*time/2.0_amrex_real) * (1.0_amrex_real / M_PI)
      end do
   end do
 
   ! x velocity
   do k = vx_l3, vx_h3
   do j = vx_l2, vx_h2
-     y = (dble(j)+0.5d0) * dx(2) + prob_lo(2)
+     y = (real(j,amrex_real)+0.5_amrex_real) * dx(2) + prob_lo(2)
      do i = vx_l1, vx_h1
-        x = dble(i) * dx(1) + prob_lo(1)
-        vx(i,j,k) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25d0/dx(2))
+        x = real(i,amrex_real) * dx(1) + prob_lo(1)
+        vx(i,j,k) =  -( (psi(i,j+1)+psi(i-1,j+1)) - (psi(i,j-1)+psi(i-1,j-1)) ) * (0.25_amrex_real/dx(2))
      end do
   end do
   end do
@@ -71,15 +71,15 @@ use amrex_base_module
   ! y velocity
   do k = vy_l3, vy_h3
   do j = vy_l2, vy_h2
-     y = dble(j) * dx(2) + prob_lo(2)
+     y = real(j,amrex_real) * dx(2) + prob_lo(2)
      do i = vy_l1, vy_h1
-        x = (dble(i)+0.5d0) * dx(1) + prob_lo(1)
-        vy(i,j,k) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25d0/dx(1))
+        x = (real(i,amrex_real)+0.5_amrex_real) * dx(1) + prob_lo(1)
+        vy(i,j,k) = ( (psi(i+1,j)+psi(i+1,j-1)) - (psi(i-1,j)+psi(i-1,j-1)) ) * (0.25_amrex_real/dx(1))
      end do
   end do
   end do
 
-  vz = 1.d0
+  vz = 1.0_amrex_real
 
   call bl_deallocate(psi)
 

--- a/Tests/FortranInterface/Advection_F_RK/Source/Src_2d/slope_2d.f90
+++ b/Tests/FortranInterface/Advection_F_RK/Source/Src_2d/slope_2d.f90
@@ -33,12 +33,12 @@ contains
        do i = lo(1)-1, hi(1)+1
           dlft = q(i  ,j) - q(i-1,j)
           drgt = q(i+1,j) - q(i  ,j)
-          dcen(i) = .5d0 * (dlft+drgt)
-          dsgn(i) = sign(1.d0, dcen(i))
-          if (dlft*drgt .ge. 0.d0) then
-             dlim(i) = 2.d0 * min( abs(dlft), abs(drgt) )
+          dcen(i) = .5_amrex_real * (dlft+drgt)
+          dsgn(i) = sign(1.0_amrex_real, dcen(i))
+          if (dlft*drgt .ge. 0.0_amrex_real) then
+             dlim(i) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
           else
-             dlim(i) = 0.d0
+             dlim(i) = 0.0_amrex_real
           endif
           df(i) = dsgn(i)*min( dlim(i), abs(dcen(i)) )
        end do
@@ -102,12 +102,12 @@ contains
        do i = lo(1)  , hi(1)
           dlft = q(i,j  ) - q(i,j-1)
           drgt = q(i,j+1) - q(i,j  )
-          dcen(i,j) = .5d0 * (dlft+drgt)
-          dsgn(i,j) = sign( 1.d0, dcen(i,j) )
-          if (dlft*drgt .ge. 0.d0) then
-             dlim(i,j) = 2.d0 * min( abs(dlft), abs(drgt) )
+          dcen(i,j) = .5_amrex_real * (dlft+drgt)
+          dsgn(i,j) = sign( 1.0_amrex_real, dcen(i,j) )
+          if (dlft*drgt .ge. 0.0_amrex_real) then
+             dlim(i,j) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
           else
-             dlim(i,j) = 0.d0
+             dlim(i,j) = 0.0_amrex_real
           endif
           df(i,j) = dsgn(i,j)*min( dlim(i,j),abs(dcen(i,j)) )
        end do

--- a/Tests/FortranInterface/Advection_F_RK/Source/Src_3d/advect_3d_mod.F90
+++ b/Tests/FortranInterface/Advection_F_RK/Source/Src_3d/advect_3d_mod.F90
@@ -26,7 +26,7 @@ subroutine advection_dudt(lo, hi, &
   implicit none
 
   integer, intent(in) :: lo(3), hi(3)
-  double precision, intent(in) :: dx(3)
+  real(amrex_real), intent(in) :: dx(3)
   integer, intent(in) :: ui_lo(3), ui_hi(3)
   integer, intent(in) :: du_lo(3), du_hi(3)
   integer, intent(in) :: vx_lo(3), vx_hi(3)
@@ -35,23 +35,23 @@ subroutine advection_dudt(lo, hi, &
   integer, intent(in) :: fx_lo(3), fx_hi(3)
   integer, intent(in) :: fy_lo(3), fy_hi(3)
   integer, intent(in) :: fz_lo(3), fz_hi(3)
-  double precision, intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2),ui_lo(3):ui_hi(3))
-  double precision, intent(  out) :: dudt(du_lo(1):du_hi(1),du_lo(2):du_hi(2),du_lo(3):du_hi(3))
-  double precision, intent(in   ) :: vx  (vx_lo(1):vx_hi(1),vx_lo(2):vx_hi(2),vx_lo(3):vx_hi(3))
-  double precision, intent(in   ) :: vy  (vy_lo(1):vy_hi(1),vy_lo(2):vy_hi(2),vy_lo(3):vy_hi(3))
-  double precision, intent(in   ) :: vz  (vz_lo(1):vz_hi(1),vz_lo(2):vz_hi(2),vz_lo(3):vz_hi(3))
-  double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
-  double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
-  double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
+  real(amrex_real), intent(in   ) :: uin (ui_lo(1):ui_hi(1),ui_lo(2):ui_hi(2),ui_lo(3):ui_hi(3))
+  real(amrex_real), intent(  out) :: dudt(du_lo(1):du_hi(1),du_lo(2):du_hi(2),du_lo(3):du_hi(3))
+  real(amrex_real), intent(in   ) :: vx  (vx_lo(1):vx_hi(1),vx_lo(2):vx_hi(2),vx_lo(3):vx_hi(3))
+  real(amrex_real), intent(in   ) :: vy  (vy_lo(1):vy_hi(1),vy_lo(2):vy_hi(2),vy_lo(3):vy_hi(3))
+  real(amrex_real), intent(in   ) :: vz  (vz_lo(1):vz_hi(1),vz_lo(2):vz_hi(2),vz_lo(3):vz_hi(3))
+  real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
+  real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
+  real(amrex_real), intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
 
   integer :: i, j, k
   integer :: glo(3), ghi(3)
-  double precision :: dxinv(3)
+  real(amrex_real) :: dxinv(3)
 
   ! Some compiler may not support 'contiguous'.  Remove it in that case.
-  double precision, dimension(:,:,:), pointer, contiguous :: slope
+  real(amrex_real), dimension(:,:,:), pointer, contiguous :: slope
 
-  dxinv = 1.d0/dx
+  dxinv = 1.0_amrex_real/dx
 
   glo = lo - 1
   ghi = hi + 1

--- a/Tests/FortranInterface/Advection_F_RK/Source/Src_3d/compute_flux_3d.f90
+++ b/Tests/FortranInterface/Advection_F_RK/Source/Src_3d/compute_flux_3d.f90
@@ -1,5 +1,7 @@
 module compute_flux_module
 
+  use amrex_base_module
+
   implicit none
 
   private
@@ -28,17 +30,17 @@ contains
     integer, intent(in) :: fx_lo(3), fx_hi(3)
     integer, intent(in) :: fy_lo(3), fy_hi(3)
     integer, intent(in) :: fz_lo(3), fz_hi(3)
-    double precision, intent(in   ) :: phi (ph_lo(1):ph_hi(1),ph_lo(2):ph_hi(2),ph_lo(3):ph_hi(3))
-    double precision, intent(in   ) :: umac( u_lo(1): u_hi(1), u_lo(2): u_hi(2), u_lo(3): u_hi(3))
-    double precision, intent(in   ) :: vmac( v_lo(1): v_hi(1), v_lo(2): v_hi(2), v_lo(3): v_hi(3))
-    double precision, intent(in   ) :: wmac( w_lo(1): w_hi(1), w_lo(2): w_hi(2), w_lo(3): w_hi(3))
-    double precision, intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
-    double precision, intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
-    double precision, intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
-    double precision, dimension(glo(1):ghi(1),glo(2):ghi(2),glo(3):ghi(3)) :: slope
+    real(amrex_real), intent(in   ) :: phi (ph_lo(1):ph_hi(1),ph_lo(2):ph_hi(2),ph_lo(3):ph_hi(3))
+    real(amrex_real), intent(in   ) :: umac( u_lo(1): u_hi(1), u_lo(2): u_hi(2), u_lo(3): u_hi(3))
+    real(amrex_real), intent(in   ) :: vmac( v_lo(1): v_hi(1), v_lo(2): v_hi(2), v_lo(3): v_hi(3))
+    real(amrex_real), intent(in   ) :: wmac( w_lo(1): w_hi(1), w_lo(2): w_hi(2), w_lo(3): w_hi(3))
+    real(amrex_real), intent(  out) :: flxx(fx_lo(1):fx_hi(1),fx_lo(2):fx_hi(2),fx_lo(3):fx_hi(3))
+    real(amrex_real), intent(  out) :: flxy(fy_lo(1):fy_hi(1),fy_lo(2):fy_hi(2),fy_lo(3):fy_hi(3))
+    real(amrex_real), intent(  out) :: flxz(fz_lo(1):fz_hi(1),fz_lo(2):fz_hi(2),fz_lo(3):fz_hi(3))
+    real(amrex_real), dimension(glo(1):ghi(1),glo(2):ghi(2),glo(3):ghi(3)) :: slope
 
     integer :: i, j, k
-    double precision :: phiface
+    real(amrex_real) :: phiface
 
     call slopex(glo, ghi, &
                 phi, ph_lo, ph_hi, &
@@ -47,10 +49,10 @@ contains
     do       k = lo(3), hi(3)
        do    j = lo(2), hi(2)
           do i = lo(1), hi(1)+1
-             if (umac(i,j,k) .lt. 0.d0) then
-                phiface = phi(i,j,k) - 0.5d0*slope(i,j,k)
+             if (umac(i,j,k) .lt. 0.0_amrex_real) then
+                phiface = phi(i,j,k) - 0.5_amrex_real*slope(i,j,k)
              else
-                phiface = phi(i-1,j,k) + 0.5d0*slope(i-1,j,k)
+                phiface = phi(i-1,j,k) + 0.5_amrex_real*slope(i-1,j,k)
              end if
 
              flxx(i,j,k) = umac(i,j,k)*phiface
@@ -65,10 +67,10 @@ contains
     do       k = lo(3), hi(3)
        do    j = lo(2), hi(2)+1
           do i = lo(1), hi(1)
-             if (vmac(i,j,k) .lt. 0.d0) then
-                phiface = phi(i,j,k) - 0.5d0*slope(i,j,k)
+             if (vmac(i,j,k) .lt. 0.0_amrex_real) then
+                phiface = phi(i,j,k) - 0.5_amrex_real*slope(i,j,k)
              else
-                phiface = phi(i,j-1,k) + 0.5d0*slope(i,j-1,k)
+                phiface = phi(i,j-1,k) + 0.5_amrex_real*slope(i,j-1,k)
              end if
 
              flxy(i,j,k) = vmac(i,j,k)*phiface
@@ -83,10 +85,10 @@ contains
     do       k = lo(3), hi(3)+1
        do    j = lo(2), hi(2)
           do i = lo(1), hi(1)
-             if (wmac(i,j,k) .lt. 0.d0) then
-                phiface = phi(i,j,k) - 0.5d0*slope(i,j,k)
+             if (wmac(i,j,k) .lt. 0.0_amrex_real) then
+                phiface = phi(i,j,k) - 0.5_amrex_real*slope(i,j,k)
              else
-                phiface = phi(i,j,k-1) + 0.5d0*slope(i,j,k-1)
+                phiface = phi(i,j,k-1) + 0.5_amrex_real*slope(i,j,k-1)
              end if
 
              flxz(i,j,k) = wmac(i,j,k)*phiface

--- a/Tests/FortranInterface/Advection_F_RK/Source/Src_3d/slope_3d.f90
+++ b/Tests/FortranInterface/Advection_F_RK/Source/Src_3d/slope_3d.f90
@@ -1,8 +1,10 @@
 module slope_module
 
+  use amrex_base_module
+
   implicit none
 
-  double precision, parameter:: four3rd=4.d0/3.d0, sixth=1.d0/6.d0
+  real(amrex_real), parameter:: four3rd=4.0_amrex_real/3.0_amrex_real, sixth=1.0_amrex_real/6.0_amrex_real
 
   private
 
@@ -17,12 +19,12 @@ contains
     implicit none
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3)
-    double precision, intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real), intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
 
     integer :: i, j, k
-    double precision, dimension(lo(1)-1:hi(1)+1) :: dsgn, dlim, df, dcen
-    double precision :: dlft, drgt, dq1
+    real(amrex_real), dimension(lo(1)-1:hi(1)+1) :: dsgn, dlim, df, dcen
+    real(amrex_real) :: dlft, drgt, dq1
 
     do    k = lo(3), hi(3)
        do j = lo(2), hi(2)
@@ -31,12 +33,12 @@ contains
           do i = lo(1)-1, hi(1)+1
              dlft = q(i  ,j,k) - q(i-1,j,k)
              drgt = q(i+1,j,k) - q(i  ,j,k)
-             dcen(i) = .5d0 * (dlft+drgt)
-             dsgn(i) = sign(1.d0, dcen(i))
-             if (dlft*drgt .ge. 0.d0) then
-                dlim(i) = 2.d0 * min( abs(dlft), abs(drgt) )
+             dcen(i) = .5_amrex_real * (dlft+drgt)
+             dsgn(i) = sign(1.0_amrex_real, dcen(i))
+             if (dlft*drgt .ge. 0.0_amrex_real) then
+                dlim(i) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
              else
-                dlim(i) = 0.d0
+                dlim(i) = 0.0_amrex_real
              endif
              df(i) = dsgn(i)*min( dlim(i), abs(dcen(i)) )
           end do
@@ -59,11 +61,11 @@ contains
     use amrex_mempool_module, only : bl_allocate, bl_deallocate
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3)
-    double precision, intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real), intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
 
     ! Some compiler may not support 'contiguous'.  Remove it in that case.
-    double precision, dimension(:,:), pointer, contiguous :: dsgn, dlim, df, dcen
+    real(amrex_real), dimension(:,:), pointer, contiguous :: dsgn, dlim, df, dcen
 
     call bl_allocate(dsgn, lo(1), hi(1), lo(2)-1, hi(2)+1)
     call bl_allocate(dlim, lo(1), hi(1), lo(2)-1, hi(2)+1)
@@ -89,15 +91,15 @@ contains
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3), &
          ddlo(2), ddhi(2)
-    double precision, intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
-    double precision              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
-    double precision              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
-    double precision              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2))
-    double precision              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real), intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real)              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real)              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real)              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2))
+    real(amrex_real)              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2))
 
     integer :: i, j, k
-    double precision :: dlft, drgt, dq1
+    real(amrex_real) :: dlft, drgt, dq1
 
     do k = lo(3), hi(3)
 
@@ -106,12 +108,12 @@ contains
           do i = lo(1)  , hi(1)
              dlft = q(i,j  ,k) - q(i,j-1,k)
              drgt = q(i,j+1,k) - q(i,j  ,k)
-             dcen(i,j) = .5d0 * (dlft+drgt)
-             dsgn(i,j) = sign( 1.d0, dcen(i,j) )
-             if (dlft*drgt .ge. 0.d0) then
-                dlim(i,j) = 2.d0 * min( abs(dlft), abs(drgt) )
+             dcen(i,j) = .5_amrex_real * (dlft+drgt)
+             dsgn(i,j) = sign( 1.0_amrex_real, dcen(i,j) )
+             if (dlft*drgt .ge. 0.0_amrex_real) then
+                dlim(i,j) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
              else
-                dlim(i,j) = 0.d0
+                dlim(i,j) = 0.0_amrex_real
              endif
              df(i,j) = dsgn(i,j)*min( dlim(i,j),abs(dcen(i,j)) )
           end do
@@ -137,11 +139,11 @@ contains
     use amrex_mempool_module, only : bl_allocate, bl_deallocate
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3)
-    double precision, intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real), intent(in ) ::  q( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq(dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
 
     ! Some compiler may not support 'contiguous'.  Remove it in that case.
-    double precision, dimension(:,:,:), pointer, contiguous :: dsgn, dlim, df, dcen
+    real(amrex_real), dimension(:,:,:), pointer, contiguous :: dsgn, dlim, df, dcen
 
     call bl_allocate(dsgn, lo(1), hi(1), lo(2), hi(2), lo(3)-1, hi(3)+1)
     call bl_allocate(dlim, lo(1), hi(1), lo(2), hi(2), lo(3)-1, hi(3)+1)
@@ -168,15 +170,15 @@ contains
 
     integer, intent(in) :: lo(3), hi(3), qlo(3), qhi(3), dqlo(3), dqhi(3), &
          ddlo(3), ddhi(3)
-    double precision, intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
-    double precision, intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
-    double precision              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
-    double precision              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
-    double precision              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
-    double precision              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    real(amrex_real), intent(in ) ::  q  ( qlo(1): qhi(1), qlo(2): qhi(2), qlo(3): qhi(3))
+    real(amrex_real), intent(out) :: dq  (dqlo(1):dqhi(1),dqlo(2):dqhi(2),dqlo(3):dqhi(3))
+    real(amrex_real)              :: dsgn(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    real(amrex_real)              :: dlim(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    real(amrex_real)              :: df  (ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
+    real(amrex_real)              :: dcen(ddlo(1):ddhi(1),ddlo(2):ddhi(2),ddlo(3):ddhi(3))
 
     integer :: i, j, k
-    double precision :: dlft, drgt, dq1
+    real(amrex_real) :: dlft, drgt, dq1
 
     ! first compute Fromm slopes
     do k       = lo(3)-1, hi(3)+1
@@ -184,12 +186,12 @@ contains
           do i = lo(1)  , hi(1)
              dlft = q(i,j,k  ) - q(i,j,k-1)
              drgt = q(i,j,k+1) - q(i,j,k  )
-             dcen(i,j,k) = .5d0 * (dlft+drgt)
-             dsgn(i,j,k) = sign( 1.d0, dcen(i,j,k) )
-             if (dlft*drgt .ge. 0.d0) then
-                dlim(i,j,k) = 2.d0 * min( abs(dlft), abs(drgt) )
+             dcen(i,j,k) = .5_amrex_real * (dlft+drgt)
+             dsgn(i,j,k) = sign( 1.0_amrex_real, dcen(i,j,k) )
+             if (dlft*drgt .ge. 0.0_amrex_real) then
+                dlim(i,j,k) = 2.0_amrex_real * min( abs(dlft), abs(drgt) )
              else
-                dlim(i,j,k) = 0.d0
+                dlim(i,j,k) = 0.0_amrex_real
              endif
              df(i,j,k) = dsgn(i,j,k)*min( dlim(i,j,k),abs(dcen(i,j,k)) )
           end do

--- a/Tests/FortranInterface/Advection_F_RK/Source/amr_data_mod.F90
+++ b/Tests/FortranInterface/Advection_F_RK/Source/amr_data_mod.F90
@@ -27,7 +27,7 @@ contains
     t_new = 0.0_rt
 
     allocate(t_old(0:amrex_max_level))
-    t_old = -1.0e100_rt
+    t_old = -1.0e30_rt
 
     allocate(phi_new(0:amrex_max_level))
     allocate(phi_old(0:amrex_max_level))

--- a/Tests/FortranInterface/Advection_F_RK/Source/my_amr_mod.F90
+++ b/Tests/FortranInterface/Advection_F_RK/Source/my_amr_mod.F90
@@ -132,7 +132,7 @@ contains
     dm = pdm
 
     t_new(lev) = time
-    t_old(lev) = time - 1.e200_amrex_real
+    t_old(lev) = time - 1.e30_amrex_real
 
     call my_clear_level(lev)
 
@@ -172,7 +172,7 @@ contains
     call my_clear_level(lev)
 
     t_new(lev) = time
-    t_old(lev) = time - 1.e200_amrex_real
+    t_old(lev) = time - 1.e30_amrex_real
 
     call amrex_multifab_build(phi_new(lev), ba, dm, ncomp, nghost)
     call amrex_multifab_build(phi_old(lev), ba, dm, ncomp, nghost)
@@ -204,7 +204,7 @@ contains
     call my_clear_level(lev)
 
     t_new(lev) = time
-    t_old(lev) = time - 1.e200_amrex_real
+    t_old(lev) = time - 1.e30_amrex_real
 
     call amrex_multifab_build(phi_new(lev), ba, dm, ncomp, nghost)
     call amrex_multifab_build(phi_old(lev), ba, dm, ncomp, nghost)

--- a/Tests/FortranInterface/Advection_octree_F/Source/amr_data_mod.F90
+++ b/Tests/FortranInterface/Advection_octree_F/Source/amr_data_mod.F90
@@ -26,7 +26,7 @@ contains
     t_new = 0.0_rt
 
     allocate(t_old(0:amrex_max_level))
-    t_old = -1.0e100_rt
+    t_old = -1.0e30_rt
 
     allocate(phi_new(0:amrex_max_level))
     allocate(phi_old(0:amrex_max_level))

--- a/Tests/FortranInterface/Advection_octree_F/Source/my_amr_mod.F90
+++ b/Tests/FortranInterface/Advection_octree_F/Source/my_amr_mod.F90
@@ -101,7 +101,7 @@ contains
     dm = pdm
 
     t_new(lev) = time
-    t_old(lev) = time - 1.e200_amrex_real
+    t_old(lev) = time - 1.e30_amrex_real
 
     call my_clear_level(lev)
 
@@ -143,7 +143,7 @@ contains
     call my_clear_level(lev)
 
     t_new(lev) = time
-    t_old(lev) = time - 1.e200_amrex_real
+    t_old(lev) = time - 1.e30_amrex_real
 
     call amrex_multifab_build(phi_new(lev), ba, dm, ncomp, nghost)
     call amrex_multifab_build(phi_old(lev), ba, dm, ncomp, nghost)
@@ -177,7 +177,7 @@ contains
     call my_clear_level(lev)
 
     t_new(lev) = time
-    t_old(lev) = time - 1.e200_amrex_real
+    t_old(lev) = time - 1.e30_amrex_real
 
     call amrex_multifab_build(phi_new(lev), ba, dm, ncomp, nghost)
     call amrex_multifab_build(phi_old(lev), ba, dm, ncomp, nghost)


### PR DESCRIPTION
Fix the Advection_F particle test crashing in 3D (#5485) and make the FortranInterface advection tests correct under all precision settings.

Advection_F (3D particle advection):
- Correct the uy/uz dummy array bounds, which used uxlo/uxhi for the third dimension.
- Point velocity(3) at uz (was uy).
- Initialize p%pos(3) from z (was x).
- Disable MFIter tiling: particles are looked up by (grid, tile) and the ParticleContainer stores one tile per grid, so a tiled MFIter would silently miss every particle.

Precision:
- Replace double precision / 0.d0 / dble() with amrex_real throughout Advection_F and Advection_F_RK, and use amrex_particle_real for particle position/velocity data.
- Replace float-overflowing sentinels (t_old = -1.0e100_rt and time - 1.e200_amrex_real) with -1.0e30 / 1.e30 so the tests build with AMREX_PRECISION=SINGLE.

CMake:
- Build Advection_F only when AMReX_PARTICLES is enabled.
- Build the FortranInterface tests only on CPU (not supported on GPU).

Verified Advection_F in 2D and 3D for all four combinations of AMREX_PRECISION and AMReX_PARTICLES_PRECISION.

Closes #5485.
