### PR TITLE
Optimize STL BVH distance traversal

### DIFF
--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -260,9 +260,9 @@ namespace {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     Real bvh_d2 (XDim3 const& pt, STLtools::BVHNodeT<M,N> const* root)
     {
-        static_assert(N <= std::numeric_limits<std::int8_t>::digits);
+        static_assert(N <= std::numeric_limits<std::uint8_t>::digits);
         Stack<int, STLtools::m_bvh_max_stack_size> nodes_to_do;
-        Stack<std::int8_t, STLtools::m_bvh_max_stack_size> nchildren_done;
+        Stack<std::uint8_t, STLtools::m_bvh_max_stack_size> nchildren_done;
         nodes_to_do.push(0);
         nchildren_done.push(0);
 
@@ -294,7 +294,7 @@ namespace {
                         }
                     }
                     if (d > closest_d2) {
-                        ndone |= static_cast<std::int8_t>(1 << closest_child);
+                        ndone = static_cast<std::uint8_t>(ndone | (1u << closest_child));
                         nodes_to_do.push(node.children[closest_child]);
                         nchildren_done.push(0);
                     } else {
@@ -304,9 +304,9 @@ namespace {
                 } else {
                     bool child_added = false;
                     for (std::int8_t ichild = 0; ichild < node.nchildren; ++ichild) {
-                        auto const child_bit = static_cast<std::int8_t>(1 << ichild);
+                        auto const child_bit = static_cast<std::uint8_t>(1u << ichild);
                         if ((ndone & child_bit) != 0) { continue; }
-                        ndone |= child_bit;
+                        ndone = static_cast<std::uint8_t>(ndone | child_bit);
                         int inode = node.children[ichild];
                         auto dmin = pt_box_min_d2(pt, root[inode].boundingbox);
                         if (d > dmin) {

--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -294,7 +294,7 @@ namespace {
                         }
                     }
                     if (d > closest_d2) {
-                        ndone = static_cast<std::uint8_t>(ndone | (1u << closest_child));
+                        ndone = static_cast<std::uint8_t>(ndone | (1 << closest_child));
                         nodes_to_do.push(node.children[closest_child]);
                         nchildren_done.push(0);
                     } else {
@@ -304,7 +304,7 @@ namespace {
                 } else {
                     bool child_added = false;
                     for (std::int8_t ichild = 0; ichild < node.nchildren; ++ichild) {
-                        auto const child_bit = static_cast<std::uint8_t>(1u << ichild);
+                        auto const child_bit = static_cast<std::uint8_t>(1 << ichild);
                         if ((ndone & child_bit) != 0) { continue; }
                         ndone = static_cast<std::uint8_t>(ndone | child_bit);
                         int inode = node.children[ichild];

--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -250,115 +250,17 @@ namespace {
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     Real pt_box_min_d2 (XDim3 const& pt, RealBox const& bbox)
     {
-        bool inside_x = (pt.x >= bbox.lo(0)) && (pt.x <= bbox.hi(0));
-        bool inside_y = (pt.y >= bbox.lo(1)) && (pt.y <= bbox.hi(1));
-        bool inside_z = (pt.z >= bbox.lo(2)) && (pt.z <= bbox.hi(2));
-        if (inside_x && inside_y && inside_z) {
-            return Real(0);
-        } else if (inside_x && inside_y) {
-            if (pt.z < bbox.lo(2)) {
-                return Math::powi<2>(pt.z-bbox.lo(2));
-            } else {
-                return Math::powi<2>(pt.z-bbox.hi(2));
-            }
-        } else if (inside_x && inside_z) {
-            if (pt.y < bbox.lo(1)) {
-                return Math::powi<2>(pt.y-bbox.lo(1));
-            } else {
-                return Math::powi<2>(pt.y-bbox.hi(1));
-            }
-        } else if (inside_y && inside_z) {
-            if (pt.x < bbox.lo(0)) {
-                return Math::powi<2>(pt.x-bbox.lo(0));
-            } else {
-                return Math::powi<2>(pt.x-bbox.hi(0));
-            }
-        } else if (inside_x) {
-            if ((pt.y < bbox.lo(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.y < bbox.lo(1)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else if ((pt.y > bbox.hi(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else {
-                return Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            }
-        } else if (inside_y) {
-            if ((pt.x < bbox.lo(0)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x < bbox.lo(0)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else if ((pt.x > bbox.hi(0)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            }
-        } else if (inside_z) {
-            if ((pt.x < bbox.lo(0)) && (pt.y < bbox.lo(1))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1));
-            } else if ((pt.x < bbox.lo(0)) && (pt.y > bbox.hi(1))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1));
-
-            } else if ((pt.x > bbox.hi(0)) && (pt.y < bbox.lo(1))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1));
-
-            } else {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1));
-
-            }
-        } else {
-            if ((pt.x < bbox.lo(0)) && (pt.y < bbox.lo(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x > bbox.hi(0)) && (pt.y < bbox.lo(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x < bbox.lo(0)) && (pt.y > bbox.hi(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x > bbox.hi(0)) && (pt.y > bbox.hi(1)) && (pt.z < bbox.lo(2))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.lo(2));
-            } else if ((pt.x < bbox.lo(0)) && (pt.y < bbox.lo(1)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else if ((pt.x > bbox.hi(0)) && (pt.y < bbox.lo(1)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.lo(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else if ((pt.x < bbox.lo(0)) && (pt.y > bbox.hi(1)) && (pt.z > bbox.hi(2))) {
-                return Math::powi<2>(pt.x-bbox.lo(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            } else {
-                return Math::powi<2>(pt.x-bbox.hi(0))
-                    +  Math::powi<2>(pt.y-bbox.hi(1))
-                    +  Math::powi<2>(pt.z-bbox.hi(2));
-            }
-        }
+        Real const dx = amrex::max(bbox.lo(0)-pt.x, Real(0), pt.x-bbox.hi(0));
+        Real const dy = amrex::max(bbox.lo(1)-pt.y, Real(0), pt.y-bbox.hi(1));
+        Real const dz = amrex::max(bbox.lo(2)-pt.z, Real(0), pt.z-bbox.hi(2));
+        return dx*dx + dy*dy + dz*dz;
     }
 
     template <int M, int N>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     Real bvh_d2 (XDim3 const& pt, STLtools::BVHNodeT<M,N> const* root)
     {
+        static_assert(N <= std::numeric_limits<std::int8_t>::digits);
         Stack<int, STLtools::m_bvh_max_stack_size> nodes_to_do;
         Stack<std::int8_t, STLtools::m_bvh_max_stack_size> nchildren_done;
         nodes_to_do.push(0);
@@ -378,20 +280,46 @@ namespace {
                 nchildren_done.pop();
             } else {
                 auto& ndone = nchildren_done.top();
-                if (ndone < node.nchildren) {
-                    for (auto ichild = ndone; ichild < node.nchildren; ++ichild) {
-                        ++ndone;
+                if (ndone == 0) {
+                    // Visit the nearest child first to tighten d before testing
+                    // the remaining children against their lower bounds.
+                    Real closest_d2 = std::numeric_limits<Real>::max();
+                    std::int8_t closest_child = 0;
+                    for (std::int8_t ichild = 0; ichild < node.nchildren; ++ichild) {
+                        auto const child_d2 = pt_box_min_d2(
+                            pt, root[node.children[ichild]].boundingbox);
+                        if (child_d2 < closest_d2) {
+                            closest_d2 = child_d2;
+                            closest_child = ichild;
+                        }
+                    }
+                    if (d > closest_d2) {
+                        ndone |= static_cast<std::int8_t>(1 << closest_child);
+                        nodes_to_do.push(node.children[closest_child]);
+                        nchildren_done.push(0);
+                    } else {
+                        nodes_to_do.pop();
+                        nchildren_done.pop();
+                    }
+                } else {
+                    bool child_added = false;
+                    for (std::int8_t ichild = 0; ichild < node.nchildren; ++ichild) {
+                        auto const child_bit = static_cast<std::int8_t>(1 << ichild);
+                        if ((ndone & child_bit) != 0) { continue; }
+                        ndone |= child_bit;
                         int inode = node.children[ichild];
                         auto dmin = pt_box_min_d2(pt, root[inode].boundingbox);
                         if (d > dmin) {
                             nodes_to_do.push(inode);
                             nchildren_done.push(0);
+                            child_added = true;
                             break;
                         }
                     }
-                } else {
-                    nodes_to_do.pop();
-                    nchildren_done.pop();
+                    if (!child_added) {
+                        nodes_to_do.pop();
+                        nchildren_done.pop();
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Simplify the calculation of the squared minimum distance from a point to a bounding box.
- Visit the nearest BVH child first and using the resulting distance to skip remaining children whose bounding boxes cannot contain a closer triangle.

## Additional background
The previous point-to-box distance calculation listed all the possible positions of a point relative to a box. The equivalent distance formulation is shorter and requires less branching.
Visiting the nearest child first also provides a tighter distance bound earlier in the traversal, allowing more distant children to be pruned. This is a performance optimization. It is not expected to change computed distances or numerical results.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
