### PR TITLE
Bugfix in State Redistribution

### DIFF
--- a/Src/EB/AMReX_EB_StateRedistribute.cpp
+++ b/Src/EB/AMReX_EB_StateRedistribute.cpp
@@ -306,7 +306,7 @@ MLStateRedistribute ( Box const& bx, int ncomp,
                             Real q_over_Q = fac2*vfrac(ii,jj,kk)/nbhd_vol(i,j,k);
 
                             // Skip if neighbor (ii,jj,kk) is outside domain_per_grown
-                            // This matches the write condition in the first loop (line 152)
+                            // This matches the write condition in the first loop
                             if (!domain_per_grown.contains(IntVect(AMREX_D_DECL(ii,jj,kk)))) continue;
 
                             Real update = qt(i,j,k,r_nbor);

--- a/Src/EB/AMReX_EB_StateRedistribute.cpp
+++ b/Src/EB/AMReX_EB_StateRedistribute.cpp
@@ -307,7 +307,9 @@ MLStateRedistribute ( Box const& bx, int ncomp,
 
                             // Skip if neighbor (ii,jj,kk) is outside domain_per_grown
                             // This matches the write condition in the first loop
-                            if (!domain_per_grown.contains(IntVect(AMREX_D_DECL(ii,jj,kk)))) continue;
+                            if (!domain_per_grown.contains(IntVect(AMREX_D_DECL(ii,jj,kk)))) {
+                                 continue;
+                            }
 
                             Real update = qt(i,j,k,r_nbor);
                             AMREX_D_TERM(update += q_over_Q * lim_slope[0] *

--- a/Src/EB/AMReX_EB_StateRedistribute.cpp
+++ b/Src/EB/AMReX_EB_StateRedistribute.cpp
@@ -305,6 +305,10 @@ MLStateRedistribute ( Box const& bx, int ncomp,
                             //
                             Real q_over_Q = fac2*vfrac(ii,jj,kk)/nbhd_vol(i,j,k);
 
+                            // Skip if neighbor (ii,jj,kk) is outside domain_per_grown
+                            // This matches the write condition in the first loop (line 152)
+                            if (!domain_per_grown.contains(IntVect(AMREX_D_DECL(ii,jj,kk)))) continue;
+
                             Real update = qt(i,j,k,r_nbor);
                             AMREX_D_TERM(update += q_over_Q * lim_slope[0] *
                                                    (ccent(r,s,t,0)-cent_hat(i,j,k,0) + static_cast<Real>(r-i));,


### PR DESCRIPTION
## Summary
This PR fixes a bug in `MLStateRedistribute` that can read uninitialized array elements and produce `NaN` values.

## Problem
`MLStateRedistribute` can read uninitialized `qt(i,j,k,i_nbor)` values when neighbors fall outside `domain_per_grown` at a non-periodic boundary:
- First loop (line 152): Only writes `qt` when `domain_per_grown.contains(r,s,t)`.
- Second loop (line 311): Reads `qt` for all neighbors, regardless of whether they are within `domain_per_grown`.
- Result: NaN from uninitialized memory access

## Solution
There are two possible approaches to fix this issue:
1. Initialize the entire `qt` array to zero. This can be expensive.
2. Apply the same boundary check when reading `qt` as when writing it.

This PR uses the second approach for efficiency.

## Test
The fix was verified in ERF applications:
1. Corrects the observed NaN issue in a complex-geometry application.
2. Does not change the solution of existing EB test cases.

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
