### PR TITLE
Add For overloads with compile time options

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -3055,6 +3055,17 @@ There are other versions of :cpp:`ParallelFor`,
     ParallelFor(box, numcomps,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) { ... });
 
+Note that on CPU :cpp:`ParallelFor` marks the innermost loop with
+``AMREX_PRAGMA_SIMD``, i.e., it promises the compiler that the loop
+iterations are independent of each other.  If the iterations are not
+independent -- for example, when different iterations may update the
+same memory location, as in scatter-style accumulation with
+:cpp:`Gpu::Atomic` operations, which are plain non-atomic updates on
+the host -- use :cpp:`amrex::For` instead.  It provides the same set
+of signatures (including the :cpp:`CompileTimeOptions` variants) and
+is identical to :cpp:`ParallelFor` on GPU, but does not add the SIMD
+pragma on CPU.
+
 Ghost Cells
 ===========
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1148,6 +1148,18 @@ CPU and they should only be used for ``simd``-capable nested loops.
 Calculations that cannot vectorize should be rewritten wherever
 possible to allow efficient utilization of GPU hardware.
 
+For loops whose iterations are *not* independent, AMReX provides
+:cpp:`amrex::For`.  It supports the same set of signatures as
+:cpp:`amrex::ParallelFor` (including the variants taking a
+:cpp:`TypeList` of :cpp:`CompileTimeOptions`) and generates identical
+code on GPU, but omits ``AMREX_PRAGMA_SIMD`` on CPU.  A common case
+requiring :cpp:`amrex::For` is scatter-style accumulation with
+:cpp:`Gpu::Atomic` operations: on the host these compile to plain
+(non-atomic) updates, so different iterations may update the same
+memory location.  Using :cpp:`amrex::ParallelFor` for such a loop
+licenses the compiler to vectorize it anyway, which can silently drop
+updates from vector lanes that touch the same address.
+
 However, it is important for applications to use these launches whenever appropriate
 because they contain optimizations for both CPU and GPU variations of nested
 loops.  For example, on the GPU the spatial coordinate loops are reduced to a single

--- a/Src/Base/AMReX_CTOParallelForImpl.H
+++ b/Src/Base/AMReX_CTOParallelForImpl.H
@@ -396,6 +396,110 @@ void ParallelFor (TypeList<CTOs...> ctos,
     ParallelFor<AMREX_GPU_MAX_THREADS>(ctos, option, box, ncomp, std::forward<F>(f));
 }
 
+template <int MT, std::integral T, class F, typename... CTOs>
+void For (TypeList<CTOs...> ctos,
+          std::array<int,sizeof...(CTOs)> const& runtime_options,
+          T N, F&& f)
+{
+    AnyCTO(ctos, runtime_options,
+        [&](auto cto_func){
+            For<MT>(N, cto_func);
+        },
+        std::forward<F>(f)
+    );
+}
+
+template <int MT, class F, int dim, typename... CTOs>
+void For (TypeList<CTOs...> ctos,
+          std::array<int,sizeof...(CTOs)> const& runtime_options,
+          BoxND<dim> const& box, F&& f)
+{
+    AnyCTO(ctos, runtime_options,
+        [&](auto cto_func){
+            For<MT>(box, cto_func);
+        },
+        std::forward<F>(f)
+    );
+}
+
+template <int MT, std::integral T, class F, int dim, typename... CTOs>
+void For (TypeList<CTOs...> ctos,
+          std::array<int,sizeof...(CTOs)> const& runtime_options,
+          BoxND<dim> const& box, T ncomp, F&& f)
+{
+    AnyCTO(ctos, runtime_options,
+        [&](auto cto_func){
+            For<MT>(box, ncomp, cto_func);
+        },
+        std::forward<F>(f)
+    );
+}
+
+/**
+ * \brief For with compile time optimization of kernels with run time options.
+ *
+ * Like the ParallelFor overload taking a TypeList of CompileTimeOptions, but
+ * without the implied promise that loop iterations are independent.  On CPU,
+ * ParallelFor marks the loop with AMREX_PRAGMA_SIMD, which licenses the
+ * compiler to vectorize across iterations; that is invalid for kernels whose
+ * iterations may touch the same memory location (e.g., particle-to-mesh
+ * scatter with Gpu::Atomic adds, which are plain updates on host).  Use this
+ * overload for such kernels.  On GPU, For and ParallelFor are identical.
+ *
+ * \param ctos   list of all possible values of the parameters.
+ * \param option the run time parameters.
+ * \param N      an integer specifying the 1D for loop's range.
+ * \param f      a callable object taking an integer and working on that iteration.
+ */
+template <std::integral T, class F, typename... CTOs>
+void For (TypeList<CTOs...> ctos,
+          std::array<int,sizeof...(CTOs)> const& option,
+          T N, F&& f)
+{
+    For<AMREX_GPU_MAX_THREADS>(ctos, option, N, std::forward<F>(f));
+}
+
+/**
+ * \brief For with compile time optimization of kernels with run time options.
+ *
+ * Like the ParallelFor overload taking a TypeList of CompileTimeOptions, but
+ * without the SIMD pragma on CPU.  See the 1D-range For overload above for
+ * when this is required.
+ *
+ * \param ctos   list of all possible values of the parameters.
+ * \param option the run time parameters.
+ * \param box    a Box specifying the 3D for loop's range.
+ * \param f      a callable object taking three integers and working on the given cell.
+ */
+template <class F, int dim, typename... CTOs>
+void For (TypeList<CTOs...> ctos,
+          std::array<int,sizeof...(CTOs)> const& option,
+          BoxND<dim> const& box, F&& f)
+{
+    For<AMREX_GPU_MAX_THREADS>(ctos, option, box, std::forward<F>(f));
+}
+
+/**
+ * \brief For with compile time optimization of kernels with run time options.
+ *
+ * Like the ParallelFor overload taking a TypeList of CompileTimeOptions, but
+ * without the SIMD pragma on CPU.  See the 1D-range For overload above for
+ * when this is required.
+ *
+ * \param ctos   list of all possible values of the parameters.
+ * \param option the run time parameters.
+ * \param box    a Box specifying the iteration in 3D space.
+ * \param ncomp  an integer specifying the range for iteration over components.
+ * \param f      a callable object taking four integers and working on the given cell and component.
+ */
+template <std::integral T, class F, int dim, typename... CTOs>
+void For (TypeList<CTOs...> ctos,
+          std::array<int,sizeof...(CTOs)> const& option,
+          BoxND<dim> const& box, T ncomp, F&& f)
+{
+    For<AMREX_GPU_MAX_THREADS>(ctos, option, box, ncomp, std::forward<F>(f));
+}
+
 }
 
 #endif

--- a/Src/Base/AMReX_CTOParallelForImpl.H
+++ b/Src/Base/AMReX_CTOParallelForImpl.H
@@ -441,10 +441,7 @@ void For (TypeList<CTOs...> ctos,
  * Like the ParallelFor overload taking a TypeList of CompileTimeOptions, but
  * without the implied promise that loop iterations are independent.  On CPU,
  * ParallelFor marks the loop with AMREX_PRAGMA_SIMD, which licenses the
- * compiler to vectorize across iterations; that is invalid for kernels whose
- * iterations may touch the same memory location (e.g., particle-to-mesh
- * scatter with Gpu::Atomic adds, which are plain updates on host).  Use this
- * overload for such kernels.  On GPU, For and ParallelFor are identical.
+ * compiler to vectorize across iterations. On GPU, For and ParallelFor are identical.
  *
  * \param ctos   list of all possible values of the parameters.
  * \param option the run time parameters.

--- a/Tests/CTOParFor/main.cpp
+++ b/Tests/CTOParFor/main.cpp
@@ -55,6 +55,76 @@ int main (int argc, char* argv[])
                 AMREX_ALWAYS_ASSERT(s == box.numPts()*(ia*10+ib));
             }
         }
+
+        // Test the For overloads with compile time options. Unlike
+        // ParallelFor, For makes no promise that iterations are independent,
+        // so exercise it with the pattern it exists for: all iterations
+        // accumulate into the same memory location. Gpu::Atomic::AddNoRet
+        // is an atomic update on GPU and a plain += on CPU, which is only
+        // safe because For carries no SIMD pragma.
+        Box accbox(IntVect(0),IntVect(0));
+        IArrayBox accfab(accbox,1);
+        auto const& accarr = accfab.array();
+
+        for (int ia = 0; ia < 2; ++ia) {
+            for (int ib = 0; ib < 3; ++ib) {
+                accfab.setVal<RunOn::Device>(0);
+                For(TypeList<CompileTimeOptions<A0,A1>,
+                             CompileTimeOptions<B0,B1,B2>>{},
+                    {ia, ib},
+                    box, [=] AMREX_GPU_DEVICE (int, int, int,
+                                               auto A_control,
+                                               auto B_control)
+                {
+                    auto const& lacc = accarr;
+                    int a, b;
+                    if constexpr (A_control.value == 0) {
+                        a = 0;
+                    } else {
+                        a = 1;
+                    }
+                    if constexpr (B_control.value == 0) {
+                        b = 0;
+                    } else if constexpr (B_control.value == 1) {
+                        b = 1;
+                    } else {
+                        b = 2;
+                    }
+                    Gpu::Atomic::AddNoRet(&lacc(0,0,0), a*10 + b);
+                });
+
+                auto s = accfab.sum<RunOn::Device>(0);
+                AMREX_ALWAYS_ASSERT(s == box.numPts()*(ia*10+ib));
+
+                accfab.setVal<RunOn::Device>(0);
+                For(TypeList<CompileTimeOptions<A0,A1>,
+                             CompileTimeOptions<B0,B1,B2>>{},
+                    {ia, ib},
+                    box.numPts(), [=] AMREX_GPU_DEVICE (Long,
+                                                        auto A_control,
+                                                        auto B_control)
+                {
+                    auto const& lacc = accarr;
+                    int a, b;
+                    if constexpr (A_control.value == 0) {
+                        a = 0;
+                    } else {
+                        a = 1;
+                    }
+                    if constexpr (B_control.value == 0) {
+                        b = 0;
+                    } else if constexpr (B_control.value == 1) {
+                        b = 1;
+                    } else {
+                        b = 2;
+                    }
+                    Gpu::Atomic::AddNoRet(&lacc(0,0,0), a*10 + b);
+                });
+
+                s = accfab.sum<RunOn::Device>(0);
+                AMREX_ALWAYS_ASSERT(s == box.numPts()*(ia*10+ib));
+            }
+        }
     }
     amrex::Finalize();
 }


### PR DESCRIPTION
## Summary

`ParallelFor` with `CompileTimeOptions` had no `For` counterpart, so kernels with non-independent iterations (e.g., particle-to-mesh scatter through `Gpu::Atomic` adds, which are plain updates on host) had no way to opt out of `AMREX_PRAGMA_SIMD` while keeping the compile-time-option dispatch. Under the pragma (GCC `ivdep`), GCC 15 vectorizes such accumulation loops and silently drops updates from SIMD lanes that hit the same address, observed in the WarpX charge/current deposition:
https://github.com/BLAST-WarpX/warpx/issues/7097

Add the six `For(TypeList<CompileTimeOptions<...>>, ...)` overloads (1D range, Box, Box + ncomp, each with and without the MT template parameter), dispatching via `AnyCTO` to the pragma-free For. On GPU, `For` and `ParallelFor` are identical.

## Additional background

https://github.com/BLAST-WarpX/warpx/issues/7097

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [x] include documentation in the code and/or rst files, if appropriate
