### PR TITLE
TinyProfiler: re-read output_file each init/finalize cycle

### DIFF
--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -64,6 +64,10 @@ namespace {
     constexpr char mainregion[] = "main";
     bool finalized = false;
     bool memprof_finalized = false;
+    // Whether tiny_profiler.output_file has been read this Initialize/Finalize
+    // cycle. Re-armed in Initialize() so processes that cycle AMReX init/finalize
+    // multiple times (e.g. Jupyter notebooks) pick up an updated value each cycle.
+    bool output_file_read = false;
 }
 
 TinyProfiler::TinyProfiler (std::string funcname) noexcept
@@ -327,6 +331,12 @@ TinyProfiler::Initialize ()
 
         pp.queryAdd("enabled", enabled);
     }
+
+    // Re-arm the output-file read for this cycle and reset the cached value, so
+    // a new tiny_profiler.output_file is picked up across init/finalize cycles
+    // and a cycle that sets nothing falls back to the default out stream.
+    output_file_read = false;
+    output_file.clear();
 
     if (!enabled) { return; }
 
@@ -1029,11 +1039,12 @@ TinyProfiler::PrintMemoryUsage (std::ostream* os, bool only_local) noexcept
 std::string const&
 TinyProfiler::get_output_file ()
 {
-    // Instead of reading it only once, we could try to read the parameter
-    // every time. But I am not sure how useful that might be.
-    static bool first = true;
-    if (first) {
-        first = false;
+    // Read the parameter once per Initialize/Finalize cycle. The guard is
+    // re-armed in Initialize(), so a value updated between cycles is honored.
+    // The guard also ensures the pre-existing file is removed at most once, so
+    // the timer and memory reports (both opened in append mode) coexist.
+    if (!output_file_read) {
+        output_file_read = true;
 
         amrex::ParmParse pp("tiny_profiler");
         pp.query("output_file", output_file);


### PR DESCRIPTION
## Summary

`TinyProfiler::get_output_file()` cached `tiny_profiler.output_file` behind a process-lifetime function-local guard, so a process that cycles AMReX `initialize`/`finalize` more than once (e.g. a Jupyter notebook running several simulations) kept writing to the first cycle's report location and could fail to open it on a later cycle.

Move the read-once guard to a namespace-scope flag (`output_file_read`) that `Initialize()` re-arms, and reset the cached output_file there. The value is still read at most once per cycle, so the timer and memory reports (both opened in append mode) continue to share one freshly-truncated file.

## Additional background

Needed for BLAST codes that like to change defaults of the TP output file in the same process (e.g., Jupyter session) for subsequent simulation runs.

- https://github.com/BLAST-ImpactX/impactx/pull/1566
- https://github.com/BLAST-WarpX/warpx/pull/7077

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
