### PR TITLE
TinyProfiler: stdout/stderr keywords for tiny_profiler.output_file

### DIFF
--- a/Docs/sphinx_documentation/source/AMReX_Profiling_Tools.rst
+++ b/Docs/sphinx_documentation/source/AMReX_Profiling_Tools.rst
@@ -93,6 +93,9 @@ it is also recommended to wrap any ``BL_PROFILE_TINY_FLUSH();`` calls in
 informative ``amrex::Print()`` lines to ensure accurate identification of each
 set of timers.
 
+The results can also be redirected, e.g. to a file or to ``stderr``, with the
+runtime parameter ``tiny_profiler.output_file`` (see :ref:`chap:inputs`).
+
 Hot Spots and Load Balance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1605,7 +1605,7 @@ enabled.
    .. versionadded:: 24.09
       Runtime parameter ``tiny_profiler.output_file``.
 
-   .. versionchanged:: 26.08
+   .. versionchanged:: 26.09
       Special names ``stdout`` and ``stderr``; the default value is now
       ``stdout`` (same behavior as the previous default, the empty string).
 

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1600,12 +1600,17 @@ enabled.
 
 .. py:data:: tiny_profiler.output_file
    :type: string
-   :value: [empty]
+   :value: stdout
 
    .. versionadded:: 24.09
       Runtime parameter ``tiny_profiler.output_file``.
 
-   If this parameter is empty, the output of tiny profiling is dumped to the
-   default output stream of AMReX. If it is not empty, it specifies the file
-   name for the output. Note that ``/dev/null`` is a special name that means
-   no output.
+   .. versionchanged:: 26.08
+      Special names ``stdout`` and ``stderr``; the default value is now
+      ``stdout`` (same behavior as the previous default, the empty string).
+
+   This parameter specifies the destination of the tiny profiling output.
+   Note that ``stdout``, ``stderr`` and ``/dev/null`` are special names that
+   mean the default output stream, the default error stream, and no output,
+   respectively. An empty value is treated the same as ``stdout``. Any other
+   value specifies the file name for the output.

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -58,7 +58,7 @@ int TinyProfiler::verbose = 0;
 double TinyProfiler::print_threshold = 1.;
 bool TinyProfiler::enabled = true;
 bool TinyProfiler::memprof_enabled = true;
-std::string TinyProfiler::output_file;
+std::string TinyProfiler::output_file{"stdout"};
 
 namespace {
     constexpr char mainregion[] = "main";
@@ -68,6 +68,35 @@ namespace {
     // cycle. Re-armed in Initialize() so processes that cycle AMReX init/finalize
     // multiple times (e.g. Jupyter notebooks) pick up an updated value each cycle.
     bool output_file_read = false;
+
+    // Output-file values that select a stream (or no output) instead of naming
+    // an actual file
+    bool is_stream_name (std::string const& filename)
+    {
+        return filename.empty() || filename == "stdout" || filename == "stderr"
+            || filename == "/dev/null";
+    }
+
+    // Select the output stream for a profiling report: "" and "stdout" mean the
+    // default out stream of AMReX, "stderr" the default error stream, and
+    // "/dev/null" no output (nullptr). Otherwise, the named file is opened in
+    // append mode.
+    std::ostream* open_output_stream (std::string const& filename, std::ofstream& ofs)
+    {
+        std::ostream* os = nullptr;
+        if (filename.empty() || filename == "stdout") {
+            os = &(amrex::OutStream());
+        } else if (filename == "stderr") {
+            os = &(amrex::ErrorStream());
+        } else if (filename != "/dev/null") {
+            ofs.open(filename, std::ios_base::app);
+            if (!ofs.is_open()) {
+                amrex::Error("TinyProfiler failed to open "+filename);
+            }
+            os = static_cast<std::ostream*>(&ofs);
+        }
+        return os;
+    }
 }
 
 TinyProfiler::TinyProfiler (std::string funcname) noexcept
@@ -334,9 +363,9 @@ TinyProfiler::Initialize ()
 
     // Re-arm the output-file read for this cycle and reset the cached value, so
     // a new tiny_profiler.output_file is picked up across init/finalize cycles
-    // and a cycle that sets nothing falls back to the default out stream.
+    // and a cycle that sets nothing falls back to the default (stdout).
     output_file_read = false;
-    output_file.clear();
+    output_file = "stdout";
 
     if (!enabled) { return; }
 
@@ -399,19 +428,11 @@ TinyProfiler::Finalize (bool bFlushing)
     std::ofstream ofs;
     std::ostream* os = nullptr;
     if (ParallelDescriptor::IOProcessor()) {
-        auto const& ofile = get_output_file();
-        if (ofile.empty()) {
-            os = &(amrex::OutStream());
-        } else if (ofile != "/dev/null") {
-            ofs.open(ofile, std::ios_base::app);
-            if (!ofs.is_open()) {
-                amrex::Error("TinyProfiler failed to open "+ofile);
-            }
-            os = static_cast<std::ostream*>(&ofs);
-        }
+        os = open_output_stream(get_output_file(), ofs);
     }
 
     IOFormatSaver iofmtsaver(amrex::OutStream());
+    IOFormatSaver iofmtsaver_estream(amrex::ErrorStream());
 
     if (os)
     {
@@ -479,16 +500,7 @@ TinyProfiler::MemoryFinalize (bool bFlushing)
     std::ofstream ofs;
     std::ostream* os = nullptr;
     if (ParallelDescriptor::IOProcessor()) {
-        auto const& ofile = get_output_file();
-        if (ofile.empty()) {
-            os = &(amrex::OutStream());
-        } else if (ofile != "/dev/null") {
-            ofs.open(ofile, std::ios_base::app);
-            if (!ofs.is_open()) {
-                amrex::Error("TinyProfiler failed to open "+ofile);
-            }
-            os = static_cast<std::ostream*>(&ofs);
-        }
+        os = open_output_stream(get_output_file(), ofs);
     }
 
     PrintMemoryUsage(os, false);
@@ -1050,10 +1062,8 @@ TinyProfiler::get_output_file ()
         pp.query("output_file", output_file);
 
         if (ParallelDescriptor::IOProcessor()) {
-            if (!output_file.empty() && output_file != "/dev/null") {
-                if (FileSystem::Exists(output_file)) {
-                    FileSystem::Remove(output_file);
-                }
+            if (!is_stream_name(output_file) && FileSystem::Exists(output_file)) {
+                FileSystem::Remove(output_file);
             }
         }
     }


### PR DESCRIPTION
## Summary

Add the special values `stdout` and `stderr` for `tiny_profiler.output_file`, which select the default out stream and the default error stream of AMReX, respectively. An explicit `stdout` value was not expressible before: the empty string served as the default, but `tiny_profiler.output_file=` is rejected by `ParmParse` ("no values for definition"), so users could not spell it out on the command line or in an inputs file.

This came up for applications that redirect the report to a file by default and want a simple way to switch back to the standard output, see the discussion in https://github.com/BLAST-WarpX/warpx/pull/7077.

The default value of the parameter is now the literal `stdout` instead of the empty string, which is self-documenting; the behavior is unchanged and an empty value is still treated the same as `stdout`.

## Additional background

For https://github.com/BLAST-WarpX/warpx/pull/7077 and https://github.com/BLAST-ImpactX/impactx/pull/1566

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
