### PR TITLE
ParticleHeader: Parse Grid Table

### DIFF
--- a/Src/Particle/AMReX_ParticleHeader.H
+++ b/Src/Particle/AMReX_ParticleHeader.H
@@ -28,6 +28,11 @@ namespace amrex {
  * The component counts follow the same convention as the on-disk format: for
  * pure Struct-of-Arrays particles the AMREX_SPACEDIM position components are
  * implicit and \p num_real counts only the remaining (runtime) real components.
+ *
+ * After the metadata prefix, the "Header" file contains a per-level grid
+ * table that locates each grid's binary particle data on disk. It can be
+ * parsed with parse_grid_table(); read() returns a fully parsed header
+ * including the table.
  */
 struct ParticleHeader
 {
@@ -57,21 +62,58 @@ struct ParticleHeader
     int finest_level = 0;
 
     /**
+     * \brief One entry of the per-level grid table.
+     *
+     * Locates the binary particle data of a single grid: the particles of a
+     * grid are stored contiguously in the data file "DATA_XXXXX" (with XXXXX
+     * = \p which), starting \p where bytes into that file.
+     */
+    struct GridEntry
+    {
+        //! index of the binary data file (DATA_XXXXX) holding this grid's particles
+        int which = 0;
+        //! number of particles stored for this grid
+        int count = 0;
+        //! byte offset of this grid's particle data within the data file
+        Long where = 0;
+    };
+
+    /**
+     * \brief Per level and grid: where each grid's particle data is stored.
+     *
+     * Filled by parse_grid_table(); grids.size() == finest_level + 1 and
+     * grids[lev].size() is the number of grids of level \p lev. Grids without
+     * particles have a zero \p count.
+     */
+    Vector<Vector<GridEntry>> grids;
+
+    /**
      * \brief Parse the metadata prefix from an input stream.
      *
      * Consumes exactly the leading metadata block (version through finest
      * level), leaving the stream positioned right after the finest-level entry
-     * and before the per-level grid table. This lets ParticleContainer::Restart
-     * continue reading the grid offsets from the same stream.
+     * and before the per-level grid table. The table can then be parsed from
+     * the same stream with parse_grid_table().
      *
      * \param is input stream positioned at the start of a particle Header
      */
     void parse (std::istream& is);
 
     /**
+     * \brief Parse the per-level grid table into \p grids.
+     *
+     * Must be called on a stream positioned right after the metadata prefix,
+     * i.e. directly following a call to parse().
+     *
+     * \param is input stream positioned at the start of the grid table
+     */
+    void parse_grid_table (std::istream& is);
+
+    /**
      * \brief Read and parse the "Header" file of a particle plotfile/checkpoint.
      *
-     * Collective: the file is read on the I/O process and broadcast.
+     * Parses the complete header: the metadata prefix and the per-level grid
+     * table. Collective: the file is read on the I/O process and broadcast.
      *
      * \param dir   plotfile/checkpoint directory
      * \param file  particle sub-directory name (e.g. "particle0")

--- a/Src/Particle/AMReX_ParticleHeader.cpp
+++ b/Src/Particle/AMReX_ParticleHeader.cpp
@@ -15,6 +15,8 @@ namespace amrex {
 void
 ParticleHeader::parse (std::istream& is)
 {
+    grids.clear();
+
     is >> version;
     AMREX_ASSERT(!version.empty());
 

--- a/Src/Particle/AMReX_ParticleHeader.cpp
+++ b/Src/Particle/AMReX_ParticleHeader.cpp
@@ -76,6 +76,30 @@ ParticleHeader::parse (std::istream& is)
     is >> finest_level;
 }
 
+void
+ParticleHeader::parse_grid_table (std::istream& is)
+{
+    AMREX_ASSERT(finest_level >= 0);
+
+    // The number of grids of every level comes first, ...
+    Vector<int> ngrids(finest_level+1);
+    for (int lev = 0; lev <= finest_level; ++lev) {
+        is >> ngrids[lev];
+        AMREX_ASSERT(ngrids[lev] > 0);
+    }
+
+    // ... followed by each level's table of (data file index, particle
+    // count, byte offset) entries, one entry per grid.
+    grids.clear();
+    grids.resize(finest_level+1);
+    for (int lev = 0; lev <= finest_level; ++lev) {
+        grids[lev].resize(ngrids[lev]);
+        for (auto& entry : grids[lev]) {
+            is >> entry.which >> entry.count >> entry.where;
+        }
+    }
+}
+
 ParticleHeader
 ParticleHeader::read (const std::string& dir, const std::string& file)
 {
@@ -101,6 +125,7 @@ ParticleHeader::read (const std::string& dir, const std::string& file)
 
     ParticleHeader header;
     header.parse(HdrFile);
+    header.parse_grid_table(HdrFile);
     return header;
 }
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -676,11 +676,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     std::string fileCharPtrString(fileCharPtr.dataPtr());
     std::istringstream HdrFile(fileCharPtrString, std::istringstream::in);
 
-    // The metadata prefix (version through finest level) is parsed by the
-    // shared ParticleHeader, which leaves HdrFile positioned at the per-level
-    // grid table read below. See AMReX_ParticleHeader.{H,cpp}.
+    // The metadata prefix (version through finest level) and the per-level
+    // grid table (data file index, particle count and byte offset per grid)
+    // are parsed by the shared ParticleHeader.
+    // See AMReX_ParticleHeader.{H,cpp}.
     ParticleHeader header;
     header.parse(HdrFile);
+    header.parse_grid_table(HdrFile);
 
     const std::string& how = header.how;
     const bool convert_ids = header.convert_ids;
@@ -740,12 +742,6 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         }
     }
 
-    Vector<int> ngrids(finest_level_in_file+1);
-    for (int lev = 0; lev <= finest_level_in_file; lev++) {
-        HdrFile >> ngrids[lev];
-        AMREX_ASSERT(ngrids[lev] > 0);
-    }
-
     resizeData();
 
     if (finest_level_in_file > finestLevel()) {
@@ -753,12 +749,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     }
 
     for (int lev = 0; lev <= finest_level_in_file; lev++) {
-        Vector<int>  which(ngrids[lev]);
-        Vector<int>  count(ngrids[lev]);
-        Vector<Long> where(ngrids[lev]);
-        for (int i = 0; i < ngrids[lev]; i++) {
-            HdrFile >> which[i] >> count[i] >> where[i];
-        }
+        auto const& grid_table = header.grids[lev];
 
         // Use the file's own layout to distribute reading across ranks.
         MFInfo info;
@@ -770,7 +761,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         }
 
         for(int grid : grids_to_read) {
-            if (count[grid] <= 0) { continue; }
+            if (grid_table[grid].count <= 0) { continue; }
 
             // The file names in the header file are relative.
             std::string name = fullname;
@@ -783,7 +774,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             name += amrex::Concatenate("", lev, 1);
             name += '/';
             name += DataPrefix();
-            name += amrex::Concatenate("", which[grid], DATA_Digits_Read);
+            name += amrex::Concatenate("", grid_table[grid].which, DATA_Digits_Read);
 
             std::ifstream ParticleFile;
 
@@ -793,21 +784,21 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                 amrex::FileOpenFailed(name);
             }
 
-            ParticleFile.seekg(where[grid], std::ios::beg);
+            ParticleFile.seekg(grid_table[grid].where, std::ios::beg);
 
             // Use if constexpr to avoid instantiating the mis-matched
             // type case and triggering the static_assert on the
             // underlying copy calls
             if (how == "single") {
                 if constexpr (std::is_same_v<ParticleReal, float>) {
-                    ReadParticles<float>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
+                    ReadParticles<float>(grid_table[grid].count, grid, lev, ParticleFile, finest_level_in_file, convert_ids);
                 } else {
                     amrex::Error("File contains single-precision data, while AMReX is compiled with ParticleReal==double");
                 }
             }
             else if (how == "double") {
                 if constexpr (std::is_same_v<ParticleReal, double>) {
-                    ReadParticles<double>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
+                    ReadParticles<double>(grid_table[grid].count, grid, lev, ParticleFile, finest_level_in_file, convert_ids);
                 } else {
                     amrex::Error("File contains double-precision data, while AMReX is compiled with ParticleReal==float");
                 }


### PR DESCRIPTION
## Summary

Extract the parsing of the per-level grid table (data file index, particle count and byte offset for each grid) from `ParticleContainer::Restart` into the shared `ParticleHeader` (follow-up to #5476), so standalone consumers - e.g. language bindings and format converters - can locate each grid's binary particle data without duplicating the on-disk format logic.

- `ParticleHeader` gains a nested `GridEntry {which, count, where}` and `Vector<Vector<GridEntry>> grids`, filled by the new `parse_grid_table()`.
- `ParticleHeader::read()` now returns a fully parsed header including the table; `parse()` still consumes exactly the metadata prefix, keeping the existing stream contract.
- `Restart` consumes the shared parser instead of inline `HdrFile >>` reads - one source of truth for the Header format.

Motivation: pyAMReX tools (runtime-SoA plotfile reading https://github.com/AMReX-Codes/pyamrex/pull/596, AMReX-Codes/pyamrex#581, and a plotfile-to-openPMD converter https://github.com/AMReX-Codes/pyamrex/pull/597) need the grid table for per-grid particle counts and parallel-read planning.

## Testing

```
cmake -S . -B build -DAMReX_ENABLE_TESTS=ON -DAMReX_TEST_TYPE=All -DAMReX_PARTICLES=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build -j6
ctest --test-dir build -R 'CheckpointRestart' -E 'HDF5|AsyncIO' --output-on-failure
```

All pass: `Particles_CheckpointRestart_3d`, `Particles_CheckpointRestartDualGrid_3d`, `Particles_CheckpointRestartDualGridSOA_3d`, `Particles_CheckpointRestartSOA_3d` (plus `Particles_Redistribute_3d` from the Small set).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)