### PR TITLE
fcompare: fix wrong variable name in "NaN present in B" report

### DIFF
--- a/Tools/Plotfile/fcompare.cpp
+++ b/Tools/Plotfile/fcompare.cpp
@@ -159,8 +159,8 @@ int main_main()
         }
     }
 
-    // also print out, as a diagnostic, those variables in plotfile 1 that
-    // are not in plotfile 2
+    // also print out, as a diagnostic, those variables in plotfile 2 that
+    // are not in plotfile 1
     for (int n_b = 0; n_b < ncomp_b; ++n_b) {
         auto r = std::ranges::find(names_a, names_b[n_b]);
         if (r == std::end(names_a)) {
@@ -319,7 +319,7 @@ int main_main()
                                << "< NaN present in A > "
                                << "\n";
             } else if (has_nan_b[icomp_a]) {
-                amrex::Print() << " " << std::setw(24) << std::left << names_b[icomp_a]
+                amrex::Print() << " " << std::setw(24) << std::left << names_a[icomp_a]
                                << "  " << std::setw(50)
                                << "< NaN present in B > "
                                << "\n";


### PR DESCRIPTION
The per-level report labeled the "< NaN present in B >" row with names_b[icomp_a], indexing the B-side name list with the A-side component number. fcompare matches variables between the two plotfiles by name rather than by position, so that index is correct only when both files happen to store their variables in the same order.

When the orders differ, the row names the wrong variable, misleading the user about which field is contaminated. When plotfile A has more variables than plotfile B and a shared variable at an A-side index
>= ncomp_b carries a NaN in B, the print reads names_b out of bounds; an
optimized build segfaults there.

Use names_a[icomp_a] instead, matching every sibling branch in the same if/else chain. The two are equal by construction: ivar_b is built by looking up names_a[icomp_a] in names_b, so a matched pair always shares a name.

Also fix a comment that described the second name-matching loop backwards. That loop reports variables present in plotfile 2 but absent from plotfile 1, not the other way around, as its own warning text says.
