### PR TITLE
Optimize STL ray-box intersection

### DIFF
--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -110,42 +110,30 @@ namespace {
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool line_box_intersects (Real const a[3], Real const b[3], RealBox const& box)
+    bool line_box_intersects (Real const a[3], Real const inv_direction[3],
+                              int parallel_direction_mask, RealBox const& box)
     {
+        Real tmin = 0.0_rt;
+        Real tmax = 1.0_rt;
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            if ((a[idim] < box.lo(idim) && b[idim] < box.lo(idim)) ||
-                (a[idim] > box.hi(idim) && b[idim] > box.hi(idim))) {
-                return false;
-            }
-        }
-        if (box.contains(a) || box.contains(b)) {
-            return true;
-        }
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            // Note that we have made bounding box slightly bigger. So it's
-            // safe to assume that a line in the plane does not intersect
-            // with the actual bounding box.
-            if (a[idim] == b[idim]) { continue; }
-            Real xi[] = {box.lo(idim), box.hi(idim)};
-            for (auto xface : xi) {
-                if (!((a[idim] > xface && b[idim] > xface) ||
-                      (a[idim] < xface && b[idim] < xface)))
-                {
-                    Real w = (xface-a[idim]) / (b[idim]-a[idim]);
-                    bool inside = true;
-                    for (int jdim = 0; jdim < AMREX_SPACEDIM; ++jdim) {
-                        if (idim != jdim) {
-                            Real xpt = a[jdim] + (b[jdim]-a[jdim]) * w;
-                            inside = inside && (xpt >= box.lo(jdim)
-                                            &&  xpt <= box.hi(jdim));
-                        }
-                    }
-                    if (inside) { return true; }
+            if ((parallel_direction_mask & (1 << idim)) != 0) {
+                if (a[idim] < box.lo(idim) || a[idim] > box.hi(idim)) {
+                    return false;
+                }
+            } else {
+                Real tlo = (box.lo(idim)-a[idim]) * inv_direction[idim];
+                Real thi = (box.hi(idim)-a[idim]) * inv_direction[idim];
+                if (tlo > thi) {
+                    amrex::Swap(tlo,thi);
+                }
+                tmin = amrex::max(tmin,tlo);
+                tmax = amrex::min(tmax,thi);
+                if (tmin > tmax) {
+                    return false;
                 }
             }
         }
-
-        return false;
+        return true;
     }
 
     template <int M, int N, typename F>
@@ -154,11 +142,25 @@ namespace {
                                   STLtools::BVHNodeT<M,N> const* root,
                                   F const& f)
     {
+        // Reuse these reciprocals for every bounding box visited by this ray.
+        Real inv_direction[AMREX_SPACEDIM];
+        int parallel_direction_mask = 0;
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            Real const direction = b[idim] - a[idim];
+            if (direction == 0.0_rt) {
+                parallel_direction_mask |= (1 << idim);
+                inv_direction[idim] = 0.0_rt;
+            } else {
+                inv_direction[idim] = 1.0_rt / direction;
+            }
+        }
+
         // Use stack to avoid recursion
         Stack<int, STLtools::m_bvh_max_stack_size> nodes_to_do;
         Stack<std::int8_t, STLtools::m_bvh_max_stack_size> nchildren_done;
 
-        if (line_box_intersects(a, b, root->boundingbox)) {
+        if (line_box_intersects(a, inv_direction, parallel_direction_mask,
+                                root->boundingbox)) {
             nodes_to_do.push(0);
             nchildren_done.push(0);
         }
@@ -176,7 +178,8 @@ namespace {
                     for (auto ichild = ndone; ichild < node.nchildren; ++ichild) {
                         ++ndone;
                         int inode = node.children[ichild];
-                        if (line_box_intersects(a, b, root[inode].boundingbox)) {
+                        if (line_box_intersects(a, inv_direction, parallel_direction_mask,
+                                                root[inode].boundingbox)) {
                             nodes_to_do.push(inode);
                             nchildren_done.push(0);
                             break;

--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -147,7 +147,7 @@ namespace {
                                   F const& f)
     {
         // Reuse these reciprocals for every bounding box visited by this ray.
-        Real inv_direction[AMREX_SPACEDIM];
+        Real inv_direction[3];
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             Real const direction = b[idim] - a[idim];
             inv_direction[idim] = (direction == 0.0_rt) ? 0.0_rt : 1.0_rt/direction;

--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -111,24 +111,28 @@ namespace {
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool line_box_intersects (Real const a[3], Real const inv_direction[3],
-                              int parallel_direction_mask, RealBox const& box)
+                              RealBox const& box)
     {
+        // Multiplying by the reciprocal loses the exactness that dividing by
+        // the direction gives when the segment ends exactly on a face plane,
+        // so open the far bound by a few ulps instead of culling a box the
+        // segment might really touch.
+        constexpr Real ulps = Real(4)*std::numeric_limits<Real>::epsilon();
         Real tmin = 0.0_rt;
         Real tmax = 1.0_rt;
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            if ((parallel_direction_mask & (1 << idim)) != 0) {
+            // A zero reciprocal marks a direction parallel to this pair of
+            // faces. 1/direction is never zero for a finite direction.
+            if (inv_direction[idim] == 0.0_rt) {
                 if (a[idim] < box.lo(idim) || a[idim] > box.hi(idim)) {
                     return false;
                 }
             } else {
-                Real tlo = (box.lo(idim)-a[idim]) * inv_direction[idim];
-                Real thi = (box.hi(idim)-a[idim]) * inv_direction[idim];
-                if (tlo > thi) {
-                    amrex::Swap(tlo,thi);
-                }
-                tmin = amrex::max(tmin,tlo);
-                tmax = amrex::min(tmax,thi);
-                if (tmin > tmax) {
+                Real const t1 = (box.lo(idim)-a[idim]) * inv_direction[idim];
+                Real const t2 = (box.hi(idim)-a[idim]) * inv_direction[idim];
+                tmin = amrex::max(tmin, amrex::min(t1,t2));
+                tmax = amrex::min(tmax, amrex::max(t1,t2));
+                if (tmin > tmax*(1.0_rt+ulps) + ulps) {
                     return false;
                 }
             }
@@ -144,23 +148,16 @@ namespace {
     {
         // Reuse these reciprocals for every bounding box visited by this ray.
         Real inv_direction[AMREX_SPACEDIM];
-        int parallel_direction_mask = 0;
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             Real const direction = b[idim] - a[idim];
-            if (direction == 0.0_rt) {
-                parallel_direction_mask |= (1 << idim);
-                inv_direction[idim] = 0.0_rt;
-            } else {
-                inv_direction[idim] = 1.0_rt / direction;
-            }
+            inv_direction[idim] = (direction == 0.0_rt) ? 0.0_rt : 1.0_rt/direction;
         }
 
         // Use stack to avoid recursion
         Stack<int, STLtools::m_bvh_max_stack_size> nodes_to_do;
         Stack<std::int8_t, STLtools::m_bvh_max_stack_size> nchildren_done;
 
-        if (line_box_intersects(a, inv_direction, parallel_direction_mask,
-                                root->boundingbox)) {
+        if (line_box_intersects(a, inv_direction, root->boundingbox)) {
             nodes_to_do.push(0);
             nchildren_done.push(0);
         }
@@ -178,8 +175,7 @@ namespace {
                     for (auto ichild = ndone; ichild < node.nchildren; ++ichild) {
                         ++ndone;
                         int inode = node.children[ichild];
-                        if (line_box_intersects(a, inv_direction, parallel_direction_mask,
-                                                root[inode].boundingbox)) {
+                        if (line_box_intersects(a, inv_direction, root[inode].boundingbox)) {
                             nodes_to_do.push(inode);
                             nchildren_done.push(0);
                             break;


### PR DESCRIPTION
## Summary

- Replace the face-by-face line-box intersection test with a slab-based test.
- Compute inverse ray directions once and reuse them.
- Handle ray directions parallel to a box axis explicitly.

## Additional background

BVH ray traversal tests the same ray against many bounding boxes. Reusing its inverse direction avoids repeated division, while the slab test reduces the work required for each box.

This is a performance optimization.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate

