### PR TITLE
SYCL: use platform default context

### DIFF
--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1686,8 +1686,13 @@ it is reset, at which point AMReX restores the previous external stream.
   :cpp:`The_Async_Arena` are still pending, in which case AMReX forces a
   synchronization to keep the arena safe.  The external stream or queue must
   belong to the active AMReX device.  For SYCL, the queue must also use the
-  same SYCL context as AMReX and must be an in-order queue.  AMReX selects the
-  active GPU during :cpp:`amrex::Initialize`, whose overloads accept an
+  same SYCL context as AMReX and must be an in-order queue.  When supported by
+  the SYCL implementation, AMReX uses the selected device platform's default
+  context.  That context can contain several devices, but each MPI rank's
+  AMReX queues still target only the GPU selected for that rank.  This also
+  makes an in-order queue created for that device with the platform default
+  context compatible with AMReX.  AMReX selects the active GPU during
+  :cpp:`amrex::Initialize`, whose overloads accept an
   optional trailing :cpp:`int device_id` argument; pass the desired GPU there
   if an external runtime needs AMReX to adopt a specific device before the
   stream is created.  Conversely, if AMReX should drive the selection, query

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -1686,13 +1686,9 @@ it is reset, at which point AMReX restores the previous external stream.
   :cpp:`The_Async_Arena` are still pending, in which case AMReX forces a
   synchronization to keep the arena safe.  The external stream or queue must
   belong to the active AMReX device.  For SYCL, the queue must also use the
-  same SYCL context as AMReX and must be an in-order queue.  When supported by
-  the SYCL implementation, AMReX uses the selected device platform's default
-  context.  That context can contain several devices, but each MPI rank's
-  AMReX queues still target only the GPU selected for that rank.  This also
-  makes an in-order queue created for that device with the platform default
-  context compatible with AMReX.  AMReX selects the active GPU during
-  :cpp:`amrex::Initialize`, whose overloads accept an
+  same SYCL context as AMReX and must be an in-order queue.  AMReX
+  selects an active GPU during :cpp:`amrex::Initialize` from the device
+  platform's default context, whose overloads accept an
   optional trailing :cpp:`int device_id` argument; pass the desired GPU there
   if an external runtime needs AMReX to adopt a specific device before the
   stream is created.  Conversely, if AMReX should drive the selection, query

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -556,8 +556,6 @@ Device::initialize_gpu (bool minimal)
         sycl_device = std::make_unique<sycl::device>(gpu_devices[device_id]);
 #if defined(SYCL_KHR_DEFAULT_CONTEXT)
         sycl_context = std::make_unique<sycl::context>(platform.khr_get_default_context());
-#elif defined(SYCL_EXT_ONEAPI_DEFAULT_CONTEXT)
-        sycl_context = std::make_unique<sycl::context>(platform.ext_oneapi_get_default_context());
 #else
         sycl_context = std::make_unique<sycl::context>(*sycl_device, amrex_sycl_error_handler);
 #endif

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -554,9 +554,16 @@ Device::initialize_gpu (bool minimal)
         sycl::platform platform(sycl::gpu_selector_v);
         auto const& gpu_devices = platform.get_devices();
         sycl_device = std::make_unique<sycl::device>(gpu_devices[device_id]);
+#if defined(SYCL_KHR_DEFAULT_CONTEXT)
+        sycl_context = std::make_unique<sycl::context>(platform.khr_get_default_context());
+#elif defined(SYCL_EXT_ONEAPI_DEFAULT_CONTEXT)
+        sycl_context = std::make_unique<sycl::context>(platform.ext_oneapi_get_default_context());
+#else
         sycl_context = std::make_unique<sycl::context>(*sycl_device, amrex_sycl_error_handler);
+#endif
         for (int i = 0; i < max_gpu_streams; ++i) {
             gpu_stream_pool[i].getStream().queue = new sycl::queue(*sycl_context, *sycl_device,
+                                         amrex_sycl_error_handler,
                                          sycl::property_list{sycl::property::queue::in_order{}});
         }
     }


### PR DESCRIPTION
## Summary

Use the KHR platform default context when available, with the legacy oneAPI extension and private context as fallbacks. Keep AMReX's asynchronous error handler on its queues.

The initialization API and rank-to-GPU mapping are unchanged: every queue still targets the GPU selected for that MPI rank. Sharing the default context enables interoperability with other SYCL libraries.

## Additional background

Close #5593

After merge, we need to merge https://github.com/AMReX-Codes/pyamrex/pull/606

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
