### PR TITLE
Generalize local mask

### DIFF
--- a/Docs/sphinx_documentation/source/Particle.rst
+++ b/Docs/sphinx_documentation/source/Particle.rst
@@ -267,6 +267,14 @@ the supplied cell count in each direction since the last :cpp:`Redistribute()`
 call. Use the global algorithm after initialization, regridding, load balancing,
 or any update that may send particles arbitrarily far.
 
+On CPU builds, local :cpp:`Redistribute()` can use a level-0 mask to speed up
+particle-to-grid lookup for short moves. AMReX bypasses this mask for multi-level
+redistribution and when the estimated mask storage is too large; in those cases,
+the local MPI communication algorithm can still be used while particle lookup
+falls back to a box search. The mask policy can be controlled with
+``particles.redistribute_use_mask``, ``particles.redistribute_mask_max_ratio``,
+and ``particles.redistribute_mask_max_bytes``.
+
 Application codes will likely want to create their own derived
 ParticleContainer class that specializes the template parameters and adds
 additional functionality, like setting the initial conditions, moving the

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1182,20 +1182,29 @@ Particles
    :type: bool
    :value: true
 
+   .. versionadded:: 26.08
+      Runtime parameter ``particles.redistribute_use_mask``.
+
    On CPU builds, this controls whether local ``Redistribute()`` may use a
    level-0 mask for particle-to-grid lookup when the call is otherwise eligible.
 
 .. py:data:: particles.redistribute_mask_max_ratio
-   :type: real
+   :type: double
    :value: 8.0
+
+   .. versionadded:: 26.08
+      Runtime parameter ``particles.redistribute_mask_max_ratio``.
 
    This is the maximum ratio of grown mask cells to valid cells for using the
    CPU local ``Redistribute()`` lookup mask. Non-positive values disable this
    ratio limit.
 
 .. py:data:: particles.redistribute_mask_max_bytes
-   :type: int
+   :type: long
    :value: 268435456
+
+   .. versionadded:: 26.08
+      Runtime parameter ``particles.redistribute_mask_max_bytes``.
 
    This is the maximum estimated per-rank storage, in bytes, for using the CPU
    local ``Redistribute()`` lookup mask. Negative values disable this byte limit.

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1178,6 +1178,28 @@ Particles
    container when writing checkpoint and plot files for particles. The
    special value of ``-1`` indicates one file per process.
 
+.. py:data:: particles.redistribute_use_mask
+   :type: bool
+   :value: true
+
+   On CPU builds, this controls whether local ``Redistribute()`` may use a
+   level-0 mask for particle-to-grid lookup when the call is otherwise eligible.
+
+.. py:data:: particles.redistribute_mask_max_ratio
+   :type: real
+   :value: 8.0
+
+   This is the maximum ratio of grown mask cells to valid cells for using the
+   CPU local ``Redistribute()`` lookup mask. Non-positive values disable this
+   ratio limit.
+
+.. py:data:: particles.redistribute_mask_max_bytes
+   :type: int
+   :value: 268435456
+
+   This is the maximum estimated per-rank storage, in bytes, for using the CPU
+   local ``Redistribute()`` lookup mask. Negative values disable this byte limit.
+
 Tiling
 ------
 

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -302,6 +302,8 @@ public:
 
 protected:
 
+    bool RedistributeMaskLooksCheap (int lev, IntVect nghost) const;
+
     void BuildRedistributeMask (int lev, IntVect nghost) const;
 
     void BuildRedistributeMask (int lev, int nghost=1) const

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -321,6 +321,11 @@ protected:
 
     mutable std::unique_ptr<iMultiFab> redistribute_mask_ptr;
     mutable IntVect redistribute_mask_nghost = IntVect(std::numeric_limits<int>::min());
+    mutable bool redistribute_mask_cost_cached = false;
+    mutable bool redistribute_mask_cost = false;
+    mutable IntVect redistribute_mask_cost_nghost = IntVect(std::numeric_limits<int>::min());
+    mutable BoxArray redistribute_mask_cost_ba;
+    mutable DistributionMapping redistribute_mask_cost_dmap;
     mutable amrex::Vector<int> neighbor_procs;
     mutable ParticleBufferMap m_buffer_map;
 

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -12,6 +12,35 @@ IntVect ParticleContainerBase::tile_size { AMREX_D_DECL(1024000,8,8) };
 bool    ParticleContainerBase::memEfficientSort = true;
 bool    ParticleContainerBase::use_comms_arena = false;
 
+namespace {
+
+struct RedistributeMaskParameters
+{
+    int use_mask = 1;
+    double max_ratio = 8.0;
+    Long max_bytes = 256L * 1024L * 1024L;
+};
+
+RedistributeMaskParameters const&
+RedistributeMaskParams ()
+{
+    static RedistributeMaskParameters params;
+    static bool initialized = false;
+
+    if (! initialized)
+    {
+        ParmParse pp("particles");
+        pp.query("redistribute_use_mask", params.use_mask);
+        pp.query("redistribute_mask_max_ratio", params.max_ratio);
+        pp.query("redistribute_mask_max_bytes", params.max_bytes);
+        initialized = true;
+    }
+
+    return params;
+}
+
+}
+
 void ParticleContainerBase::Define (const Geometry            & geom,
                                     const DistributionMapping & dmap,
                                     const BoxArray            & ba)
@@ -335,47 +364,64 @@ bool ParticleContainerBase::RedistributeMaskLooksCheap (int lev, IntVect nghost)
 
     AMREX_ASSERT(lev == 0);
 
-    int use_mask = 1;
-    Real max_ratio = 8.0;
-    Long max_bytes = 256L * 1024L * 1024L;
+    const auto& params = RedistributeMaskParams();
 
-    ParmParse pp("particles");
-    pp.query("redistribute_use_mask", use_mask);
-    pp.query("redistribute_mask_max_ratio", max_ratio);
-    pp.query("redistribute_mask_max_bytes", max_bytes);
+    if (!params.use_mask) { return false; }
 
-    if (!use_mask) { return false; }
-
-    Long valid_cells = 0;
-    Long grown_cells = 0;
     const BoxArray& ba = this->ParticleBoxArray(lev);
     const DistributionMapping& dmap = this->ParticleDistributionMap(lev);
 
-    for (MFIter mfi(ba, dmap); mfi.isValid(); ++mfi)
+    if (redistribute_mask_cost_cached &&
+        redistribute_mask_cost_nghost == nghost &&
+        BoxArray::SameRefs(redistribute_mask_cost_ba, ba) &&
+        DistributionMapping::SameRefs(redistribute_mask_cost_dmap, dmap))
     {
-        const Box& box = mfi.validbox();
-        valid_cells += box.numPts();
-        grown_cells += amrex::grow(box, nghost).numPts();
+        return redistribute_mask_cost;
     }
 
-    if (grown_cells == 0) { return true; }
+    Vector<Long> valid_cells(ParallelContext::NProcsSub(), 0);
+    Vector<Long> grown_cells(ParallelContext::NProcsSub(), 0);
 
-    if (max_bytes >= 0) {
-        const auto estimated_bytes = static_cast<long double>(grown_cells)
-            * static_cast<long double>(2 * sizeof(int));
-        if (estimated_bytes > static_cast<long double>(max_bytes)) {
-            return false;
+    for (int i = 0; i < ba.size(); ++i)
+    {
+        const int rank = ParallelContext::global_to_local_rank(dmap[i]);
+        AMREX_ASSERT(rank >= 0 && rank < ParallelContext::NProcsSub());
+        valid_cells[rank] += ba[i].numPts();
+        grown_cells[rank] += amrex::grow(ba[i], nghost).numPts();
+    }
+
+    bool looks_cheap = true;
+    const Long bytes_per_cell = 2L * static_cast<Long>(sizeof(int));
+    for (int rank = 0; rank < ParallelContext::NProcsSub(); ++rank)
+    {
+        if (grown_cells[rank] == 0) { continue; }
+
+        if (params.max_bytes >= 0 &&
+            grown_cells[rank] > params.max_bytes / bytes_per_cell)
+        {
+            looks_cheap = false;
+            break;
+        }
+
+        if (params.max_ratio > 0.0 && valid_cells[rank] > 0)
+        {
+            const auto ratio = static_cast<double>(grown_cells[rank])
+                / static_cast<double>(valid_cells[rank]);
+            if (ratio > params.max_ratio)
+            {
+                looks_cheap = false;
+                break;
+            }
         }
     }
 
-    if (max_ratio > 0.0 && valid_cells > 0) {
-        const auto ratio = static_cast<Real>(grown_cells) / static_cast<Real>(valid_cells);
-        if (ratio > max_ratio) {
-            return false;
-        }
-    }
+    redistribute_mask_cost_cached = true;
+    redistribute_mask_cost = looks_cheap;
+    redistribute_mask_cost_nghost = nghost;
+    redistribute_mask_cost_ba = ba;
+    redistribute_mask_cost_dmap = dmap;
 
-    return true;
+    return looks_cheap;
 }
 
 void ParticleContainerBase::BuildRedistributeMask (int lev, IntVect nghost) const

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -329,6 +329,55 @@ int ParticleContainerBase::AggregationBuffer ()
     return aggregation_buffer;
 }
 
+bool ParticleContainerBase::RedistributeMaskLooksCheap (int lev, IntVect nghost) const
+{
+    BL_PROFILE("ParticleContainer::RedistributeMaskLooksCheap");
+
+    AMREX_ASSERT(lev == 0);
+
+    int use_mask = 1;
+    Real max_ratio = 8.0;
+    Long max_bytes = 256L * 1024L * 1024L;
+
+    ParmParse pp("particles");
+    pp.query("redistribute_use_mask", use_mask);
+    pp.query("redistribute_mask_max_ratio", max_ratio);
+    pp.query("redistribute_mask_max_bytes", max_bytes);
+
+    if (!use_mask) { return false; }
+
+    Long valid_cells = 0;
+    Long grown_cells = 0;
+    const BoxArray& ba = this->ParticleBoxArray(lev);
+    const DistributionMapping& dmap = this->ParticleDistributionMap(lev);
+
+    for (MFIter mfi(ba, dmap); mfi.isValid(); ++mfi)
+    {
+        const Box& box = mfi.validbox();
+        valid_cells += box.numPts();
+        grown_cells += amrex::grow(box, nghost).numPts();
+    }
+
+    if (grown_cells == 0) { return true; }
+
+    if (max_bytes >= 0) {
+        const auto estimated_bytes = static_cast<long double>(grown_cells)
+            * static_cast<long double>(2 * sizeof(int));
+        if (estimated_bytes > static_cast<long double>(max_bytes)) {
+            return false;
+        }
+    }
+
+    if (max_ratio > 0.0 && valid_cells > 0) {
+        const auto ratio = static_cast<Real>(grown_cells) / static_cast<Real>(valid_cells);
+        if (ratio > max_ratio) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void ParticleContainerBase::BuildRedistributeMask (int lev, IntVect nghost) const
 {
     BL_PROFILE("ParticleContainer::BuildRedistributeMask");

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -1445,12 +1445,6 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 ::Redistribute_impl (int lev_min, int lev_max, IntVect nGrow,
                      bool local, IntVect max_cells_moved, bool remove_negative)
 {
-    if (local) {
-        AMREX_ASSERT(max_cells_moved.allGE(0));
-        AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max,
-                                            max_cells_moved) == 0);
-    }
-
     BL_PROFILE("ParticleContainer::Redistribute_impl()");
     BL_PROFILE_VAR_NS("Redistribute_partition", blp_partition);
 
@@ -1478,10 +1472,18 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     }
     AMREX_ASSERT(lev_max <= finestLevel());
 
+    if (local) {
+        AMREX_ASSERT(max_cells_moved.allGE(0));
+        AMREX_ASSERT(numParticlesOutOfRange(*this, lev_min, lev_max,
+                                            max_cells_moved) == 0);
+    }
+
     this->defineBufferMap();
 
 #ifndef AMREX_USE_GPU
-    if (local) { BuildRedistributeMask(0, max_cells_moved); }
+    const bool use_mask_lookup = local && lev_min == 0 && lev_max == 0
+        && RedistributeMaskLooksCheap(0, max_cells_moved);
+    if (use_mask_lookup) { BuildRedistributeMask(0, max_cells_moved); }
 #else
     if (! m_particle_locator.isValid(GetParGDB(), do_tiling, tile_size)) { m_particle_locator.build(GetParGDB(), do_tiling, tile_size); }
     m_particle_locator.setGeometry(GetParGDB());
@@ -1587,7 +1589,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         auto& periodic_shift = *periodic_shift_ptrs[pmap_it];
         *new_size_ptrs[pmap_it] = hostPartitionTile(src_tile,
                                                     lev, gid, tid,
-                                                    lev_min, lev_max, nGrow, local,
+                                                    lev_min, lev_max, nGrow, use_mask_lookup,
                                                     remove_negative, myproc,
                                                     boxes, levels, tiles,
                                                     src_indices, periodic_shift);
@@ -1656,7 +1658,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             auto& periodic_shift = op.m_periodic_shift[lev][index];
             new_size = hostPartitionTile(src_tile,
                                          lev, gid, tid,
-                                         lev_min, lev_max, nGrow, local,
+                                         lev_min, lev_max, nGrow, use_mask_lookup,
                                          remove_negative, myproc,
                                          boxes, levels, tiles,
                                          src_indices, periodic_shift);

--- a/Tests/Particles/Redistribute/CMakeLists.txt
+++ b/Tests/Particles/Redistribute/CMakeLists.txt
@@ -13,7 +13,11 @@ foreach(D IN LISTS AMReX_SPACEDIM)
       set(_exe_dir ${CMAKE_CURRENT_BINARY_DIR}/${D}d)
       set(_exe_name Test_Particles_Redistribute_${D}d)
 
-      file(COPY inputs.rt.local_multilevel inputs.rt.local_nomask DESTINATION ${_exe_dir})
+      file(COPY
+        inputs.rt.local_multilevel
+        inputs.rt.local_nomask
+        inputs.rt.local_nomask_uneven
+        DESTINATION ${_exe_dir})
 
       if (AMReX_OMP)
         add_test(
@@ -50,6 +54,17 @@ foreach(D IN LISTS AMReX_SPACEDIM)
           COMMAND           ${_exe_dir}/${_exe_name} inputs.rt.local_nomask
           WORKING_DIRECTORY ${_exe_dir}
         )
+      endif ()
+
+      if (AMReX_MPI)
+        add_test(
+          NAME              Particles_Redistribute_${D}d_LocalNoMaskUnevenMPI
+          COMMAND           mpiexec -n 3 ${_exe_dir}/${_exe_name} inputs.rt.local_nomask_uneven
+          WORKING_DIRECTORY ${_exe_dir}
+        )
+        if (AMReX_OMP)
+          set_tests_properties(Particles_Redistribute_${D}d_LocalNoMaskUnevenMPI PROPERTIES ENVIRONMENT OMP_NUM_THREADS=2)
+        endif ()
       endif ()
     endif ()
 

--- a/Tests/Particles/Redistribute/CMakeLists.txt
+++ b/Tests/Particles/Redistribute/CMakeLists.txt
@@ -59,7 +59,7 @@ foreach(D IN LISTS AMReX_SPACEDIM)
       if (AMReX_MPI)
         add_test(
           NAME              Particles_Redistribute_${D}d_LocalNoMaskUnevenMPI
-          COMMAND           mpiexec -n 3 ${_exe_dir}/${_exe_name} inputs.rt.local_nomask_uneven
+          COMMAND           mpiexec -n 2 ${_exe_dir}/${_exe_name} inputs.rt.local_nomask_uneven
           WORKING_DIRECTORY ${_exe_dir}
         )
         if (AMReX_OMP)

--- a/Tests/Particles/Redistribute/CMakeLists.txt
+++ b/Tests/Particles/Redistribute/CMakeLists.txt
@@ -8,6 +8,51 @@ foreach(D IN LISTS AMReX_SPACEDIM)
 
     setup_test(${D} _sources _input_files)
 
+
+    if (D EQUAL 3 AND AMReX_GPU_BACKEND STREQUAL NONE)
+      set(_exe_dir ${CMAKE_CURRENT_BINARY_DIR}/${D}d)
+      set(_exe_name Test_Particles_Redistribute_${D}d)
+
+      file(COPY inputs.rt.local_multilevel inputs.rt.local_nomask DESTINATION ${_exe_dir})
+
+      if (AMReX_OMP)
+        add_test(
+          NAME              Particles_Redistribute_${D}d_LocalMultiLevel
+          COMMAND           ${_exe_dir}/${_exe_name} inputs.rt.local_multilevel
+          WORKING_DIRECTORY ${_exe_dir}
+        )
+        set_tests_properties(Particles_Redistribute_${D}d_LocalMultiLevel PROPERTIES ENVIRONMENT OMP_NUM_THREADS=2)
+        add_test(
+          NAME              Particles_Redistribute_${D}d_LocalNoMask
+          COMMAND           ${_exe_dir}/${_exe_name} inputs.rt.local_nomask
+          WORKING_DIRECTORY ${_exe_dir}
+        )
+        set_tests_properties(Particles_Redistribute_${D}d_LocalNoMask PROPERTIES ENVIRONMENT OMP_NUM_THREADS=2)
+      elseif (AMReX_MPI)
+        add_test(
+          NAME              Particles_Redistribute_${D}d_LocalMultiLevel
+          COMMAND           mpiexec -n 2 ${_exe_dir}/${_exe_name} inputs.rt.local_multilevel
+          WORKING_DIRECTORY ${_exe_dir}
+        )
+        add_test(
+          NAME              Particles_Redistribute_${D}d_LocalNoMask
+          COMMAND           mpiexec -n 2 ${_exe_dir}/${_exe_name} inputs.rt.local_nomask
+          WORKING_DIRECTORY ${_exe_dir}
+        )
+      else ()
+        add_test(
+          NAME              Particles_Redistribute_${D}d_LocalMultiLevel
+          COMMAND           ${_exe_dir}/${_exe_name} inputs.rt.local_multilevel
+          WORKING_DIRECTORY ${_exe_dir}
+        )
+        add_test(
+          NAME              Particles_Redistribute_${D}d_LocalNoMask
+          COMMAND           ${_exe_dir}/${_exe_name} inputs.rt.local_nomask
+          WORKING_DIRECTORY ${_exe_dir}
+        )
+      endif ()
+    endif ()
+
     if (D EQUAL 3 AND NOT AMReX_GPU_BACKEND STREQUAL NONE)
       set(_exe_dir ${CMAKE_CURRENT_BINARY_DIR}/${D}d)
       set(_exe_name Test_Particles_Redistribute_${D}d)

--- a/Tests/Particles/Redistribute/inputs.rt.local_multilevel
+++ b/Tests/Particles/Redistribute/inputs.rt.local_multilevel
@@ -1,0 +1,14 @@
+redistribute.size = (16, 16, 16)
+redistribute.max_grid_size = 8
+redistribute.is_periodic = 1
+redistribute.num_ppc = 1
+redistribute.move_dir = (1, 1, 1)
+redistribute.do_random = 1
+redistribute.nsteps = 5
+redistribute.nlevs = 3
+redistribute.do_regrid = 0
+
+redistribute.num_runtime_real = 1
+redistribute.num_runtime_int = 1
+
+particles.do_tiling=1

--- a/Tests/Particles/Redistribute/inputs.rt.local_nomask
+++ b/Tests/Particles/Redistribute/inputs.rt.local_nomask
@@ -1,0 +1,17 @@
+redistribute.size = (16, 16, 16)
+redistribute.max_grid_size = 8
+redistribute.is_periodic = 1
+redistribute.num_ppc = 1
+redistribute.move_dir = (1, 1, 1)
+redistribute.do_random = 1
+redistribute.nsteps = 3
+redistribute.nlevs = 1
+redistribute.do_regrid = 0
+redistribute.max_cells_moved = (16, 16, 16)
+redistribute.expected_mask_lookup = 0
+
+redistribute.num_runtime_real = 1
+redistribute.num_runtime_int = 1
+
+particles.redistribute_mask_max_bytes = 1
+particles.do_tiling=1

--- a/Tests/Particles/Redistribute/inputs.rt.local_nomask_uneven
+++ b/Tests/Particles/Redistribute/inputs.rt.local_nomask_uneven
@@ -1,4 +1,4 @@
-redistribute.size = (16, 16, 16)
+redistribute.size = (24, 8, 8)
 redistribute.max_grid_size = 8
 redistribute.is_periodic = 1
 redistribute.num_ppc = 1
@@ -13,5 +13,5 @@ redistribute.expected_mask_lookup = 0
 redistribute.num_runtime_real = 1
 redistribute.num_runtime_int = 1
 
-particles.redistribute_mask_max_bytes = 20000
+particles.redistribute_mask_max_bytes = 12000
 particles.do_tiling=1

--- a/Tests/Particles/Redistribute/inputs.rt.local_nomask_uneven
+++ b/Tests/Particles/Redistribute/inputs.rt.local_nomask_uneven
@@ -1,0 +1,17 @@
+redistribute.size = (16, 16, 16)
+redistribute.max_grid_size = 8
+redistribute.is_periodic = 1
+redistribute.num_ppc = 1
+redistribute.move_dir = (1, 1, 1)
+redistribute.do_random = 1
+redistribute.nsteps = 3
+redistribute.nlevs = 1
+redistribute.do_regrid = 0
+redistribute.max_cells_moved = (1, 1, 1)
+redistribute.expected_mask_lookup = 0
+
+redistribute.num_runtime_real = 1
+redistribute.num_runtime_int = 1
+
+particles.redistribute_mask_max_bytes = 20000
+particles.do_tiling=1

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -62,14 +62,19 @@ public:
         }
     }
 
-    void RedistributeLocal (bool remove_neg=true)
+    void RedistributeLocal (bool remove_neg=true,
+                            IntVect max_cells_moved=IntVect(1))
     {
         const int lev_min = 0;
         const int lev_max = finestLevel();
         const IntVect nGrow(0);
         const bool local = true;
-        const IntVect max_cells_moved(1);
         Redistribute(lev_min, lev_max, nGrow, local, max_cells_moved, remove_neg);
+    }
+
+    bool RedistributeMaskLooksCheapForTest (IntVect max_cells_moved) const
+    {
+        return RedistributeMaskLooksCheap(0, max_cells_moved);
     }
 
     void RedistributeGlobal (bool remove_neg=true)
@@ -353,6 +358,8 @@ struct TestParams
     int sort;
     int test_level_lost = 0;
     int stable_redistribute = 0;
+    IntVect max_cells_moved = IntVect(1);
+    int expected_mask_lookup = -1;
 };
 
 void testRedistribute();
@@ -470,6 +477,8 @@ void get_test_params(TestParams& params, const std::string& prefix)
     pp.query("num_runtime_int", num_runtime_int);
     pp.query("remove_negative", remove_negative);
     pp.query("stable_redistribute", params.stable_redistribute);
+    pp.query("max_cells_moved", params.max_cells_moved);
+    pp.query("expected_mask_lookup", params.expected_mask_lookup);
 
     params.sort = 0;
     pp.query("sort", params.sort);
@@ -524,6 +533,11 @@ void testRedistribute ()
     TestParticleContainer pc(geom, dm, ba, rr);
     pc.setStableRedistribute(params.stable_redistribute);
 
+    if (params.expected_mask_lookup >= 0) {
+        const bool mask_lookup = pc.RedistributeMaskLooksCheapForTest(params.max_cells_moved);
+        AMREX_ALWAYS_ASSERT(mask_lookup == static_cast<bool>(params.expected_mask_lookup));
+    }
+
     IntVect nppc(params.num_ppc);
 
     amrex::Print() << "About to initialize particles \n";
@@ -542,11 +556,11 @@ void testRedistribute ()
         if (!remove_negative) {
             auto old = pc.TotalNumberOfParticles();
             pc.negateEven();
-            pc.RedistributeLocal(false);
+            pc.RedistributeLocal(false, params.max_cells_moved);
             AMREX_ALWAYS_ASSERT(old == pc.TotalNumberOfParticles(false));
             pc.negateEven();
         }
-        pc.RedistributeLocal();
+        pc.RedistributeLocal(true, params.max_cells_moved);
         if (params.sort) { pc.SortParticlesByCell(); }
         pc.checkAnswer();
     }


### PR DESCRIPTION
The "local" argument to Redistribute really lumps together two distinct things: 1) whether to do point-to-point MPI communication for the particle count exchange, and 2) whether to use a mask for the grid/tile lookup. This separates these into distinct options. 

It also adds a heuristic to fall back to the full BoxArray search in cases where the mask would be too expensive too use.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
