### PR TITLE
Add fconvert plotfile tool for native-to-HDF5 conversion

### DIFF
--- a/Docs/sphinx_documentation/source/IO.rst
+++ b/Docs/sphinx_documentation/source/IO.rst
@@ -230,6 +230,11 @@ options include:
     * ``ZFP_ACCURACY@accuracy``
     * ``ZFP_REVERSIBLE@reversible``
 
+AMReX also provides the ``fconvert`` tool in ``Tools/Plotfile`` for converting
+existing native plotfiles to HDF5 plotfiles after a simulation has completed.
+It accepts the same compression descriptor string and can therefore be used for
+post-processing workflows that want HDF5 output with ZLIB or ZFP compression.
+
 Using compression requires data to be stored in a chunked format. The size of these
 chunks can (and generally should) be configured by changing the ``HDF5_CHUNK_SIZE``
 environment variable, with a default value of 1024 elements provided.

--- a/Docs/sphinx_documentation/source/Post_Processing.rst
+++ b/Docs/sphinx_documentation/source/Post_Processing.rst
@@ -295,6 +295,31 @@ Typing ``./fextrema.gnu.ex`` without inputs will bring up usage and options.
                        0.03                       1          2.349724636         8.277319027e-17          1.157052145         8.277319027e-17          1.156713078           0.03595941273                    1         8.277319027e-17         0.4924203149         8.277319027e-17         0.4922760141           0.01530367099                    1         -0.005172583789       0.005172583789         -0.005172583789       0.005172583789         -0.005287367803       0.005287367803         -0.005287367803       0.005287367803         -0.004924487345        0.05687549245
 
 
+fconvert
+--------
+
+Converts one or more native AMReX plotfiles to HDF5 plotfiles. The tool passes
+through AMReX HDF5 compression descriptors such as ``None@0``, ``ZLIB@5``,
+and ``ZFP_ACCURACY@0.001``.
+
+**How to build and run**
+
+In ``amrex/Tools/Plotfile``, type ``make programs=fconvert`` and then
+``./fconvert.gnu.ex`` to run. Typing ``./fconvert.gnu.ex`` without inputs will
+bring up usage and options.
+
+**Example**
+
+.. code-block:: console
+
+    user@machine:~/AMReX/amrex/Tools/Plotfile$ ./fconvert.gnu.ex \
+    > --compression ZFP_ACCURACY@0.001 \
+    > --output converted \
+    > ~/AMReX/FHDeX/exec/multispec/Reg_DetBubble_2d_Bench/plt0000000
+    fconvert: converting /home/user/AMReX/FHDeX/exec/multispec/Reg_DetBubble_2d_Bench/plt0000000 -> converted.h5 with compression ZFP_ACCURACY@0.001
+    fconvert: finished converted.h5 in 0.123456 seconds
+
+
 faverage
 --------
 

--- a/Docs/sphinx_documentation/source/Post_Processing.rst
+++ b/Docs/sphinx_documentation/source/Post_Processing.rst
@@ -304,9 +304,9 @@ and ``ZFP_ACCURACY@0.001``.
 
 **How to build and run**
 
-In ``amrex/Tools/Plotfile``, type ``make programs=fconvert`` and then
-``./fconvert.gnu.ex`` to run. Typing ``./fconvert.gnu.ex`` without inputs will
-bring up usage and options.
+In ``amrex/Tools/Plotfile``, type ``make programs=fconvert USE_HDF5=TRUE HDF5_HOME=/path/to/hdf5``
+and then ``./fconvert.gnu.ex`` to run. Typing ``./fconvert.gnu.ex`` without
+inputs will bring up usage and options.
 
 **Example**
 

--- a/Tools/Plotfile/CMakeLists.txt
+++ b/Tools/Plotfile/CMakeLists.txt
@@ -9,6 +9,7 @@ project(AMReX-PlotfileTools
 set(_exe_names
    fboxinfo
    fcompare
+   fconvert
    fextract
    fextrema
    fgradient

--- a/Tools/Plotfile/GNUmakefile
+++ b/Tools/Plotfile/GNUmakefile
@@ -15,6 +15,7 @@ programs ?=
 ifeq ($(strip $(programs)),)
   programs += fboxinfo
   programs += fcompare
+  programs += fconvert
   programs += fextract
   programs += fextrema
   programs += fgradient

--- a/Tools/Plotfile/fconvert.cpp
+++ b/Tools/Plotfile/fconvert.cpp
@@ -1,0 +1,169 @@
+#include <AMReX.H>
+#include <AMReX_Print.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_PlotFileUtil.H>
+
+#ifdef AMREX_USE_HDF5
+#include <AMReX_PlotFileUtilHDF5.H>
+#endif
+
+#include <memory>
+
+using namespace amrex;
+
+namespace
+{
+    void PrintUsage ()
+    {
+        amrex::Print()
+            << "\n"
+            << " Convert one or more native AMReX plotfiles to HDF5 plotfiles.\n"
+            << "\n"
+            << " usage:\n"
+            << "    fconvert [-c|--compression descriptor] [-o|--output output] plotfile [plotfile ...]\n"
+            << "\n"
+            << " optional arguments:\n"
+            << "    -c|--compression descriptor : HDF5 compression descriptor.\n"
+            << "                                  Default: ZFP_ACCURACY@0.001\n"
+            << "                                  Examples: None@0, ZLIB@5, ZFP_RATE@8,\n"
+            << "                                            ZFP_PRECISION@12,\n"
+            << "                                            ZFP_ACCURACY@0.001,\n"
+            << "                                            ZFP_REVERSIBLE@1\n"
+            << "    -o|--output output         : output name for one plotfile, or output prefix\n"
+            << "                                  for multiple plotfiles\n"
+            << '\n';
+    }
+
+    [[nodiscard]] std::string BaseName (std::string const& path)
+    {
+        auto pos = path.find_last_of("/\\");
+        if (pos == std::string::npos) {
+            return path;
+        } else {
+            return path.substr(pos+1);
+        }
+    }
+
+    [[nodiscard]] std::string OutputName (std::string const& input,
+                                          std::string const& output,
+                                          bool multiple_inputs)
+    {
+        if (output.empty()) {
+            return input;
+        }
+
+        if (!multiple_inputs) {
+            return output;
+        }
+
+        if (output.back() == '/' || output.back() == '\\') {
+            return output + BaseName(input);
+        } else {
+            return output + "_" + BaseName(input);
+        }
+    }
+}
+
+void main_main ()
+{
+    const int narg = amrex::command_argument_count();
+
+    if (narg == 0) {
+        PrintUsage();
+        return;
+    }
+
+    std::string compression = "ZFP_ACCURACY@0.001";
+    std::string output_name;
+
+    int farg = 1;
+    while (farg <= narg) {
+        const std::string& name = amrex::get_command_argument(farg);
+        if (name == "-h" || name == "--help") {
+            PrintUsage();
+            return;
+        } else if (name == "-c" || name == "--compression") {
+            if (farg == narg) {
+                amrex::Abort("fconvert requires an argument after --compression");
+            }
+            compression = amrex::get_command_argument(++farg);
+        } else if (name == "-o" || name == "--output") {
+            if (farg == narg) {
+                amrex::Abort("fconvert requires an argument after --output");
+            }
+            output_name = amrex::get_command_argument(++farg);
+        } else {
+            break;
+        }
+        ++farg;
+    }
+
+    if (farg > narg) {
+        PrintUsage();
+        return;
+    }
+
+#ifndef AMREX_USE_HDF5
+    amrex::Abort("fconvert requires AMReX to be built with AMReX_HDF5=ON. "
+                 "Build with AMReX_HDF5_ZFP=ON as well when using ZFP_* "
+                 "compression descriptors.");
+#else
+    Vector<std::string> infiles;
+    infiles.reserve(narg-farg+1);
+    for (int i = farg; i <= narg; ++i) {
+        infiles.push_back(amrex::get_command_argument(i));
+    }
+
+    bool const multiple_inputs = infiles.size() > 1;
+
+    for (auto const& infile : infiles) {
+        auto const start_time = amrex::second();
+
+        PlotFileData plotfile(infile);
+        int const finest_level = plotfile.finestLevel();
+        int const nlevels = finest_level + 1;
+
+        Vector<std::unique_ptr<MultiFab> > mf(nlevels);
+        Vector<const MultiFab*> mf_ptrs(nlevels);
+        Vector<Geometry> geom;
+        Vector<int> level_steps(nlevels);
+        Vector<IntVect> ref_ratio(finest_level);
+
+        geom.reserve(nlevels);
+        RealBox rb(plotfile.probLo(), plotfile.probHi());
+        Array<int,AMREX_SPACEDIM> is_per{AMREX_D_DECL(0,0,0)};
+
+        for (int ilev = 0; ilev < nlevels; ++ilev) {
+            mf[ilev] = std::make_unique<MultiFab>(plotfile.get(ilev));
+            mf_ptrs[ilev] = mf[ilev].get();
+            geom.emplace_back(plotfile.probDomain(ilev), rb,
+                              plotfile.coordSys(), is_per.data());
+            level_steps[ilev] = plotfile.levelStep(ilev);
+            if (ilev < finest_level) {
+                ref_ratio[ilev] = plotfile.refRatioVect(ilev);
+            }
+        }
+
+        auto const outfile = OutputName(infile, output_name, multiple_inputs);
+
+        amrex::Print() << "fconvert: converting " << infile
+                       << " -> " << outfile << ".h5"
+                       << " with compression " << compression << '\n';
+
+        WriteMultiLevelPlotfileHDF5(outfile, nlevels, mf_ptrs,
+                                    plotfile.varNames(), geom, plotfile.time(),
+                                    level_steps, ref_ratio, compression);
+
+        amrex::Print() << "fconvert: finished " << outfile << ".h5 in "
+                       << amrex::second() - start_time << " seconds\n";
+    }
+#endif
+}
+
+int main (int argc, char* argv[])
+{
+    amrex::SetVerbose(0);
+    amrex::Initialize(argc, argv, false);
+    main_main();
+    amrex::Finalize();
+}

--- a/Tools/Plotfile/fconvert.cpp
+++ b/Tools/Plotfile/fconvert.cpp
@@ -136,8 +136,8 @@ void main_main ()
         for (int ilev = 0; ilev < nlevels; ++ilev) {
             mf[ilev] = std::make_unique<MultiFab>(plotfile.get(ilev));
             mf_ptrs[ilev] = mf[ilev].get();
-            geom.emplace_back(plotfile.probDomain(ilev), rb,
-                              plotfile.coordSys(), is_per.data());
+            geom.push_back(Geometry(plotfile.probDomain(ilev), rb,
+                                    plotfile.coordSys(), is_per));
             level_steps[ilev] = plotfile.levelStep(ilev);
             if (ilev < finest_level) {
                 ref_ratio[ilev] = plotfile.refRatioVect(ilev);

--- a/Tools/Plotfile/fconvert.cpp
+++ b/Tools/Plotfile/fconvert.cpp
@@ -44,6 +44,7 @@ namespace
         }
     }
 
+#ifdef AMREX_USE_HDF5
     [[nodiscard]] std::string OutputName (std::string const& input,
                                           std::string const& output,
                                           bool multiple_inputs)
@@ -62,6 +63,7 @@ namespace
             return output + "_" + BaseName(input);
         }
     }
+#endif
 }
 
 void main_main ()
@@ -105,7 +107,7 @@ void main_main ()
 
 #ifndef AMREX_USE_HDF5
     amrex::Abort("fconvert requires AMReX to be built with AMReX_HDF5=ON. "
-                 "Build with AMReX_HDF5_ZFP=ON as well when using ZFP_* "
+                 "Build with AMReX_HDF5_ZFP=ON as well to use ZFP_* "
                  "compression descriptors.");
 #else
     Vector<std::string> infiles;

--- a/Tools/Plotfile/fconvert.cpp
+++ b/Tools/Plotfile/fconvert.cpp
@@ -11,7 +11,6 @@
 
 using namespace amrex;
 
-#ifdef AMREX_USE_HDF5
 namespace
 {
     void PrintUsage ()
@@ -35,6 +34,7 @@ namespace
             << '\n';
     }
 
+#ifdef AMREX_USE_HDF5
     [[nodiscard]] std::string BaseName (std::string const& path)
     {
         auto pos = path.find_last_of("/\\");
@@ -63,8 +63,8 @@ namespace
             return output + "_" + BaseName(input);
         }
     }
-}
 #endif
+}
 
 void main_main ()
 {

--- a/Tools/Plotfile/fconvert.cpp
+++ b/Tools/Plotfile/fconvert.cpp
@@ -35,6 +35,15 @@ namespace
     }
 
 #ifdef AMREX_USE_HDF5
+    [[nodiscard]] std::string StripTrailingSlashes (std::string path)
+    {
+        while (path.size() > 1 &&
+               (path.back() == '/' || path.back() == '\\')) {
+            path.pop_back();
+        }
+        return path;
+    }
+
     [[nodiscard]] std::string BaseName (std::string const& path)
     {
         auto pos = path.find_last_of("/\\");
@@ -106,14 +115,14 @@ void main_main ()
     }
 
 #ifndef AMREX_USE_HDF5
-    amrex::Abort("fconvert requires AMReX to be built with AMReX_HDF5=ON. "
-                 "Build with AMReX_HDF5_ZFP=ON as well to use ZFP_* "
+    amrex::Abort("fconvert requires AMReX to be built with HDF5 enabled. "
+                 "Build with ZFP enabled as well to use ZFP_* "
                  "compression descriptors.");
 #else
     Vector<std::string> infiles;
     infiles.reserve(narg-farg+1);
     for (int i = farg; i <= narg; ++i) {
-        infiles.push_back(amrex::get_command_argument(i));
+        infiles.push_back(StripTrailingSlashes(amrex::get_command_argument(i)));
     }
 
     bool const multiple_inputs = infiles.size() > 1;

--- a/Tools/Plotfile/fconvert.cpp
+++ b/Tools/Plotfile/fconvert.cpp
@@ -11,6 +11,7 @@
 
 using namespace amrex;
 
+#ifdef AMREX_USE_HDF5
 namespace
 {
     void PrintUsage ()
@@ -44,7 +45,6 @@ namespace
         }
     }
 
-#ifdef AMREX_USE_HDF5
     [[nodiscard]] std::string OutputName (std::string const& input,
                                           std::string const& output,
                                           bool multiple_inputs)
@@ -63,8 +63,8 @@ namespace
             return output + "_" + BaseName(input);
         }
     }
-#endif
 }
+#endif
 
 void main_main ()
 {


### PR DESCRIPTION
## Summary

Copilot with Opus 4.8 wrote this.

This adds `Tools/Plotfile/fconvert`, a native AMReX plotfile postprocessing tool that rewrites one or more native plotfiles as HDF5 plotfiles using AMReX’s existing HDF5 writer and compression descriptors. It follows the existing `f*` tool conventions and is wired into both CMake and GNUmake builds.

- **New tool**
  - Adds `Tools/Plotfile/fconvert.cpp` with the standard plotfile-tool structure (`main_main()`, command-line parsing via `command_argument_count()` / `get_command_argument()`, `Initialize(argc, argv, false)`).
  - Reads all levels/components from `amrex::PlotFileData`, reconstructs `Geometry`, `level_steps`, and `ref_ratio`, and calls `WriteMultiLevelPlotfileHDF5(...)`.
  - Supports multiple input plotfiles, `--compression` / `-c`, and `--output` / `-o`.

- **HDF5 / ZFP behavior**
  - HDF5-specific codepaths are guarded with `#ifdef AMREX_USE_HDF5`.
  - Non-HDF5 builds abort at runtime with an actionable message instead of failing at compile time.
  - Compression handling is passed through unchanged to AMReX, e.g.
    ```bash
    fconvert --compression ZFP_ACCURACY@0.001 plt00010
    ```

- **Build integration**
  - Adds `fconvert` to `Tools/Plotfile/CMakeLists.txt` so it builds/installs alongside the existing plotfile tools.
  - Adds `fconvert` to `Tools/Plotfile/GNUmakefile`.

- **Documentation**
  - Documents `fconvert` in `Docs/sphinx_documentation/source/Post_Processing.rst`.
  - Adds an HDF5 postprocessing note in `Docs/sphinx_documentation/source/IO.rst`.

## Additional background

`fconvert` is intended for post-simulation conversion/compression of existing native plotfiles without requiring applications to emit HDF5 directly. Output naming defaults to the input plotfile name, with optional override for single-file output or multi-file prefixing.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate