### PR TITLE
Make STL geometry independent of BVH optimization

### DIFF
--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -504,7 +504,13 @@ STLtools::prepare (Gpu::PinnedVector<Triangle> a_tri_pts)
         std::size_t nnodes = 0;
         bvh_size(int(a_tri_pts.size()), nnodes);
         bvh_nodes.reserve(nnodes);
-        build_bvh(a_tri_pts.data(), a_tri_pts.data()+a_tri_pts.size(), bvh_nodes);
+        // build_bvh sorts the triangles it is given.  It works on a copy so
+        // that the order stored in m_tri_pts_d, and therefore the reference
+        // point derived from the first triangle below, is the order the file
+        // was read in whether or not the BVH is built.  The nodes hold their
+        // own copies of the triangles, so they do not depend on this array.
+        Gpu::PinnedVector<Triangle> bvh_tri_pts(a_tri_pts);
+        build_bvh(bvh_tri_pts.data(), bvh_tri_pts.data()+bvh_tri_pts.size(), bvh_nodes);
 #ifdef AMREX_USE_GPU
         m_bvh_nodes.resize(bvh_nodes.size());
         Gpu::copyAsync(Gpu::hostToDevice, bvh_nodes.begin(), bvh_nodes.end(),
@@ -1132,10 +1138,9 @@ STLtools::getIntercept (Array<Array4<Real>,AMREX_SPACEDIM> const& inter_arr,
                                                            tri.v1, tri.v2, tri.v3,
                                                            tri_norm[it],
                                                            lst(i+1,j,k)-lst(i,j,k));
-                            if (tmp.first) {
+                            if (tmp.first && (!found || tmp.second < r)) {
                                 r = tmp.second;
                                 found = true;
-                                break;
                             }
                         }
                     } else {
@@ -1151,10 +1156,9 @@ STLtools::getIntercept (Array<Array4<Real>,AMREX_SPACEDIM> const& inter_arr,
                                                                tri.v1, tri.v2, tri.v3,
                                                                ptrinorm[it],
                                                                lst(i+1,j,k)-lst(i,j,k));
-                                if (tmp.first) {
+                                if (tmp.first && (!found || tmp.second < r)) {
                                     r = tmp.second;
                                     found = true;
-                                    return 1;
                                 }
                             }
                             return 0;
@@ -1176,10 +1180,9 @@ STLtools::getIntercept (Array<Array4<Real>,AMREX_SPACEDIM> const& inter_arr,
                                                            XDim3{.x = tri.v3.y, .y = tri.v3.z, .z = tri.v3.x},
                                                            XDim3{.x =   norm.y, .y =   norm.z, .z =   norm.x},
                                                            lst(i,j+1,k)-lst(i,j,k));
-                            if (tmp.first) {
+                            if (tmp.first && (!found || tmp.second < r)) {
                                 r = tmp.second;
                                 found = true;
-                                break;
                             }
                         }
                     } else {
@@ -1198,10 +1201,9 @@ STLtools::getIntercept (Array<Array4<Real>,AMREX_SPACEDIM> const& inter_arr,
                                                                XDim3{.x = tri.v3.y, .y = tri.v3.z, .z = tri.v3.x},
                                                                XDim3{.x =   norm.y, .y =   norm.z, .z =   norm.x},
                                                                lst(i,j+1,k)-lst(i,j,k));
-                                if (tmp.first) {
+                                if (tmp.first && (!found || tmp.second < r)) {
                                     r = tmp.second;
                                     found = true;
-                                    return 1;
                                 }
                             }
                             return 0;
@@ -1225,10 +1227,9 @@ STLtools::getIntercept (Array<Array4<Real>,AMREX_SPACEDIM> const& inter_arr,
                                                            XDim3{.x = tri.v3.z, .y = tri.v3.x, .z = tri.v3.y},
                                                            XDim3{.x =   norm.z, .y =   norm.x, .z =   norm.y},
                                                            lst(i,j,k+1)-lst(i,j,k));
-                            if (tmp.first) {
+                            if (tmp.first && (!found || tmp.second < r)) {
                                 r = tmp.second;
                                 found = true;
-                                break;
                             }
                         }
                     } else {
@@ -1247,10 +1248,9 @@ STLtools::getIntercept (Array<Array4<Real>,AMREX_SPACEDIM> const& inter_arr,
                                                                XDim3{.x = tri.v3.z, .y = tri.v3.x, .z = tri.v3.y},
                                                                XDim3{.x =   norm.z, .y =   norm.x, .z =   norm.y},
                                                                lst(i,j,k+1)-lst(i,j,k));
-                                if (tmp.first) {
+                                if (tmp.first && (!found || tmp.second < r)) {
                                     r = tmp.second;
                                     found = true;
-                                    return 1;
                                 }
                             }
                             return 0;


### PR DESCRIPTION
## Summary

STL EB geometry depends on whether BVH acceleration is enabled. Although `eb2.stl_use_bvh` is intended purely as an optimization, toggling it changes the resulting geometry. For a small STL on a $$48^3$$ grid, the volume-fraction field differs by roughly 30%: the computed fluid volume is `0.0191364` with BVH enabled versus `0.0147104` without it, with 1110 versus 906 cut cells, respectively. Since BVH is enabled by default, users take the BVH path, which in this case disagrees with the non-BVH reference.

The fixes address two sources of order dependence:

1. **The reference point depended on the BVH build.** `build_bvh` sorts the triangle array in place, while `prepare()` subsequently uses `a_tri_pts[0]` to seed `m_ptref`. Without BVH, this is the first triangle in the STL file; with BVH, it is whichever triangle sorts first. This changes the reference point and therefore the rays used for crossing tests, which can flip crossing parity at nodes lying exactly on the surface. `build_bvh` now sorts a copy of the triangle array instead. Simply hoisting the `tri0` capture is insufficient because the sidedness reduction skips index 0 to avoid a degenerate self-intersection, relying on the invariant `tri0 == tri_pts[0]`.

2. **`getIntercept` selected the first intersecting triangle rather than the nearest one.** This makes the result dependent on triangle ordering whenever an edge intersects multiple triangles; the test model contains 10 such x-edges. All six interception sites now select the nearest crossing, eliminating this source of order dependence.

## Additional background


## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [x] changes answers in the test suite to more than roundoff level
- [x] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate

STL EB users will see their geometry change, since the BVH is on by default. The new result is the order-independent one matching the unaccelerated path. It is not identical to either previous variant, because the nearest-crossing rule also changes the non-BVH path on multi-crossing edges.

P.S Template filled using an AI model