### PR TITLE
CI: use built-in `gh cache` instead of the gh-actions-cache extension

### DIFF
--- a/.github/workflows/cleanup-cache-postpr.yml
+++ b/.github/workflows/cleanup-cache-postpr.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v7
       - name: Clean up ccache
         run: |
-          gh extension install actions/gh-actions-cache
-
           REPO=${{ github.repository }}
 
           # For debugging cat ${GITHUB_EVENT_PATH} to see the payload.
@@ -33,11 +31,10 @@ jobs:
           # Setting this to not fail the workflow while deleting cache keys.
           set +e
 
-          keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH | cut -f 1)
-          # $keys might contain spaces. Thus we set IFS to \n.
-          IFS=$'\n'
-          for k in $keys
+          # Note that `gh cache delete` has no ref filter, so we delete by
+          # cache id, not by key.
+          ids=$(gh cache list -L 100 -R $REPO --ref $BRANCH --json id --jq '.[].id')
+          for i in $ids
           do
-            gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
+            gh cache delete "$i" -R $REPO
           done
-          unset IFS

--- a/.github/workflows/cleanup-cache-postpr.yml
+++ b/.github/workflows/cleanup-cache-postpr.yml
@@ -36,5 +36,7 @@ jobs:
           ids=$(gh cache list -L 100 -R $REPO --ref $BRANCH --json id --jq '.[].id')
           for i in $ids
           do
-            gh cache delete "$i" -R $REPO
+            # `|| true` so that a failed deletion does not fail the step: the
+            # step's exit status is that of the last command run.
+            gh cache delete "$i" -R $REPO || true
           done

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -60,7 +60,7 @@ jobs:
             old_ids=$(gh cache list -L 100 -R $REPO --ref $BRANCH --key "${j}-git-" --sort last_accessed_at --order desc --json id --jq '.[].id' | tail -n +2)
             for i in $old_ids
             do
-              gh cache delete "$i" -R $REPO
+              gh cache delete "$i" -R $REPO || true
             done
           done
           unset IFS

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -2,7 +2,7 @@ name: CleanUpCache
 
 on:
   workflow_run:
-    workflows: [bittree, LinuxClang, cuda, LinuxGcc, hip, Hypre, intel, macos, PETSc, SUNDIALS, CodeQL, smoke, apps]
+    workflows: [bittree, LinuxClang, cuda, LinuxGCC, hip, Hypre, intel, macos, PETSc, SUNDIALS, CodeQL, smoke, apps]
     types:
       - completed
 
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v7
       - name: Clean up ccache
         run: |
-          gh extension install actions/gh-actions-cache
-
           REPO=${{ github.repository }}
 
           # push or pull_request or schedule or ...
@@ -50,18 +48,19 @@ jobs:
           # something like ccache-LinuxClang-
           keyprefix="ccache-${WORKFLOW_NAME}-"
 
-          cached_jobs=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "$keyprefix" | awk -F '-git-' '{print $1}' | sort | uniq)
+          cached_jobs=$(gh cache list -L 100 -R $REPO --ref $BRANCH --key "$keyprefix" --json key --jq '.[].key' | awk -F '-git-' '{print $1}' | sort | uniq)
 
           # cached_jobs is something like "ccache-LinuxClang-configure-1d ccache-LinuxClang-configure-2d".
           # It might also contain spaces. Thus we set IFS to \n.
           IFS=$'\n'
           for j in $cached_jobs
           do
-            # Delete all entries except the last used one
-            old_keys=$(gh actions-cache list -L 100 -R $REPO -B $BRANCH --key "${j}-git-" --sort last-used | cut -f 1 | tail -n +2)
-            for k in $old_keys
+            # Delete all entries except the last used one. Note that `gh cache
+            # delete` has no ref filter, so we delete by cache id, not by key.
+            old_ids=$(gh cache list -L 100 -R $REPO --ref $BRANCH --key "${j}-git-" --sort last_accessed_at --order desc --json id --jq '.[].id' | tail -n +2)
+            for i in $old_ids
             do
-              gh actions-cache delete "$k" -R $REPO -B $BRANCH --confirm
+              gh cache delete "$i" -R $REPO
             done
           done
           unset IFS


### PR DESCRIPTION
The actions/gh-actions-cache extension is now part of the gh CLI itself, so drop the `gh extension install` steps and switch to `gh cache list` and `gh cache delete`.

Flag mapping:
  - `gh actions-cache list -B <ref>`   -> `gh cache list --ref <ref>`
  - `--sort last-used`                 -> `--sort last_accessed_at --order desc`
  - `gh actions-cache delete <key> -B <ref> --confirm` -> `gh cache delete <id>`

Two behavioral notes. First, `gh cache delete` has no ref filter, so we select and delete by cache id rather than by key to avoid deleting a same-named cache on another ref. Second, the two tools lay out their table output differently (the built-in leads with an ID column), so the `cut -f 1` parsing is replaced by `--json`/`--jq`, which does not depend on column position.

Also fix the `workflow_run` trigger list, which spelled the LinuxGCC workflow as "LinuxGcc". Matching there is case-insensitive so the trigger did fire, but the name now matches gcc.yml exactly.
