### PR TITLE
Fix tensor operators always reporting needsUpdate

### DIFF
--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -805,6 +805,13 @@ viscous term `divtau` explicitly:
 
    solver.apply(GetVecOfPtrs(divtau), GetVecOfPtrs(vel));
 
+A tensor operator and the :cpp:`MLMG` object built on it may be reused for any
+number of ``solve`` and ``apply`` calls, provided the coefficients are left
+untouched after the first call.  Unlike the other operators, the tensor
+operators do not support updating coefficients in place: calling
+``setShearViscosity``, ``setBulkViscosity``, ``setACoeffs``, or their EB
+counterparts on an operator that has already been used will abort on the next
+call.  Build a new operator when the viscosities change.
 
 Multi-Component Operators
 =========================

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.H
@@ -150,11 +150,21 @@ public:
     [[nodiscard]] bool isCrossStencil () const final { return false; }
     [[nodiscard]] bool isTensorOp () const final { return true; }
 
-    //! True if coefficients/viscosities must be refreshed before apply().
+    /**
+     * \brief True if coefficients have changed since the last prepareForSolve().
+     *
+     * The operator may be reused for any number of solves as long as its
+     * coefficients are left untouched.
+     */
     [[nodiscard]] bool needsUpdate () const final {
         return (m_needs_update || MLEBABecLap::needsUpdate());
     }
-    //! Refresh coefficient averages (not yet implemented).
+    /**
+     * \brief Not implemented for tensor operators.
+     *
+     * Changing viscosity or `a` coefficients after prepareForSolve() is not
+     * supported; build a new operator instead.
+     */
     void update () final {
         amrex::Abort("MLEBTensorOp: update TODO");
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
@@ -90,6 +90,7 @@ MLEBTensorOp::setBulkViscosity (int amrlev, const Array<MultiFab const*,AMREX_SP
         MultiFab::Copy(m_kappa[amrlev][0][idim], *kappa[idim], 0, 0, 1, 0);
     }
     m_has_kappa = true;
+    m_needs_update = true;
 }
 
 void
@@ -99,24 +100,28 @@ MLEBTensorOp::setBulkViscosity (int amrlev, Real kappa)
         m_kappa[amrlev][0][idim].setVal(kappa);
     }
     m_has_kappa = true;
+    m_needs_update = true;
 }
 
 void
 MLEBTensorOp::setEBShearViscosity (int amrlev, MultiFab const& eta)
 {
     MLEBABecLap::setEBHomogDirichlet(amrlev, eta);
+    m_needs_update = true;
 }
 
 void
 MLEBTensorOp::setEBShearViscosity (int amrlev, Real eta)
 {
     MLEBABecLap::setEBHomogDirichlet(amrlev, eta);
+    m_needs_update = true;
 }
 
 void
 MLEBTensorOp::setEBShearViscosityWithInflow (int amrlev, MultiFab const& eta, MultiFab const& eb_vel)
 {
     MLEBABecLap::setEBDirichlet(amrlev, eb_vel, eta);
+    m_needs_update = true;
 }
 
 void
@@ -124,6 +129,7 @@ MLEBTensorOp::setEBBulkViscosity (int amrlev, MultiFab const& kappa)
 {
     MultiFab::Copy(m_eb_kappa[amrlev][0], kappa, 0, 0, 1, 0);
     m_has_eb_kappa = true;
+    m_needs_update = true;
 }
 
 void
@@ -131,6 +137,7 @@ MLEBTensorOp::setEBBulkViscosity (int amrlev, Real kappa)
 {
     m_eb_kappa[amrlev][0].setVal(kappa);
     m_has_eb_kappa = true;
+    m_needs_update = true;
 }
 
 void
@@ -192,6 +199,8 @@ MLEBTensorOp::prepareForSolve ()
     }
 
     MLEBABecLap::prepareForSolve();
+
+    m_needs_update = false;
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.H
@@ -128,11 +128,21 @@ public:
     [[nodiscard]] bool isCrossStencil () const final { return false; }
     [[nodiscard]] bool isTensorOp () const final { return true; }
 
-    //! True if viscosity coefficients need to be rebuilt before apply().
+    /**
+     * \brief True if coefficients have changed since the last prepareForSolve().
+     *
+     * The operator may be reused for any number of solves as long as its
+     * coefficients are left untouched.
+     */
     [[nodiscard]] bool needsUpdate () const final {
         return (m_needs_update || MLABecLaplacian::needsUpdate());
     }
-    //! Rebuild coefficient averages (not yet implemented).
+    /**
+     * \brief Not implemented for tensor operators.
+     *
+     * Changing viscosity or `a` coefficients after prepareForSolve() is not
+     * supported; build a new operator instead.
+     */
     void update () final {
         amrex::Abort("MLTensorOp: update TODO");
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -111,6 +111,7 @@ MLTensorOp::setBulkViscosity (int amrlev, const Array<MultiFab const*,AMREX_SPAC
         MultiFab::Copy(m_kappa[amrlev][0][idim], *kappa[idim], 0, 0, 1, 0);
     }
     m_has_kappa = true;
+    m_needs_update = true;
 }
 
 void
@@ -120,6 +121,7 @@ MLTensorOp::setBulkViscosity (int amrlev, Real kappa)
         m_kappa[amrlev][0][idim].setVal(kappa);
     }
     m_has_kappa = true;
+    m_needs_update = true;
 }
 
 void
@@ -192,6 +194,8 @@ MLTensorOp::prepareForSolve ()
             }
         }
     }
+
+    m_needs_update = false;
 }
 
 void


### PR DESCRIPTION
MLTensorOp and MLEBTensorOp never cleared their own m_needs_update, so needsUpdate() stayed true after prepareForSolve() and MLMG called the unimplemented update(), aborting on any reuse of a prepared linop.

Clear the flag at the end of both prepareForSolve(), and set it in the bulk-viscosity setters so changed kappa is still detected (the shear setters already flag via the ABecLaplacian base). Document that tensor operators are reusable only while their coefficients are untouched.
