### PR TITLE
Particles: Cross-Precision Restart

### DIFF
--- a/Src/Particle/AMReX_ParticleHeader.H
+++ b/Src/Particle/AMReX_ParticleHeader.H
@@ -28,6 +28,11 @@ namespace amrex {
  * The component counts follow the same convention as the on-disk format: for
  * pure Struct-of-Arrays particles the AMREX_SPACEDIM position components are
  * implicit and \p num_real counts only the remaining (runtime) real components.
+ *
+ * After the metadata prefix, the "Header" file contains a per-level grid
+ * table that locates each grid's binary particle data on disk. It can be
+ * parsed with parse_grid_table(); read() returns a fully parsed header
+ * including the table.
  */
 struct ParticleHeader
 {
@@ -57,21 +62,58 @@ struct ParticleHeader
     int finest_level = 0;
 
     /**
+     * \brief One entry of the per-level grid table.
+     *
+     * Locates the binary particle data of a single grid: the particles of a
+     * grid are stored contiguously in the data file "DATA_XXXXX" (with XXXXX
+     * = \p which), starting \p where bytes into that file.
+     */
+    struct GridEntry
+    {
+        //! index of the binary data file (DATA_XXXXX) holding this grid's particles
+        int which = 0;
+        //! number of particles stored for this grid
+        int count = 0;
+        //! byte offset of this grid's particle data within the data file
+        Long where = 0;
+    };
+
+    /**
+     * \brief Per level and grid: where each grid's particle data is stored.
+     *
+     * Filled by parse_grid_table(); grids.size() == finest_level + 1 and
+     * grids[lev].size() is the number of grids of level \p lev. Grids without
+     * particles have a zero \p count.
+     */
+    Vector<Vector<GridEntry>> grids;
+
+    /**
      * \brief Parse the metadata prefix from an input stream.
      *
      * Consumes exactly the leading metadata block (version through finest
      * level), leaving the stream positioned right after the finest-level entry
-     * and before the per-level grid table. This lets ParticleContainer::Restart
-     * continue reading the grid offsets from the same stream.
+     * and before the per-level grid table. The table can then be parsed from
+     * the same stream with parse_grid_table().
      *
      * \param is input stream positioned at the start of a particle Header
      */
     void parse (std::istream& is);
 
     /**
+     * \brief Parse the per-level grid table into \p grids.
+     *
+     * Must be called on a stream positioned right after the metadata prefix,
+     * i.e. directly following a call to parse().
+     *
+     * \param is input stream positioned at the start of the grid table
+     */
+    void parse_grid_table (std::istream& is);
+
+    /**
      * \brief Read and parse the "Header" file of a particle plotfile/checkpoint.
      *
-     * Collective: the file is read on the I/O process and broadcast.
+     * Parses the complete header: the metadata prefix and the per-level grid
+     * table. Collective: the file is read on the I/O process and broadcast.
      *
      * \param dir   plotfile/checkpoint directory
      * \param file  particle sub-directory name (e.g. "particle0")

--- a/Src/Particle/AMReX_ParticleHeader.cpp
+++ b/Src/Particle/AMReX_ParticleHeader.cpp
@@ -76,6 +76,30 @@ ParticleHeader::parse (std::istream& is)
     is >> finest_level;
 }
 
+void
+ParticleHeader::parse_grid_table (std::istream& is)
+{
+    AMREX_ASSERT(finest_level >= 0);
+
+    // The number of grids of every level comes first, ...
+    Vector<int> ngrids(finest_level+1);
+    for (int lev = 0; lev <= finest_level; ++lev) {
+        is >> ngrids[lev];
+        AMREX_ASSERT(ngrids[lev] > 0);
+    }
+
+    // ... followed by each level's table of (data file index, particle
+    // count, byte offset) entries, one entry per grid.
+    grids.clear();
+    grids.resize(finest_level+1);
+    for (int lev = 0; lev <= finest_level; ++lev) {
+        grids[lev].resize(ngrids[lev]);
+        for (auto& entry : grids[lev]) {
+            is >> entry.which >> entry.count >> entry.where;
+        }
+    }
+}
+
 ParticleHeader
 ParticleHeader::read (const std::string& dir, const std::string& file)
 {
@@ -101,6 +125,7 @@ ParticleHeader::read (const std::string& dir, const std::string& file)
 
     ParticleHeader header;
     header.parse(HdrFile);
+    header.parse_grid_table(HdrFile);
     return header;
 }
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -786,22 +786,15 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
             ParticleFile.seekg(grid_table[grid].where, std::ios::beg);
 
-            // Use if constexpr to avoid instantiating the mis-matched
-            // type case and triggering the static_assert on the
-            // underlying copy calls
+            // The file's precision does not need to match this build's
+            // ParticleReal: values are read in the file's precision and
+            // converted. Note that reading double-precision data into a
+            // single-precision build narrows the values.
             if (how == "single") {
-                if constexpr (std::is_same_v<ParticleReal, float>) {
-                    ReadParticles<float>(grid_table[grid].count, grid, lev, ParticleFile, finest_level_in_file, convert_ids);
-                } else {
-                    amrex::Error("File contains single-precision data, while AMReX is compiled with ParticleReal==double");
-                }
+                ReadParticles<float>(grid_table[grid].count, grid, lev, ParticleFile, finest_level_in_file, convert_ids);
             }
             else if (how == "double") {
-                if constexpr (std::is_same_v<ParticleReal, double>) {
-                    ReadParticles<double>(grid_table[grid].count, grid, lev, ParticleFile, finest_level_in_file, convert_ids);
-                } else {
-                    amrex::Error("File contains double-precision data, while AMReX is compiled with ParticleReal==float");
-                }
+                ReadParticles<double>(grid_table[grid].count, grid, lev, ParticleFile, finest_level_in_file, convert_ids);
             }
             else {
                 std::string msg("ParticleContainer::Restart(): bad parameter: ");
@@ -848,10 +841,17 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     Vector<int> istuff(std::size_t(cnt)*iChunkSize);
     readIntData(istuff.dataPtr(), istuff.size(), ifs, FPC::NativeIntDescriptor());
 
-    // Then the real data in binary.
+    // Then the real data in binary.  Read in the file's precision (RTYPE),
+    // which may differ from this build's ParticleReal, with the matching
+    // descriptor: the file was written with the writing code's
+    // ParticleRealDescriptor, i.e. the native descriptor of its precision.
     const int rChunkSize = ParticleType::is_soa_particle ? NStructReal + NumRealComps() : AMREX_SPACEDIM + NStructReal + NumRealComps();
     Vector<RTYPE> rstuff(std::size_t(cnt)*rChunkSize);
-    ReadParticleRealData(rstuff.dataPtr(), rstuff.size(), ifs);
+    if constexpr (sizeof(RTYPE) == 4) {
+        readFloatData(rstuff.dataPtr(), rstuff.size(), ifs, FPC::Native32RealDescriptor());
+    } else {
+        readDoubleData(rstuff.dataPtr(), rstuff.size(), ifs, FPC::Native64RealDescriptor());
+    }
 
     // Now reassemble the particles.
     int*   iptr = istuff.dataPtr();
@@ -864,8 +864,11 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     host_particles.reserve(15);
     host_particles.resize(finest_level_in_file+1);
 
+    // Buffered in ParticleReal (not RTYPE): the file's precision may differ
+    // from the build's ParticleReal, so convert each value on insertion. This
+    // also keeps the value types of the Gpu::copyAsync calls below identical.
     Vector<std::map<std::pair<int, int>,
-                    std::vector<Gpu::HostVector<RTYPE> > > > host_real_attribs;
+                    std::vector<Gpu::HostVector<ParticleReal> > > > host_real_attribs;
     host_real_attribs.reserve(15);
     host_real_attribs.resize(finest_level_in_file+1);
 
@@ -929,7 +932,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
 
             // add the real...
             for (int icomp = 0; icomp < NumRealComps(); icomp++) {
-                host_real_attribs[lev][ind][icomp].push_back(*rptr);
+                host_real_attribs[lev][ind][icomp].push_back(ParticleReal(*rptr));
                 ++rptr;
             }
 
@@ -950,7 +953,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             // read all other SoA
             // add the real...
             for (int icomp = AMREX_SPACEDIM; icomp < NumRealComps(); icomp++) {
-                host_real_attribs[lev][ind][icomp].push_back(*rptr);
+                host_real_attribs[lev][ind][icomp].push_back(ParticleReal(*rptr));
                 ++rptr;
             }
 

--- a/Src/Particle/AMReX_ParticleIO.H
+++ b/Src/Particle/AMReX_ParticleIO.H
@@ -676,11 +676,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     std::string fileCharPtrString(fileCharPtr.dataPtr());
     std::istringstream HdrFile(fileCharPtrString, std::istringstream::in);
 
-    // The metadata prefix (version through finest level) is parsed by the
-    // shared ParticleHeader, which leaves HdrFile positioned at the per-level
-    // grid table read below. See AMReX_ParticleHeader.{H,cpp}.
+    // The metadata prefix (version through finest level) and the per-level
+    // grid table (data file index, particle count and byte offset per grid)
+    // are parsed by the shared ParticleHeader.
+    // See AMReX_ParticleHeader.{H,cpp}.
     ParticleHeader header;
     header.parse(HdrFile);
+    header.parse_grid_table(HdrFile);
 
     const std::string& how = header.how;
     const bool convert_ids = header.convert_ids;
@@ -740,12 +742,6 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         }
     }
 
-    Vector<int> ngrids(finest_level_in_file+1);
-    for (int lev = 0; lev <= finest_level_in_file; lev++) {
-        HdrFile >> ngrids[lev];
-        AMREX_ASSERT(ngrids[lev] > 0);
-    }
-
     resizeData();
 
     if (finest_level_in_file > finestLevel()) {
@@ -753,12 +749,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     }
 
     for (int lev = 0; lev <= finest_level_in_file; lev++) {
-        Vector<int>  which(ngrids[lev]);
-        Vector<int>  count(ngrids[lev]);
-        Vector<Long> where(ngrids[lev]);
-        for (int i = 0; i < ngrids[lev]; i++) {
-            HdrFile >> which[i] >> count[i] >> where[i];
-        }
+        auto const& grid_table = header.grids[lev];
 
         // Use the file's own layout to distribute reading across ranks.
         MFInfo info;
@@ -770,7 +761,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         }
 
         for(int grid : grids_to_read) {
-            if (count[grid] <= 0) { continue; }
+            if (grid_table[grid].count <= 0) { continue; }
 
             // The file names in the header file are relative.
             std::string name = fullname;
@@ -783,7 +774,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             name += amrex::Concatenate("", lev, 1);
             name += '/';
             name += DataPrefix();
-            name += amrex::Concatenate("", which[grid], DATA_Digits_Read);
+            name += amrex::Concatenate("", grid_table[grid].which, DATA_Digits_Read);
 
             std::ifstream ParticleFile;
 
@@ -793,21 +784,21 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
                 amrex::FileOpenFailed(name);
             }
 
-            ParticleFile.seekg(where[grid], std::ios::beg);
+            ParticleFile.seekg(grid_table[grid].where, std::ios::beg);
 
             // Use if constexpr to avoid instantiating the mis-matched
             // type case and triggering the static_assert on the
             // underlying copy calls
             if (how == "single") {
                 if constexpr (std::is_same_v<ParticleReal, float>) {
-                    ReadParticles<float>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
+                    ReadParticles<float>(grid_table[grid].count, grid, lev, ParticleFile, finest_level_in_file, convert_ids);
                 } else {
                     amrex::Error("File contains single-precision data, while AMReX is compiled with ParticleReal==double");
                 }
             }
             else if (how == "double") {
                 if constexpr (std::is_same_v<ParticleReal, double>) {
-                    ReadParticles<double>(count[grid], grid, lev, ParticleFile, finest_level_in_file, convert_ids);
+                    ReadParticles<double>(grid_table[grid].count, grid, lev, ParticleFile, finest_level_in_file, convert_ids);
                 } else {
                     amrex::Error("File contains double-precision data, while AMReX is compiled with ParticleReal==float");
                 }


### PR DESCRIPTION
## Summary

Allow `ParticleContainer::Restart` to read files whose particle precision differs from the build's `ParticleReal`, e.g. single-precision plotfiles/checkpoints in a double-precision build:

- `ReadParticles` buffers the real components in `ParticleReal` (converting each value on insertion) instead of the file's precision `RTYPE`, so the host-to-device copies are well-typed for any file precision.
- The real data is read with the descriptor matching the file's precision (`FPC::Native32/64RealDescriptor()`, i.e. what the writing code's `ParticleRealDescriptor` was) instead of this build's - a no-op for matched reads.
- The `amrex::Error` precision-mismatch branches in `Restart` are removed. Reading double data into a single-precision build narrows the values (documented); the reverse is exact.

Stacked on #5577 (includes its commit); will rebase once that merges. Motivation: a general plotfile converter (pyAMReX) must read single-precision particle output with default double-precision Python builds.

## Testing

Matched precision (as in #5577, all pass):

```
ctest --test-dir build -R 'CheckpointRestart' -E 'HDF5|AsyncIO' --output-on-failure
```

Cross precision, verified manually (candidate for a CI fixture, feedback welcome):

1. Built `Tests/Particles/CheckpointRestartSOA` with `-DAMReX_PARTICLES_PRECISION=SINGLE` and wrote a plotfile (`Version_Two_Dot_One_single`, 4096 particles, 12 real + 4 int SoA comps at known constants, 8 grids).
2. Restarted it in a double-precision build with a standalone verifier: particle count matches the header and grid table; positions in range; all non-position real components and all int components reproduced **exactly** (the constants are float-representable).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)