### PR TITLE
[WIP] Host Thread Safety: Make Global State Race-Free

### DIFF
--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -2738,10 +2738,16 @@ AMReX's process-global state is safe under that:
   generator, seeded from the same sequence as the OpenMP ones. Only the OpenMP
   generators take part in :cpp:`SaveRandomState`/:cpp:`RestoreRandomState`.
 - Particle IDs (:cpp:`Particle::NextID()`) are handed out atomically.
-- The GPU stream index is per thread, so each host thread submits to a stream of
-  its own from :cpp:`Gpu::Device::gpuStream()`.
+- The current-stream index is per thread, so one host thread can no longer
+  change the stream another is submitting to. The stream *pool* is still
+  shared, and an :cpp:`MFIter` walks it from index 0 in every thread, so two
+  threads can still land on the same stream.
 - :cpp:`amrex::Tokenize()` uses per-thread scratch and returns a per-thread
   result.
+- :cpp:`VisMF`'s persistent input streams are per thread, since an
+  :cpp:`std::ifstream` carries a single read position. Note that
+  :cpp:`VisMF::CloseAllStreams()` therefore closes only the calling thread's;
+  the rest close when their thread exits.
 
 What remains the caller's responsibility:
 
@@ -2753,7 +2759,7 @@ What remains the caller's responsibility:
 - :cpp:`amrex::InitRandom()` -- and therefore
   :cpp:`ParticleContainer::InitRandom()`, which calls it -- *reseeds* the
   global generators, and on a GPU build frees and reallocates the device RNG
-  state. Concurrent calls are serialised, but reseeding while another thread
+  state. Concurrent calls are serialized, but reseeding while another thread
   draws numbers is still a logical race (a use-after-free on the device). Seed
   before starting worker threads.
 - **MPI**, unless AMReX is built with ``AMReX_MPI_THREAD_MULTIPLE=ON``.

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -2708,6 +2708,65 @@ assertion, one could call
     logical :: old_flag
     old_flag = amrex_mfiter_allow_multiple(.true.)
 
+.. _sec:basics:hostthreads:
+
+Host Thread Safety
+==================
+
+.. highlight:: c++
+
+Besides OpenMP, AMReX can also be driven from host threads it did not create
+itself -- most commonly Python threads on a free-threaded (`PEP 703
+<https://peps.python.org/pep-0703/>`__) interpreter through `pyAMReX
+<https://pyamrex.readthedocs.io>`__, but equally :cpp:`std::thread` in a C++
+application. Such a thread is not part of any OpenMP team, so
+:cpp:`amrex::OpenMP::get_thread_num()` reports ``0`` for it -- and in a build
+without OpenMP it reports ``0`` for every thread.
+
+AMReX's process-global state is safe under that:
+
+- The caches behind :cpp:`MFIter`, :cpp:`FillBoundary` and :cpp:`ParallelCopy`,
+  and the reference counts that decide when they are flushed, are mutex
+  protected.
+- The nesting counter behind the "Nested or multiple active MFIters" assertion
+  is per thread, so **each thread may drive its own MFIter**, including over the
+  same :cpp:`FabArray`. Consequently :cpp:`MFIter::currentDepth()` reports the
+  calling thread's nesting only.
+- The :cpp:`ParmParse` table is mutex protected, including on *query*, which
+  updates the entry's use count and type hint.
+- :cpp:`amrex::Random()` and friends give a thread AMReX did not create its own
+  generator, seeded from the same sequence as the OpenMP ones. Only the OpenMP
+  generators take part in :cpp:`SaveRandomState`/:cpp:`RestoreRandomState`.
+- Particle IDs (:cpp:`Particle::NextID()`) are handed out atomically.
+- The GPU stream index is per thread, so each host thread submits to a stream of
+  its own from :cpp:`Gpu::Device::gpuStream()`.
+- :cpp:`amrex::Tokenize()` uses per-thread scratch and returns a per-thread
+  result.
+
+What remains the caller's responsibility:
+
+- **Concurrent writes to the same data.** Two threads writing the same box, or
+  overlapping regions of one :cpp:`Array4`, is a data race, exactly as it would
+  be inside an OpenMP region.
+- :cpp:`amrex::Initialize()` and :cpp:`amrex::Finalize()`, and process-wide
+  policy such as :cpp:`SetVerbose()` or the error handler: one thread only.
+- :cpp:`amrex::InitRandom()` -- and therefore
+  :cpp:`ParticleContainer::InitRandom()`, which calls it -- *reseeds* the
+  global generators, and on a GPU build frees and reallocates the device RNG
+  state. Concurrent calls are serialised, but reseeding while another thread
+  draws numbers is still a logical race (a use-after-free on the device). Seed
+  before starting worker threads.
+- **MPI**, unless AMReX is built with ``AMReX_MPI_THREAD_MULTIPLE=ON``.
+  Otherwise AMReX calls :cpp:`MPI_Init` rather than :cpp:`MPI_Init_thread`, and
+  collectives must not be entered from two threads at once.
+- :cpp:`TinyProfiler`: its section stack is global and asserts on nesting.
+- :cpp:`Gpu::setExternalStream()`, and dynamic :cpp:`MFIter` scheduling
+  (:cpp:`MFItInfo::SetDynamic`), which shares one counter across an OpenMP team.
+
+Note that host threads and OpenMP are two thread pools over the same cores.
+Using both oversubscribes the node; pick one, or cap ``OMP_NUM_THREADS`` so that
+the product matches the core count.
+
 .. _sec:basics:fortran:
 
 Fortran and C++ Kernels

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -2768,6 +2768,16 @@ What remains the caller's responsibility:
 - :cpp:`TinyProfiler`: its section stack is global and asserts on nesting.
 - :cpp:`Gpu::setExternalStream()`, and dynamic :cpp:`MFIter` scheduling
   (:cpp:`MFItInfo::SetDynamic`), which shares one counter across an OpenMP team.
+- The GPU execution-scope guards -- :cpp:`Gpu::LaunchSafeGuard`,
+  :cpp:`Gpu::GraphSafeGuard`, :cpp:`Gpu::SingleStreamRegion`,
+  :cpp:`Gpu::NoSyncRegion` -- and :cpp:`Gpu::setExternalStream()`. These set
+  process-wide mode flags and restore them on scope exit, so one thread's guard
+  changes what every other thread does. They are deliberately *not* per-thread:
+  an OpenMP program opens them outside a parallel region and expects the team
+  inside to observe them.
+- The AMReX instance stack accessors :cpp:`AMReX::empty()`, :cpp:`size()` and
+  :cpp:`top()` are unlocked, so they inherit the Initialize/Finalize rule above:
+  do not call them while another thread may be pushing or erasing an instance.
 
 Note that host threads and OpenMP are two thread pools over the same cores.
 Using both oversubscribes the node; pick one, or cap ``OMP_NUM_THREADS`` so that

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -2773,19 +2773,26 @@ What remains the caller's responsibility:
 - :cpp:`TinyProfiler`: its section stack is global and asserts on nesting.
 - :cpp:`Gpu::setExternalStream()`, and dynamic :cpp:`MFIter` scheduling
   (:cpp:`MFItInfo::SetDynamic`), which shares one counter across an OpenMP team.
-- The GPU execution-scope guards -- :cpp:`Gpu::LaunchSafeGuard`,
-  :cpp:`Gpu::GraphSafeGuard`, :cpp:`Gpu::SingleStreamRegion`,
-  :cpp:`Gpu::NoSyncRegion`. These set
-  process-wide mode flags and restore them on scope exit, so one thread's guard
-  changes what every other thread does. They are deliberately *not* per-thread:
-  an OpenMP program opens them outside a parallel region and expects the team
-  inside to observe them.
 - The AMReX instance stack accessors :cpp:`AMReX::empty()`, :cpp:`size()` and
   :cpp:`top()` are unlocked, so they inherit the Initialize/Finalize rule above:
   do not call them while another thread may be pushing or erasing an instance.
 - :cpp:`EB2::Build()` pushes onto an unguarded process-global index-space
   stack that :cpp:`EB2::TopIndexSpace()` reads, so building embedded-boundary
   geometry belongs on one thread, before other threads start using it.
+
+The GPU execution-scope guards -- :cpp:`Gpu::LaunchSafeGuard`,
+:cpp:`Gpu::GraphSafeGuard`, :cpp:`Gpu::SingleStreamRegion` and
+:cpp:`Gpu::NoSyncRegion` -- *are* per-thread, so one host thread's guard no
+longer changes what another one does. This could not be left to caller
+discipline: AMReX opens these guards itself inside ordinary API calls
+(:cpp:`ParticleContainer::addParticles()` opens a :cpp:`Gpu::NoSyncRegion`,
+:cpp:`Gpu::AnyOf()` behind :cpp:`MultiFab::contains_nan()` opens a
+:cpp:`Gpu::LaunchSafeGuard`), so two threads calling those would interleave the
+save/restore pairs and leave a flag stuck on for the rest of the run. An OpenMP
+team still observes a guard opened outside it, because the setters broadcast to
+the team; what remains unsupported is an ``AMReX_OMP=ON`` build driven from
+several host threads at once, which shares those broadcast slots -- the same
+caveat :cpp:`amrex::Random()` carries.
 
 Note that host threads and OpenMP are two thread pools over the same cores.
 Using both oversubscribes the node; pick one, or cap ``OMP_NUM_THREADS`` so that

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -2770,7 +2770,7 @@ What remains the caller's responsibility:
   (:cpp:`MFItInfo::SetDynamic`), which shares one counter across an OpenMP team.
 - The GPU execution-scope guards -- :cpp:`Gpu::LaunchSafeGuard`,
   :cpp:`Gpu::GraphSafeGuard`, :cpp:`Gpu::SingleStreamRegion`,
-  :cpp:`Gpu::NoSyncRegion` -- and :cpp:`Gpu::setExternalStream()`. These set
+  :cpp:`Gpu::NoSyncRegion`. These set
   process-wide mode flags and restore them on scope exit, so one thread's guard
   changes what every other thread does. They are deliberately *not* per-thread:
   an OpenMP program opens them outside a parallel region and expects the team
@@ -2778,6 +2778,9 @@ What remains the caller's responsibility:
 - The AMReX instance stack accessors :cpp:`AMReX::empty()`, :cpp:`size()` and
   :cpp:`top()` are unlocked, so they inherit the Initialize/Finalize rule above:
   do not call them while another thread may be pushing or erasing an instance.
+- :cpp:`EB2::Build()` pushes onto an unguarded process-global index-space
+  stack that :cpp:`EB2::TopIndexSpace()` reads, so building embedded-boundary
+  geometry belongs on one thread, before other threads start using it.
 
 Note that host threads and OpenMP are two thread pools over the same cores.
 Using both oversubscribes the node; pick one, or cap ``OMP_NUM_THREADS`` so that

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -2737,6 +2737,11 @@ AMReX's process-global state is safe under that:
 - :cpp:`amrex::Random()` and friends give a thread AMReX did not create its own
   generator, seeded from the same sequence as the OpenMP ones. Only the OpenMP
   generators take part in :cpp:`SaveRandomState`/:cpp:`RestoreRandomState`.
+  The exception is *inside* an OpenMP parallel region, where the generator is
+  still selected by :cpp:`OpenMP::get_thread_num()`: in an ``AMReX_OMP=ON``
+  build, two host threads that each open their own team index the same
+  per-team generators and race on them. Draw random numbers from your own
+  threads or from an OpenMP team, not from both at once.
 - Particle IDs (:cpp:`Particle::NextID()`) are handed out atomically.
 - The current-stream index is per thread, so one host thread can no longer
   change the stream another is submitting to. The stream *pool* is still

--- a/Docs/sphinx_documentation/source/Faq.rst
+++ b/Docs/sphinx_documentation/source/Faq.rst
@@ -133,7 +133,10 @@ each thread will have its own dedicated Random Number Generator that
 is totally independent of the others. A host thread that AMReX did not create --
 a Python thread on a free-threaded interpreter, say -- also gets its own
 generator, seeded from the same sequence; note that only the OpenMP generators
-are written by :cpp:`SaveRandomState`. See :ref:`sec:basics:hostthreads`.
+are written by :cpp:`SaveRandomState`. Inside an OpenMP parallel region the
+generator is still picked by thread number, so do not have several of your own
+host threads each open a team and draw at the same time.
+See :ref:`sec:basics:hostthreads`.
 
 |
 

--- a/Docs/sphinx_documentation/source/Faq.rst
+++ b/Docs/sphinx_documentation/source/Faq.rst
@@ -130,7 +130,10 @@ Are they thread safe with MPI and OpenMP?
 
 **A.** (Thread safe) Yes, :cpp:`amrex::Random()` is thread safe. When OpenMP is on,
 each thread will have its own dedicated Random Number Generator that
-is totally independent of the others.
+is totally independent of the others. A host thread that AMReX did not create --
+a Python thread on a free-threaded interpreter, say -- also gets its own
+generator, seeded from the same sequence; note that only the OpenMP generators
+are written by :cpp:`SaveRandomState`. See :ref:`sec:basics:hostthreads`.
 
 |
 

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -331,7 +331,7 @@ namespace
      * Guards the two callback stacks above and the AMReX instance stack.
      *
      * amrex::Initialize() and Finalize() are meant to be called from one
-     * thread, but ExecOnFinalize() is reached from lazy initialisation deep
+     * thread, but ExecOnFinalize() is reached from lazy initialization deep
      * inside otherwise thread-safe code, so the stacks themselves have to
      * tolerate concurrent pushes.
      */

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -60,6 +60,7 @@
 #endif
 
 #include <iterator>
+#include <mutex>
 
 #ifdef AMREX_USE_OMP
 #include <AMReX_OpenMP.H>
@@ -325,17 +326,29 @@ namespace
 {
     std::stack<std::function<void()>> The_Finalize_Function_Stack;
     std::stack<std::function<void()>> The_Initialize_Function_Stack;
+
+    /**
+     * Guards the two callback stacks above and the AMReX instance stack.
+     *
+     * amrex::Initialize() and Finalize() are meant to be called from one
+     * thread, but ExecOnFinalize() is reached from lazy initialisation deep
+     * inside otherwise thread-safe code, so the stacks themselves have to
+     * tolerate concurrent pushes.
+     */
+    std::mutex amrex_instance_mutex;
 }
 
 void
 amrex::ExecOnFinalize (std::function<void()> f)
 {
+    std::scoped_lock lock(amrex_instance_mutex);
     The_Finalize_Function_Stack.push(std::move(f));
 }
 
 void
 amrex::ExecOnInitialize (std::function<void()> f)
 {
+    std::scoped_lock lock(amrex_instance_mutex);
     The_Initialize_Function_Stack.push(std::move(f));
 }
 
@@ -438,16 +451,18 @@ amrex::Initialize (int& argc, char**& argv, bool build_parm_parse,
     upcxx::init();
 #endif
 
-    while ( ! The_Initialize_Function_Stack.empty())
+    while (true)
     {
-        //
-        // Call the registered function.
-        //
-        The_Initialize_Function_Stack.top()();
-        //
-        // And then remove it from the stack.
-        //
-        The_Initialize_Function_Stack.pop();
+        // Pop under the lock, then run the callback without it: a callback is
+        // free to register another one, and would otherwise deadlock.
+        std::function<void()> f;
+        {
+            std::scoped_lock lock(amrex_instance_mutex);
+            if (The_Initialize_Function_Stack.empty()) { break; }
+            f = std::move(The_Initialize_Function_Stack.top());
+            The_Initialize_Function_Stack.pop();
+        }
+        f();
     }
 
     BL_PROFILE_INITIALIZE();
@@ -851,16 +866,18 @@ amrex::Finalize (amrex::AMReX* pamrex)
     Lazy::Finalize();
 #endif
 
-    while (!The_Finalize_Function_Stack.empty())
+    while (true)
     {
-        //
-        // Call the registered function.
-        //
-        The_Finalize_Function_Stack.top()();
-        //
-        // And then remove it from the stack.
-        //
-        The_Finalize_Function_Stack.pop();
+        // Pop under the lock, then run the callback without it: a callback is
+        // free to register another one, and would otherwise deadlock.
+        std::function<void()> f;
+        {
+            std::scoped_lock lock(amrex_instance_mutex);
+            if (The_Finalize_Function_Stack.empty()) { break; }
+            f = std::move(The_Finalize_Function_Stack.top());
+            The_Finalize_Function_Stack.pop();
+        }
+        f();
     }
 
     // The MemPool stuff is not using The_Finalize_Function_Stack so that
@@ -1010,6 +1027,7 @@ AMReX::~AMReX ()
 void
 AMReX::push (AMReX* pamrex)
 {
+    std::scoped_lock lock(amrex_instance_mutex);
     auto r = std::find_if(m_instance.begin(), m_instance.end(),
                           [=] (const std::unique_ptr<AMReX>& x) -> bool
                           { return x.get() == pamrex; });
@@ -1023,12 +1041,14 @@ AMReX::push (AMReX* pamrex)
 void
 AMReX::push (std::unique_ptr<AMReX> pamrex)
 {
+    std::scoped_lock lock(amrex_instance_mutex);
     m_instance.push_back(std::move(pamrex));
 }
 
 void
 AMReX::erase (AMReX* pamrex)
 {
+    std::scoped_lock lock(amrex_instance_mutex);
     auto r = std::find_if(m_instance.begin(), m_instance.end(),
                           [=] (const std::unique_ptr<AMReX>& x) -> bool
                           { return x.get() == pamrex; });

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -1437,9 +1437,29 @@ BoxArray::complementIn (BoxList& bl, const Box& bx) const
     }
 }
 
+namespace {
+    /**
+     * Guards the lazily built BARef hash map.
+     *
+     * A real mutex rather than `omp critical`: the hash map is built lazily
+     * from a const method, so any host thread can be the one to build it --
+     * including threads AMReX did not create, which an OpenMP critical section
+     * does not exclude (and which a build without OpenMP would not exclude at
+     * all).
+     *
+     * clear_hash_bin() takes it as well as getHashMap(). uniqify() only calls
+     * clear_hash_bin() when it believes it is the sole owner of the BARef, but
+     * that use_count() == 1 test is a check-then-act: another thread copying
+     * the BoxArray raises the count right after it is read, and then the
+     * "sole owner" is tearing down a hash map that copy is entitled to build.
+     */
+    std::mutex hashmap_mutex; // NOLINT(cert-err58-cpp)
+}
+
 void
 BoxArray::clear_hash_bin () const
 {
+    std::scoped_lock lock(hashmap_mutex);
     if (!m_ref->hash.empty())
     {
 #ifdef AMREX_MEM_PROFILING
@@ -1567,12 +1587,6 @@ BoxArray::getHashMap () const
     if (m_ref->HasHashMap()) { return BoxHashMap; }
 
     {
-        // A real mutex rather than `omp critical`: the hash map is built
-        // lazily from a const method, so any host thread can be the one to
-        // build it -- including threads AMReX did not create, which an
-        // OpenMP critical section does not exclude (and which a build without
-        // OpenMP would not exclude at all).
-        static std::mutex hashmap_mutex;
         std::scoped_lock lock(hashmap_mutex);
 
         if (!m_ref->HasHashMap() && size() > 0)

--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -16,6 +16,7 @@
 #include <cstdlib>
 #include <functional>
 #include <iostream>
+#include <mutex>
 
 namespace amrex {
 
@@ -1565,10 +1566,15 @@ BoxArray::getHashMap () const
 
     if (m_ref->HasHashMap()) { return BoxHashMap; }
 
-#ifdef AMREX_USE_OMP
-#pragma omp critical(intersections_lock)
-#endif
     {
+        // A real mutex rather than `omp critical`: the hash map is built
+        // lazily from a const method, so any host thread can be the one to
+        // build it -- including threads AMReX did not create, which an
+        // OpenMP critical section does not exclude (and which a build without
+        // OpenMP would not exclude at all).
+        static std::mutex hashmap_mutex;
+        std::scoped_lock lock(hashmap_mutex);
+
         if (!m_ref->HasHashMap() && size() > 0)
         {
             //

--- a/Src/Base/AMReX_CArena.H
+++ b/Src/Base/AMReX_CArena.H
@@ -277,7 +277,16 @@ protected:
     //! The max amount of memory given out via alloc().
     std::size_t m_max_actually_used{0};
 
-    mutable std::mutex carena_mutex;
+    /**
+     * Guards the free/busy lists, the allocation vector and the usage counters.
+     *
+     * Recursive because the out-of-memory path re-enters on the same thread:
+     * alloc() takes this, alloc_protected() calls allocate_system(), and if
+     * that fails Arena::out_of_memory_abort() prints every arena's usage --
+     * back through CArena::PrintUsage(std::ostream&), which needs it too. With
+     * a plain std::mutex that diagnostic deadlocks instead of aborting.
+     */
+    mutable std::recursive_mutex carena_mutex;
 
     //! Print a summary of the arena's free and busy lists to \p os.
     friend std::ostream& operator<< (std::ostream& os, const CArena& arena);

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -493,12 +493,14 @@ CArena::hasFreeDeviceMemory (std::size_t sz)
 std::size_t
 CArena::heap_space_used () const noexcept
 {
+    std::scoped_lock lock(carena_mutex);
     return m_used;
 }
 
 std::size_t
 CArena::heap_space_actually_used () const noexcept
 {
+    std::scoped_lock lock(carena_mutex);
     return m_actually_used;
 }
 
@@ -508,6 +510,7 @@ CArena::sizeOf (void* p) const noexcept
     if (p == nullptr) {
         return 0;
     } else {
+        std::scoped_lock lock(carena_mutex);
         auto it = m_busylist.find(Node(p,nullptr,0));
         if (it == m_busylist.end()) {
             return 0;
@@ -520,11 +523,18 @@ CArena::sizeOf (void* p) const noexcept
 void
 CArena::PrintUsage (std::string const& name, bool print_max_usage) const
 {
-    Long min_megabytes = static_cast<Long>(
-        (print_max_usage ? m_max_used : heap_space_used()) / (1024*1024));
+    // Snapshot under the lock, then reduce outside it: every allocation path
+    // takes carena_mutex, and holding it across an MPI collective would block
+    // any thread that needs to allocate before it can reach its own.
+    Long min_megabytes, actual_min_megabytes;
+    {
+        std::scoped_lock lock(carena_mutex);
+        min_megabytes = static_cast<Long>(
+            (print_max_usage ? m_max_used : m_used) / (1024*1024));
+        actual_min_megabytes = static_cast<Long>(
+            (print_max_usage ? m_max_actually_used : m_actually_used) / (1024*1024));
+    }
     Long max_megabytes = min_megabytes;
-    Long actual_min_megabytes = static_cast<Long>(
-        (print_max_usage ? m_max_actually_used : heap_space_actually_used()) / (1024*1024));
     Long actual_max_megabytes = actual_min_megabytes;
     const int IOProc = ParallelDescriptor::IOProcessorNumber();
     ParallelReduce::Min<Long>({min_megabytes, actual_min_megabytes},
@@ -547,12 +557,21 @@ CArena::PrintUsage (std::string const& name, bool print_max_usage) const
 void
 CArena::PrintUsage (std::ostream& os, std::string const& name, std::string const& space) const
 {
-    auto megabytes = heap_space_used() / (1024*1024);
-    auto actual_megabytes = heap_space_actually_used() / (1024*1024);
+    std::size_t megabytes, actual_megabytes, n_alloc, n_busy, n_free;
+    {
+        // The container sizes especially: reading them while another thread
+        // allocates is reading a std::set that is being rebalanced.
+        std::scoped_lock lock(carena_mutex);
+        megabytes = m_used / (1024*1024);
+        actual_megabytes = m_actually_used / (1024*1024);
+        n_alloc = m_alloc.size();
+        n_busy = m_busylist.size();
+        n_free = m_freelist.size();
+    }
     os << space << "[" << name << "] space allocated (MB): " << megabytes << "\n";
     os << space << "[" << name << "] space used      (MB): " << actual_megabytes << "\n";
-    os << space << "[" << name << "]: " << m_alloc.size() << " allocs, "
-       << m_busylist.size() << " busy blocks, " << m_freelist.size() << " free blocks\n";
+    os << space << "[" << name << "]: " << n_alloc << " allocs, "
+       << n_busy << " busy blocks, " << n_free << " free blocks\n";
 }
 
 std::ostream& operator<< (std::ostream& os, const CArena& arena)

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -393,6 +393,7 @@ CArena::freeUnused ()
 std::size_t
 CArena::freeableMemory () const
 {
+    std::scoped_lock lock(carena_mutex);
     std::size_t nbytes = 0;
     for (auto const& [p, sz] : m_alloc) {
         auto it = m_freelist.find(Node(p,nullptr,0));
@@ -560,7 +561,7 @@ CArena::PrintUsage (std::ostream& os, std::string const& name, std::string const
     std::size_t megabytes, actual_megabytes, n_alloc, n_busy, n_free;
     {
         // The container sizes especially: reading them while another thread
-        // allocates is reading a std::set that is being rebalanced.
+        // allocates is reading containers that are being rehashed/rebalanced.
         std::scoped_lock lock(carena_mutex);
         megabytes = m_used / (1024*1024);
         actual_megabytes = m_actually_used / (1024*1024);
@@ -576,6 +577,9 @@ CArena::PrintUsage (std::ostream& os, std::string const& name, std::string const
 
 std::ostream& operator<< (std::ostream& os, const CArena& arena)
 {
+    // Same lock as every mutator: this walks m_alloc/m_freelist/m_busylist.
+    std::scoped_lock lock(arena.carena_mutex);
+
     os << "CArea:\n"
        << "    Hunk size: " << arena.m_hunk << "\n"
        << "    Memory allocated: " << arena.m_used << "\n"

--- a/Src/Base/AMReX_CArena.cpp
+++ b/Src/Base/AMReX_CArena.cpp
@@ -559,10 +559,21 @@ void
 CArena::PrintUsage (std::ostream& os, std::string const& name, std::string const& space) const
 {
     std::size_t megabytes, actual_megabytes, n_alloc, n_busy, n_free;
+    // try_to_lock, not a blocking lock. This overload is on the
+    // out-of-memory path (Arena::out_of_memory_abort -> PrintUsageToStream),
+    // which walks *every* arena in turn. A thread that OOMs inside The_Arena
+    // therefore arrives here holding The_Arena's mutex and asking for
+    // The_Pinned_Arena's, while a thread that OOMs inside The_Pinned_Arena
+    // does the mirror image -- a classic AB-BA hang, with no diagnostic, in
+    // exactly the situation the diagnostic exists for. Two threads exhausting
+    // memory at once is the ordinary case under free threading, so a
+    // best-effort read is the right trade: a dying process must not block.
+    //
+    // The mutex is recursive, so the same thread's re-entry (depth 1 -> 2)
+    // still succeeds and reads consistent state -- alloc_protected() mutates
+    // nothing between its last consistent point and allocate_system().
+    std::unique_lock<std::recursive_mutex> lk(carena_mutex, std::try_to_lock);
     {
-        // The container sizes especially: reading them while another thread
-        // allocates is reading containers that are being rehashed/rebalanced.
-        std::scoped_lock lock(carena_mutex);
         megabytes = m_used / (1024*1024);
         actual_megabytes = m_actually_used / (1024*1024);
         n_alloc = m_alloc.size();
@@ -572,13 +583,16 @@ CArena::PrintUsage (std::ostream& os, std::string const& name, std::string const
     os << space << "[" << name << "] space allocated (MB): " << megabytes << "\n";
     os << space << "[" << name << "] space used      (MB): " << actual_megabytes << "\n";
     os << space << "[" << name << "]: " << n_alloc << " allocs, "
-       << n_busy << " busy blocks, " << n_free << " free blocks\n";
+       << n_busy << " busy blocks, " << n_free << " free blocks"
+       << (lk.owns_lock() ? "" : "  (read without the lock: busy)") << "\n";
 }
 
 std::ostream& operator<< (std::ostream& os, const CArena& arena)
 {
-    // Same lock as every mutator: this walks m_alloc/m_freelist/m_busylist.
-    std::scoped_lock lock(arena.carena_mutex);
+    // Same lock as every mutator, since this walks m_alloc/m_freelist/
+    // m_busylist -- but try_to_lock, for the reason given in PrintUsage above:
+    // this is diagnostic output and must never be the thing that hangs.
+    std::unique_lock<std::recursive_mutex> lk(arena.carena_mutex, std::try_to_lock);
 
     os << "CArea:\n"
        << "    Hunk size: " << arena.m_hunk << "\n"

--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 #include <queue>
 #include <algorithm>
+#include <mutex>
 #include <numeric>
 #include <string>
 #include <cstring>
@@ -1909,41 +1910,56 @@ DistributionMapping::makeSFC (const BoxArray& ba, bool use_box_vol, int nprocs)
     return r;
 }
 
-const Vector<int>&
-DistributionMapping::getIndexArray ()
-{
-    if (m_ref->m_index_array.empty())
+namespace {
+    /**
+     * Guards the lazy build of DMRef::m_index_array / m_ownership.
+     *
+     * Copies of a DistributionMapping share one DMRef, so every FabArray built
+     * from the same map reaches the same two vectors. Without this, two host
+     * threads constructing FabArrays concurrently both find them empty and both
+     * push_back into them.
+     */
+    std::mutex dm_index_array_mutex;
+
+    /**
+     * Fill m_index_array and m_ownership if they are not there yet.
+     *
+     * The emptiness test has to be inside the lock: testing it outside would
+     * let a second thread see the vector already non-empty while the first is
+     * still pushing into (and reallocating) it, and hand back a reference to
+     * a vector under construction. Once built, neither vector is modified
+     * again for the life of the DMRef, so the references the getters return
+     * stay valid after the lock is dropped.
+     */
+    void buildIndexArray (DMRef& ref)
     {
+        std::scoped_lock lock(dm_index_array_mutex);
+        if (!ref.m_index_array.empty()) { return; }
+
         int myProc = ParallelDescriptor::MyProc();
 
-        for(int i = 0, N = static_cast<int>(m_ref->m_pmap.size()); i < N; ++i) {
-            int rank = m_ref->m_pmap[i];
+        for(int i = 0, N = static_cast<int>(ref.m_pmap.size()); i < N; ++i) {
+            int rank = ref.m_pmap[i];
             if (ParallelDescriptor::sameTeam(rank)) {
                 // If Team is not used (i.e., team size == 1), distributionMap[i] == myProc
-                m_ref->m_index_array.push_back(i);
-                m_ref->m_ownership.push_back(myProc == rank);
+                ref.m_index_array.push_back(i);
+                ref.m_ownership.push_back(myProc == rank);
             }
         }
     }
+}
+
+const Vector<int>&
+DistributionMapping::getIndexArray ()
+{
+    buildIndexArray(*m_ref);
     return m_ref->m_index_array;
 }
 
 const std::vector<bool>&
 DistributionMapping::getOwnerShip ()
 {
-    if (m_ref->m_ownership.empty())
-    {
-        int myProc = ParallelDescriptor::MyProc();
-
-        for(int i = 0, N = static_cast<int>(m_ref->m_pmap.size()); i < N; ++i) {
-            int rank = m_ref->m_pmap[i];
-            if (ParallelDescriptor::sameTeam(rank)) {
-                // If Team is not used (i.e., team size == 1), distributionMap[i] == myProc
-                m_ref->m_index_array.push_back(i);
-                m_ref->m_ownership.push_back(myProc == rank);
-            }
-        }
-    }
+    buildIndexArray(*m_ref);
     return m_ref->m_ownership;
 }
 

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -2540,7 +2540,9 @@ FabArray<FAB>::AllocFabs (const FabFactory<FAB>& factory, Arena* ar,
 
     m_tags.clear();
     m_tags.emplace_back("All");
-    for (auto const& t : m_region_tag) {
+    // A snapshot, not m_region_tag itself: push/popRegionTag() mutate that
+    // under a lock this header cannot see.
+    for (auto const& t : FabArrayBase::regionTags()) {
         m_tags.push_back(t);
     }
     for (auto const& t : tags) {

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -812,7 +812,8 @@ public:
     struct FabArrayStats
     {
         // Atomic because recordBuild()/recordDelete() run from every FabArray
-        // constructor and destructor, which any host thread may reach.
+        // constructor and destructor, which any host thread may reach. This
+        // makes FabArrayStats non-copyable and non-movable; use reset().
         std::atomic<int>  num_fabarrays{0};
         std::atomic<int>  max_num_fabarrays{0};
         std::atomic<int>  max_num_boxarrays{0};

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -21,6 +21,7 @@
 #include <omp.h>
 #endif
 
+#include <atomic>
 #include <cstdint>
 #include <ostream>
 #include <string>
@@ -810,25 +811,46 @@ public:
     //
     struct FabArrayStats
     {
-        int  num_fabarrays{0};
-        int  max_num_fabarrays{0};
-        int  max_num_boxarrays{0};
-        int  max_num_ba_use{1};
-        Long num_build{0};
+        // Atomic because recordBuild()/recordDelete() run from every FabArray
+        // constructor and destructor, which any host thread may reach.
+        std::atomic<int>  num_fabarrays{0};
+        std::atomic<int>  max_num_fabarrays{0};
+        std::atomic<int>  max_num_boxarrays{0};
+        std::atomic<int>  max_num_ba_use{1};
+        std::atomic<Long> num_build{0};
+
+        //! Raise `target` to `n` if `n` is larger.
+        template <typename T>
+        static void recordMax (std::atomic<T>& target, T n) noexcept {
+            T current = target.load(std::memory_order_relaxed);
+            while (current < n &&
+                   !target.compare_exchange_weak(current, n,
+                                                 std::memory_order_relaxed)) {
+                // current was reloaded with the value that beat us; retry
+            }
+        }
 
         void recordBuild () noexcept {
-            ++num_fabarrays;
-            ++num_build;
-            max_num_fabarrays = std::max(max_num_fabarrays, num_fabarrays);
+            int const n = num_fabarrays.fetch_add(1, std::memory_order_relaxed) + 1;
+            num_build.fetch_add(1, std::memory_order_relaxed);
+            recordMax(max_num_fabarrays, n);
         }
         void recordDelete () noexcept {
-            --num_fabarrays;
+            num_fabarrays.fetch_sub(1, std::memory_order_relaxed);
         }
         void recordMaxNumBoxArrays (int n) noexcept {
-            max_num_boxarrays = std::max(max_num_boxarrays, n);
+            recordMax(max_num_boxarrays, n);
         }
         void recordMaxNumBAUse (int n) noexcept {
-            max_num_ba_use = std::max(max_num_ba_use, n);
+            recordMax(max_num_ba_use, n);
+        }
+        //! Back to the state right after construction.
+        void reset () noexcept {
+            num_fabarrays.store(0);
+            max_num_fabarrays.store(0);
+            max_num_boxarrays.store(0);
+            max_num_ba_use.store(1);
+            num_build.store(0);
         }
         void print () const {
             amrex::Print(Print::AllProcs) << "### FabArray ###\n"

--- a/Src/Base/AMReX_FabArrayBase.H
+++ b/Src/Base/AMReX_FabArrayBase.H
@@ -475,6 +475,21 @@ public:
     //! Pop the most recent region tag. The tag stack must be nonempty.
     static void popRegionTag ();
 
+    //! A snapshot of the region-tag stack, taken under the cache lock.
+    static std::vector<std::string> regionTags ();
+
+    /**
+     * The region-tag stack used to label memory-usage accounting.
+     *
+     * push/popRegionTag() take fabarray_cache_mutex and so does the one
+     * reader, FabArray::AllocFabs(). That keeps the vector itself safe, but
+     * note a *stack* shared by threads is only meaningful when one thread
+     * uses it: RegionTag is RAII, so two overlapping guards on different
+     * threads pop each other's tag. Making it thread_local would fix that,
+     * and would also mean an OpenMP team no longer inherits a tag opened
+     * outside it -- a behaviour change wanting its own PR. Only Src/Amr uses
+     * it today.
+     */
     static AMREX_EXPORT std::vector<std::string> m_region_tag;
     struct RegionTag {
         RegionTag (const char* t) : tagged(true) { pushRegionTag(t); }

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -155,22 +155,32 @@ FabArrayBase::Initialize ()
 #ifdef AMREX_MEM_PROFILING
     MemProfiler::add(m_TAC_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
+                         // Written under fabarray_cache_mutex by updateMemUsage()
+                         std::scoped_lock lock(fabarray_cache_mutex);
                          return {m_TAC_stats.bytes, m_TAC_stats.bytes_hwm};
                      }));
     MemProfiler::add(m_FBC_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
+                         // Written under fabarray_cache_mutex by updateMemUsage()
+                         std::scoped_lock lock(fabarray_cache_mutex);
                          return {m_FBC_stats.bytes, m_FBC_stats.bytes_hwm};
                      }));
     MemProfiler::add(m_CPC_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
+                         // Written under fabarray_cache_mutex by updateMemUsage()
+                         std::scoped_lock lock(fabarray_cache_mutex);
                          return {m_CPC_stats.bytes, m_CPC_stats.bytes_hwm};
                      }));
     MemProfiler::add(m_FPinfo_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
+                         // Written under fabarray_cache_mutex by updateMemUsage()
+                         std::scoped_lock lock(fabarray_cache_mutex);
                          return {m_FPinfo_stats.bytes, m_FPinfo_stats.bytes_hwm};
                      }));
     MemProfiler::add(m_CFinfo_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
+                         // Written under fabarray_cache_mutex by updateMemUsage()
+                         std::scoped_lock lock(fabarray_cache_mutex);
                          return {m_CFinfo_stats.bytes, m_CFinfo_stats.bytes_hwm};
                      }));
 #endif

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -2724,6 +2724,13 @@ FabArrayBase::queryMemUsageHWM (const std::string& t)
     }
 }
 
+std::vector<std::string>
+FabArrayBase::regionTags ()
+{
+    std::scoped_lock lock(fabarray_cache_mutex);
+    return m_region_tag;
+}
+
 void
 FabArrayBase::pushRegionTag (const char* t)
 {

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -23,9 +23,29 @@
 #endif
 
 #include <algorithm>
+#include <atomic>
+#include <mutex>
 #include <utility>
 
 namespace amrex {
+
+namespace {
+    /**
+     * Guards every process-global FabArrayBase cache: the tile arrays, the
+     * FillBoundary/ParallelCopy/rotate/FillPatch/CrseFine/ParFor plans, their
+     * statistics, and the BoxArray-DistributionMapping reference counts that
+     * decide when those caches are flushed.
+     *
+     * The `omp critical` that used to guard the tile-array cache only excluded
+     * threads inside the same OpenMP contention group, and vanished entirely
+     * in a build without OpenMP -- so host threads that AMReX did not create
+     * (Python threads on a free-threaded interpreter, say) had no protection
+     * at all. A real mutex covers both.
+     *
+     * Recursive because clearThisBD() calls the flushers while holding it.
+     */
+    std::recursive_mutex fabarray_cache_mutex;
+}
 
 int FabArrayBase::MaxComp = 25;
 
@@ -88,7 +108,8 @@ bool                               FabArrayBase::m_alloc_single_chunk = false;
 namespace
 {
     bool initialized = false;
-    std::uint64_t comm_meta_data_id = 0;
+    //! Handed out to every CommMetaData, from any host thread.
+    std::atomic<std::uint64_t> comm_meta_data_id{0};
 }
 
 void
@@ -512,6 +533,7 @@ FabArrayBase::CPC::CPC (const BoxArray& ba, const IntVect& ng,
 void
 FabArrayBase::flushCPC (bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
 
@@ -555,6 +577,7 @@ FabArrayBase::flushCPC (bool no_assertion) const
 void
 FabArrayBase::flushCPCache ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     std::vector<CPC*> cpcs;
     for (auto const& it : m_TheCPCache)
     {
@@ -577,6 +600,7 @@ FabArrayBase::getCPC (const IntVect& dstng, const FabArrayBase& src, const IntVe
                       const Periodicity& period, bool to_ghost_cells_only,
                       const IntVect& offset) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     BL_PROFILE("FabArrayBase::getCPC()");
 
     BL_ASSERT(getBDKey() == m_bdkey);
@@ -1266,6 +1290,7 @@ FabArrayBase::FB::define_sb (const FabArrayBase& fa)
 void
 FabArrayBase::flushFB (bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
     std::pair<FBCacheIter,FBCacheIter> er_it = m_TheFBCache.equal_range(m_bdkey);
@@ -1283,6 +1308,7 @@ FabArrayBase::flushFB (bool no_assertion) const
 void
 FabArrayBase::flushFBCache ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     for (auto const& it : m_TheFBCache)
     {
         m_FBC_stats.recordErase(it.second->m_nuse);
@@ -1299,6 +1325,7 @@ FabArrayBase::getFB (const IntVect& nghost, const Periodicity& period,
                      bool cross, bool enforce_periodicity_only,
                      bool override_sync, IntVect const& sumboundary_src_nghost) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     BL_PROFILE("FabArrayBase::getFB()");
 
     BL_ASSERT(getBDKey() == m_bdkey);
@@ -1486,6 +1513,7 @@ FabArrayBase::RB90::define (const FabArrayBase& fa)
 void
 FabArrayBase::flushRB90 (bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     amrex::ignore_unused(no_assertion);
     AMREX_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_TheRB90Cache.equal_range(m_bdkey);
@@ -1498,6 +1526,7 @@ FabArrayBase::flushRB90 (bool no_assertion) const
 void
 FabArrayBase::flushRB90Cache ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     for (auto const& it : m_TheRB90Cache) {
         delete it.second;
     }
@@ -1507,6 +1536,7 @@ FabArrayBase::flushRB90Cache ()
 const FabArrayBase::RB90&
 FabArrayBase::getRB90 (const IntVect& nghost, const Box& domain) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     BL_PROFILE("FabArrayBase::getRB90()");
 
     AMREX_ASSERT(getBDKey() == m_bdkey);
@@ -1650,6 +1680,7 @@ FabArrayBase::RB180::define (const FabArrayBase& fa)
 void
 FabArrayBase::flushRB180 (bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     amrex::ignore_unused(no_assertion);
     AMREX_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_TheRB180Cache.equal_range(m_bdkey);
@@ -1662,6 +1693,7 @@ FabArrayBase::flushRB180 (bool no_assertion) const
 void
 FabArrayBase::flushRB180Cache ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     for (auto const& it : m_TheRB180Cache) {
         delete it.second;
     }
@@ -1671,6 +1703,7 @@ FabArrayBase::flushRB180Cache ()
 const FabArrayBase::RB180&
 FabArrayBase::getRB180 (const IntVect& nghost, const Box& domain) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     BL_PROFILE("FabArrayBase::getRB180()");
 
     AMREX_ASSERT(getBDKey() == m_bdkey);
@@ -1836,6 +1869,7 @@ FabArrayBase::PolarB::define (const FabArrayBase& fa)
 void
 FabArrayBase::flushPolarB (bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     amrex::ignore_unused(no_assertion);
     AMREX_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_ThePolarBCache.equal_range(m_bdkey);
@@ -1848,6 +1882,7 @@ FabArrayBase::flushPolarB (bool no_assertion) const
 void
 FabArrayBase::flushPolarBCache ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     for (auto const& it : m_ThePolarBCache) {
         delete it.second;
     }
@@ -1857,6 +1892,7 @@ FabArrayBase::flushPolarBCache ()
 const FabArrayBase::PolarB&
 FabArrayBase::getPolarB (const IntVect& nghost, const Box& domain) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     BL_PROFILE("FabArrayBase::getPolarB()");
 
     AMREX_ASSERT(getBDKey() == m_bdkey);
@@ -2071,6 +2107,7 @@ FabArrayBase::TheFPinfo (const FabArrayBase& srcfa,
                          const Geometry&     cgeom,
                          const EB2::IndexSpace* index_space)
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     BL_PROFILE("FabArrayBase::TheFPinfo()");
 
     Box dstdomain = fgeom.Domain();
@@ -2125,6 +2162,7 @@ FabArrayBase::TheFPinfo (const FabArrayBase& srcfa,
 void
 FabArrayBase::flushFPinfo (bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
 
@@ -2245,6 +2283,7 @@ FabArrayBase::TheCFinfo (const FabArrayBase& finefa,
                          bool                include_periodic,
                          bool                include_physbndry)
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     BL_PROFILE("FabArrayBase::TheCFinfo()");
 
     const BDKey& key = finefa.getBDKey();
@@ -2283,6 +2322,7 @@ FabArrayBase::TheCFinfo (const FabArrayBase& finefa,
 void
 FabArrayBase::flushCFinfo (bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_TheCrseFineCache.equal_range(m_bdkey);
@@ -2300,6 +2340,7 @@ FabArrayBase::flushCFinfo (bool no_assertion) const
 void
 FabArrayBase::Finalize ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     FabArrayBase::flushFBCache();
     FabArrayBase::flushCPCache();
     FabArrayBase::flushRB90Cache();
@@ -2333,7 +2374,7 @@ FabArrayBase::Finalize ()
 
     m_BD_count.clear();
 
-    m_FA_stats = FabArrayStats();
+    m_FA_stats.reset();
 
     initialized = false;
 }
@@ -2343,10 +2384,9 @@ FabArrayBase::getTileArray (const IntVect& tilesize) const
 {
     TileArray* p;
 
-#ifdef AMREX_USE_OMP
-#pragma omp critical(gettilearray)
-#endif
     {
+        std::scoped_lock lock(fabarray_cache_mutex);
+
         BL_ASSERT(getBDKey() == m_bdkey);
 
         const IntVect& crse_ratio = boxArray().crseRatio();
@@ -2468,6 +2508,7 @@ FabArrayBase::buildTileArray (const IntVect& tileSize, TileArray& ta) const
 void
 FabArrayBase::flushTileArray (const IntVect& tileSize, bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
 
@@ -2505,6 +2546,7 @@ FabArrayBase::flushTileArray (const IntVect& tileSize, bool no_assertion) const
 void
 FabArrayBase::flushTileArrayCache ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     for (auto const& tao_it : m_TheTileArrayCache) {
         for (auto const& tai_it : tao_it.second) {
             m_TAC_stats.recordErase(tai_it.second.nuse);
@@ -2519,6 +2561,7 @@ FabArrayBase::flushTileArrayCache ()
 void
 FabArrayBase::clearThisBD (bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     BL_ASSERT(boxarray.empty() || no_assertion || getBDKey() == m_bdkey);
 
     auto cnt_it = m_BD_count.find(m_bdkey);
@@ -2549,6 +2592,7 @@ FabArrayBase::clearThisBD (bool no_assertion) const
 void
 FabArrayBase::addThisBD ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     m_bdkey = getBDKey();
     int cnt = ++(m_BD_count[m_bdkey]);
     if (cnt == 1) { // new one
@@ -2561,6 +2605,7 @@ FabArrayBase::addThisBD ()
 void
 FabArrayBase::updateBDKey ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     if (getBDKey() != m_bdkey) {
         clearThisBD(true);
         addThisBD();
@@ -2626,6 +2671,7 @@ operator<< (std::ostream& os, const FabArrayBase::BDKey& id)
 void
 FabArrayBase::updateMemUsage (std::string const& tag, Long nbytes, Arena const* /*ar*/)
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     auto& mi = m_mem_usage[tag];
     mi.nbytes += nbytes;
     mi.nbytes_hwm = std::max(mi.nbytes, mi.nbytes_hwm);
@@ -2634,6 +2680,7 @@ FabArrayBase::updateMemUsage (std::string const& tag, Long nbytes, Arena const* 
 void
 FabArrayBase::printMemUsage ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     if (ParallelContext::IOProcessorSub())
     {
         std::cout << "MultiFab Tag, current usage and hwm in bytes\n";
@@ -2646,6 +2693,7 @@ FabArrayBase::printMemUsage ()
 Long
 FabArrayBase::queryMemUsage (const std::string& t)
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     auto r = m_mem_usage.find(t);
     if (r != m_mem_usage.end()) {
         return r->second.nbytes;
@@ -2657,6 +2705,7 @@ FabArrayBase::queryMemUsage (const std::string& t)
 Long
 FabArrayBase::queryMemUsageHWM (const std::string& t)
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     auto r = m_mem_usage.find(t);
     if (r != m_mem_usage.end()) {
         return r->second.nbytes_hwm;
@@ -2668,18 +2717,21 @@ FabArrayBase::queryMemUsageHWM (const std::string& t)
 void
 FabArrayBase::pushRegionTag (const char* t)
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     m_region_tag.emplace_back(t);
 }
 
 void
 FabArrayBase::pushRegionTag (std::string t)
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     m_region_tag.emplace_back(std::move(t));
 }
 
 void
 FabArrayBase::popRegionTag ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     m_region_tag.pop_back();
 }
 
@@ -2754,6 +2806,7 @@ FabArrayBase::ParForInfo::~ParForInfo ()
 FabArrayBase::ParForInfo const&
 FabArrayBase::getParForInfo (const IntVect& nghost) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     AMREX_ASSERT(getBDKey() == m_bdkey);
     auto er_it = m_TheParForCache.equal_range(m_bdkey);
     for (auto it = er_it.first; it != er_it.second; ++it) {
@@ -2773,6 +2826,7 @@ FabArrayBase::getParForInfo (const IntVect& nghost) const
 void
 FabArrayBase::flushParForInfo (bool no_assertion) const
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     amrex::ignore_unused(no_assertion);
     AMREX_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_TheParForCache.equal_range(m_bdkey);
@@ -2785,6 +2839,7 @@ FabArrayBase::flushParForInfo (bool no_assertion) const
 void
 FabArrayBase::flushParForCache ()
 {
+    std::scoped_lock lock(fabarray_cache_mutex);
     for (auto it = m_TheParForCache.begin(); it != m_TheParForCache.end(); ++it) {
         delete it->second;
     }
@@ -2796,7 +2851,7 @@ FabArrayBase::flushParForCache ()
 std::uint64_t
 FabArrayBase::getNextCommMetaDataId ()
 {
-    return comm_meta_data_id++;
+    return comm_meta_data_id.fetch_add(1, std::memory_order_relaxed);
 }
 
 /// \cond DOXYGEN_IGNORE

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -43,15 +43,12 @@ namespace {
      * at all. A real mutex covers both.
      *
      * Recursive because clearThisBD() calls the flushers while holding it.
-     */
-    /**
-     * Guards the FabArrayBase cache family and the memory-usage bookkeeping.
      *
-     * Function-local for the same reason as ParmParse's table mutex:
-     * std::recursive_mutex is not constant-initializable, and a
-     * namespace-scope one can be reached before construction by a
-     * static-storage object -- here, anything that builds or destroys a
-     * FabArray during static initialization.
+     * Function-local rather than namespace-scope because std::recursive_mutex
+     * is not guaranteed constant-initializable, so a namespace-scope one can
+     * be reached before construction by a static-storage object -- here,
+     * anything that builds or destroys a FabArray during static
+     * initialization.
      */
     std::recursive_mutex& fabarray_cache_mutex ()
     {

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -44,7 +44,20 @@ namespace {
      *
      * Recursive because clearThisBD() calls the flushers while holding it.
      */
-    std::recursive_mutex fabarray_cache_mutex;
+    /**
+     * Guards the FabArrayBase cache family and the memory-usage bookkeeping.
+     *
+     * Function-local for the same reason as ParmParse's table mutex:
+     * std::recursive_mutex is not constant-initializable, and a
+     * namespace-scope one can be reached before construction by a
+     * static-storage object -- here, anything that builds or destroys a
+     * FabArray during static initialization.
+     */
+    std::recursive_mutex& fabarray_cache_mutex ()
+    {
+        static std::recursive_mutex m;
+        return m;
+    }
 }
 
 int FabArrayBase::MaxComp = 25;
@@ -156,31 +169,31 @@ FabArrayBase::Initialize ()
     MemProfiler::add(m_TAC_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
                          // Written under fabarray_cache_mutex by updateMemUsage()
-                         std::scoped_lock lock(fabarray_cache_mutex);
+                         std::scoped_lock lock(fabarray_cache_mutex());
                          return {m_TAC_stats.bytes, m_TAC_stats.bytes_hwm};
                      }));
     MemProfiler::add(m_FBC_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
                          // Written under fabarray_cache_mutex by updateMemUsage()
-                         std::scoped_lock lock(fabarray_cache_mutex);
+                         std::scoped_lock lock(fabarray_cache_mutex());
                          return {m_FBC_stats.bytes, m_FBC_stats.bytes_hwm};
                      }));
     MemProfiler::add(m_CPC_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
                          // Written under fabarray_cache_mutex by updateMemUsage()
-                         std::scoped_lock lock(fabarray_cache_mutex);
+                         std::scoped_lock lock(fabarray_cache_mutex());
                          return {m_CPC_stats.bytes, m_CPC_stats.bytes_hwm};
                      }));
     MemProfiler::add(m_FPinfo_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
                          // Written under fabarray_cache_mutex by updateMemUsage()
-                         std::scoped_lock lock(fabarray_cache_mutex);
+                         std::scoped_lock lock(fabarray_cache_mutex());
                          return {m_FPinfo_stats.bytes, m_FPinfo_stats.bytes_hwm};
                      }));
     MemProfiler::add(m_CFinfo_stats.name, std::function<MemProfiler::MemInfo()>
                      ([] () -> MemProfiler::MemInfo {
                          // Written under fabarray_cache_mutex by updateMemUsage()
-                         std::scoped_lock lock(fabarray_cache_mutex);
+                         std::scoped_lock lock(fabarray_cache_mutex());
                          return {m_CFinfo_stats.bytes, m_CFinfo_stats.bytes_hwm};
                      }));
 #endif
@@ -543,7 +556,7 @@ FabArrayBase::CPC::CPC (const BoxArray& ba, const IntVect& ng,
 void
 FabArrayBase::flushCPC (bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
 
@@ -587,7 +600,7 @@ FabArrayBase::flushCPC (bool no_assertion) const
 void
 FabArrayBase::flushCPCache ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     std::vector<CPC*> cpcs;
     for (auto const& it : m_TheCPCache)
     {
@@ -610,7 +623,7 @@ FabArrayBase::getCPC (const IntVect& dstng, const FabArrayBase& src, const IntVe
                       const Periodicity& period, bool to_ghost_cells_only,
                       const IntVect& offset) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     BL_PROFILE("FabArrayBase::getCPC()");
 
     BL_ASSERT(getBDKey() == m_bdkey);
@@ -1300,7 +1313,7 @@ FabArrayBase::FB::define_sb (const FabArrayBase& fa)
 void
 FabArrayBase::flushFB (bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
     std::pair<FBCacheIter,FBCacheIter> er_it = m_TheFBCache.equal_range(m_bdkey);
@@ -1318,7 +1331,7 @@ FabArrayBase::flushFB (bool no_assertion) const
 void
 FabArrayBase::flushFBCache ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     for (auto const& it : m_TheFBCache)
     {
         m_FBC_stats.recordErase(it.second->m_nuse);
@@ -1335,7 +1348,7 @@ FabArrayBase::getFB (const IntVect& nghost, const Periodicity& period,
                      bool cross, bool enforce_periodicity_only,
                      bool override_sync, IntVect const& sumboundary_src_nghost) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     BL_PROFILE("FabArrayBase::getFB()");
 
     BL_ASSERT(getBDKey() == m_bdkey);
@@ -1523,7 +1536,7 @@ FabArrayBase::RB90::define (const FabArrayBase& fa)
 void
 FabArrayBase::flushRB90 (bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     amrex::ignore_unused(no_assertion);
     AMREX_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_TheRB90Cache.equal_range(m_bdkey);
@@ -1536,7 +1549,7 @@ FabArrayBase::flushRB90 (bool no_assertion) const
 void
 FabArrayBase::flushRB90Cache ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     for (auto const& it : m_TheRB90Cache) {
         delete it.second;
     }
@@ -1546,7 +1559,7 @@ FabArrayBase::flushRB90Cache ()
 const FabArrayBase::RB90&
 FabArrayBase::getRB90 (const IntVect& nghost, const Box& domain) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     BL_PROFILE("FabArrayBase::getRB90()");
 
     AMREX_ASSERT(getBDKey() == m_bdkey);
@@ -1690,7 +1703,7 @@ FabArrayBase::RB180::define (const FabArrayBase& fa)
 void
 FabArrayBase::flushRB180 (bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     amrex::ignore_unused(no_assertion);
     AMREX_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_TheRB180Cache.equal_range(m_bdkey);
@@ -1703,7 +1716,7 @@ FabArrayBase::flushRB180 (bool no_assertion) const
 void
 FabArrayBase::flushRB180Cache ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     for (auto const& it : m_TheRB180Cache) {
         delete it.second;
     }
@@ -1713,7 +1726,7 @@ FabArrayBase::flushRB180Cache ()
 const FabArrayBase::RB180&
 FabArrayBase::getRB180 (const IntVect& nghost, const Box& domain) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     BL_PROFILE("FabArrayBase::getRB180()");
 
     AMREX_ASSERT(getBDKey() == m_bdkey);
@@ -1879,7 +1892,7 @@ FabArrayBase::PolarB::define (const FabArrayBase& fa)
 void
 FabArrayBase::flushPolarB (bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     amrex::ignore_unused(no_assertion);
     AMREX_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_ThePolarBCache.equal_range(m_bdkey);
@@ -1892,7 +1905,7 @@ FabArrayBase::flushPolarB (bool no_assertion) const
 void
 FabArrayBase::flushPolarBCache ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     for (auto const& it : m_ThePolarBCache) {
         delete it.second;
     }
@@ -1902,7 +1915,7 @@ FabArrayBase::flushPolarBCache ()
 const FabArrayBase::PolarB&
 FabArrayBase::getPolarB (const IntVect& nghost, const Box& domain) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     BL_PROFILE("FabArrayBase::getPolarB()");
 
     AMREX_ASSERT(getBDKey() == m_bdkey);
@@ -2117,7 +2130,7 @@ FabArrayBase::TheFPinfo (const FabArrayBase& srcfa,
                          const Geometry&     cgeom,
                          const EB2::IndexSpace* index_space)
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     BL_PROFILE("FabArrayBase::TheFPinfo()");
 
     Box dstdomain = fgeom.Domain();
@@ -2172,7 +2185,7 @@ FabArrayBase::TheFPinfo (const FabArrayBase& srcfa,
 void
 FabArrayBase::flushFPinfo (bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
 
@@ -2293,7 +2306,7 @@ FabArrayBase::TheCFinfo (const FabArrayBase& finefa,
                          bool                include_periodic,
                          bool                include_physbndry)
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     BL_PROFILE("FabArrayBase::TheCFinfo()");
 
     const BDKey& key = finefa.getBDKey();
@@ -2332,7 +2345,7 @@ FabArrayBase::TheCFinfo (const FabArrayBase& finefa,
 void
 FabArrayBase::flushCFinfo (bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_TheCrseFineCache.equal_range(m_bdkey);
@@ -2350,7 +2363,7 @@ FabArrayBase::flushCFinfo (bool no_assertion) const
 void
 FabArrayBase::Finalize ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     FabArrayBase::flushFBCache();
     FabArrayBase::flushCPCache();
     FabArrayBase::flushRB90Cache();
@@ -2395,7 +2408,7 @@ FabArrayBase::getTileArray (const IntVect& tilesize) const
     TileArray* p;
 
     {
-        std::scoped_lock lock(fabarray_cache_mutex);
+        std::scoped_lock lock(fabarray_cache_mutex());
 
         BL_ASSERT(getBDKey() == m_bdkey);
 
@@ -2518,7 +2531,7 @@ FabArrayBase::buildTileArray (const IntVect& tileSize, TileArray& ta) const
 void
 FabArrayBase::flushTileArray (const IntVect& tileSize, bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     amrex::ignore_unused(no_assertion);
     BL_ASSERT(no_assertion || getBDKey() == m_bdkey);
 
@@ -2556,7 +2569,7 @@ FabArrayBase::flushTileArray (const IntVect& tileSize, bool no_assertion) const
 void
 FabArrayBase::flushTileArrayCache ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     for (auto const& tao_it : m_TheTileArrayCache) {
         for (auto const& tai_it : tao_it.second) {
             m_TAC_stats.recordErase(tai_it.second.nuse);
@@ -2571,7 +2584,7 @@ FabArrayBase::flushTileArrayCache ()
 void
 FabArrayBase::clearThisBD (bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     BL_ASSERT(boxarray.empty() || no_assertion || getBDKey() == m_bdkey);
 
     auto cnt_it = m_BD_count.find(m_bdkey);
@@ -2602,7 +2615,7 @@ FabArrayBase::clearThisBD (bool no_assertion) const
 void
 FabArrayBase::addThisBD ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     m_bdkey = getBDKey();
     int cnt = ++(m_BD_count[m_bdkey]);
     if (cnt == 1) { // new one
@@ -2615,7 +2628,7 @@ FabArrayBase::addThisBD ()
 void
 FabArrayBase::updateBDKey ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     if (getBDKey() != m_bdkey) {
         clearThisBD(true);
         addThisBD();
@@ -2681,7 +2694,7 @@ operator<< (std::ostream& os, const FabArrayBase::BDKey& id)
 void
 FabArrayBase::updateMemUsage (std::string const& tag, Long nbytes, Arena const* /*ar*/)
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     auto& mi = m_mem_usage[tag];
     mi.nbytes += nbytes;
     mi.nbytes_hwm = std::max(mi.nbytes, mi.nbytes_hwm);
@@ -2690,7 +2703,7 @@ FabArrayBase::updateMemUsage (std::string const& tag, Long nbytes, Arena const* 
 void
 FabArrayBase::printMemUsage ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     if (ParallelContext::IOProcessorSub())
     {
         std::cout << "MultiFab Tag, current usage and hwm in bytes\n";
@@ -2703,7 +2716,7 @@ FabArrayBase::printMemUsage ()
 Long
 FabArrayBase::queryMemUsage (const std::string& t)
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     auto r = m_mem_usage.find(t);
     if (r != m_mem_usage.end()) {
         return r->second.nbytes;
@@ -2715,7 +2728,7 @@ FabArrayBase::queryMemUsage (const std::string& t)
 Long
 FabArrayBase::queryMemUsageHWM (const std::string& t)
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     auto r = m_mem_usage.find(t);
     if (r != m_mem_usage.end()) {
         return r->second.nbytes_hwm;
@@ -2727,28 +2740,28 @@ FabArrayBase::queryMemUsageHWM (const std::string& t)
 std::vector<std::string>
 FabArrayBase::regionTags ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     return m_region_tag;
 }
 
 void
 FabArrayBase::pushRegionTag (const char* t)
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     m_region_tag.emplace_back(t);
 }
 
 void
 FabArrayBase::pushRegionTag (std::string t)
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     m_region_tag.emplace_back(std::move(t));
 }
 
 void
 FabArrayBase::popRegionTag ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     m_region_tag.pop_back();
 }
 
@@ -2823,7 +2836,7 @@ FabArrayBase::ParForInfo::~ParForInfo ()
 FabArrayBase::ParForInfo const&
 FabArrayBase::getParForInfo (const IntVect& nghost) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     AMREX_ASSERT(getBDKey() == m_bdkey);
     auto er_it = m_TheParForCache.equal_range(m_bdkey);
     for (auto it = er_it.first; it != er_it.second; ++it) {
@@ -2843,7 +2856,7 @@ FabArrayBase::getParForInfo (const IntVect& nghost) const
 void
 FabArrayBase::flushParForInfo (bool no_assertion) const
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     amrex::ignore_unused(no_assertion);
     AMREX_ASSERT(no_assertion || getBDKey() == m_bdkey);
     auto er_it = m_TheParForCache.equal_range(m_bdkey);
@@ -2856,7 +2869,7 @@ FabArrayBase::flushParForInfo (bool no_assertion) const
 void
 FabArrayBase::flushParForCache ()
 {
-    std::scoped_lock lock(fabarray_cache_mutex);
+    std::scoped_lock lock(fabarray_cache_mutex());
     for (auto it = m_TheParForCache.begin(); it != m_TheParForCache.end(); ++it) {
         delete it->second;
     }

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -214,6 +214,12 @@ Geometry::Setup (const RealBox* rb, int coord, int const* isper)
 void
 Geometry::ResetDefaultProbDomain (const RealBox& rb) noexcept
 {
+    // Same lock as Setup()/define(): these write the very fields define()
+    // reads out of the default Geometry. Note the lock only keeps a reader
+    // from seeing a half-written RealBox -- resetting a default that other
+    // Geometry objects were already built from is a semantic question the
+    // docs still put on the caller.
+    std::scoped_lock lock(default_geometry_mutex);
     Geometry* gg = AMReX::top()->getDefaultGeometry();
     gg->prob_domain.setLo(rb.lo());
     gg->prob_domain.setHi(rb.hi());
@@ -223,6 +229,7 @@ Geometry::ResetDefaultProbDomain (const RealBox& rb) noexcept
 void
 Geometry::ResetDefaultPeriodicity (const Array<int,AMREX_SPACEDIM>& is_per) noexcept
 {
+    std::scoped_lock lock(default_geometry_mutex);
     Geometry* gg = AMReX::top()->getDefaultGeometry();
     gg->setPeriodicity(is_per);
 }
@@ -231,6 +238,7 @@ void
 Geometry::ResetDefaultCoord (int coord) noexcept
 {
     AMREX_ASSERT(coord >= -1 && coord <= 2);
+    std::scoped_lock lock(default_geometry_mutex);
     Geometry* gg = AMReX::top()->getDefaultGeometry();
     gg->SetCoord(static_cast<CoordType>(coord)); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
 }

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -59,6 +59,7 @@ operator>> (std::istream& is, Geometry& g)
         is >> is_per;
         g.setPeriodicity({{AMREX_D_DECL(is_per[0],is_per[1],is_per[2])}});
     } else {
+        std::scoped_lock lock(default_geometry_mutex);
         g.setPeriodicity(DefaultGeometry().isPeriodic());
     }
 
@@ -67,7 +68,16 @@ operator>> (std::istream& is, Geometry& g)
 
 Geometry::Geometry () noexcept
 {
-    if (!AMReX::empty()) { *this = DefaultGeometry(); }
+    // Copying the process-global default is a read of everything
+    // ResetDefault*() writes, so it takes the same lock. pyAMReX binds both
+    // this constructor and all three ResetDefault* functions, so
+    // `amr.Geometry()` on one Python thread concurrent with
+    // `g.ResetDefaultProbDomain(rb)` on another is otherwise a torn read of a
+    // RealBox from pure Python.
+    if (!AMReX::empty()) {
+        std::scoped_lock lock(default_geometry_mutex);
+        *this = DefaultGeometry();
+    }
 }
 
 Geometry::Geometry (const Box& dom, const RealBox* rb, int coord,

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -11,8 +11,31 @@
 #include <AMReX_OpenMP.H>
 
 #include <iostream>
+#include <mutex>
 
 namespace amrex {
+
+namespace {
+    /**
+     * Guards the process-global default Geometry, AMReX::top()->getDefaultGeometry().
+     *
+     * Setup() is a check-then-act on that object: it returns early if the
+     * default has already been filled in, and otherwise writes its coordinate
+     * system, problem domain, offset and periodicity field by field. Every
+     * Geometry::define() calls it, so without this two threads constructing
+     * the first Geometry of the process both see ok == false, both run the
+     * body, and either can read a half-written RealBox.
+     *
+     * The lock is also what orders the reads back in define(): a thread that
+     * finds the default already set up still acquires this mutex on the way
+     * in, so the values it then reads out of the default Geometry are the
+     * ones the thread that filled them in published.
+     *
+     * The window reopens on every amrex::Initialize(), because the default
+     * Geometry hangs off AMReX::top().
+     */
+    std::mutex default_geometry_mutex; // NOLINT(cert-err58-cpp)
+}
 
 std::ostream&
 operator<< (std::ostream& os, const Geometry& g)
@@ -74,28 +97,35 @@ Geometry::define (const Box& dom, const RealBox* rb, int coord,
 
     Setup(rb,coord,is_per);
 
-    Geometry* gg = AMReX::top()->getDefaultGeometry();
+    {
+        // Whatever this constructor did not get told explicitly is inherited
+        // from the default Geometry, so read it under the same lock Setup()
+        // fills it in under.
+        std::scoped_lock lock(default_geometry_mutex);
 
-    if (coord <= -1 || coord > 2) {
-        c_sys = gg->Coord();
-    } else {
-        c_sys = static_cast<CoordType>(coord);
-    }
+        Geometry* gg = AMReX::top()->getDefaultGeometry();
 
-    if (is_per == nullptr) {
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            is_periodic[idim] = gg->isPeriodic(idim);
+        if (coord <= -1 || coord > 2) {
+            c_sys = gg->Coord();
+        } else {
+            c_sys = static_cast<CoordType>(coord);
         }
-    } else {
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            is_periodic[idim] = is_per[idim];
-        }
-    }
 
-    if (rb == nullptr) {
-        prob_domain = gg->ProbDomain();
-    } else {
-        prob_domain = *rb;
+        if (is_per == nullptr) {
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                is_periodic[idim] = gg->isPeriodic(idim);
+            }
+        } else {
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                is_periodic[idim] = is_per[idim];
+            }
+        }
+
+        if (rb == nullptr) {
+            prob_domain = gg->ProbDomain();
+        } else {
+            prob_domain = *rb;
+        }
     }
 
     domain = dom;
@@ -107,6 +137,8 @@ Geometry::define (const Box& dom, const RealBox* rb, int coord,
 void
 Geometry::Setup (const RealBox* rb, int coord, int const* isper)
 {
+    std::scoped_lock lock(default_geometry_mutex);
+
     Geometry* gg = AMReX::top()->getDefaultGeometry();
 
     if (gg->ok) { return; }

--- a/Src/Base/AMReX_GpuControl.H
+++ b/Src/Base/AMReX_GpuControl.H
@@ -83,26 +83,19 @@ namespace Gpu {
 
 #if defined(AMREX_USE_GPU)
 
-    /* The execution-scope flags below (in_launch_region, in_graph_region,
-     * in_single_stream_region, in_nosync_region) are process-global, and the
-     * RAII guards further down save and restore them. That means one host
-     * thread's guard changes what every other host thread does, and two
-     * overlapping guards on different threads restore each other's values --
-     * see the host-thread-safety section of the docs, which lists them as the
-     * caller's responsibility.
+    /* The execution-scope flags (launch, graph, single-stream, nosync) are
+     * per-thread: one host thread's RAII guard must not change what another
+     * one does. An OpenMP team still observes a guard opened outside it,
+     * because the setters broadcast to the team. See AMReX_GpuControl.cpp for
+     * why this could not be left to caller discipline -- AMReX opens these
+     * guards itself inside ordinary APIs.
      *
-     * They are not simply thread_local because an OpenMP program opens a guard
-     * *outside* a parallel region and expects the team inside to observe it.
-     * Making them per-thread with the guard broadcasting to the current team
-     * on entry would serve both, and looks affordable; it wants its own PR.
-     * Note MSVC forbids dllexport on a thread_local, so per-thread storage
-     * here needs the accessor-function treatment used for
+     * Out of line rather than inline over a thread_local, because MSVC forbids
+     * dllexport on a thread_local; same treatment as
      * Gpu::Device::getStreamIndex().
      */
-    extern bool in_launch_region;
-
-    [[nodiscard]] inline bool inLaunchRegion () noexcept { return in_launch_region; }
-    [[nodiscard]] inline bool notInLaunchRegion () noexcept { return !in_launch_region; }
+    [[nodiscard]] bool inLaunchRegion () noexcept;
+    [[nodiscard]] inline bool notInLaunchRegion () noexcept { return !inLaunchRegion(); }
 
     /**
      * Enable/disable GPU kernel launches.
@@ -123,21 +116,14 @@ namespace Gpu {
      * Will disable the launching of GPU kernels between the calls.
      */
 
-    inline bool setLaunchRegion (bool launch) noexcept {
-        bool r = in_launch_region;
-        in_launch_region = launch;
-        return r;
-    }
+    bool setLaunchRegion (bool launch) noexcept;
 
-    extern bool in_graph_region;
-    [[nodiscard]] inline bool inGraphRegion() { return (in_graph_region && in_launch_region); }
-    [[nodiscard]] inline bool notInGraphRegion() { return (!in_graph_region || !in_launch_region); }
+    //! The graph flag on its own; inGraphRegion() also requires the launch flag.
+    [[nodiscard]] bool inGraphRegionFlag () noexcept;
+    [[nodiscard]] inline bool inGraphRegion() { return (inGraphRegionFlag() && inLaunchRegion()); }
+    [[nodiscard]] inline bool notInGraphRegion() { return (!inGraphRegionFlag() || !inLaunchRegion()); }
 
-    inline bool setGraphRegion (bool graph) {
-        bool r = in_graph_region;
-        in_graph_region = graph;
-        return r;
-    }
+    bool setGraphRegion (bool graph) noexcept;
 
     struct [[nodiscard]] LaunchSafeGuard
     {
@@ -157,19 +143,11 @@ namespace Gpu {
         bool m_old;
     };
 
-    extern bool in_single_stream_region;
-    extern bool in_nosync_region;
+    [[nodiscard]] bool inSingleStreamRegion () noexcept;
+    [[nodiscard]] bool inNoSyncRegion () noexcept;
 
-    [[nodiscard]] inline bool inSingleStreamRegion () noexcept { return in_single_stream_region; }
-    [[nodiscard]] inline bool inNoSyncRegion () noexcept { return in_nosync_region; }
-
-    inline bool setSingleStreamRegion (bool b) noexcept {
-        return std::exchange(in_single_stream_region, b);
-    }
-
-    inline bool setNoSyncRegion (bool b) noexcept {
-        return std::exchange(in_nosync_region, b);
-    }
+    bool setSingleStreamRegion (bool b) noexcept;
+    bool setNoSyncRegion (bool b) noexcept;
 
     /**
      * This struct provides a RAII-style mechanism for changing the number
@@ -178,10 +156,10 @@ namespace Gpu {
     struct [[nodiscard]] SingleStreamRegion
     {
         SingleStreamRegion () noexcept
-            : m_prev_flag(std::exchange(in_single_stream_region,true))
+            : m_prev_flag(setSingleStreamRegion(true))
         {}
 
-        ~SingleStreamRegion () { in_single_stream_region = m_prev_flag; }
+        ~SingleStreamRegion () { setSingleStreamRegion(m_prev_flag); }
 
     private:
         bool m_prev_flag;
@@ -195,10 +173,10 @@ namespace Gpu {
     struct [[nodiscard]] NoSyncRegion
     {
         NoSyncRegion () noexcept
-            : m_prev_flag(std::exchange(in_nosync_region,true))
+            : m_prev_flag(setNoSyncRegion(true))
         {}
 
-        ~NoSyncRegion () { in_nosync_region = m_prev_flag; }
+        ~NoSyncRegion () { setNoSyncRegion(m_prev_flag); }
 
         [[nodiscard]] bool inNoSyncRegionPreviously () const { return m_prev_flag; }
 

--- a/Src/Base/AMReX_GpuControl.H
+++ b/Src/Base/AMReX_GpuControl.H
@@ -83,6 +83,22 @@ namespace Gpu {
 
 #if defined(AMREX_USE_GPU)
 
+    /* The execution-scope flags below (in_launch_region, in_graph_region,
+     * in_single_stream_region, in_nosync_region) are process-global, and the
+     * RAII guards further down save and restore them. That means one host
+     * thread's guard changes what every other host thread does, and two
+     * overlapping guards on different threads restore each other's values --
+     * see the host-thread-safety section of the docs, which lists them as the
+     * caller's responsibility.
+     *
+     * They are not simply thread_local because an OpenMP program opens a guard
+     * *outside* a parallel region and expects the team inside to observe it.
+     * Making them per-thread with the guard broadcasting to the current team
+     * on entry would serve both, and looks affordable; it wants its own PR.
+     * Note MSVC forbids dllexport on a thread_local, so per-thread storage
+     * here needs the accessor-function treatment used for
+     * Gpu::Device::getStreamIndex().
+     */
     extern bool in_launch_region;
 
     [[nodiscard]] inline bool inLaunchRegion () noexcept { return in_launch_region; }

--- a/Src/Base/AMReX_GpuControl.cpp
+++ b/Src/Base/AMReX_GpuControl.cpp
@@ -1,13 +1,131 @@
 
 #include <AMReX_GpuControl.H>
+#include <AMReX_OpenMP.H>
 
 namespace amrex::Gpu {
 
 #if defined(AMREX_USE_GPU)
-bool in_launch_region = true;
-bool in_graph_region = false;
-bool in_single_stream_region = false;
-bool in_nosync_region = false;
+
+namespace {
+    /* Per-thread execution-scope flags.
+     *
+     * These used to be four process-global bools, which the RAII guards save
+     * and restore. That is unsound as soon as more than one host thread runs
+     * AMReX, and not only for a caller that touches them directly: AMReX opens
+     * the guards itself inside ordinary bound APIs -- Gpu::NoSyncRegion in
+     * ParticleContainer::addParticles(), Gpu::LaunchSafeGuard in Gpu::AnyOf()
+     * behind MultiFab::contains_nan()/contains_inf(). Two Python threads
+     * calling add_particles() interleave as save(false) / save(true) /
+     * restore(false) / restore(true), leaving in_nosync_region stuck true for
+     * the rest of the process, after which AMReX silently stops synchronizing
+     * streams. No caller discipline avoids that, which is why these became
+     * per-thread rather than being documented away.
+     *
+     * File scope rather than class data members because MSVC forbids dllexport
+     * on a thread_local -- the same reason Gpu::Device::getStreamIndex() is out
+     * of line.
+     */
+    thread_local bool tl_in_launch_region        = true;
+    thread_local bool tl_in_graph_region         = false;
+    thread_local bool tl_in_single_stream_region = false;
+    thread_local bool tl_in_nosync_region        = false;
+
+#ifdef AMREX_USE_OMP
+    /* What an OpenMP team observes.
+     *
+     * A team is created after the guard enclosing it, so its members do not
+     * inherit the opening thread's thread_local. Opening a guard outside a
+     * parallel region and having the team inside honour it is long-established
+     * behaviour, so the setters broadcast here and a query from inside a team
+     * reads this instead. Note the `if (Gpu::notInLaunchRegion())` clauses on
+     * AMReX's own `omp parallel` directives are evaluated by the encountering
+     * thread, which is outside the team, so those read the thread_local.
+     *
+     * Written only by a thread that is not itself in a parallel region, and
+     * read only from inside one. Two host threads that each open a guard and
+     * then each open a team still share these: an AMReX_OMP=ON build driven
+     * from several host threads is out of scope, the same caveat the
+     * per-thread RNG carries.
+     */
+    bool team_in_launch_region        = true;
+    bool team_in_graph_region         = false;
+    bool team_in_single_stream_region = false;
+    bool team_in_nosync_region        = false;
+#endif
+}
+
+bool inLaunchRegion () noexcept
+{
+#ifdef AMREX_USE_OMP
+    if (OpenMP::in_parallel()) { return team_in_launch_region; }
+#endif
+    return tl_in_launch_region;
+}
+
+bool setLaunchRegion (bool launch) noexcept
+{
+    bool const r = tl_in_launch_region;
+    tl_in_launch_region = launch;
+#ifdef AMREX_USE_OMP
+    if (!OpenMP::in_parallel()) { team_in_launch_region = launch; }
+#endif
+    return r;
+}
+
+bool inGraphRegionFlag () noexcept
+{
+#ifdef AMREX_USE_OMP
+    if (OpenMP::in_parallel()) { return team_in_graph_region; }
+#endif
+    return tl_in_graph_region;
+}
+
+bool setGraphRegion (bool graph) noexcept
+{
+    bool const r = tl_in_graph_region;
+    tl_in_graph_region = graph;
+#ifdef AMREX_USE_OMP
+    if (!OpenMP::in_parallel()) { team_in_graph_region = graph; }
+#endif
+    return r;
+}
+
+bool inSingleStreamRegion () noexcept
+{
+#ifdef AMREX_USE_OMP
+    if (OpenMP::in_parallel()) { return team_in_single_stream_region; }
+#endif
+    return tl_in_single_stream_region;
+}
+
+bool setSingleStreamRegion (bool b) noexcept
+{
+    bool const r = tl_in_single_stream_region;
+    tl_in_single_stream_region = b;
+#ifdef AMREX_USE_OMP
+    if (!OpenMP::in_parallel()) { team_in_single_stream_region = b; }
+#endif
+    return r;
+}
+
+bool inNoSyncRegion () noexcept
+{
+#ifdef AMREX_USE_OMP
+    if (OpenMP::in_parallel()) { return team_in_nosync_region; }
+#endif
+    return tl_in_nosync_region;
+}
+
+bool setNoSyncRegion (bool b) noexcept
+{
+    bool const r = tl_in_nosync_region;
+    tl_in_nosync_region = b;
+#ifdef AMREX_USE_OMP
+    if (!OpenMP::in_parallel()) { team_in_nosync_region = b; }
+#endif
+    return r;
+}
+
 #endif
 
 }

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -82,6 +82,7 @@ public:
     static void Initialize (bool minimal, int a_device_id);
     static void Finalize ();
 
+#if defined(AMREX_USE_GPU)
     /**
      * Index into gpu_stream_pool of the stream the calling thread submits to.
      *
@@ -98,7 +99,6 @@ public:
      */
     static int getStreamIndex () noexcept;
 
-#if defined(AMREX_USE_GPU)
     static gpuStream_t gpuStream () noexcept {
         if (!external_stream_stack.empty()) {
             AMREX_ASSERT(external_stream_stack.back().manager != nullptr);

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -88,8 +88,7 @@ public:
             AMREX_ASSERT(external_stream_stack.back().manager != nullptr);
             return external_stream_stack.back().manager->getStream();
         } else {
-            int tid = OpenMP::get_thread_num();
-            return gpu_stream_pool[gpu_stream_index[tid]].getStream();
+            return gpu_stream_pool[gpu_stream_index].getStream();
         }
     }
 #ifdef AMREX_USE_CUDA
@@ -260,9 +259,17 @@ private:
     static AMREX_EXPORT dim3 numBlocksOverride, numThreadsOverride;
 
     static AMREX_EXPORT Vector<StreamManager> gpu_stream_pool; // The size of this is max_gpu_stream
-    // The non-owning gpu_stream_index is used to store the current stream index that will be used.
-    // gpu_stream_index is a vector so that it's thread safe to write to it.
-    static AMREX_EXPORT Vector<int> gpu_stream_index; // The size of this is omp_max_threads
+    /**
+     * Index into gpu_stream_pool of the stream the calling thread submits to.
+     *
+     * Thread-local. It used to be a vector indexed by OpenMP::get_thread_num(),
+     * which is a compile-time 0 in a build without OpenMP -- so every host
+     * thread shared one slot and could silently launch onto another thread's
+     * stream. With this, a thread AMReX did not create (a Python thread on a
+     * free-threaded interpreter, say) gets its own stream just like an OpenMP
+     * thread does.
+     */
+    static AMREX_EXPORT thread_local int gpu_stream_index;
     static AMREX_EXPORT gpuDeviceProp_t device_prop;
     static AMREX_EXPORT int memory_pools_supported;
     static AMREX_EXPORT unsigned int max_blocks_per_launch;

--- a/Src/Base/AMReX_GpuDevice.H
+++ b/Src/Base/AMReX_GpuDevice.H
@@ -82,13 +82,29 @@ public:
     static void Initialize (bool minimal, int a_device_id);
     static void Finalize ();
 
+    /**
+     * Index into gpu_stream_pool of the stream the calling thread submits to.
+     *
+     * Backed by thread-local storage, so a thread AMReX did not create (a
+     * Python thread on a free-threaded interpreter, say) gets its own stream
+     * just like an OpenMP thread does. It used to be a vector indexed by
+     * OpenMP::get_thread_num(), which is a compile-time 0 in a build without
+     * OpenMP -- so every host thread shared one slot and could silently launch
+     * onto another thread's stream.
+     *
+     * Out of line rather than a thread_local data member, because MSVC forbids
+     * dllexport on a thread_local and this is reached from the inline
+     * gpuStream() below.
+     */
+    static int getStreamIndex () noexcept;
+
 #if defined(AMREX_USE_GPU)
     static gpuStream_t gpuStream () noexcept {
         if (!external_stream_stack.empty()) {
             AMREX_ASSERT(external_stream_stack.back().manager != nullptr);
             return external_stream_stack.back().manager->getStream();
         } else {
-            return gpu_stream_pool[gpu_stream_index].getStream();
+            return gpu_stream_pool[getStreamIndex()].getStream();
         }
     }
 #ifdef AMREX_USE_CUDA
@@ -258,18 +274,10 @@ private:
     static AMREX_EXPORT dim3 numThreadsMin;
     static AMREX_EXPORT dim3 numBlocksOverride, numThreadsOverride;
 
+    //! Set the calling thread's stream index; see getStreamIndex().
+    static void setStreamIndexTL (int idx) noexcept;
+
     static AMREX_EXPORT Vector<StreamManager> gpu_stream_pool; // The size of this is max_gpu_stream
-    /**
-     * Index into gpu_stream_pool of the stream the calling thread submits to.
-     *
-     * Thread-local. It used to be a vector indexed by OpenMP::get_thread_num(),
-     * which is a compile-time 0 in a build without OpenMP -- so every host
-     * thread shared one slot and could silently launch onto another thread's
-     * stream. With this, a thread AMReX did not create (a Python thread on a
-     * free-threaded interpreter, say) gets its own stream just like an OpenMP
-     * thread does.
-     */
-    static AMREX_EXPORT thread_local int gpu_stream_index;
     static AMREX_EXPORT gpuDeviceProp_t device_prop;
     static AMREX_EXPORT int memory_pools_supported;
     static AMREX_EXPORT unsigned int max_blocks_per_launch;

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -106,14 +106,21 @@ namespace {
     thread_local int tl_gpu_stream_index = 0;
 }
 
-int  Device::getStreamIndex   () noexcept {
+int
+Device::getStreamIndex () noexcept
+{
     // Clamped: a thread that outlives a Finalize()/Initialize() cycle keeps its
     // index, and max_gpu_streams is re-read from the inputs on every
     // Initialize(), so the pool may have shrunk underneath it.
     return (tl_gpu_stream_index >= 0 && tl_gpu_stream_index < max_gpu_streams)
         ? tl_gpu_stream_index : 0;
 }
-void Device::setStreamIndexTL (int idx) noexcept { tl_gpu_stream_index = idx; }
+
+void
+Device::setStreamIndexTL (int idx) noexcept
+{
+    tl_gpu_stream_index = idx;
+}
 gpuDeviceProp_t         Device::device_prop;
 int                     Device::memory_pools_supported = 0;
 #ifdef AMREX_USE_GPU
@@ -655,8 +662,10 @@ Device::initialize_gpu (bool minimal)
     }
 #endif
 
-    // Every thread starts on stream 0; a thread that has since moved to
-    // another one gets a fresh index from its next MFIter.
+    // Reset *this* thread to stream 0. Unlike the vector this replaced, it
+    // cannot reset the other threads' indices -- a thread that outlives a
+    // Finalize()/Initialize() cycle keeps the index it had, which is why
+    // getStreamIndex() clamps, and picks up a fresh one at its next MFIter.
     Device::setStreamIndexTL(0);
 
     ParmParse pp("device");

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -100,7 +100,7 @@ dim3 Device::numBlocksOverride  = dim3(0, 0, 0);
 unsigned int Device::max_blocks_per_launch = 2560;
 
 Vector<StreamManager>   Device::gpu_stream_pool;
-Vector<int>             Device::gpu_stream_index;
+thread_local int        Device::gpu_stream_index = 0;
 gpuDeviceProp_t         Device::device_prop;
 int                     Device::memory_pools_supported = 0;
 #ifdef AMREX_USE_GPU
@@ -481,8 +481,6 @@ Device::Finalize ()
     }
 #endif
 
-    gpu_stream_index.clear();
-
 #ifdef AMREX_USE_ACC
     amrex_finalize_acc();
 #endif
@@ -644,7 +642,9 @@ Device::initialize_gpu (bool minimal)
     }
 #endif
 
-    gpu_stream_index.resize(OpenMP::get_max_threads(), 0);
+    // Every thread starts on stream 0; a thread that has since moved to
+    // another one gets a fresh index from its next MFIter.
+    gpu_stream_index = 0;
 
     ParmParse pp("device");
 
@@ -735,7 +735,7 @@ Device::setStreamIndex (int idx) noexcept
 {
     amrex::ignore_unused(idx);
 #ifdef AMREX_USE_GPU
-    gpu_stream_index[OpenMP::get_thread_num()] = idx % max_gpu_streams;
+    gpu_stream_index = idx % max_gpu_streams;
 #ifdef AMREX_USE_ACC
     amrex_set_acc_stream(idx % max_gpu_streams);
 #endif
@@ -747,14 +747,13 @@ gpuStream_t
 Device::resetStream () noexcept
 {
     gpuStream_t r = gpuStream();
-    gpu_stream_index[OpenMP::get_thread_num()] = 0;
+    gpu_stream_index = 0;
     return r;
 }
 
 gpuStream_t
 Device::setStream (gpuStream_t s) noexcept
 {
-    int const tid = OpenMP::get_thread_num();
     gpuStream_t r = gpuStream();
     for (auto it = external_stream_stack.rbegin(); it != external_stream_stack.rend(); ++it) {
         AMREX_ASSERT(it->manager != nullptr);
@@ -767,7 +766,7 @@ Device::setStream (gpuStream_t s) noexcept
     if (idx == std::ssize(gpu_stream_pool)) {
         amrex::Abort("Gpu::Device::setStream: stream is not managed by AMReX.");
     }
-    gpu_stream_index[tid] = idx;
+    gpu_stream_index = idx;
     return r;
 }
 
@@ -811,7 +810,7 @@ Device::setExternalStream (gpuStream_t s)
     // these regions.
     external_stream_stack.emplace_back(
         ExternalStream{std::make_unique<StreamManager>(),
-                       gpu_stream_index[OpenMP::get_thread_num()]});
+                       gpu_stream_index});
     external_stream_stack.back().manager->getStream() = s;
 }
 
@@ -865,8 +864,7 @@ Device::streamSynchronize () noexcept
         AMREX_ASSERT(external_stream_stack.back().manager != nullptr);
         external_stream_stack.back().manager->sync();
     } else {
-        int tid = OpenMP::get_thread_num();
-        gpu_stream_pool[gpu_stream_index[tid]].sync();
+        gpu_stream_pool[gpu_stream_index].sync();
     }
 #endif
 }
@@ -945,8 +943,7 @@ Device::freeAsync (Arena* arena, void* mem) noexcept
         AMREX_ASSERT(external_stream_stack.back().manager != nullptr);
         external_stream_stack.back().manager->free_async(arena, mem);
     } else {
-        int tid = OpenMP::get_thread_num();
-        gpu_stream_pool[gpu_stream_index[tid]].free_async(arena, mem);
+        gpu_stream_pool[gpu_stream_index].free_async(arena, mem);
     }
 #else
     arena->free(mem);

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -106,7 +106,12 @@ namespace {
     thread_local int tl_gpu_stream_index = 0;
 }
 
-int  Device::getStreamIndex   () noexcept { return tl_gpu_stream_index; }
+int  Device::getStreamIndex   () noexcept {
+    // Clamped: a thread that outlives a Finalize()/Initialize() cycle keeps its
+    // index, and max_gpu_streams is re-read from the inputs on every
+    // Initialize(), so the pool may have shrunk underneath it.
+    return (tl_gpu_stream_index < max_gpu_streams) ? tl_gpu_stream_index : 0;
+}
 void Device::setStreamIndexTL (int idx) noexcept { tl_gpu_stream_index = idx; }
 gpuDeviceProp_t         Device::device_prop;
 int                     Device::memory_pools_supported = 0;

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -109,10 +109,13 @@ namespace {
 int
 Device::getStreamIndex () noexcept
 {
-    // Clamped: a thread that outlives a Finalize()/Initialize() cycle keeps its
-    // index, and max_gpu_streams is re-read from the inputs on every
-    // Initialize(), so the pool may have shrunk underneath it.
-    return (tl_gpu_stream_index >= 0 && tl_gpu_stream_index < max_gpu_streams)
+    // Clamped against the pool itself, not max_gpu_streams: a thread that
+    // outlives a Finalize()/Initialize() cycle keeps its index, and
+    // max_gpu_streams is re-read from the inputs early in Initialize() while
+    // gpu_stream_pool is only resized to match later -- so between the two a
+    // grown max_gpu_streams would otherwise hand back an index past the end.
+    return (tl_gpu_stream_index >= 0 &&
+            tl_gpu_stream_index < static_cast<int>(gpu_stream_pool.size()))
         ? tl_gpu_stream_index : 0;
 }
 

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -110,7 +110,8 @@ int  Device::getStreamIndex   () noexcept {
     // Clamped: a thread that outlives a Finalize()/Initialize() cycle keeps its
     // index, and max_gpu_streams is re-read from the inputs on every
     // Initialize(), so the pool may have shrunk underneath it.
-    return (tl_gpu_stream_index < max_gpu_streams) ? tl_gpu_stream_index : 0;
+    return (tl_gpu_stream_index >= 0 && tl_gpu_stream_index < max_gpu_streams)
+        ? tl_gpu_stream_index : 0;
 }
 void Device::setStreamIndexTL (int idx) noexcept { tl_gpu_stream_index = idx; }
 gpuDeviceProp_t         Device::device_prop;

--- a/Src/Base/AMReX_GpuDevice.cpp
+++ b/Src/Base/AMReX_GpuDevice.cpp
@@ -100,7 +100,14 @@ dim3 Device::numBlocksOverride  = dim3(0, 0, 0);
 unsigned int Device::max_blocks_per_launch = 2560;
 
 Vector<StreamManager>   Device::gpu_stream_pool;
-thread_local int        Device::gpu_stream_index = 0;
+namespace {
+    //! See Device::getStreamIndex(). File scope rather than a class member,
+    //! because MSVC forbids dllexport on a thread_local.
+    thread_local int tl_gpu_stream_index = 0;
+}
+
+int  Device::getStreamIndex   () noexcept { return tl_gpu_stream_index; }
+void Device::setStreamIndexTL (int idx) noexcept { tl_gpu_stream_index = idx; }
 gpuDeviceProp_t         Device::device_prop;
 int                     Device::memory_pools_supported = 0;
 #ifdef AMREX_USE_GPU
@@ -644,7 +651,7 @@ Device::initialize_gpu (bool minimal)
 
     // Every thread starts on stream 0; a thread that has since moved to
     // another one gets a fresh index from its next MFIter.
-    gpu_stream_index = 0;
+    Device::setStreamIndexTL(0);
 
     ParmParse pp("device");
 
@@ -735,7 +742,7 @@ Device::setStreamIndex (int idx) noexcept
 {
     amrex::ignore_unused(idx);
 #ifdef AMREX_USE_GPU
-    gpu_stream_index = idx % max_gpu_streams;
+    Device::setStreamIndexTL(idx % max_gpu_streams);
 #ifdef AMREX_USE_ACC
     amrex_set_acc_stream(idx % max_gpu_streams);
 #endif
@@ -747,7 +754,7 @@ gpuStream_t
 Device::resetStream () noexcept
 {
     gpuStream_t r = gpuStream();
-    gpu_stream_index = 0;
+    Device::setStreamIndexTL(0);
     return r;
 }
 
@@ -766,7 +773,7 @@ Device::setStream (gpuStream_t s) noexcept
     if (idx == std::ssize(gpu_stream_pool)) {
         amrex::Abort("Gpu::Device::setStream: stream is not managed by AMReX.");
     }
-    gpu_stream_index = idx;
+    Device::setStreamIndexTL(idx);
     return r;
 }
 
@@ -810,7 +817,7 @@ Device::setExternalStream (gpuStream_t s)
     // these regions.
     external_stream_stack.emplace_back(
         ExternalStream{std::make_unique<StreamManager>(),
-                       gpu_stream_index});
+                       Device::getStreamIndex()});
     external_stream_stack.back().manager->getStream() = s;
 }
 
@@ -864,7 +871,7 @@ Device::streamSynchronize () noexcept
         AMREX_ASSERT(external_stream_stack.back().manager != nullptr);
         external_stream_stack.back().manager->sync();
     } else {
-        gpu_stream_pool[gpu_stream_index].sync();
+        gpu_stream_pool[Device::getStreamIndex()].sync();
     }
 #endif
 }
@@ -943,7 +950,7 @@ Device::freeAsync (Arena* arena, void* mem) noexcept
         AMREX_ASSERT(external_stream_stack.back().manager != nullptr);
         external_stream_stack.back().manager->free_async(arena, mem);
     } else {
-        gpu_stream_pool[gpu_stream_index].free_async(arena, mem);
+        gpu_stream_pool[Device::getStreamIndex()].free_async(arena, mem);
     }
 #else
     arena->free(mem);

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -251,7 +251,9 @@ protected:
      * is a per-thread property. Two independent host threads, each iterating
      * its own MFIter, are fine and each see a depth of one.
      */
-    static AMREX_EXPORT thread_local int depth;
+    // Not AMREX_EXPORT: MSVC forbids dllexport on a thread_local, and this
+    // is only ever touched from inside the library.
+    static thread_local int depth;
     static AMREX_EXPORT int allow_multiple_mfiters;
 
     void Initialize ();

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -257,7 +257,9 @@ protected:
      * zero -- unchanged from when this was a global.
      */
     // Not AMREX_EXPORT: MSVC forbids dllexport on a thread_local, and this
-    // is only ever touched from inside the library.
+    // is only ever touched from inside the library (including Src/Amr, where
+    // FillPatchIterator zeroes it -- now only for the calling thread, which is
+    // what that code wants).
     static thread_local int depth;
     static AMREX_EXPORT std::atomic<int> allow_multiple_mfiters;
 

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -4,6 +4,7 @@
 
 #include <AMReX_FabArrayBase.H>
 
+#include <atomic>
 #include <memory>
 
 namespace amrex {
@@ -250,11 +251,15 @@ protected:
      * of control starting a second MFIter before finishing the first -- which
      * is a per-thread property. Two independent host threads, each iterating
      * its own MFIter, are fine and each see a depth of one.
+     *
+     * Inside an OpenMP parallel region only the team's master increments it
+     * (see the `omp master` in Initialize()), so the other team members see
+     * zero -- unchanged from when this was a global.
      */
     // Not AMREX_EXPORT: MSVC forbids dllexport on a thread_local, and this
     // is only ever touched from inside the library.
     static thread_local int depth;
-    static AMREX_EXPORT int allow_multiple_mfiters;
+    static AMREX_EXPORT std::atomic<int> allow_multiple_mfiters;
 
     void Initialize ();
 };

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -198,6 +198,8 @@ public:
 
     static int allowMultipleMFIters (int allow);
 
+    //! How deeply MFIters are nested on the *calling* thread. Other threads
+    //! iterating their own MFIters do not contribute to this count.
     static int currentDepth ();
 
     void Finalize ();
@@ -241,7 +243,15 @@ protected:
     const Vector<int>* num_local_tiles;
 
     static AMREX_EXPORT int nextDynamicIndex;
-    static AMREX_EXPORT int depth;
+    /**
+     * Nesting depth of the MFIters currently alive on the calling thread.
+     *
+     * Thread-local, because what it guards against is *nesting* -- one thread
+     * of control starting a second MFIter before finishing the first -- which
+     * is a per-thread property. Two independent host threads, each iterating
+     * its own MFIter, are fine and each see a depth of one.
+     */
+    static AMREX_EXPORT thread_local int depth;
     static AMREX_EXPORT int allow_multiple_mfiters;
 
     void Initialize ();

--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -253,8 +253,11 @@ protected:
      * its own MFIter, are fine and each see a depth of one.
      *
      * Inside an OpenMP parallel region only the team's master increments it
-     * (see the `omp master` in Initialize()), so the other team members see
-     * zero -- unchanged from when this was a global.
+     * (see the `omp master` in Initialize()), so the other team members now
+     * see zero. This *is* a behaviour change: when depth was a plain global,
+     * a non-master member read the master's incremented value. It only shows
+     * through currentDepth(), which has no in-tree caller, but a downstream
+     * OpenMP code that branches on it should know.
      */
     // Not AMREX_EXPORT: MSVC forbids dllexport on a thread_local, and this
     // is only ever touched from inside the library (including Src/Amr, where

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -7,7 +7,7 @@
 namespace amrex {
 
 int MFIter::nextDynamicIndex = std::numeric_limits<int>::min();
-int MFIter::depth = 0;
+thread_local int MFIter::depth = 0;
 int MFIter::allow_multiple_mfiters = 0;
 
 int
@@ -20,12 +20,7 @@ MFIter::allowMultipleMFIters (int allow)
 int
 MFIter::currentDepth ()
 {
-    int r;
-#ifdef AMREX_USE_OMP
-#pragma omp atomic read
-#endif
-    r = MFIter::depth;
-    return r;
+    return MFIter::depth;
 }
 
 MFIter::MFIter (const FabArrayBase& fabarray_,

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -264,6 +264,11 @@ MFIter::Finalize ()
 #pragma omp master
 #endif
     {
+        // Note: assignment, not --depth. With allowMultipleMFIters(true) an
+        // inner MFIter's destruction therefore zeroes the outer one's depth
+        // too. Pre-existing, and harmless while the counter only gates the
+        // nesting assertion, but now that it is documented as a per-thread
+        // nesting count it is worth naming.
         depth = 0;
     }
 }

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -8,13 +8,12 @@ namespace amrex {
 
 int MFIter::nextDynamicIndex = std::numeric_limits<int>::min();
 thread_local int MFIter::depth = 0;
-int MFIter::allow_multiple_mfiters = 0;
+std::atomic<int> MFIter::allow_multiple_mfiters{0};
 
 int
 MFIter::allowMultipleMFIters (int allow)
 {
-    std::swap(allow, allow_multiple_mfiters);
-    return allow;
+    return allow_multiple_mfiters.exchange(allow);
 }
 
 int

--- a/Src/Base/AMReX_ParallelContext.cpp
+++ b/Src/Base/AMReX_ParallelContext.cpp
@@ -1,6 +1,7 @@
 #include <AMReX_ParallelContext.H>
 #include <AMReX_ParallelDescriptor.H>
 
+#include <mutex>
 #include <sstream>
 #include <fstream>
 
@@ -102,6 +103,13 @@ Frame::global_to_local_rank (int* local, const int* global, int n)
 int
 Frame::get_inc_mpi_tag ()
 {
+    // Guarded rather than made atomic: Frame lives in a Vector and has to stay
+    // movable. Two host threads handing themselves the same tag would cross
+    // messages between unrelated communications, and this is reached even in a
+    // serial build (NFilesIter's constructor calls SeqNum()).
+    static std::mutex mpi_tag_mutex;
+    std::scoped_lock lock(mpi_tag_mutex);
+
     int cur_tag = m_mpi_tag;
     m_mpi_tag = (m_mpi_tag < ParallelDescriptor::MaxTag()) ?
         m_mpi_tag + 1 : ParallelDescriptor::MinTag();

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1190,6 +1190,7 @@ public:
               std::same_as<T,double>)
     int queryAddWithParser (std::string_view name, T& ref)
     {
+        std::scoped_lock lock(tableMutex());
         int exist = this->queryWithParser(name, ref);
         if (!exist) {
             this->add(name, ref);

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -15,6 +15,7 @@
 #include <array>
 #include <concepts>
 #include <iosfwd>
+#include <mutex>
 #include <optional>
 #include <set>
 #include <string>
@@ -1045,6 +1046,7 @@ public:
      */
     template <typename T>
     int queryAdd (std::string_view name, T& ref) {
+        std::scoped_lock lock(tableMutex());
         int exist = this->query(name, ref);
         if (!exist) {
             this->add(name, ref);
@@ -1053,6 +1055,7 @@ public:
     }
 
     int queryAdd (std::string_view name, std::string& ref) {
+        std::scoped_lock lock(tableMutex());
         int exist = this->query(name, ref);
         if (!exist && !ref.empty()) {
             this->add(name, ref);
@@ -1071,6 +1074,7 @@ public:
      */
     template <typename T>
     int queryAdd (std::string_view name, std::vector<T>& ref) {
+        std::scoped_lock lock(tableMutex());
         std::vector<T> empty;
         int exist = this->queryarr(name, empty);
         if (exist) {
@@ -1095,6 +1099,7 @@ public:
      */
     template <typename T>
     int queryAdd (std::string_view name, std::vector<T>& ref, int num_val) {
+        std::scoped_lock lock(tableMutex());
         int exist = this->queryarr(name, ref, 0, num_val);
         if (!exist) {
             this->addarr(name, ref);
@@ -1110,6 +1115,7 @@ public:
      */
     template <typename T, std::size_t N>
     int queryAdd (std::string_view name, std::array<T,N>& ref) {
+        std::scoped_lock lock(tableMutex());
         std::vector<T> v;
         int exist = this->queryarr(name, v);
         if (exist) {
@@ -1722,6 +1728,17 @@ public:
 
     static int Verbose ();
     static void SetVerbose (int v);
+
+    /**
+     * \brief The lock guarding the parameter table.
+     *
+     * Exposed because the queryAdd() templates live in this header and have to
+     * hold it across their query-then-add: query() and add() each take it on
+     * their own, so without this two threads querying the same absent name
+     * both miss and both add, leaving a duplicate entry with m_count == 2. It
+     * is recursive, so taking it here and again inside query()/add() is fine.
+     */
+    static std::recursive_mutex& tableMutex ();
 
     //! Write the contents of the table in ASCII to the ostream (diagnostic only, not valid ParmParse syntax).
     //! Diagnostic view of the internal table. This text is not valid ParmParse syntax

--- a/Src/Base/AMReX_ParmParse.H
+++ b/Src/Base/AMReX_ParmParse.H
@@ -1789,6 +1789,17 @@ public:
 
     [[nodiscard]] const Table& table() const {return *m_table;}
 
+    /**
+     * \brief A snapshot of the table, taken under the table lock.
+     *
+     * table() hands out a reference to process-global state that a concurrent
+     * query or add mutates -- a query is a writer, because it updates the
+     * entry's use count, type hint and last value through mutable members.
+     * Copy through this instead when another host thread may be using
+     * ParmParse.
+     */
+    [[nodiscard]] Table tableCopy () const;
+
     //! keyword for files to load
     static std::string const FileKeyword;
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -48,17 +48,13 @@ namespace {
      * Recursive because the parser path re-enters squeryval() to resolve
      * symbols. This also serializes g_parser_recursive_symbols, whose
      * per-thread slot is indexed by OpenMP::get_thread_num().
-     */
-    /**
-     * Guards g_table.
      *
      * Function-local rather than namespace-scope because std::recursive_mutex
-     * has no constexpr constructor, so a namespace-scope one is dynamically
-     * initialized -- and ParmParse::tableMutex() now hands it to the inline
-     * queryAdd() templates in every translation unit. A static-storage object
-     * whose constructor queries ParmParse would otherwise be able to reach it
-     * before it exists. (Destruction order at exit is still the caller's
-     * problem, as for any static.)
+     * is not guaranteed constant-initializable -- true on libc++ and MSVC,
+     * though libstdc++ with glibc does constant-initialize it -- and
+     * ParmParse::tableMutex() now hands it to the inline queryAdd() templates
+     * in every translation unit. A static-storage object whose constructor
+     * queries ParmParse could otherwise reach it before it is constructed.
      */
     std::recursive_mutex& g_table_mutex ()
     {
@@ -612,10 +608,7 @@ ppindex (const ParmParse::Table& table, int n, const std::string& name)
     auto found = table.find(name);
     if (found == table.cend()) { return nullptr; }
 
-#ifdef AMREX_USE_OMP
-#pragma omp atomic update
-#endif
-    ++(found->second.m_count);
+    ++(found->second.m_count);  // under g_table_mutex()
 
     if (n == ParmParse::LAST) {
         return &(found->second.m_vals.back());
@@ -938,16 +931,16 @@ bool pp_parser (const ParmParse::Table& table, const std::string& parser_prefix,
 template <typename T>
 void pp_entry_set_last_val (ParmParse::PP_entry const& entry, int ival, T ref, bool parsed)
 {
-#ifdef AMREX_USE_OMP
-#pragma omp single nowait
-#endif
-    {
-        if (ival >= std::ssize(entry.m_last_vals)) {
-            entry.m_last_vals.resize(ival+1);
-        }
-        entry.m_last_vals[ival] = ref;
-        if (parsed) { entry.m_parsed = true; }
+    // Callers hold g_table_mutex(). The `omp single nowait` that used to guard
+    // this is gone with it, and not just as dead weight: `single` means one
+    // team member executes, so with the mutex serialising arrivals the other
+    // members' writes were silently dropped. It was also a landmine -- take
+    // away the `nowait` and the implicit barrier deadlocks against the mutex.
+    if (ival >= std::ssize(entry.m_last_vals)) {
+        entry.m_last_vals.resize(ival+1);
     }
+    entry.m_last_vals[ival] = ref;
+    if (parsed) { entry.m_parsed = true; }
 }
 
 template <typename T>
@@ -1108,13 +1101,10 @@ squeryval (const ParmParse::Table& table,
 
     auto const& entry = table.at(name);
 
-#ifdef AMREX_USE_OMP
-#pragma omp single nowait
-#endif
-    {
+    // under g_table_mutex(); `omp single` here executed on one
+    // team member only, discarding the others' type hints.
         using T_ptr = std::decay_t<T>*;
         entry.m_typehint = static_cast<T_ptr>(nullptr);
-    }
 
     //
     // Handle TOML array: stored as single token "$$ARR[v0,v1,...]"
@@ -1277,13 +1267,10 @@ squeryarr (const ParmParse::Table& table,
 
     auto const& entry = table.at(name);
 
-#ifdef AMREX_USE_OMP
-#pragma omp single nowait
-#endif
-    {
+    // under g_table_mutex(); `omp single` here executed on one
+    // team member only, discarding the others' type hints.
         using T_ptr = std::decay_t<T>*;
         entry.m_typehint = static_cast<T_ptr>(nullptr);
-    }
 
     //
     // Does it have sufficient number of values and are they all
@@ -2841,10 +2828,7 @@ ParmParse::contains (std::string_view name) const
     auto pname = prefixedName(name);
     auto found = m_table->find(pname);
     if (found != m_table->cend()) {
-#ifdef AMREX_USE_OMP
-#pragma omp atomic update
-#endif
-        ++(found->second.m_count);
+        ++(found->second.m_count);  // under g_table_mutex()
         return true;
     } else {
         return false;
@@ -2893,13 +2877,10 @@ bool squeryWithParser (const ParmParse::Table& table,
 
     if (pp_parser(table, parser_prefix, name, combined_string, ref, true))
     {
-#ifdef AMREX_USE_OMP
-#pragma omp single nowait
-#endif
-        {
+        // under g_table_mutex(); `omp single` here executed on one
+        // team member only, discarding the others' type hints.
             using T_ptr = std::decay_t<T>*;
             entry.m_typehint = static_cast<T_ptr>(nullptr);
-        }
 
         if constexpr (is_integral_floating) {
             pp_entry_set_last_val(entry, 0, ref, true);
@@ -2948,13 +2929,10 @@ bool squeryarrWithParser (const ParmParse::Table& table,
         }
     }
 
-#ifdef AMREX_USE_OMP
-#pragma omp single nowait
-#endif
-    {
+    // under g_table_mutex(); `omp single` here executed on one
+    // team member only, discarding the others' type hints.
         using T_ptr = std::decay_t<T>*;
         entry.m_typehint = static_cast<T_ptr>(nullptr);
-    }
 
     return true;
 }

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1559,6 +1559,9 @@ pp_make_parser (std::string const& func, Vector<std::string> const& vars,
     }
 
     bool recursive = false;
+    // g_parser_recursive_symbols is indexed by OpenMP::get_thread_num(), i.e.
+    // slot 0 for every host thread without OpenMP. Safe because every caller
+    // already holds g_table_mutex.
     auto& recursive_symbols = g_parser_recursive_symbols[OpenMP::get_thread_num()];
 
     for (auto const& s : symbols) {
@@ -1601,6 +1604,9 @@ bool pp_parser (const ParmParse::Table& table, const std::string& parser_prefix,
                 const std::string& name, const std::string& val, T& ref,
                 bool use_querywithparser)
 {
+    // g_parser_recursive_symbols is indexed by OpenMP::get_thread_num(), i.e.
+    // slot 0 for every host thread without OpenMP. Safe because every caller
+    // already holds g_table_mutex.
     auto& recursive_symbols = g_parser_recursive_symbols[OpenMP::get_thread_num()];
     if (auto found = recursive_symbols.find(name); found != recursive_symbols.end()) {
         amrex::Error("ParmParse: recursive reference to "+name+" is not allowed");

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -1769,9 +1769,18 @@ ParmParse::getEntries (const std::string& prefix)
     return r;
 }
 
+std::recursive_mutex&
+ParmParse::tableMutex ()
+{
+    return g_table_mutex;
+}
+
 int
 ParmParse::Verbose ()
 {
+    // Recursive: Finalize() and the unused-parameter warning path already hold
+    // this when they call in here.
+    std::scoped_lock lock(g_table_mutex);
     if (pp_detail::verbose < 0) {
         pp_detail::verbose = std::max(amrex::Verbose(),0);
         ParmParse pp("amrex.parmparse");
@@ -1785,6 +1794,7 @@ ParmParse::Verbose ()
 void
 ParmParse::SetVerbose (int v)
 {
+    std::scoped_lock lock(g_table_mutex);
     pp_detail::verbose = v;
 }
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <iterator>
 #include <limits>
+#include <mutex>
 #include <numeric>
 #include <unordered_map>
 #include <regex>
@@ -34,6 +35,21 @@ namespace {
     ParmParse::Table g_table;
     std::vector<std::set<std::string>> g_parser_recursive_symbols(1);
     std::string g_toml_table_key;
+
+    /**
+     * Guards the process-global parameter table.
+     *
+     * Every ParmParse object aliases the single g_table, and a *query* is not
+     * read-only: it bumps the entry's use count and records its type hint and
+     * last value through mutable members. Those writes were guarded only by
+     * `omp atomic` / `omp single nowait`, which do nothing outside an OpenMP
+     * parallel region and nothing at all in a build without OpenMP.
+     *
+     * Recursive because the parser path re-enters squeryval() to resolve
+     * symbols. This also serialises g_parser_recursive_symbols, whose
+     * per-thread slot is indexed by OpenMP::get_thread_num().
+     */
+    std::recursive_mutex g_table_mutex;
     /// \cond DOXYGEN_IGNORE
     namespace pp_detail {
         int verbose = -1;
@@ -1058,6 +1074,7 @@ squeryval (const ParmParse::Table& table,
            int                     ival,
            int                     occurrence)
 {
+    std::scoped_lock lock(g_table_mutex);
     //
     // Get specified occurrence of name in table.
     //
@@ -1220,6 +1237,7 @@ squeryarr (const ParmParse::Table& table,
            int                     num_val,
            int                     occurrence)
 {
+    std::scoped_lock lock(g_table_mutex);
     //
     // Get last occurrence of name in table.
     //
@@ -1619,6 +1637,7 @@ ParmParse::prefixedName (std::string_view str) const
 
 void
 ParmParse::addfile (std::string const& filename) {
+    std::scoped_lock lock(g_table_mutex);
 #ifdef AMREX_USE_MPI
     // this is required because we will BCast the file content in sub-function calls
     if (ParallelDescriptor::Communicator() == MPI_COMM_NULL)
@@ -1652,6 +1671,7 @@ ParmParse::Initialize (int         argc,
                        char**      argv,
                        const char* parfile)
 {
+    std::scoped_lock lock(g_table_mutex);
     if ( initialized )
     {
         amrex::Error("ParmParse::Initialize(): already initialized!");
@@ -1667,6 +1687,7 @@ ParmParse::Initialize (int         argc,
 bool
 ParmParse::QueryUnusedInputs ()
 {
+    std::scoped_lock lock(g_table_mutex);
     if ( ParallelDescriptor::IOProcessor() && unused_table_entries_q(g_table))
     {
         if (ParmParse::Verbose()) {
@@ -1682,12 +1703,14 @@ ParmParse::QueryUnusedInputs ()
 bool
 ParmParse::hasUnusedInputs (const std::string& prefix)
 {
+    std::scoped_lock lock(g_table_mutex);
     return unused_table_entries_q(g_table, prefix);
 }
 
 std::vector<std::string>
 ParmParse::getUnusedInputs (const std::string& prefix)
 {
+    std::scoped_lock lock(g_table_mutex);
     std::vector<std::string> sorted_names;
     const std::string prefixdot = prefix.empty() ? std::string() : prefix+".";
     for (auto const& [name, entry] : g_table) {
@@ -1718,6 +1741,7 @@ ParmParse::getUnusedInputs (const std::string& prefix)
 std::set<std::string>
 ParmParse::getEntries (const std::string& prefix)
 {
+    std::scoped_lock lock(g_table_mutex);
     std::set<std::string> r;
     const std::string prefixdot = prefix.empty() ? std::string() : prefix+".";
     for (auto const& [name, entry] : g_table) {
@@ -1750,6 +1774,7 @@ ParmParse::SetVerbose (int v)
 void
 ParmParse::Finalize ()
 {
+    std::scoped_lock lock(g_table_mutex);
     if ( ParallelDescriptor::IOProcessor() && unused_table_entries_q(g_table))
     {
         if (ParmParse::Verbose()) {
@@ -1777,6 +1802,7 @@ ParmParse::Finalize ()
 void
 ParmParse::SetParserPrefix (std::string a_prefix)
 {
+    std::scoped_lock lock(g_table_mutex);
     ParmParse::ParserPrefix = std::move(a_prefix);
 }
 
@@ -1785,6 +1811,7 @@ ParmParse::SetParserPrefix (std::string a_prefix)
 void
 ParmParse::dumpTable (std::ostream& os, bool prettyPrint)
 {
+    std::scoped_lock lock(g_table_mutex);
     std::vector<std::string> sorted_names;
     sorted_names.reserve(g_table.size());
     for (auto const& [name, entry] : g_table) {
@@ -1849,18 +1876,21 @@ void pretty_print_table (std::ostream& os, PPFlag pp_flag)
 void
 ParmParse::prettyPrintTable (std::ostream& os)
 {
+    std::scoped_lock lock(g_table_mutex);
     pretty_print_table(os, PPFlag::all);
 }
 
 void
 ParmParse::prettyPrintUnusedInputs (std::ostream& os)
 {
+    std::scoped_lock lock(g_table_mutex);
     pretty_print_table(os, PPFlag::unused);
 }
 
 void
 ParmParse::prettyPrintUsedInputs (std::ostream& os)
 {
+    std::scoped_lock lock(g_table_mutex);
     pretty_print_table(os, PPFlag::used);
 }
 
@@ -1868,6 +1898,7 @@ int
 ParmParse::countval (std::string_view name,
                      int              n) const
 {
+    std::scoped_lock lock(g_table_mutex);
     //
     // First find n'th occurrence of name in table.
     //
@@ -1955,6 +1986,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 bool       val)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddval(prefixedName(name),val);
 }
 
@@ -1997,6 +2029,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 int        val)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddval(prefixedName(name),val);
 }
 
@@ -2042,6 +2075,7 @@ void
 ParmParse::addarr (std::string_view        name, // NOLINT(readability-make-member-function-const)
                    const std::vector<int>& ref)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddarr(prefixedName(name),ref);
 }
 
@@ -2085,6 +2119,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 long       val)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddval(prefixedName(name),val);
 }
 
@@ -2129,6 +2164,7 @@ ParmParse::queryarr (std::string_view   name,
 void
 ParmParse::addarr (std::string_view name, const std::vector<long>& ref) // NOLINT(readability-make-member-function-const)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddarr(prefixedName(name),ref);
 }
 
@@ -2171,6 +2207,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 long long  val)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddval(prefixedName(name),val);
 }
 
@@ -2216,6 +2253,7 @@ void
 ParmParse::addarr (std::string_view              name, // NOLINT(readability-make-member-function-const)
                    const std::vector<long long>& ref)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddarr(prefixedName(name),ref);
 }
 
@@ -2258,6 +2296,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 float      val)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddval(prefixedName(name),val);
 }
 
@@ -2303,6 +2342,7 @@ void
 ParmParse::addarr (std::string_view          name, // NOLINT(readability-make-member-function-const)
                    const std::vector<float>& ref)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddarr(prefixedName(name),ref);
 }
 
@@ -2347,6 +2387,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 double     val)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddval(prefixedName(name),val);
 }
 
@@ -2392,6 +2433,7 @@ void
 ParmParse::addarr (std::string_view           name, // NOLINT(readability-make-member-function-const)
                    const std::vector<double>& ref)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddarr(prefixedName(name),ref);
 }
 
@@ -2436,6 +2478,7 @@ void
 ParmParse::add (std::string_view   name, // NOLINT(readability-make-member-function-const)
                 const std::string& val)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddval(prefixedName(name),val);
 }
 
@@ -2481,6 +2524,7 @@ void
 ParmParse::addarr (std::string_view                name, // NOLINT(readability-make-member-function-const)
                    const std::vector<std::string>& ref)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddarr(prefixedName(name),ref);
 }
 
@@ -2525,6 +2569,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 const IntVect&   val)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddval(prefixedName(name),val);
 }
 
@@ -2570,6 +2615,7 @@ void
 ParmParse::addarr (std::string_view            name, // NOLINT(readability-make-member-function-const)
                    const std::vector<IntVect>& ref)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddarr(prefixedName(name),ref);
 }
 
@@ -2612,6 +2658,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 const Box&       val)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddval(prefixedName(name),val);
 }
 
@@ -2657,6 +2704,7 @@ void
 ParmParse::addarr (std::string_view        name, // NOLINT(readability-make-member-function-const)
                    const std::vector<Box>& ref)
 {
+    std::scoped_lock lock(g_table_mutex);
     saddarr(prefixedName(name),ref);
 }
 
@@ -2730,6 +2778,7 @@ ParmParse::queryline (std::string_view name, std::string& ref) const
 int
 ParmParse::countname (std::string_view name) const
 {
+    std::scoped_lock lock(g_table_mutex);
     auto pname = prefixedName(name);
     auto found = m_table->find(pname);
     if (found != m_table->cend()) {
@@ -2746,6 +2795,7 @@ ParmParse::countname (std::string_view name) const
 bool
 ParmParse::contains (std::string_view name) const
 {
+    std::scoped_lock lock(g_table_mutex);
     auto pname = prefixedName(name);
     auto found = m_table->find(pname);
     if (found != m_table->cend()) {
@@ -2762,6 +2812,7 @@ ParmParse::contains (std::string_view name) const
 int
 ParmParse::remove (std::string_view name)
 {
+    std::scoped_lock lock(g_table_mutex);
     auto const pname = prefixedName(name);
     auto n = m_table->erase(pname);
     return static_cast<int>(n);
@@ -2934,6 +2985,7 @@ Parser
 ParmParse::makeParser (std::string const& func,
                        Vector<std::string> const& vars) const
 {
+    std::scoped_lock lock(g_table_mutex);
     return pp_make_parser<double>(func, vars, *m_table, m_parser_prefix, true);
 }
 
@@ -2941,6 +2993,7 @@ IParser
 ParmParse::makeIParser (std::string const& func,
                         Vector<std::string> const& vars) const
 {
+    std::scoped_lock lock(g_table_mutex);
     return pp_make_parser<long long>(func, vars, *m_table, m_parser_prefix, true);
 }
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -46,7 +46,7 @@ namespace {
      * parallel region and nothing at all in a build without OpenMP.
      *
      * Recursive because the parser path re-enters squeryval() to resolve
-     * symbols. This also serialises g_parser_recursive_symbols, whose
+     * symbols. This also serializes g_parser_recursive_symbols, whose
      * per-thread slot is indexed by OpenMP::get_thread_num().
      */
     std::recursive_mutex g_table_mutex;
@@ -1534,6 +1534,10 @@ pp_make_parser (std::string const& func, Vector<std::string> const& vars,
                 ParmParse::Table const& table, std::string const& parser_prefix,
                 bool use_querywithparser)
 {
+    // Guards g_parser_recursive_symbols, whose slot is indexed by
+    // OpenMP::get_thread_num() and is therefore shared by every host thread in
+    // a build without OpenMP. Recursive: this re-enters squeryval() below.
+    std::scoped_lock lock(g_table_mutex);
     using value_t =  std::conditional_t<std::is_integral_v<T> && !std::is_same_v<bool,T>,
                                         long long, double>;
 
@@ -2825,6 +2829,11 @@ bool squeryWithParser (const ParmParse::Table& table,
                        const std::string&      name,
                        T&                      ref)
 {
+    // Held across the whole function: the parser path below writes the entry's
+    // mutable m_typehint and m_last_vals after squeryarr() has returned.
+    // Recursive, so the nested squeryarr() is fine.
+    std::scoped_lock lock(g_table_mutex);
+
     std::vector<std::string> vals;
     bool exist = squeryarr(table, parser_prefix, name, vals,
                            ParmParse::FIRST, ParmParse::ALL, ParmParse::LAST);
@@ -2871,6 +2880,10 @@ bool squeryarrWithParser (const ParmParse::Table& table,
                           int                     nvals,
                           T*                      ptr)
 {
+    // Held across the whole function: the parser path below writes the entry's
+    // mutable m_typehint and m_last_vals after squeryarr() has returned.
+    // Recursive, so the nested squeryarr() is fine.
+    std::scoped_lock lock(g_table_mutex);
     std::vector<std::string> vals;
     bool exist = squeryarr(table, parser_prefix, name, vals,
                            ParmParse::FIRST, ParmParse::ALL, ParmParse::LAST);

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -67,6 +67,13 @@ ParmParse::ParmParse (std::string prefix, std::string parser_prefix)
       m_table(&g_table)
 {}
 
+ParmParse::Table
+ParmParse::tableCopy () const
+{
+    std::scoped_lock lock(g_table_mutex);
+    return *m_table;
+}
+
 namespace
 {
 

--- a/Src/Base/AMReX_ParmParse.cpp
+++ b/Src/Base/AMReX_ParmParse.cpp
@@ -49,7 +49,22 @@ namespace {
      * symbols. This also serializes g_parser_recursive_symbols, whose
      * per-thread slot is indexed by OpenMP::get_thread_num().
      */
-    std::recursive_mutex g_table_mutex;
+    /**
+     * Guards g_table.
+     *
+     * Function-local rather than namespace-scope because std::recursive_mutex
+     * has no constexpr constructor, so a namespace-scope one is dynamically
+     * initialized -- and ParmParse::tableMutex() now hands it to the inline
+     * queryAdd() templates in every translation unit. A static-storage object
+     * whose constructor queries ParmParse would otherwise be able to reach it
+     * before it exists. (Destruction order at exit is still the caller's
+     * problem, as for any static.)
+     */
+    std::recursive_mutex& g_table_mutex ()
+    {
+        static std::recursive_mutex m;
+        return m;
+    }
     /// \cond DOXYGEN_IGNORE
     namespace pp_detail {
         int verbose = -1;
@@ -70,7 +85,7 @@ ParmParse::ParmParse (std::string prefix, std::string parser_prefix)
 ParmParse::Table
 ParmParse::tableCopy () const
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     return *m_table;
 }
 
@@ -1081,7 +1096,7 @@ squeryval (const ParmParse::Table& table,
            int                     ival,
            int                     occurrence)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     //
     // Get specified occurrence of name in table.
     //
@@ -1244,7 +1259,7 @@ squeryarr (const ParmParse::Table& table,
            int                     num_val,
            int                     occurrence)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     //
     // Get last occurrence of name in table.
     //
@@ -1544,7 +1559,7 @@ pp_make_parser (std::string const& func, Vector<std::string> const& vars,
     // Guards g_parser_recursive_symbols, whose slot is indexed by
     // OpenMP::get_thread_num() and is therefore shared by every host thread in
     // a build without OpenMP. Recursive: this re-enters squeryval() below.
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     using value_t =  std::conditional_t<std::is_integral_v<T> && !std::is_same_v<bool,T>,
                                         long long, double>;
 
@@ -1654,7 +1669,7 @@ ParmParse::prefixedName (std::string_view str) const
 
 void
 ParmParse::addfile (std::string const& filename) {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
 #ifdef AMREX_USE_MPI
     // this is required because we will BCast the file content in sub-function calls
     if (ParallelDescriptor::Communicator() == MPI_COMM_NULL)
@@ -1688,7 +1703,7 @@ ParmParse::Initialize (int         argc,
                        char**      argv,
                        const char* parfile)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     if ( initialized )
     {
         amrex::Error("ParmParse::Initialize(): already initialized!");
@@ -1704,7 +1719,7 @@ ParmParse::Initialize (int         argc,
 bool
 ParmParse::QueryUnusedInputs ()
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     if ( ParallelDescriptor::IOProcessor() && unused_table_entries_q(g_table))
     {
         if (ParmParse::Verbose()) {
@@ -1720,14 +1735,14 @@ ParmParse::QueryUnusedInputs ()
 bool
 ParmParse::hasUnusedInputs (const std::string& prefix)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     return unused_table_entries_q(g_table, prefix);
 }
 
 std::vector<std::string>
 ParmParse::getUnusedInputs (const std::string& prefix)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     std::vector<std::string> sorted_names;
     const std::string prefixdot = prefix.empty() ? std::string() : prefix+".";
     for (auto const& [name, entry] : g_table) {
@@ -1758,7 +1773,7 @@ ParmParse::getUnusedInputs (const std::string& prefix)
 std::set<std::string>
 ParmParse::getEntries (const std::string& prefix)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     std::set<std::string> r;
     const std::string prefixdot = prefix.empty() ? std::string() : prefix+".";
     for (auto const& [name, entry] : g_table) {
@@ -1772,7 +1787,7 @@ ParmParse::getEntries (const std::string& prefix)
 std::recursive_mutex&
 ParmParse::tableMutex ()
 {
-    return g_table_mutex;
+    return g_table_mutex();
 }
 
 int
@@ -1780,7 +1795,7 @@ ParmParse::Verbose ()
 {
     // Recursive: Finalize() and the unused-parameter warning path already hold
     // this when they call in here.
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     if (pp_detail::verbose < 0) {
         pp_detail::verbose = std::max(amrex::Verbose(),0);
         ParmParse pp("amrex.parmparse");
@@ -1794,14 +1809,14 @@ ParmParse::Verbose ()
 void
 ParmParse::SetVerbose (int v)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     pp_detail::verbose = v;
 }
 
 void
 ParmParse::Finalize ()
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     if ( ParallelDescriptor::IOProcessor() && unused_table_entries_q(g_table))
     {
         if (ParmParse::Verbose()) {
@@ -1829,7 +1844,7 @@ ParmParse::Finalize ()
 void
 ParmParse::SetParserPrefix (std::string a_prefix)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     ParmParse::ParserPrefix = std::move(a_prefix);
 }
 
@@ -1838,7 +1853,7 @@ ParmParse::SetParserPrefix (std::string a_prefix)
 void
 ParmParse::dumpTable (std::ostream& os, bool prettyPrint)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     std::vector<std::string> sorted_names;
     sorted_names.reserve(g_table.size());
     for (auto const& [name, entry] : g_table) {
@@ -1903,21 +1918,21 @@ void pretty_print_table (std::ostream& os, PPFlag pp_flag)
 void
 ParmParse::prettyPrintTable (std::ostream& os)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     pretty_print_table(os, PPFlag::all);
 }
 
 void
 ParmParse::prettyPrintUnusedInputs (std::ostream& os)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     pretty_print_table(os, PPFlag::unused);
 }
 
 void
 ParmParse::prettyPrintUsedInputs (std::ostream& os)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     pretty_print_table(os, PPFlag::used);
 }
 
@@ -1925,7 +1940,7 @@ int
 ParmParse::countval (std::string_view name,
                      int              n) const
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     //
     // First find n'th occurrence of name in table.
     //
@@ -2013,7 +2028,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 bool       val)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddval(prefixedName(name),val);
 }
 
@@ -2056,7 +2071,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 int        val)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddval(prefixedName(name),val);
 }
 
@@ -2102,7 +2117,7 @@ void
 ParmParse::addarr (std::string_view        name, // NOLINT(readability-make-member-function-const)
                    const std::vector<int>& ref)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddarr(prefixedName(name),ref);
 }
 
@@ -2146,7 +2161,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 long       val)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddval(prefixedName(name),val);
 }
 
@@ -2191,7 +2206,7 @@ ParmParse::queryarr (std::string_view   name,
 void
 ParmParse::addarr (std::string_view name, const std::vector<long>& ref) // NOLINT(readability-make-member-function-const)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddarr(prefixedName(name),ref);
 }
 
@@ -2234,7 +2249,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 long long  val)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddval(prefixedName(name),val);
 }
 
@@ -2280,7 +2295,7 @@ void
 ParmParse::addarr (std::string_view              name, // NOLINT(readability-make-member-function-const)
                    const std::vector<long long>& ref)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddarr(prefixedName(name),ref);
 }
 
@@ -2323,7 +2338,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 float      val)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddval(prefixedName(name),val);
 }
 
@@ -2369,7 +2384,7 @@ void
 ParmParse::addarr (std::string_view          name, // NOLINT(readability-make-member-function-const)
                    const std::vector<float>& ref)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddarr(prefixedName(name),ref);
 }
 
@@ -2414,7 +2429,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 double     val)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddval(prefixedName(name),val);
 }
 
@@ -2460,7 +2475,7 @@ void
 ParmParse::addarr (std::string_view           name, // NOLINT(readability-make-member-function-const)
                    const std::vector<double>& ref)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddarr(prefixedName(name),ref);
 }
 
@@ -2505,7 +2520,7 @@ void
 ParmParse::add (std::string_view   name, // NOLINT(readability-make-member-function-const)
                 const std::string& val)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddval(prefixedName(name),val);
 }
 
@@ -2551,7 +2566,7 @@ void
 ParmParse::addarr (std::string_view                name, // NOLINT(readability-make-member-function-const)
                    const std::vector<std::string>& ref)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddarr(prefixedName(name),ref);
 }
 
@@ -2596,7 +2611,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 const IntVect&   val)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddval(prefixedName(name),val);
 }
 
@@ -2642,7 +2657,7 @@ void
 ParmParse::addarr (std::string_view            name, // NOLINT(readability-make-member-function-const)
                    const std::vector<IntVect>& ref)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddarr(prefixedName(name),ref);
 }
 
@@ -2685,7 +2700,7 @@ void
 ParmParse::add (std::string_view name, // NOLINT(readability-make-member-function-const)
                 const Box&       val)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddval(prefixedName(name),val);
 }
 
@@ -2731,7 +2746,7 @@ void
 ParmParse::addarr (std::string_view        name, // NOLINT(readability-make-member-function-const)
                    const std::vector<Box>& ref)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     saddarr(prefixedName(name),ref);
 }
 
@@ -2805,7 +2820,7 @@ ParmParse::queryline (std::string_view name, std::string& ref) const
 int
 ParmParse::countname (std::string_view name) const
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     auto pname = prefixedName(name);
     auto found = m_table->find(pname);
     if (found != m_table->cend()) {
@@ -2822,7 +2837,7 @@ ParmParse::countname (std::string_view name) const
 bool
 ParmParse::contains (std::string_view name) const
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     auto pname = prefixedName(name);
     auto found = m_table->find(pname);
     if (found != m_table->cend()) {
@@ -2839,7 +2854,7 @@ ParmParse::contains (std::string_view name) const
 int
 ParmParse::remove (std::string_view name)
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     auto const pname = prefixedName(name);
     auto n = m_table->erase(pname);
     return static_cast<int>(n);
@@ -2855,7 +2870,7 @@ bool squeryWithParser (const ParmParse::Table& table,
     // Held across the whole function: the parser path below writes the entry's
     // mutable m_typehint and m_last_vals after squeryarr() has returned.
     // Recursive, so the nested squeryarr() is fine.
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
 
     std::vector<std::string> vals;
     bool exist = squeryarr(table, parser_prefix, name, vals,
@@ -2906,7 +2921,7 @@ bool squeryarrWithParser (const ParmParse::Table& table,
     // Held across the whole function: the parser path below writes the entry's
     // mutable m_typehint and m_last_vals after squeryarr() has returned.
     // Recursive, so the nested squeryarr() is fine.
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     std::vector<std::string> vals;
     bool exist = squeryarr(table, parser_prefix, name, vals,
                            ParmParse::FIRST, ParmParse::ALL, ParmParse::LAST);
@@ -3021,7 +3036,7 @@ Parser
 ParmParse::makeParser (std::string const& func,
                        Vector<std::string> const& vars) const
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     return pp_make_parser<double>(func, vars, *m_table, m_parser_prefix, true);
 }
 
@@ -3029,7 +3044,7 @@ IParser
 ParmParse::makeIParser (std::string const& func,
                         Vector<std::string> const& vars) const
 {
-    std::scoped_lock lock(g_table_mutex);
+    std::scoped_lock lock(g_table_mutex());
     return pp_make_parser<long long>(func, vars, *m_table, m_parser_prefix, true);
 }
 

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -46,7 +46,7 @@ namespace
     std::atomic<int>  next_foreign_slot{0};
     std::atomic<bool> slot0_claimed{false};
 
-    //! Serialises InitRandom, which reseeds process-global state.
+    //! Serializes InitRandom, which reseeds process-global state.
     std::mutex init_random_mutex;
 
     std::mt19937& get_generator ()
@@ -350,7 +350,7 @@ void FillRandom (Real* p, Long N)
 
 #else
     std::uniform_real_distribution<Real> distribution(Real(0.0), Real(1.0));
-    auto& gen = generators[OpenMP::get_thread_num()];
+    auto& gen = get_generator();
     for (Long i = 0; i < N; ++i) {
         p[i] = distribution(gen);
     }
@@ -397,7 +397,7 @@ void FillRandomNormal (Real* p, Long N, Real mean, Real stddev)
 #else
 
     std::normal_distribution<Real> distribution(mean, stddev);
-    auto& gen = generators[OpenMP::get_thread_num()];
+    auto& gen = get_generator();
     for (Long i = 0; i < N; ++i) {
         p[i] = distribution(gen);
     }

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -194,11 +194,14 @@ InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
     // The cost is that if this thread never draws, generators[0] goes unused,
     // and Save/RestoreRandomState -- which persist only that generator -- have
     // nothing to say about the threads that did.
-    if (tl_which == ThreadGenerator::unassigned) {
-        bool unclaimed = false;
-        if (slot0_claimed.compare_exchange_strong(unclaimed, true)) {
-            tl_which = ThreadGenerator::shared_slot0;
-        }
+    // Unconditional, not guarded on tl_which == unassigned: a thread that
+    // already drew (legally -- get_generator() copes with nthreads == 0) is
+    // 'own' by now and would not claim, leaving slot 0 for whichever arbitrary
+    // worker next reaches InitRandom while unassigned. That worker would then
+    // share generators[0] with team member 0 of any OpenMP region another host
+    // thread opens, which is the race this claim exists to prevent.
+    if (!slot0_claimed.exchange(true)) {
+        tl_which = ThreadGenerator::shared_slot0;
     }
 
 #ifdef AMREX_USE_GPU

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -56,7 +56,9 @@ namespace
         // and generators was sized for exactly that. Note this also means two
         // host threads that each open their own team share these slots -- see
         // the OpenMP caveat in the Host Thread Safety docs.
-        if (OpenMP::in_parallel()) { return generators[OpenMP::get_thread_num()]; }
+        if (amrex::OpenMP::in_parallel()) {
+            return generators[amrex::OpenMP::get_thread_num()];
+        }
 #endif
         if (tl_which == ThreadGenerator::unassigned) {
             // The first thread to actually draw takes generators[0], the one

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -56,6 +56,8 @@ namespace
 #endif
         if (tl_which == ThreadGenerator::shared_slot0) { return generators[0]; }
         if (tl_which == ThreadGenerator::unassigned) {
+            // seed_base/seed_stride/nthreads are written by InitRandom, which
+            // the docs put on one thread before any worker starts.
             int const slot = nthreads + next_foreign_slot.fetch_add(1);
             tl_own_generator.seed(seed_base
                                   + static_cast<amrex::ULong>(slot)
@@ -168,7 +170,9 @@ InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
     // Continue the same seed sequence for any thread AMReX did not create.
     seed_base = cpu_seed;
     seed_stride = nprocs;
-    next_foreign_slot.store(0);
+    // Deliberately not reset: a thread that already took a slot keeps its
+    // generator, and reusing slot numbers after a re-Initialize would hand a
+    // new thread the same seed as a live one.
 
     // The first thread through here keeps generators[0]; a later caller on
     // another thread keeps whatever generator it already had.

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -5,6 +5,8 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_OpenMP.H>
 
+#include <atomic>
+#include <mutex>
 #include <iterator>
 #include <limits>
 
@@ -23,6 +25,45 @@ namespace
 {
     int nthreads;
     amrex::Vector<std::mt19937> generators;
+
+    // AMReX gives every OpenMP thread its own generator, indexed by
+    // OpenMP::get_thread_num(). Host threads that AMReX did not create -- e.g.
+    // Python threads on a free-threaded interpreter -- all report thread 0, so
+    // they would share one std::mt19937 and race on its state. Hand each of
+    // them a generator of its own instead, seeded from the same base.
+    //
+    // The first thread to call InitRandom keeps generators[0], so serial runs
+    // have their existing stream and stay checkpointable through
+    // Save/RestoreRandomState. Every other thread gets tl_own_generator, which
+    // is not part of the checkpoint.
+    enum class ThreadGenerator { unassigned, shared_slot0, own };
+
+    thread_local std::mt19937     tl_own_generator;
+    thread_local ThreadGenerator  tl_which = ThreadGenerator::unassigned;
+
+    amrex::ULong      seed_base = 0;
+    int               seed_stride = 1;
+    std::atomic<int>  next_foreign_slot{0};
+    std::atomic<bool> slot0_claimed{false};
+
+    //! Serialises InitRandom, which reseeds process-global state.
+    std::mutex init_random_mutex;
+
+    std::mt19937& get_generator ()
+    {
+#ifdef AMREX_USE_OMP
+        if (omp_in_parallel()) { return generators[omp_get_thread_num()]; }
+#endif
+        if (tl_which == ThreadGenerator::shared_slot0) { return generators[0]; }
+        if (tl_which == ThreadGenerator::unassigned) {
+            int const slot = nthreads + next_foreign_slot.fetch_add(1);
+            tl_own_generator.seed(seed_base
+                                  + static_cast<amrex::ULong>(slot)
+                                  * static_cast<amrex::ULong>(seed_stride));
+            tl_which = ThreadGenerator::own;
+        }
+        return tl_own_generator;
+    }
 }
 
 #ifdef AMREX_USE_GPU
@@ -98,6 +139,14 @@ namespace amrex {
 void
 InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
 {
+    // InitRandom reseeds process-global state: the per-OpenMP-thread generator
+    // vector and, on GPU, the device state array (which it frees and
+    // reallocates). The lock keeps two threads from doing that at once. It
+    // does *not* make reseeding safe against another thread that is drawing
+    // numbers at the same time -- see the host-thread-safety section of the
+    // docs; reseed before starting worker threads.
+    std::scoped_lock lock(init_random_mutex);
+
     nthreads = OpenMP::get_max_threads();
     generators.resize(nthreads);
 
@@ -116,6 +165,20 @@ InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
         generators[tid].seed(init_seed);
     }
 
+    // Continue the same seed sequence for any thread AMReX did not create.
+    seed_base = cpu_seed;
+    seed_stride = nprocs;
+    next_foreign_slot.store(0);
+
+    // The first thread through here keeps generators[0]; a later caller on
+    // another thread keeps whatever generator it already had.
+    if (tl_which == ThreadGenerator::unassigned) {
+        bool unclaimed = false;
+        if (slot0_claimed.compare_exchange_strong(unclaimed, true)) {
+            tl_which = ThreadGenerator::shared_slot0;
+        }
+    }
+
 #ifdef AMREX_USE_GPU
     ResizeRandomSeed(gpu_seed);
 #else
@@ -126,45 +189,39 @@ InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
 Real RandomNormal (Real mean, Real stddev)
 {
     std::normal_distribution<Real> distribution(mean, stddev);
-    int tid = OpenMP::get_thread_num();
-    return distribution(generators[tid]);
+    return distribution(get_generator());
 }
 
 Real Random ()
 {
     std::uniform_real_distribution<Real> distribution(0.0, 1.0);
-    int tid = OpenMP::get_thread_num();
-    return distribution(generators[tid]);
+    return distribution(get_generator());
 }
 
 unsigned int RandomPoisson (Real lambda)
 {
     std::poisson_distribution<unsigned int> distribution(lambda);
-    int tid = OpenMP::get_thread_num();
-    return distribution(generators[tid]);
+    return distribution(get_generator());
 }
 
 Real RandomGamma (Real alpha, Real beta)
 {
     std::gamma_distribution<Real> distribution(alpha, beta);
-    int tid = OpenMP::get_thread_num();
-    return distribution(generators[tid]);
+    return distribution(get_generator());
 }
 
 unsigned int Random_int (unsigned int n)
 {
     if (n == 0) {return 0;}
     std::uniform_int_distribution<unsigned int> distribution(0, n-1);
-    int tid = OpenMP::get_thread_num();
-    return distribution(generators[tid]);
+    return distribution(get_generator());
 }
 
 ULong Random_long (ULong n)
 {
     if (n == 0) {return 0;}
     std::uniform_int_distribution<ULong> distribution(0, n-1);
-    int tid = OpenMP::get_thread_num();
-    return distribution(generators[tid]);
+    return distribution(get_generator());
 }
 
 void

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -32,10 +32,10 @@ namespace
     // they would share one std::mt19937 and race on its state. Hand each of
     // them a generator of its own instead, seeded from the same base.
     //
-    // The first thread to call InitRandom keeps generators[0], so serial runs
-    // have their existing stream and stay checkpointable through
-    // Save/RestoreRandomState. Every other thread gets tl_own_generator, which
-    // is not part of the checkpoint.
+    // The first thread to draw keeps generators[0], so serial runs have their
+    // existing stream and stay checkpointable through Save/RestoreRandomState.
+    // Every other thread gets tl_own_generator, which is not part of the
+    // checkpoint.
     enum class ThreadGenerator { unassigned, shared_slot0, own };
 
     thread_local std::mt19937     tl_own_generator;
@@ -52,18 +52,35 @@ namespace
     std::mt19937& get_generator ()
     {
 #ifdef AMREX_USE_OMP
-        if (omp_in_parallel()) { return generators[omp_get_thread_num()]; }
+        // Inside a team the OpenMP thread number is the identity that matters,
+        // and generators was sized for exactly that. Note this also means two
+        // host threads that each open their own team share these slots -- see
+        // the OpenMP caveat in the Host Thread Safety docs.
+        if (OpenMP::in_parallel()) { return generators[OpenMP::get_thread_num()]; }
 #endif
-        if (tl_which == ThreadGenerator::shared_slot0) { return generators[0]; }
         if (tl_which == ThreadGenerator::unassigned) {
-            // seed_base/seed_stride/nthreads are written by InitRandom, which
-            // the docs put on one thread before any worker starts.
-            int const slot = nthreads + next_foreign_slot.fetch_add(1);
-            tl_own_generator.seed(seed_base
-                                  + static_cast<amrex::ULong>(slot)
-                                  * static_cast<amrex::ULong>(seed_stride));
-            tl_which = ThreadGenerator::own;
+            // The first thread to actually draw takes generators[0], the one
+            // Save/RestoreRandomState persist. Claiming it in InitRandom()
+            // instead would orphan it whenever the thread that initialized
+            // AMReX never draws itself, silently turning those two into
+            // no-ops. (A thread that claims it and then exits still orphans
+            // it; slot 0 is deliberately never handed out a second time, so
+            // that a re-Initialize cannot give a new thread the same seed as
+            // a live one.)
+            bool unclaimed = false;
+            if (slot0_claimed.compare_exchange_strong(unclaimed, true)) {
+                tl_which = ThreadGenerator::shared_slot0;
+            } else {
+                // seed_base/seed_stride/nthreads are written by InitRandom,
+                // which the docs put on one thread before any worker starts.
+                int const slot = nthreads + next_foreign_slot.fetch_add(1);
+                tl_own_generator.seed(seed_base
+                                      + static_cast<amrex::ULong>(slot)
+                                      * static_cast<amrex::ULong>(seed_stride));
+                tl_which = ThreadGenerator::own;
+            }
         }
+        if (tl_which == ThreadGenerator::shared_slot0) { return generators[0]; }
         return tl_own_generator;
     }
 }
@@ -170,18 +187,11 @@ InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
     // Continue the same seed sequence for any thread AMReX did not create.
     seed_base = cpu_seed;
     seed_stride = nprocs;
-    // Deliberately not reset: a thread that already took a slot keeps its
-    // generator, and reusing slot numbers after a re-Initialize would hand a
-    // new thread the same seed as a live one.
-
-    // The first thread through here keeps generators[0]; a later caller on
-    // another thread keeps whatever generator it already had.
-    if (tl_which == ThreadGenerator::unassigned) {
-        bool unclaimed = false;
-        if (slot0_claimed.compare_exchange_strong(unclaimed, true)) {
-            tl_which = ThreadGenerator::shared_slot0;
-        }
-    }
+    // next_foreign_slot is deliberately not reset here: a thread that already
+    // took a slot keeps its generator, and reusing slot numbers after a
+    // re-Initialize would hand a new thread the same seed as a live one.
+    //
+    // Slot 0 is claimed lazily, on first draw, in get_generator().
 
 #ifdef AMREX_USE_GPU
     ResizeRandomSeed(gpu_seed);

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -32,10 +32,10 @@ namespace
     // they would share one std::mt19937 and race on its state. Hand each of
     // them a generator of its own instead, seeded from the same base.
     //
-    // The first thread to draw keeps generators[0], so serial runs have their
-    // existing stream and stay checkpointable through Save/RestoreRandomState.
-    // Every other thread gets tl_own_generator, which is not part of the
-    // checkpoint.
+    // The first thread to call InitRandom keeps generators[0], so serial runs
+    // have their existing stream and stay checkpointable through
+    // Save/RestoreRandomState. Every other thread gets tl_own_generator, which
+    // is not part of the checkpoint.
     enum class ThreadGenerator { unassigned, shared_slot0, own };
 
     thread_local std::mt19937     tl_own_generator;
@@ -60,29 +60,16 @@ namespace
             return generators[amrex::OpenMP::get_thread_num()];
         }
 #endif
-        if (tl_which == ThreadGenerator::unassigned) {
-            // The first thread to actually draw takes generators[0], the one
-            // Save/RestoreRandomState persist. Claiming it in InitRandom()
-            // instead would orphan it whenever the thread that initialized
-            // AMReX never draws itself, silently turning those two into
-            // no-ops. (A thread that claims it and then exits still orphans
-            // it; slot 0 is deliberately never handed out a second time, so
-            // that a re-Initialize cannot give a new thread the same seed as
-            // a live one.)
-            bool unclaimed = false;
-            if (slot0_claimed.compare_exchange_strong(unclaimed, true)) {
-                tl_which = ThreadGenerator::shared_slot0;
-            } else {
-                // seed_base/seed_stride/nthreads are written by InitRandom,
-                // which the docs put on one thread before any worker starts.
-                int const slot = nthreads + next_foreign_slot.fetch_add(1);
-                tl_own_generator.seed(seed_base
-                                      + static_cast<amrex::ULong>(slot)
-                                      * static_cast<amrex::ULong>(seed_stride));
-                tl_which = ThreadGenerator::own;
-            }
-        }
         if (tl_which == ThreadGenerator::shared_slot0) { return generators[0]; }
+        if (tl_which == ThreadGenerator::unassigned) {
+            // seed_base/seed_stride/nthreads are written by InitRandom, which
+            // the docs put on one thread before any worker starts.
+            int const slot = nthreads + next_foreign_slot.fetch_add(1);
+            tl_own_generator.seed(seed_base
+                                  + static_cast<amrex::ULong>(slot)
+                                  * static_cast<amrex::ULong>(seed_stride));
+            tl_which = ThreadGenerator::own;
+        }
         return tl_own_generator;
     }
 }
@@ -192,8 +179,27 @@ InitRandom (ULong cpu_seed, int nprocs, ULong gpu_seed)
     // next_foreign_slot is deliberately not reset here: a thread that already
     // took a slot keeps its generator, and reusing slot numbers after a
     // re-Initialize would hand a new thread the same seed as a live one.
+
+    // The first thread through here keeps generators[0]; a later caller on
+    // another thread keeps whatever generator it already had.
     //
-    // Slot 0 is claimed lazily, on first draw, in get_generator().
+    // The claim belongs here rather than at the first draw, because this is
+    // amrex::Initialize's thread, which is also the OpenMP master -- and the
+    // OpenMP branch of get_generator() hands generators[0] to team member 0.
+    // Tying slot 0 to any other thread would let that thread and the master
+    // inside a team draw from one std::mt19937 at the same time. It also
+    // keeps a draw made before InitRandom() out of the then-empty generators
+    // vector.
+    //
+    // The cost is that if this thread never draws, generators[0] goes unused,
+    // and Save/RestoreRandomState -- which persist only that generator -- have
+    // nothing to say about the threads that did.
+    if (tl_which == ThreadGenerator::unassigned) {
+        bool unclaimed = false;
+        if (slot0_claimed.compare_exchange_strong(unclaimed, true)) {
+            tl_which = ThreadGenerator::shared_slot0;
+        }
+    }
 
 #ifdef AMREX_USE_GPU
     ResizeRandomSeed(gpu_seed);

--- a/Src/Base/AMReX_Utility.cpp
+++ b/Src/Base/AMReX_Utility.cpp
@@ -28,11 +28,14 @@
 #include <thread>
 
 namespace {
-    bool tokenize_initialized = false;
-    char* line = nullptr;
-    void CleanupTokenizeStatics ()
+    //! Reentrant strtok: POSIX spells it strtok_r, MSVC spells it strtok_s.
+    inline char* amrex_strtok_r (char* str, const char* delim, char** saveptr)
     {
-        delete [] line;
+#ifdef _MSC_VER
+        return strtok_s(str, delim, saveptr);
+#else
+        return strtok_r(str, delim, saveptr);
+#endif
     }
 }
 
@@ -40,34 +43,32 @@ const std::vector<std::string>&
 amrex::Tokenize (const std::string& instr,
                   const std::string& separators)
 {
-    if (!tokenize_initialized) {
-        amrex::ExecOnFinalize(CleanupTokenizeStatics);
-        tokenize_initialized = true;
-    }
-
-    static std::vector<char*>       ptr;
-    static std::vector<std::string> tokens;
-    static int                      linelen = 0;
+    // All of the scratch below is per-thread, and so is the vector whose
+    // reference we hand back: two host threads tokenizing at the same time
+    // would otherwise scribble over each other's tokens, and over the result
+    // the first caller is still holding. Freed when the thread exits, so
+    // there is nothing to clean up at amrex::Finalize().
+    static thread_local std::vector<char>        line;
+    static thread_local std::vector<char*>       ptr;
+    static thread_local std::vector<std::string> tokens;
     //
     // Make copy of line that we can modify.
     //
     const int len = static_cast<int>(instr.size()) + 1;
 
-    if (len > linelen)
-    {
-        delete [] line;
-        line = new char[len];
-        linelen = len;
-    }
+    if (len > static_cast<int>(line.size())) { line.resize(len); }
 
-    (void) std::strncpy(line, instr.c_str(), len);
+    (void) std::strncpy(line.data(), instr.c_str(), len);
 
     char* token = nullptr;
+    char* saveptr = nullptr;
 
-    if (!((token = std::strtok(line, separators.c_str())) == nullptr)) // NOLINT(bugprone-assignment-in-if-condition)
+    // strtok_r rather than strtok: strtok's parsing state is a single static,
+    // which two threads tokenizing concurrently would share.
+    if (!((token = amrex_strtok_r(line.data(), separators.c_str(), &saveptr)) == nullptr)) // NOLINT(bugprone-assignment-in-if-condition)
     {
         ptr.push_back(token);
-        while (!((token = std::strtok(nullptr, separators.c_str())) == nullptr)) { // NOLINT(bugprone-assignment-in-if-condition)
+        while (!((token = amrex_strtok_r(nullptr, separators.c_str(), &saveptr)) == nullptr)) { // NOLINT(bugprone-assignment-in-if-condition)
             ptr.push_back(token);
         }
     }

--- a/Src/Base/AMReX_Utility.cpp
+++ b/Src/Base/AMReX_Utility.cpp
@@ -54,9 +54,9 @@ amrex::Tokenize (const std::string& instr,
     //
     // Make copy of line that we can modify.
     //
-    const int len = static_cast<int>(instr.size()) + 1;
+    const std::size_t len = instr.size() + 1;
 
-    if (len > static_cast<int>(line.size())) { line.resize(len); }
+    if (len > line.size()) { line.resize(len); }
 
     (void) std::strncpy(line.data(), instr.c_str(), len);
 

--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -350,7 +350,9 @@ private:
     * has its own cache, closed when the thread exits; CloseAllStreams() closes
     * the calling thread's.
     */
-    static AMREX_EXPORT thread_local std::map<std::string, VisMF::PersistentIFStream> persistentIFStreams;
+    // Not AMREX_EXPORT: MSVC forbids dllexport on a thread_local, and this
+    // is private and only touched from AMReX_VisMF.cpp.
+    static thread_local std::map<std::string, VisMF::PersistentIFStream> persistentIFStreams;
     //! The number of files to write for a FabArray<FArrayBox>.
     static AMREX_EXPORT int nOutFiles;
     static AMREX_EXPORT int nMFFileInStreams;

--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -344,8 +344,13 @@ private:
     * \brief Persistent streams.  These open on demand and should
     * be closed when not needed with CloseAllStreams.
     * ~VisMF also closes them.  [filename, pifs]
+    *
+    * Per thread: an ifstream carries a single read position, so two host
+    * threads reading the same file must not share one. Each thread therefore
+    * has its own cache, closed when the thread exits; CloseAllStreams() closes
+    * the calling thread's.
     */
-    static AMREX_EXPORT std::map<std::string, VisMF::PersistentIFStream> persistentIFStreams;
+    static AMREX_EXPORT thread_local std::map<std::string, VisMF::PersistentIFStream> persistentIFStreams;
     //! The number of files to write for a FabArray<FArrayBox>.
     static AMREX_EXPORT int nOutFiles;
     static AMREX_EXPORT int nMFFileInStreams;

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -21,7 +21,7 @@ namespace {
     const char *TheFabOnDiskPrefix = "FabOnDisk:";
 }
 
-std::map<std::string, VisMF::PersistentIFStream> VisMF::persistentIFStreams;
+thread_local std::map<std::string, VisMF::PersistentIFStream> VisMF::persistentIFStreams;
 
 int VisMF::verbose(0);
 VisMF::Header::Version VisMF::currentVersion(VisMF::Header::Version_v1);

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <iterator>
 #include <limits>
+#include <mutex>
 #include <vector>
 #include <utility>
 
@@ -69,8 +70,26 @@ namespace
 
     std::vector<std::pair<std::weak_ptr<BARef>, std::weak_ptr<DMRef>>> s_layout_cache;
 
+    /**
+     * Guards s_layout_cache.
+     *
+     * VisMF::Read() reaches vismf_make_dm() whenever it is handed an
+     * undefined MultiFab, which is what pyAMReX's amr.VisMF.Read(name) does on
+     * every call. Without this, two host threads reading -- the same file or
+     * different ones -- erase() and emplace_back() the same vector while the
+     * other is iterating it.
+     *
+     * Note this serialises the local threads only. The
+     * ParallelDescriptor::ReduceBoolAnd below is still a collective, and
+     * calling it from more than one thread remains the caller's
+     * responsibility, as for every other collective in AMReX.
+     */
+    std::mutex layout_cache_mutex; // NOLINT(cert-err58-cpp)
+
     DistributionMapping vismf_make_dm (BoxArray& ba)
     {
+        std::scoped_lock lock(layout_cache_mutex);
+
         auto& ba_ref = ba.getSharedRef();
 
         std::shared_ptr<DMRef> dm_ref;
@@ -151,6 +170,7 @@ void
 VisMF::Finalize ()
 {
     initialized = false;
+    std::scoped_lock lock(layout_cache_mutex);
     s_layout_cache.clear();
 }
 

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -6,6 +6,7 @@
 #include <AMReX_Utility.H>
 #include <AMReX_VisMF.H>
 
+#include <atomic>
 #include <cerrno>
 #include <cstdio>
 #include <iterator>
@@ -1590,7 +1591,9 @@ VisMF::Read (FabArray<FArrayBox> &mf,
     VisMF::Header hdr;
     double hEndTime, hStartTime, faCopyTime(0.0);
     double startTime(amrex::second());
-    static double totalTime(0.0);
+    // Atomic: VisMF::Read is reachable from several host threads (PlotFileData),
+    // and this accumulates across calls. Only touched when verbose is on.
+    static std::atomic<double> totalTime(0.0);
     int myProc(ParallelDescriptor::MyProc());
     int messTotal(0);
 
@@ -2070,13 +2073,14 @@ VisMF::Read (FabArray<FArrayBox> &mf,
 
     if(myProc == coordinatorProc && verbose) {
       auto mfReadTime = amrex::second() - startTime;
-      totalTime += mfReadTime;
+      double const totalTimeSoFar =
+          totalTime.fetch_add(mfReadTime, std::memory_order_relaxed) + mfReadTime;
       amrex::AllPrint() << "FARead ::  nBoxes = " << hdr.m_ba.size()
                         << "  nMessages = " << messTotal << '\n'
                         << "FARead ::  hTime = " << (hEndTime - hStartTime) << '\n'
                         << "FARead ::  faCopyTime = " << faCopyTime << '\n'
                         << "FARead ::  mfReadTime = " << mfReadTime
-                        << "  totalTime = " << totalTime << '\n';
+                        << "  totalTime = " << totalTimeSoFar << '\n';
     }
 
     BL_ASSERT(mf.ok());

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -79,10 +79,14 @@ namespace
      * different ones -- erase() and emplace_back() the same vector while the
      * other is iterating it.
      *
-     * Note this serialises the local threads only. The
-     * ParallelDescriptor::ReduceBoolAnd below is still a collective, and
-     * calling it from more than one thread remains the caller's
-     * responsibility, as for every other collective in AMReX.
+     * Note this serialises the local threads only, and it is *held across*
+     * the ParallelDescriptor::ReduceBoolAnd below. That is deliberate -- the
+     * cache lookup, the agreement across ranks and the insert have to be one
+     * step -- but it does not make multi-rank concurrent Read() safe: two
+     * threads can be admitted here in different orders on different ranks and
+     * then pair up the collective wrongly. Concurrent VisMF::Read is
+     * therefore host-safe on one rank, and still subject to the usual
+     * one-thread rule for collectives across ranks.
      */
     std::mutex layout_cache_mutex; // NOLINT(cert-err58-cpp)
 

--- a/Src/EB/AMReX_EBCellFlag.cpp
+++ b/Src/EB/AMReX_EBCellFlag.cpp
@@ -1,8 +1,22 @@
 #include <AMReX_EBCellFlag.H>
 #include <AMReX_Reduce.H>
 #include <iostream>
+#include <mutex>
 
 namespace amrex {
+
+namespace {
+    /**
+     * Guards EBCellFlagFab::m_typemap, the lazily filled cell-count cache that
+     * getType() and the getNum*Cells() queries share.
+     *
+     * A real mutex rather than `omp critical`, which excludes only threads in
+     * the same OpenMP contention group and is compiled out entirely in a build
+     * without OpenMP -- these are const queries, so any host thread can be the
+     * one that fills the cache.
+     */
+    std::mutex ebcellflag_typemap_mutex;
+}
 
 EBCellFlagFab::EBCellFlagFab (Arena* ar) noexcept
     : BaseFab<EBCellFlag>(ar)
@@ -104,27 +118,24 @@ EBCellFlagFab::getType (const Box& bx_in) const noexcept
     else
     {
         const Box& bx = amrex::enclosedCells(bx_in);
-        std::map<Box,NumCells>::iterator it;
-#ifdef AMREX_USE_OMP
-#pragma omp critical (amrex_ebcellflagfab_gettype)
-#endif
-        it = m_typemap.find(bx);
-        if (it != m_typemap.end())
         {
-            return it->second.type;
+            std::scoped_lock lock(ebcellflag_typemap_mutex);
+            auto it = m_typemap.find(bx);
+            if (it != m_typemap.end())
+            {
+                return it->second.type;
+            }
         }
-        else
-        {
-            auto const& flag = this->const_array();
-            auto const& t = countCells(flag, bx);
 
-#ifdef AMREX_USE_OMP
-#pragma omp critical (amrex_ebcellflagfab_gettype)
-#endif
+        auto const& flag = this->const_array();
+        auto const& t = countCells(flag, bx);
+
+        {
+            std::scoped_lock lock(ebcellflag_typemap_mutex);
             m_typemap.insert({bx,t});
-
-            return t.type;
         }
+
+        return t.type;
     }
 }
 
@@ -160,27 +171,24 @@ EBCellFlagFab::getNumRegularCells (const Box& bx_in) const noexcept
     }
     else
     {
-        std::map<Box,NumCells>::iterator it;
-#ifdef AMREX_USE_OMP
-#pragma omp critical (amrex_ebcellflagfab_gettype)
-#endif
-        it = m_typemap.find(bx);
-        if (it != m_typemap.end())
         {
-            return it->second.nregular;
+            std::scoped_lock lock(ebcellflag_typemap_mutex);
+            auto it = m_typemap.find(bx);
+            if (it != m_typemap.end())
+            {
+                return it->second.nregular;
+            }
         }
-        else
-        {
-            auto const& flag = this->const_array();
-            auto const& t = countCells(flag, bx);
 
-#ifdef AMREX_USE_OMP
-#pragma omp critical (amrex_ebcellflagfab_gettype)
-#endif
+        auto const& flag = this->const_array();
+        auto const& t = countCells(flag, bx);
+
+        {
+            std::scoped_lock lock(ebcellflag_typemap_mutex);
             m_typemap.insert({bx,t});
-
-            return t.nregular;
         }
+
+        return t.nregular;
     }
 }
 
@@ -198,27 +206,24 @@ EBCellFlagFab::getNumCutCells (const Box& bx_in) const noexcept
     }
     else
     {
-        std::map<Box,NumCells>::iterator it;
-#ifdef AMREX_USE_OMP
-#pragma omp critical (amrex_ebcellflagfab_gettype)
-#endif
-        it = m_typemap.find(bx);
-        if (it != m_typemap.end())
         {
-            return it->second.nsingle;
+            std::scoped_lock lock(ebcellflag_typemap_mutex);
+            auto it = m_typemap.find(bx);
+            if (it != m_typemap.end())
+            {
+                return it->second.nsingle;
+            }
         }
-        else
-        {
-            auto const& flag = this->const_array();
-            auto const& t = countCells(flag, bx);
 
-#ifdef AMREX_USE_OMP
-#pragma omp critical (amrex_ebcellflagfab_gettype)
-#endif
+        auto const& flag = this->const_array();
+        auto const& t = countCells(flag, bx);
+
+        {
+            std::scoped_lock lock(ebcellflag_typemap_mutex);
             m_typemap.insert({bx,t});
-
-            return t.nsingle;
         }
+
+        return t.nsingle;
     }
 }
 
@@ -239,27 +244,24 @@ EBCellFlagFab::getNumCoveredCells (const Box& bx_in) const noexcept
     }
     else
     {
-        std::map<Box,NumCells>::iterator it;
-#ifdef AMREX_USE_OMP
-#pragma omp critical (amrex_ebcellflagfab_gettype)
-#endif
-        it = m_typemap.find(bx);
-        if (it != m_typemap.end())
         {
-            return it->second.ncovered;
+            std::scoped_lock lock(ebcellflag_typemap_mutex);
+            auto it = m_typemap.find(bx);
+            if (it != m_typemap.end())
+            {
+                return it->second.ncovered;
+            }
         }
-        else
-        {
-            auto const& flag = this->const_array();
-            auto const& t = countCells(flag, bx);
 
-#ifdef AMREX_USE_OMP
-#pragma omp critical (amrex_ebcellflagfab_gettype)
-#endif
+        auto const& flag = this->const_array();
+        auto const& t = countCells(flag, bx);
+
+        {
+            std::scoped_lock lock(ebcellflag_typemap_mutex);
             m_typemap.insert({bx,t});
-
-            return t.ncovered;
         }
+
+        return t.ncovered;
     }
 }
 

--- a/Src/EB/AMReX_EBCellFlag.cpp
+++ b/Src/EB/AMReX_EBCellFlag.cpp
@@ -142,8 +142,13 @@ EBCellFlagFab::getType (const Box& bx_in) const noexcept
 void
 EBCellFlagFab::resetType (int ng)
 {
-    this->setType(FabType::undefined);
-    m_typemap.clear();
+    {
+        // getType() below takes this lock too, so it has to be released first
+        // -- ebcellflag_typemap_mutex is a plain std::mutex.
+        std::scoped_lock lock(ebcellflag_typemap_mutex);
+        this->setType(FabType::undefined);
+        m_typemap.clear();
+    }
 
     Box const& bx = this->box();
     auto typ = this->getType(bx);

--- a/Src/Particle/AMReX_Particle.H
+++ b/Src/Particle/AMReX_Particle.H
@@ -9,6 +9,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_RealVect.H>
 
+#include <atomic>
 #include <type_traits>
 
 
@@ -418,7 +419,8 @@ struct alignas(sizeof(double)) Particle
     using RealType = ParticleReal;
     using IntType = int;
 
-    static Long the_next_id;
+    //! Atomic: particle ids are handed out from any host thread.
+    static std::atomic<Long> the_next_id;
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     ParticleCPUWrapper cpu () & { return ParticleCPUWrapper(this->m_idcpu); }
@@ -588,21 +590,16 @@ struct alignas(sizeof(double)) Particle
     static void NextID (Long nextid);
 };
 
-template <int NReal, int NInt> Long Particle<NReal, NInt>::the_next_id = 1;
+template <int NReal, int NInt> std::atomic<Long> Particle<NReal, NInt>::the_next_id{1};
 
 template <int NReal, int NInt>
 Long
 Particle<NReal, NInt>::NextID ()
 {
-    Long next;
-// we should be able to test on _OPENMP < 201107 for capture (version 3.1)
-// but we must work around a bug in gcc < 4.9
-#if defined(AMREX_USE_OMP) && defined(_OPENMP) && _OPENMP < 201307
-#pragma omp critical (amrex_particle_nextid)
-#elif defined(AMREX_USE_OMP)
-#pragma omp atomic capture
-#endif
-    next = the_next_id++;
+    // std::atomic rather than `omp atomic capture`: the latter is compiled
+    // out in a build without OpenMP, leaving a bare increment that any two
+    // host threads adding particles would race on.
+    Long const next = the_next_id.fetch_add(1, std::memory_order_relaxed);
 
     if (next > LongParticleIds::LastParticleID) {
         amrex::Abort("Particle<NReal, NInt>::NextID() -- too many particles");
@@ -615,7 +612,7 @@ template <int NReal, int NInt>
 Long
 Particle<NReal, NInt>::UnprotectedNextID ()
 {
-    Long next = the_next_id++;
+    Long const next = the_next_id.fetch_add(1, std::memory_order_relaxed);
     if (next > LongParticleIds::LastParticleID) {
         amrex::Abort("Particle<NReal, NInt>::NextID() -- too many particles");
     }

--- a/Src/Particle/AMReX_ParticleContainerBase.H
+++ b/Src/Particle/AMReX_ParticleContainerBase.H
@@ -286,6 +286,19 @@ public:
         m_arena = a;
     }
 
+    /**
+     * Read the container-wide "particles.*" settings from the inputs, once.
+     *
+     * do_tiling, tile_size, memEfficientSort and use_comms_arena are static
+     * members of this non-template base, so the guard has to live here too. A guard in
+     * ParticleContainer's constructor is one guard per *instantiation*, and
+     * pyAMReX registers a dozen of those in a single module -- two threads
+     * each constructing their first container of a different type would both
+     * run the body, tearing the IntVect tile_size and double-adding the
+     * queryAdd entries.
+     */
+    static void ReadStaticParameters ();
+
     static const std::string& CheckpointVersion ();
     static const std::string& PlotfileVersion ();
     static const std::string& DataPrefix ();

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -24,17 +24,16 @@ struct RedistributeMaskParameters
 RedistributeMaskParameters const&
 RedistributeMaskParams ()
 {
-    static RedistributeMaskParameters params;
-    static bool initialized = false;
-
-    if (! initialized)
-    {
+    // Function-local static: the C++ runtime makes the initialisation
+    // thread-safe, which a `static bool initialized` flag does not.
+    static RedistributeMaskParameters const params = [] {
+        RedistributeMaskParameters p;
         ParmParse pp("particles");
-        pp.query("redistribute_use_mask", params.use_mask);
-        pp.query("redistribute_mask_max_ratio", params.max_ratio);
-        pp.query("redistribute_mask_max_bytes", params.max_bytes);
-        initialized = true;
-    }
+        pp.query("redistribute_use_mask", p.use_mask);
+        pp.query("redistribute_mask_max_ratio", p.max_ratio);
+        pp.query("redistribute_mask_max_bytes", p.max_bytes);
+        return p;
+    }();
 
     return params;
 }
@@ -273,22 +272,18 @@ const std::string& ParticleContainerBase::DataPrefix ()
 
 int ParticleContainerBase::MaxReaders ()
 {
-    const int Max_Readers_def = 64;
-    static int Max_Readers;
-    static bool first = true;
-
-    if (first)
-    {
-        first = false;
+    static int const Max_Readers = [] {
+        const int Max_Readers_def = 64;
+        int n = Max_Readers_def;
         ParmParse pp("particles");
-        Max_Readers = Max_Readers_def;
-        pp.query("nreaders", Max_Readers);
-        Max_Readers = std::min(ParallelDescriptor::NProcs(),Max_Readers);
-        if (Max_Readers <= 0)
+        pp.query("nreaders", n);
+        n = std::min(ParallelDescriptor::NProcs(), n);
+        if (n <= 0)
         {
             amrex::Abort("particles.nreaders must be positive");
         }
-    }
+        return n;
+    }();
 
     return Max_Readers;
 }
@@ -299,61 +294,49 @@ Long ParticleContainerBase::MaxParticlesPerRead ()
     // This is the maximum particles that "each" reader will attempt to read
     // before doing a Redistribute().
     //
-    const Long Max_Particles_Per_Read_def = 100000;
-    static Long Max_Particles_Per_Read;
-    static bool first = true;
-
-    if (first)
-    {
-        first = false;
+    static Long const Max_Particles_Per_Read = [] {
+        const Long Max_Particles_Per_Read_def = 100000;
+        Long n = Max_Particles_Per_Read_def;
         ParmParse pp("particles");
-        Max_Particles_Per_Read = Max_Particles_Per_Read_def;
-        pp.query("nparts_per_read", Max_Particles_Per_Read);
-        if (Max_Particles_Per_Read <= 0)
+        pp.query("nparts_per_read", n);
+        if (n <= 0)
         {
             amrex::Abort("particles.nparts_per_read must be positive");
         }
-    }
+        return n;
+    }();
 
     return Max_Particles_Per_Read;
 }
 
 const std::string& ParticleContainerBase::AggregationType ()
 {
-    static std::string aggregation_type;
-    static bool first = true;
-
-    if (first)
-    {
-        first = false;
-        aggregation_type = "None";
+    static std::string const aggregation_type = [] {
+        std::string t = "None";
         ParmParse pp("particles");
-        pp.query("aggregation_type", aggregation_type);
-        if (!(aggregation_type == "None" || aggregation_type == "Cell"))
+        pp.query("aggregation_type", t);
+        if (!(t == "None" || t == "Cell"))
         {
             amrex::Abort("particles.aggregation_type not implemented.");
         }
-    }
+        return t;
+    }();
 
     return aggregation_type;
 }
 
 int ParticleContainerBase::AggregationBuffer ()
 {
-    static int aggregation_buffer;
-    static bool first = true;
-
-    if (first)
-    {
-        first = false;
-        aggregation_buffer = 2;
+    static int const aggregation_buffer = [] {
+        int n = 2;
         ParmParse pp("particles");
-        pp.query("aggregation_buffer", aggregation_buffer);
-        if (aggregation_buffer <= 0)
+        pp.query("aggregation_buffer", n);
+        if (n <= 0)
         {
             amrex::Abort("particles.aggregation_buffer must be positive");
         }
-    }
+        return n;
+    }();
 
     return aggregation_buffer;
 }

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -24,7 +24,7 @@ struct RedistributeMaskParameters
 RedistributeMaskParameters const&
 RedistributeMaskParams ()
 {
-    // Function-local static: the C++ runtime makes the initialisation
+    // Function-local static: the C++ runtime makes the initialization
     // thread-safe, which a `static bool initialized` flag does not.
     static RedistributeMaskParameters const params = [] {
         RedistributeMaskParameters p;

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -270,6 +270,21 @@ const std::string& ParticleContainerBase::DataPrefix ()
     return data;
 }
 
+void ParticleContainerBase::ReadStaticParameters ()
+{
+    [[maybe_unused]] static const bool read_once = [] {
+        ParmParse pp("particles");
+        pp.queryAdd("do_tiling", do_tiling);
+        Vector<int> tilesize(AMREX_SPACEDIM);
+        if (pp.queryarr("tile_size", tilesize, 0, AMREX_SPACEDIM)) {
+            for (int i=0; i<AMREX_SPACEDIM; ++i) { tile_size[i] = tilesize[i]; }
+        }
+        pp.queryAdd("do_mem_efficient_sort", memEfficientSort);
+        pp.queryAdd("use_comms_arena", use_comms_arena);
+        return true;
+    }();
+}
+
 int ParticleContainerBase::MaxReaders ()
 {
     static int const Max_Readers = [] {

--- a/Src/Particle/AMReX_ParticleContainerBase.cpp
+++ b/Src/Particle/AMReX_ParticleContainerBase.cpp
@@ -5,6 +5,8 @@
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_iMultiFab.H>
 
+#include <mutex>
+
 namespace amrex {
 
 bool    ParticleContainerBase::do_tiling = false;
@@ -272,17 +274,33 @@ const std::string& ParticleContainerBase::DataPrefix ()
 
 void ParticleContainerBase::ReadStaticParameters ()
 {
-    [[maybe_unused]] static const bool read_once = [] {
-        ParmParse pp("particles");
-        pp.queryAdd("do_tiling", do_tiling);
-        Vector<int> tilesize(AMREX_SPACEDIM);
-        if (pp.queryarr("tile_size", tilesize, 0, AMREX_SPACEDIM)) {
-            for (int i=0; i<AMREX_SPACEDIM; ++i) { tile_size[i] = tilesize[i]; }
-        }
-        pp.queryAdd("do_mem_efficient_sort", memEfficientSort);
-        pp.queryAdd("use_comms_arena", use_comms_arena);
-        return true;
-    }();
+    // Once per amrex::Initialize(), not once per process: ParmParse::Finalize()
+    // clears the table, so a container type first constructed in a later
+    // initialize/finalize cycle -- which is every pyAMReX test, since the suite
+    // initializes and finalizes around each one -- has to read the inputs
+    // again. Otherwise its "particles.*" entries are never queried, and turn up
+    // under "Unused ParmParse Variables" (fatal with
+    // amrex.abort_on_unused_inputs=1).
+    static std::mutex read_mutex;
+    static bool have_read = false;
+
+    std::scoped_lock lock(read_mutex);
+    if (have_read) { return; }
+
+    ParmParse pp("particles");
+    pp.queryAdd("do_tiling", do_tiling);
+    Vector<int> tilesize(AMREX_SPACEDIM);
+    if (pp.queryarr("tile_size", tilesize, 0, AMREX_SPACEDIM)) {
+        for (int i=0; i<AMREX_SPACEDIM; ++i) { tile_size[i] = tilesize[i]; }
+    }
+    pp.queryAdd("do_mem_efficient_sort", memEfficientSort);
+    pp.queryAdd("use_comms_arena", use_comms_arena);
+
+    have_read = true;
+    amrex::ExecOnFinalize([] {
+        std::scoped_lock reset_lock(read_mutex);
+        have_read = false;
+    });
 }
 
 int ParticleContainerBase::MaxReaders ()

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -72,12 +72,22 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         m_soa_idata_names.push_back(getDefaultCompNameInt<ParticleType>(i));
     }
 
-    static bool initialized = false;
-    if ( ! initialized)
-    {
-        static_assert(sizeof(ParticleType)%sizeof(RealType) == 0,
-                      "sizeof ParticleType is not a multiple of sizeof RealType");
+    static_assert(sizeof(ParticleType)%sizeof(RealType) == 0,
+                  "sizeof ParticleType is not a multiple of sizeof RealType");
+    static_assert(std::is_standard_layout_v<ParticleType>,
+                  "Particle type must be standard layout");
+    //                   && std::is_trivial<ParticleType>::value,
+    //                      "Particle type must be standard layout and trivial.");
 
+    // Read the settings once. A function-local static gives us thread-safe
+    // initialisation, which a `static bool initialized` flag does not -- two
+    // host threads building containers at the same time would both run the
+    // body and both write the class statics below.
+    //
+    // `this` is captured because usePrePost/doUnlink are per-container
+    // members: as before, only the container that gets here first reads them
+    // from the inputs.
+    static const bool read_settings_once = [this] {
         ParmParse pp("particles");
         pp.queryAdd("do_tiling", do_tiling);
         Vector<int> tilesize(AMREX_SPACEDIM);
@@ -85,18 +95,13 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
             for (int i=0; i<AMREX_SPACEDIM; ++i) { tile_size[i] = tilesize[i]; }
         }
 
-        static_assert(std::is_standard_layout_v<ParticleType>,
-                      "Particle type must be standard layout");
-        //                   && std::is_trivial<ParticleType>::value,
-        //                      "Particle type must be standard layout and trivial.");
-
         pp.query("use_prepost", usePrePost);
         pp.query("do_unlink", doUnlink);
         pp.queryAdd("do_mem_efficient_sort", memEfficientSort);
         pp.queryAdd("use_comms_arena", use_comms_arena);
-
-        initialized = true;
-    }
+        return true;
+    }();
+    amrex::ignore_unused(read_settings_once);
 }
 
 template<

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -82,7 +82,7 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     // Read the settings once. A function-local static gives us thread-safe
     // initialisation, which a `static bool initialized` flag does not -- two
     // host threads building containers at the same time would both run the
-    // body and both write the class statics below.
+    // body and both write the static members below.
     //
     // `this` is captured because usePrePost/doUnlink are per-container
     // members: as before, only the container that gets here first reads them

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -80,14 +80,17 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     //                      "Particle type must be standard layout and trivial.");
 
     // Read the settings once. A function-local static gives us thread-safe
-    // initialisation, which a `static bool initialized` flag does not -- two
+    // initialization, which a `static bool initialized` flag does not -- two
     // host threads building containers at the same time would both run the
     // body and both write the static members below.
     //
     // `this` is captured because usePrePost/doUnlink are per-container
-    // members: as before, only the container that gets here first reads them
-    // from the inputs.
-    static const bool read_settings_once = [this] {
+    // members, and this preserves the previous behaviour: only the container
+    // that gets here first reads them from the inputs. Note that both are
+    // declared without an initializer and are only assigned if the
+    // corresponding input is present, so they can be read indeterminate --
+    // pre-existing, and worth a separate fix.
+    [[maybe_unused]] static const bool read_settings_once = [this] {
         ParmParse pp("particles");
         pp.queryAdd("do_tiling", do_tiling);
         Vector<int> tilesize(AMREX_SPACEDIM);
@@ -101,7 +104,6 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
         pp.queryAdd("use_comms_arena", use_comms_arena);
         return true;
     }();
-    amrex::ignore_unused(read_settings_once);
 }
 
 template<

--- a/Src/Particle/AMReX_ParticleContainerI.H
+++ b/Src/Particle/AMReX_ParticleContainerI.H
@@ -79,29 +79,23 @@ ParticleContainer_impl<ParticleType, NArrayReal, NArrayInt, Allocator, CellAssig
     //                   && std::is_trivial<ParticleType>::value,
     //                      "Particle type must be standard layout and trivial.");
 
-    // Read the settings once. A function-local static gives us thread-safe
-    // initialization, which a `static bool initialized` flag does not -- two
-    // host threads building containers at the same time would both run the
-    // body and both write the static members below.
-    //
-    // `this` is captured because usePrePost/doUnlink are per-container
-    // members, and this preserves the previous behaviour: only the container
-    // that gets here first reads them from the inputs. Note that both are
-    // declared without an initializer and are only assigned if the
-    // corresponding input is present, so they can be read indeterminate --
-    // pre-existing, and worth a separate fix.
+    // The settings shared by every container type live on the non-template
+    // base, and so does the guard that reads them: a guard here would be one
+    // per instantiation, and pyAMReX registers a dozen of those in one module.
+    // See ParticleContainerBase::ReadStaticParameters().
+    ParticleContainerBase::ReadStaticParameters();
+
+    // usePrePost/doUnlink are per-container members, so this guard does belong
+    // here. A function-local static gives thread-safe initialization, which
+    // the `static bool initialized` flag it replaced did not. It keeps the
+    // previous behaviour of only the container that gets here first reading
+    // them from the inputs. Note both are declared without an initializer and
+    // are only assigned if the corresponding input is present, so they can be
+    // read indeterminate -- pre-existing, and worth a separate fix.
     [[maybe_unused]] static const bool read_settings_once = [this] {
         ParmParse pp("particles");
-        pp.queryAdd("do_tiling", do_tiling);
-        Vector<int> tilesize(AMREX_SPACEDIM);
-        if (pp.queryarr("tile_size", tilesize, 0, AMREX_SPACEDIM)) {
-            for (int i=0; i<AMREX_SPACEDIM; ++i) { tile_size[i] = tilesize[i]; }
-        }
-
         pp.query("use_prepost", usePrePost);
         pp.query("do_unlink", doUnlink);
-        pp.queryAdd("do_mem_efficient_sort", memEfficientSort);
-        pp.queryAdd("use_comms_arena", use_comms_arena);
         return true;
     }();
 }

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <atomic>
+#include <mutex>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -407,7 +408,8 @@ struct alignas(sizeof(double)) SoAParticle : SoAParticleBase
     {
     }
 
-    static Long the_next_id;
+    //! Atomic: particle ids are handed out from any host thread.
+    static std::atomic<Long> the_next_id;
 
     //functions to get id and cpu in the SOA data
 
@@ -471,21 +473,16 @@ private :
 };
 
 //template <int NArrayReal, int NArrayInt> Long ConstSoAParticle<NArrayReal, NArrayInt>::the_next_id = 1;
-template <int NArrayReal, int NArrayInt> Long SoAParticle<NArrayReal, NArrayInt>::the_next_id = 1;
+template <int NArrayReal, int NArrayInt> std::atomic<Long> SoAParticle<NArrayReal, NArrayInt>::the_next_id{1};
 
 template <int NArrayReal, int NArrayInt>
 Long
 SoAParticle<NArrayReal, NArrayInt>::NextID ()
 {
-    Long next;
-// we should be able to test on _OPENMP < 201107 for capture (version 3.1)
-// but we must work around a bug in gcc < 4.9
-#if defined(AMREX_USE_OMP) && defined(_OPENMP) && _OPENMP < 201307
-#pragma omp critical (amrex_particle_nextid)
-#elif defined(AMREX_USE_OMP)
-#pragma omp atomic capture
-#endif
-    next = the_next_id++;
+    // std::atomic rather than `omp atomic capture`: the latter is compiled
+    // out in a build without OpenMP, leaving a bare increment that any two
+    // host threads adding particles would race on.
+    Long const next = the_next_id.fetch_add(1, std::memory_order_relaxed);
 
     if (next > LongParticleIds::LastParticleID) {
         amrex::Abort("SoAParticle<NArrayReal, NArrayInt>::NextID() -- too many particles");
@@ -498,7 +495,7 @@ template <int NArrayReal, int NArrayInt>
 Long
 SoAParticle<NArrayReal, NArrayInt>::UnprotectedNextID ()
 {
-    Long next = the_next_id++;
+    Long const next = the_next_id.fetch_add(1, std::memory_order_relaxed);
     if (next > LongParticleIds::LastParticleID) {
         amrex::Abort("SoAParticle<NArrayReal, NArrayInt>::NextID() -- too many particles");
     }
@@ -1469,10 +1466,12 @@ private:
         if (!m_runtime_ptrs_dirty.load(std::memory_order_acquire)) {
             return;
         }
-#if defined(AMREX_USE_OMP)
-#pragma omp critical (amrex_particle_tile_data_cache)
-#endif
+        // A real mutex rather than `omp critical`, which excludes only
+        // threads in the same OpenMP contention group and disappears in a
+        // build without OpenMP. Only reached on the rare dirty path.
+        static std::mutex cache_mutex;
         {
+            std::scoped_lock lock(cache_mutex);
             if (m_runtime_ptrs_dirty.load(std::memory_order_relaxed)) {
                 m_runtime_r_ptrs.resize(m_soa_tile.NumRealComps() - NArrayReal);
                 m_runtime_i_ptrs.resize(m_soa_tile.NumIntComps() - NArrayInt);
@@ -1525,10 +1524,10 @@ private:
         if (!m_runtime_cptrs_dirty.load(std::memory_order_acquire)) {
             return;
         }
-#if defined(AMREX_USE_OMP)
-#pragma omp critical (amrex_const_particle_tile_data_cache)
-#endif
+        // See refreshRuntimePtrCaches() above.
+        static std::mutex const_cache_mutex;
         {
+            std::scoped_lock lock(const_cache_mutex);
             if (m_runtime_cptrs_dirty.load(std::memory_order_relaxed)) {
                 m_runtime_r_cptrs.resize(m_soa_tile.NumRealComps() - NArrayReal);
                 m_runtime_i_cptrs.resize(m_soa_tile.NumIntComps() - NArrayInt);

--- a/Src/Particle/AMReX_ParticleTileRT.H
+++ b/Src/Particle/AMReX_ParticleTileRT.H
@@ -11,6 +11,7 @@
 #include <AMReX_RealVect.H>
 
 #include <array>
+#include <atomic>
 #include <numeric>
 #include <string>
 #include <type_traits>
@@ -333,22 +334,18 @@ private:
 };
 
 struct NextIDRTSoA {
-    inline static Long the_next_id = 1;
+    //! Atomic: particle ids are handed out from any host thread.
+    inline static std::atomic<Long> the_next_id{1};
 };
 
 template <class RType, class IType>
 Long
 RTSoAParticle<RType, IType>::NextID ()
 {
-    Long next;
-// we should be able to test on _OPENMP < 201107 for capture (version 3.1)
-// but we must work around a bug in gcc < 4.9
-#if defined(AMREX_USE_OMP) && defined(_OPENMP) && _OPENMP < 201307
-#pragma omp critical (amrex_particle_nextid)
-#elif defined(AMREX_USE_OMP)
-#pragma omp atomic capture
-#endif
-    next = NextIDRTSoA::the_next_id++;
+    // std::atomic rather than `omp atomic capture`: the latter is compiled
+    // out in a build without OpenMP, leaving a bare increment that any two
+    // host threads adding particles would race on.
+    Long const next = NextIDRTSoA::the_next_id.fetch_add(1, std::memory_order_relaxed);
 
     if (next > LongParticleIds::LastParticleID) {
         amrex::Abort("RTSoAParticle<RType, IType>::NextID() -- too many particles");
@@ -361,7 +358,7 @@ template <class RType, class IType>
 Long
 RTSoAParticle<RType, IType>::UnprotectedNextID ()
 {
-    Long next = NextIDRTSoA::the_next_id++;
+    Long const next = NextIDRTSoA::the_next_id.fetch_add(1, std::memory_order_relaxed);
     if (next > LongParticleIds::LastParticleID) {
         amrex::Abort("RTSoAParticle<RType, IType>::NextID() -- too many particles");
     }


### PR DESCRIPTION
I wanted to see what it takes to make AMReX thread-safe (enough) to support a [GIL-free Python](https://github.com/AMReX-Codes/pyamrex/issues/612) ([PR 614](https://github.com/AMReX-Codes/pyamrex/pull/614), [docs preview](https://pyamrex--614.org.readthedocs.build/en/614/usage/threading.html)) implementation of pyAMReX. This is what it took and the overhead seems basically negligently (+0.2%) low so far.

I do not expect we need to merge this desperately, but it's an idea I would like to explore and discuss :)

---

Claude artifacts summary: https://claude.ai/code/artifact/81c8f43e-4cdd-483f-8060-2bcf6c24f6f5?via=auto_preview

---

## Summary

AMReX can be driven from host threads it did not create — most commonly Python threads on a free-threaded ([PEP 703](https://peps.python.org/pep-0703/)) interpreter through [pyAMReX](https://github.com/AMReX-Codes/pyamrex), but equally `std::thread` in a C++ application. This makes the process-global state such a program reaches race-free.

One line explains why the surface is as large as it is — `Src/Base/AMReX_OpenMP.H:38`:

```cpp
constexpr int get_thread_num () { return 0; }   // when !AMREX_USE_OMP
```

Without OpenMP every host thread reports itself as OpenMP thread 0. So per-thread state indexed by that number collapsed onto one slot, and `omp critical` / `omp atomic` — AMReX's only mutual exclusion for several global caches — excluded nothing at all.

## What changed

| State | Where | Fix |
|---|---|---|
| `MFIter::depth`, the counter behind `AMREX_ALWAYS_ASSERT(depth == 1)` | `AMReX_MFIter.cpp` | `thread_local` — nesting is a per-thread property, so **each thread may now drive its own MFIter**, including over the same `FabArray` |
| Tile-array, FillBoundary, ParallelCopy, rotate, FillPatch, CrseFine, ParFor caches; `m_BD_count`; all flushers; the region-tag stack | `AMReX_FabArrayBase.cpp` | one `std::recursive_mutex`; the one reader, `FabArray::AllocFabs()`, goes through a new locked `regionTags()` snapshot |
| `FabArrayStats` counters, `comm_meta_data_id` | `AMReX_FabArrayBase.{H,cpp}` | atomics |
| `DistributionMapping::getIndexArray()` — lazily fills two vectors in the *shared* `DMRef` | `AMReX_DistributionMapping.cpp` | mutex, with no unlocked fast path |
| `BoxArray::getHashMap()` / `clear_hash_bin()`, `EBCellFlagFab::m_typemap` (including `resetType()`), ParticleTile runtime-pointer caches | 3 files | `omp critical` → `std::mutex` |
| The **default `Geometry`**. `Setup()` is a check-then-act on it and *every* `Geometry::define()` calls it, so two threads building the first `Geometry` of the process both ran the body and either could read a half-written `RealBox`. The window reopens on every `Initialize()`, since the default hangs off `AMReX::top()` | `AMReX_Geometry.cpp` | one mutex over `Setup()`, `define()`'s reads, all three `ResetDefault*`, the default-copying constructor and `operator>>` |
| `amrex::Random()` generators, indexed by `get_thread_num()` | `AMReX_Random.cpp` | per-thread generator; `InitRandom()` serialised, and it claims `generators[0]` so that slot stays tied to the OpenMP master |
| ParmParse table — a *query* writes the entry's use count, type hint and last value | `AMReX_ParmParse.cpp` | one `std::recursive_mutex`; `queryAdd()`/`queryAddWithParser()` hold it across the query-then-add (a new `tableMutex()` accessor lets the header templates do that); a new `tableCopy()` for callers that want to walk the table; the `omp atomic` / `omp single nowait` directives are gone, the latter having silently dropped every team member's write but the first |
| **GPU execution-scope flags** — `in_launch_region`, `in_graph_region`, `in_single_stream_region`, `in_nosync_region` | `AMReX_GpuControl.{H,cpp}` | `thread_local` behind out-of-line accessors, with the setters broadcasting so an OpenMP team still observes a guard opened outside it |
| `Gpu::Device::gpu_stream_index` | `AMReX_GpuDevice.{H,cpp}` | `thread_local` — each host thread gets its own stream |
| **`CArena`** — every mutator already took `carena_mutex`, but `PrintUsage`, `operator<<`, `heap_space_used()`, `heap_space_actually_used()`, `sizeOf()` and `freeableMemory()` read that state unlocked, including `m_busylist.size()` on a container another thread is rehashing. `Arena::print_usage`/`print_usage_to_files` are bound in pyAMReX | `AMReX_CArena.{H,cpp}` | readers locked; mutex made recursive because the out-of-memory path re-enters on the same thread; the OOM diagnostic itself uses `try_to_lock` (see below) |
| `Particle::the_next_id` (three mirrored copies) | `AMReX_Particle.H` et al. | `std::atomic<Long>` |
| `Tokenize()` scratch + `strtok`; `VisMF::persistentIFStreams`; `VisMF`'s `s_layout_cache`, reached by `VisMF::Read()` whenever it is handed an undefined MultiFab — which is what pyAMReX's `amr.VisMF.Read(name)` does every call | `AMReX_Utility.cpp`, `AMReX_VisMF.*` | `thread_local`, `strtok_r`, and a mutex for the layout cache |
| `VisMF::Read`'s `static double totalTime` accumulator (only written when `vismf.verbose`) | `AMReX_VisMF.cpp` | `std::atomic<double>` |
| `ParallelContext::Frame::get_inc_mpi_tag()` | `AMReX_ParallelContext.cpp` | mutex — locally unique tags (see the caveat below) |
| Lazy `static X; static bool first;` blocks | `AMReX_ParticleContainerBase.cpp`, `AMReX_ParticleContainerI.H` | function-local statics; the shared `particles.*` settings move to `ParticleContainerBase::ReadStaticParameters()`, guarded once per `Initialize()` rather than once per template instantiation |

## Three worth calling out

**`MFIter::currentDepth()` changes meaning.** It now reports the *calling thread's* nesting, not a process-wide count. It has no in-tree callers, but note this is also an OpenMP behaviour change: a non-master team member used to read the master's incremented value and now reads zero.

**`InitRandom()` reseeds global state.** `ParticleContainer::InitRandom()` forwards to it, and on a GPU build it frees and reallocates the device RNG array — four threads calling it concurrently was a host-heap double free. It is now serialised, but no locking makes reseed-while-others-draw meaningful, so it is documented as belonging on one thread before workers start. That is an API-shape question worth a separate look.

**The GPU execution-scope flags could not be left to caller discipline.** They were process-global with save/restore RAII guards, and the first version of this PR documented them as the caller's problem. That is not achievable: AMReX opens those guards *itself* inside ordinary API calls — `ParticleContainer::addParticles()` opens a `Gpu::NoSyncRegion`, `Gpu::AnyOf()` behind `MultiFab::contains_nan()`/`contains_inf()` opens a `Gpu::LaunchSafeGuard`, and both are bound in pyAMReX. Two threads calling `add_particles()` interleave as save(false) / save(true) / restore(false) / restore(true), leaving `in_nosync_region` stuck `true` for the rest of the run, after which AMReX silently stops synchronizing streams. Hence the per-thread rework. AMReX's own `omp parallel if (Gpu::notInLaunchRegion())` clauses are evaluated by the encountering thread, so they read the thread-local; only queries made *inside* a team read the broadcast value.

Relatedly, the out-of-memory diagnostic must never block. `Arena::out_of_memory_abort()` walks *every* arena taking each `carena_mutex`, and `the_pinned_arena` is a separate `CArena` even in a CPU-only build — so a thread OOMing inside `The_Arena` and one OOMing inside `The_Pinned_Arena` would deadlock against each other, with no diagnostic, in exactly the situation the diagnostic exists for. Two threads exhausting memory at once is the ordinary case under free threading, so `CArena::PrintUsage(std::ostream&)` and `operator<<` take the lock with `try_to_lock` and print unlocked (marked as such) when it is busy.

## Docs

New `Host Thread Safety` section in `Basics.rst` stating what is guaranteed and what stays the caller's responsibility: concurrent writes to the same data, `Initialize`/`Finalize`, MPI without `AMReX_MPI_THREAD_MULTIPLE`, `TinyProfiler`, `Gpu::setExternalStream()`, dynamic `MFIter` scheduling, the unlocked `AMReX::empty()`/`size()`/`top()` accessors, and `EB2::Build()`'s unguarded index-space stack. The GPU execution-scope guards have *moved off* that list, since they are now per-thread. The `Random()` FAQ entry is updated, including the caveat that inside an OpenMP parallel region the generator is still selected by thread number.

## Testing

Exercised through pyAMReX's free-threading suite (AMReX-Codes/pyamrex#614) on CPython 3.14 free-threaded, built against this branch:

- **CPU** — full pyAMReX suite 249 passed / 95 skipped with `PYTHON_GIL=0` and `=1` alike; 450/450 over 30 repeats of the concurrency tests. pyAMReX CI now has a job on a genuinely free-threaded interpreter (`3.14t`) which asserts `Py_GIL_DISABLED`, asserts the GIL is still off *after* importing pyAMReX, and runs the suite both ways — previously nothing in CI checked the headline claim.
- **AMReX's own test suite** — 76/76 with `AMReX_OMP=ON` + MPI + EB in Debug, and 76/76 on CUDA (nvcc 13.3, RTX A2000), including `GPU_ExternalStream_3d`.
- **ThreadSanitizer** — no remaining races in AMReX code. TSan found two of the fixes above (`FabArrayStats`, the `ParticleContainer` lazy init) that value-asserting tests could not. Run against an earlier revision of this branch.
- **SYCL** — run on hardware (Intel Iris Xe, icpx 2026.1) against an earlier revision. At the current head the backends are compile-verified only: AMReX's own CI plus pyAMReX#614's matrix, pinned at this commit, build it green under SYCL, ROCm/HIP 6.3.2, ICPX, MSVC and clang-cl. The Windows jobs matter here — MSVC forbids `dllexport` on a `thread_local`, which is why the stream index and the execution-scope flags sit behind out-of-line accessors.
- **Cost** — an `MFIter` + `FillBoundary` loop, six alternating runs against an unmodified `development` build: paired mean **+2.0 %, standard deviation 4.4 %**, best-of-six **−0.3 %**. Each build's own run-to-run spread is 10–13 % on this machine, so the added locking is below what this setup can resolve; it is not a measurement of zero, just of "smaller than the noise". A quiet machine would be needed to put a real bound on it.

Several of the fixes came from tests failing (the `DistributionMapping` segfault, the CUDA `InitRandom` double free), two from TSan, and a large majority from six rounds of adversarial review — including three cases where a fix in one round introduced the bug found in the next (the `CArena` OOM deadlock and its cross-arena successor, and the RNG slot-0 claim).

## Not addressed here

- **`Gpu::Device::gpuStream()` no longer inlines** (GPU builds). It calls the out-of-line `Device::getStreamIndex()`, so every kernel launch, `streamSynchronize()` and `freeAsync()` pays a call plus a TLS access plus a bounds check, where `gpu_stream_pool[gpu_stream_index[tid]]` used to inline; the scope-flag queries above are out-of-line for the same reason. Deliberate: the alternative is an `extern thread_local` in the header, and MSVC forbids `dllexport` on a `thread_local` — on a Windows shared build an unexported one would give the DLL and the module *separate* instances, i.e. silently wrong streams. Against a ~5–10 µs launch the added ~10–20 ns is well under 1 %, but anyone measuring many-small-kernel launch overhead should check it and can add a platform-specific fast path.
- An `AMReX_OMP=ON` build driven from **several host threads at once** remains out of scope: the RNG selects by OpenMP thread number inside a parallel region, and the GPU scope flags share their broadcast slots. Pick one thread pool.
- `noexcept` functions that now take a lock (`CArena::heap_space_used`/`heap_space_actually_used`/`sizeOf`, `Geometry::ResetDefault*`, the four `EBCellFlagFab` queries): `std::scoped_lock`'s constructor can in principle throw `std::system_error`, which inside `noexcept` is `std::terminate`. Dropping `noexcept` would change public signatures, and AMReX aborts on errors anyway.
- `EBCellFlagFab::getType(Box)` takes a process-global mutex per call. That matches the `omp critical` it replaced when `AMReX_OMP=ON`, but in an OMP=OFF build the old code compiled to nothing — the serial build is the one that pays for the correctness. Same shape as the `fabarray_cache_mutex` and `g_table_mutex` additions.
- `FabArray::build_arrays()` (`AMReX_FabArray.H:2092`) builds a `mutable` cache from a `const` method with no lock. Not reachable from pyAMReX, but it contradicts "concurrent reads of one object are safe".
- `MFIter::nextDynamicIndex` is correct within an OpenMP team but shared across teams.
- The region-tag stack is now locked, but a *stack* shared by threads is only meaningful when one thread uses it — `RegionTag` is RAII, so two overlapping guards on different threads still pop each other's tag. `thread_local` would fix that and would also stop an OpenMP team inheriting a tag opened outside it; only `Src/Amr` uses it today.
- MPI: `get_inc_mpi_tag()` is now locally unique, but two ranks can still pair up mismatched tags if they admit threads in different orders; the same applies to the `ReduceBoolAnd` inside `VisMF::Read`. AMReX also never stores the provided MPI thread level. Worth its own PR.
- `NFilesIter::currentDeciderIndex` (`AMReX_NFiles.cpp:10`) and `StreamRetry::nStreamErrors` (`AMReX_Utility.cpp:558`) are process-global and written unlocked on the plotfile-write path. Covered by the existing "plotfile writes are MPI-collective, one thread" rule, except in a no-MPI build where two concurrent writes would otherwise be reasonable.
- The lazy MPI datatype/op handles in `AMReX_ParallelDescriptor` are check-then-act on process-global handles. In-tree the only instantiation pyAMReX can reach needs multi-GiB-per-rank MultiFabs; the real exposure is downstream `Bcast<IntVect>`/`<Box>`.
- `AMREX_MEM_PROFILING`-only counters — `num_multifabs*` (`AMReX_MultiFab.cpp:31`) and `BARef::numboxarrays`/`total_*_bytes*` (`AMReX_BoxArray.cpp:26`) — are plain `++`/`--`/max in constructors and destructors. Left alone deliberately: no CI job sets `AMReX_MEM_PROFILE=ON`, so converting them would be an untested change to an untested configuration.
- `EB2::IndexSpace::m_instance` is an unguarded push/erase stack; already documented as the caller's responsibility, as is `Lazy::reduction_queue` (which the CMake build never enables).

## Build note for SYCL

`AMReX_SYCL_SPLIT_KERNEL` defaults `ON`, emitting one device image per kernel. Linking pyAMReX that way drove `sycl-post-link` past 31 GB and it was still climbing after an hour on a 62 GB machine; with `AMReX_SYCL_SPLIT_KERNEL=OFF` the whole build takes about twenty minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
