### PR TITLE
MLTensorOp/MLEBTensorOp: fix scalar bulk viscosity setters

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
@@ -24,8 +24,9 @@ namespace amrex {
 // The user needs to provide `a` by `setACoeffs`, eta by `setShearViscosity`,
 // and kappa by `setBulkViscosity`.  If `setBulkViscosity` is not called,
 // kappa is set to zero.  The user must also call `setEBShearViscosity` to set
-// viscosity on EB.  Optionally, `setEBBulkViscosity` can be used to set
-// bulk viscosity on EB.
+// viscosity on EB, and `setEBBulkViscosity` to set bulk viscosity on EB.
+// `setBulkViscosity` and `setEBBulkViscosity` must either both be called or
+// both be omitted.  Passing a value of zero still counts as calling them.
 //
 // The scalars alpha and beta can be set with `setScalar(Real, Real)`.  If
 // they are not set, their default value is 1.
@@ -135,6 +136,9 @@ public:
     void setEBBulkViscosity (int amrlev, MultiFab const& kappa);
     /**
      * \brief Set EB bulk viscosity to a constant value.
+     *
+     * Passing zero still counts as providing the EB bulk viscosity, so
+     * `setBulkViscosity` must be called as well.
      *
      * \param amrlev AMR level receiving the value.
      * \param kappa  Scalar EB bulk viscosity.

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
@@ -129,10 +129,8 @@ MLEBTensorOp::setEBBulkViscosity (int amrlev, MultiFab const& kappa)
 void
 MLEBTensorOp::setEBBulkViscosity (int amrlev, Real kappa)
 {
-    if (kappa != 0.0) {
-        m_eb_kappa[amrlev][0].setVal(kappa);
-        m_has_eb_kappa = true;
-    }
+    m_eb_kappa[amrlev][0].setVal(kappa);
+    m_has_eb_kappa = true;
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -116,12 +116,10 @@ MLTensorOp::setBulkViscosity (int amrlev, const Array<MultiFab const*,AMREX_SPAC
 void
 MLTensorOp::setBulkViscosity (int amrlev, Real kappa)
 {
-    if (kappa != 0.0) {
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            m_kappa[amrlev][0][idim].setVal(kappa);
-        }
-        m_has_kappa = true;
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        m_kappa[amrlev][0][idim].setVal(kappa);
     }
+    m_has_kappa = true;
 }
 
 void


### PR DESCRIPTION
Skipping setVal for zero kappa left the coefficients uninitialized when zero and nonzero values were mixed across AMR levels, and the asymmetric flag handling made prepareForSolve's m_has_kappa == m_has_eb_kappa assertion unsatisfiable for valid configurations.  Always set both.
