### PR TITLE
FabArray: Enable prefetch on non-CUDA GPU backends

### DIFF
--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -541,7 +541,9 @@ public:
     void prefetchToHost (const MFIter& mfi) const noexcept
     requires (BaseFabType<FAB>)
     {
-#ifdef AMREX_USE_CUDA
+        // BaseFab::prefetchToHost() does the managed-memory check and the
+        // per-backend dispatch, so guard only against non-GPU builds here.
+#ifdef AMREX_USE_GPU
         this->fabPtr(mfi)->prefetchToHost();
 #else
         amrex::ignore_unused(mfi);
@@ -551,7 +553,9 @@ public:
     void prefetchToDevice (const MFIter& mfi) const noexcept
     requires (BaseFabType<FAB>)
     {
-#ifdef AMREX_USE_CUDA
+        // BaseFab::prefetchToDevice() does the managed-memory check and the
+        // per-backend dispatch, so guard only against non-GPU builds here.
+#ifdef AMREX_USE_GPU
         this->fabPtr(mfi)->prefetchToDevice();
 #else
         amrex::ignore_unused(mfi);


### PR DESCRIPTION
FabArray::prefetchToHost and FabArray::prefetchToDevice were guarded by AMREX_USE_CUDA, so they compiled to nothing on SYCL and HIP builds. BaseFab::prefetchToDevice already has a working SYCL implementation, which was therefore unreachable through FabArray.

Both BaseFab functions do their own managed-memory check and per-backend dispatch, so the FabArray wrappers only need to exclude non-GPU builds. This also makes them consistent with the free functions amrex::prefetchToHost/prefetchToDevice in AMReX_FabArrayUtility.H and with the direct BaseFab calls in AMReX_EB2_Level.H, both already guarded by AMREX_USE_GPU.

CUDA and non-GPU builds are unaffected.  On HIP, and for prefetchToHost on SYCL, BaseFab is still a no-op pending backend support, so FabArray will pick those up automatically once they land.
