### PR TITLE
Optimize STL BVH traversal

### DIFF
--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -950,8 +950,7 @@ STLtools::getBoxType (Box const& box, Geometry const& geom, RunOn) const
         } else {
             return classify_on_cpu(std::false_type{});
         }
-#endif
-
+#else
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<int> reduce_data(reduce_op);
         using ReduceTuple = typename decltype(reduce_data)::Type;
@@ -1015,6 +1014,7 @@ STLtools::getBoxType (Box const& box, Geometry const& geom, RunOn) const
         } else {
             return mixedcells;
         }
+#endif
     }
 }
 

--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_Stack.H>
 
 #include <cstring>
+#include <type_traits>
 
 // Reference for BVH: https://rmrsk.github.io/EBGeometry/Concepts.html#bounding-volume-hierarchies
 
@@ -110,42 +111,30 @@ namespace {
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool line_box_intersects (Real const a[3], Real const b[3], RealBox const& box)
+    bool line_box_intersects (Real const a[3], Real const inv_direction[3],
+                              int parallel_direction_mask, RealBox const& box)
     {
+        Real tmin = 0.0_rt;
+        Real tmax = 1.0_rt;
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            if ((a[idim] < box.lo(idim) && b[idim] < box.lo(idim)) ||
-                (a[idim] > box.hi(idim) && b[idim] > box.hi(idim))) {
-                return false;
-            }
-        }
-        if (box.contains(a) || box.contains(b)) {
-            return true;
-        }
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            // Note that we have made bounding box slightly bigger. So it's
-            // safe to assume that a line in the plane does not intersect
-            // with the actual bounding box.
-            if (a[idim] == b[idim]) { continue; }
-            Real xi[] = {box.lo(idim), box.hi(idim)};
-            for (auto xface : xi) {
-                if (!((a[idim] > xface && b[idim] > xface) ||
-                      (a[idim] < xface && b[idim] < xface)))
-                {
-                    Real w = (xface-a[idim]) / (b[idim]-a[idim]);
-                    bool inside = true;
-                    for (int jdim = 0; jdim < AMREX_SPACEDIM; ++jdim) {
-                        if (idim != jdim) {
-                            Real xpt = a[jdim] + (b[jdim]-a[jdim]) * w;
-                            inside = inside && (xpt >= box.lo(jdim)
-                                            &&  xpt <= box.hi(jdim));
-                        }
-                    }
-                    if (inside) { return true; }
+            if ((parallel_direction_mask & (1 << idim)) != 0) {
+                if (a[idim] < box.lo(idim) || a[idim] > box.hi(idim)) {
+                    return false;
+                }
+            } else {
+                Real tlo = (box.lo(idim)-a[idim]) * inv_direction[idim];
+                Real thi = (box.hi(idim)-a[idim]) * inv_direction[idim];
+                if (tlo > thi) {
+                    amrex::Swap(tlo,thi);
+                }
+                tmin = amrex::max(tmin,tlo);
+                tmax = amrex::min(tmax,thi);
+                if (tmin > tmax) {
+                    return false;
                 }
             }
         }
-
-        return false;
+        return true;
     }
 
     template <int M, int N, typename F>
@@ -154,11 +143,25 @@ namespace {
                                   STLtools::BVHNodeT<M,N> const* root,
                                   F const& f)
     {
+        // Reuse these reciprocals for every bounding box visited by this ray.
+        Real inv_direction[AMREX_SPACEDIM];
+        int parallel_direction_mask = 0;
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            Real const direction = b[idim] - a[idim];
+            if (direction == 0.0_rt) {
+                parallel_direction_mask |= (1 << idim);
+                inv_direction[idim] = 0.0_rt;
+            } else {
+                inv_direction[idim] = 1.0_rt / direction;
+            }
+        }
+
         // Use stack to avoid recursion
         Stack<int, STLtools::m_bvh_max_stack_size> nodes_to_do;
         Stack<std::int8_t, STLtools::m_bvh_max_stack_size> nchildren_done;
 
-        if (line_box_intersects(a, b, root->boundingbox)) {
+        if (line_box_intersects(a, inv_direction, parallel_direction_mask,
+                                root->boundingbox)) {
             nodes_to_do.push(0);
             nchildren_done.push(0);
         }
@@ -176,7 +179,8 @@ namespace {
                     for (auto ichild = ndone; ichild < node.nchildren; ++ichild) {
                         ++ndone;
                         int inode = node.children[ichild];
-                        if (line_box_intersects(a, b, root[inode].boundingbox)) {
+                        if (line_box_intersects(a, inv_direction, parallel_direction_mask,
+                                                root[inode].boundingbox)) {
                             nodes_to_do.push(inode);
                             nchildren_done.push(0);
                             break;
@@ -250,119 +254,21 @@ namespace {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     Real pt_box_min_d2 (XDim3 const& pt, RealBox const& bbox)
     {
-        bool inside_x = (pt.x >= bbox.lo(0)) && (pt.x <= bbox.hi(0));
-        bool inside_y = (pt.y >= bbox.lo(1)) && (pt.y <= bbox.hi(1));
-        bool inside_z = (pt.z >= bbox.lo(2)) && (pt.z <= bbox.hi(2));
-        if (inside_x && inside_y && inside_z) {
-            return Real(0);
-        } else if (inside_x && inside_y) {
-            if (pt.z < bbox.lo(2)) {
-                return Math::powi<2>(pt.z-bbox.lo(2));
-            } else {
-                return Math::powi<2>(pt.z-bbox.hi(2));
-            }
-        } else if (inside_x && inside_z) {
-            if (pt.y < bbox.lo(1)) {
-                return Math::powi<2>(pt.y-bbox.lo(1));
-            } else {
-                return Math::powi<2>(pt.y-bbox.hi(1));
-            }
-        } else if (inside_y && inside_z) {
-            if (pt.x < bbox.lo(0)) {
-                return Math::powi<2>(pt.x-bbox.lo(0));
-            } else {
-                return Math::powi<2>(pt.x-bbox.hi(0));
-            }
-        } else if (inside_x) {
-            if ((pt.y < bbox.lo(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.y < bbox.lo(1)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else if ((pt.y > bbox.hi(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else {
-                return Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            }
-        } else if (inside_y) {
-            if ((pt.x < bbox.lo(0)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x < bbox.lo(0)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else if ((pt.x > bbox.hi(0)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            }
-        } else if (inside_z) {
-            if ((pt.x < bbox.lo(0)) && (pt.y < bbox.lo(1))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1));
-            } else if ((pt.x < bbox.lo(0)) && (pt.y > bbox.hi(1))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1));
-
-            } else if ((pt.x > bbox.hi(0)) && (pt.y < bbox.lo(1))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1));
-
-            } else {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1));
-
-            }
-        } else {
-            if ((pt.x < bbox.lo(0)) && (pt.y < bbox.lo(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x > bbox.hi(0)) && (pt.y < bbox.lo(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x < bbox.lo(0)) && (pt.y > bbox.hi(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x > bbox.hi(0)) && (pt.y > bbox.hi(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x < bbox.lo(0)) && (pt.y < bbox.lo(1)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else if ((pt.x > bbox.hi(0)) && (pt.y < bbox.lo(1)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else if ((pt.x < bbox.lo(0)) && (pt.y > bbox.hi(1)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            }
-        }
+        Real const dx = amrex::max(bbox.lo(0)-pt.x, Real(0), pt.x-bbox.hi(0));
+        Real const dy = amrex::max(bbox.lo(1)-pt.y, Real(0), pt.y-bbox.hi(1));
+        Real const dz = amrex::max(bbox.lo(2)-pt.z, Real(0), pt.z-bbox.hi(2));
+        return dx*dx + dy*dy + dz*dz;
     }
 
     template <int M, int N>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     Real bvh_d2 (XDim3 const& pt, STLtools::BVHNodeT<M,N> const* root)
     {
+        static_assert(N <= std::numeric_limits<std::uint8_t>::digits);
         Stack<int, STLtools::m_bvh_max_stack_size> nodes_to_do;
-        Stack<std::int8_t, STLtools::m_bvh_max_stack_size> nchildren_done;
+        Stack<std::uint8_t, STLtools::m_bvh_max_stack_size> children_done;
         nodes_to_do.push(0);
-        nchildren_done.push(0);
+        children_done.push(0);
 
         Real d = std::numeric_limits<Real>::max();
 
@@ -375,23 +281,49 @@ namespace {
                     if (d == 0) { return 0; }
                 }
                 nodes_to_do.pop();
-                nchildren_done.pop();
+                children_done.pop();
             } else {
-                auto& ndone = nchildren_done.top();
-                if (ndone < node.nchildren) {
-                    for (auto ichild = ndone; ichild < node.nchildren; ++ichild) {
-                        ++ndone;
+                auto& done = children_done.top();
+                if (done == 0) {
+                    // Visit the nearest child first to tighten d before testing
+                    // the remaining children against their lower bounds.
+                    Real closest_d2 = std::numeric_limits<Real>::max();
+                    std::int8_t closest_child = 0;
+                    for (std::int8_t ichild = 0; ichild < node.nchildren; ++ichild) {
+                        auto const child_d2 = pt_box_min_d2(
+                            pt, root[node.children[ichild]].boundingbox);
+                        if (child_d2 < closest_d2) {
+                            closest_d2 = child_d2;
+                            closest_child = ichild;
+                        }
+                    }
+                    if (d > closest_d2) {
+                        done |= static_cast<std::uint8_t>(1 << closest_child);
+                        nodes_to_do.push(node.children[closest_child]);
+                        children_done.push(0);
+                    } else {
+                        nodes_to_do.pop();
+                        children_done.pop();
+                    }
+                } else {
+                    bool child_added = false;
+                    for (std::int8_t ichild = 0; ichild < node.nchildren; ++ichild) {
+                        auto const child_bit = static_cast<std::uint8_t>(1 << ichild);
+                        if ((done & child_bit) != 0) { continue; }
+                        done |= child_bit;
                         int inode = node.children[ichild];
                         auto dmin = pt_box_min_d2(pt, root[inode].boundingbox);
                         if (d > dmin) {
                             nodes_to_do.push(inode);
-                            nchildren_done.push(0);
+                            children_done.push(0);
+                            child_added = true;
                             break;
                         }
                     }
-                } else {
-                    nodes_to_do.pop();
-                    nchildren_done.pop();
+                    if (!child_added) {
+                        nodes_to_do.pop();
+                        children_done.pop();
+                    }
                 }
             }
         }
@@ -951,6 +883,74 @@ STLtools::getBoxType (Box const& box, Geometry const& geom, RunOn) const
         int ref_value = m_boundry_is_outside ? 1 : 0;
 
         auto const* bvh_root = m_bvh_nodes.data();
+
+#ifndef AMREX_USE_GPU
+        // Unlike the device reduction, the serial host path can stop as soon
+        // as it sees both signs.
+        auto classify_on_cpu = [&] (auto use_bvh) -> int
+        {
+            int first_value = -1;
+            if (blo.x < ptmin.x || blo.y < ptmin.y || blo.z < ptmin.z ||
+                bhi.x > ptmax.x || bhi.y > ptmax.y || bhi.z > ptmax.z)
+            {
+                first_value = ref_value;
+            }
+
+            const Dim3 lo = amrex::lbound(box);
+            const Dim3 hi = amrex::ubound(box);
+            for (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+            for (int i = lo.x; i <= hi.x; ++i) {
+                Real coords[3];
+                coords[0]=plo[0]+static_cast<Real>(i)*dx[0];
+                coords[1]=plo[1]+static_cast<Real>(j)*dx[1];
+#if (AMREX_SPACEDIM == 2)
+                amrex::ignore_unused(k);
+                coords[2]=Real(0.);
+#else
+                coords[2]=plo[2]+static_cast<Real>(k)*dx[2];
+#endif
+                if (coords[0] < ptmin.x || coords[0] > ptmax.x ||
+                    coords[1] < ptmin.y || coords[1] > ptmax.y ||
+                    coords[2] < ptmin.z || coords[2] > ptmax.z)
+                {
+                    continue;
+                }
+
+                Real pr[] = {ptref.x, ptref.y, ptref.z};
+                int num_intersects = 0;
+                if constexpr (decltype(use_bvh)::value) {
+                    bvh_line_tri_intersects(pr, coords, bvh_root,
+                                            [&] (int ntri, Triangle const* tri,
+                                                    XDim3 const*) -> int
+                    {
+                        for (int tr = 0; tr < ntri; ++tr) {
+                            num_intersects += line_tri_intersects(pr, coords, tri[tr]);
+                        }
+                        return 0;
+                    });
+                } else {
+                    for (int tr = 0; tr < num_triangles; ++tr) {
+                        num_intersects += line_tri_intersects(pr, coords, tri_pts[tr]);
+                    }
+                }
+
+                int const value = (num_intersects % 2 == 0) ? ref_value : 1-ref_value;
+                if (first_value < 0) {
+                    first_value = value;
+                } else if (value != first_value) {
+                    return mixedcells;
+                }
+            }}}
+            return first_value == 1 ? allregular : allcovered;
+        };
+
+        if (m_bvh_optimization) {
+            return classify_on_cpu(std::true_type{});
+        } else {
+            return classify_on_cpu(std::false_type{});
+        }
+#endif
 
         ReduceOps<ReduceOpSum> reduce_op;
         ReduceData<int> reduce_data(reduce_op);


### PR DESCRIPTION
## Summary
  - Using a slab-based ray-box intersection test with reused inverse ray directions.
  - Simplifying point-to-box distance calculations and visiting nearer BVH children first.
  - Allowing the CPU `getBoxType` path to stop once both covered and regular points are found.

## Additional background

For a representative `(128^3)` Stanford bunny case, these changes reduced `STLtools::getBoxType` from about 1.87 s to 0.003 s and reduced build time from about 5.50 s to 3.81s. Results remained unchanged.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
