### PR TITLE
Fix duplicate public attribute bug in Fortran interface

### DIFF
--- a/Src/F_Interfaces/AmrCore/AMReX_fillpatch_mod.F90
+++ b/Src/F_Interfaces/AmrCore/AMReX_fillpatch_mod.F90
@@ -22,7 +22,7 @@ module amrex_fillpatch_module
      module procedure amrex_fillcoarsepatch_faces
   end interface amrex_fillcoarsepatch
 
-  type, public :: amrex_fillpatcher
+  type :: amrex_fillpatcher
      logical     :: owner = .false.
      type(c_ptr) :: p = c_null_ptr
      integer     :: nghost = 0


### PR DESCRIPTION
## Summary
I tried to build AMReX and its Fortran Interface with `v22.1.3` of LLVM Flang and encountered a compile time error because of a duplicate public attribute in `Src/F_Interfaces/AmrCore/AMReX_fillpatch_mod`. This requires only a very minor change to fix and then LLVM Flang can build AMReX and its Fortran interface.

Fixes #5603.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
