### PR TITLE
Index-based mlebabeclap_gsrb kernel

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -368,7 +368,7 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_gsrb (Box const& box,
+void mlebabeclap_gsrb (int i, int j, int k, int n,
                        Array4<Real> const& phi, Array4<Real const> const& rhs,
                        Real alpha, Array4<Real const> const& a,
                        Real dhx, Real dhy, Real dh,
@@ -381,206 +381,203 @@ void mlebabeclap_gsrb (Box const& box,
                        Array4<const int> const& ccm, Array4<Real const> const& beb,
                        EBData const& ebdata,
                        bool is_dirichlet, bool beta_on_centroid, bool phi_on_centroid,
-                       Box const& vbox, int redblack, int ncomp) noexcept
+                       Box const& vbox, int redblack) noexcept
 {
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    if ((i+j+k+redblack) % 2 == 0)
     {
-        if ((i+j+k+redblack) % 2 == 0)
+        auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
+        if (flag.isCovered())
         {
-            auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
-            if (flag.isCovered())
+            phi(i,j,k,n) = Real(0.0);
+        }
+        else
+        {
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
+                ? f0(vlo.x,j,k,n) : Real(0.0);
+            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
+                ? f1(i,vlo.y,k,n) : Real(0.0);
+            Real cf2 = (i == vhi.x && m2(vhi.x+1,j,k) > 0)
+                ? f2(vhi.x,j,k,n) : Real(0.0);
+            Real cf3 = (j == vhi.y && m3(i,vhi.y+1,k) > 0)
+                ? f3(i,vhi.y,k,n) : Real(0.0);
+
+            if (flag.isRegular())
             {
-                phi(i,j,k,n) = Real(0.0);
+                Real gamma = alpha*a(i,j,k)
+                    + dhx * (bX(i+1,j,k,n) + bX(i,j,k,n))
+                    + dhy * (bY(i,j+1,k,n) + bY(i,j,k,n));
+
+                Real rho =  dhx * (bX(i+1,j,k,n)*phi(i+1,j,k,n)
+                                 + bX(i  ,j,k,n)*phi(i-1,j,k,n))
+                          + dhy * (bY(i,j+1,k,n)*phi(i,j+1,k,n)
+                                 + bY(i,j  ,k,n)*phi(i,j-1,k,n));
+
+                Real delta = dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf2)
+                    +        dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf3);
+
+                Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+                phi(i,j,k,n) += res/(gamma-delta);
             }
             else
             {
-                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                    ? f0(vlo.x,j,k,n) : Real(0.0);
-                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                    ? f1(i,vlo.y,k,n) : Real(0.0);
-                Real cf2 = (i == vhi.x && m2(vhi.x+1,j,k) > 0)
-                    ? f2(vhi.x,j,k,n) : Real(0.0);
-                Real cf3 = (j == vhi.y && m3(i,vhi.y+1,k) > 0)
-                    ? f3(i,vhi.y,k,n) : Real(0.0);
+                Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
+                Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k);
+                Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k);
+                Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k);
+                Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k);
 
-                if (flag.isRegular())
-                {
-                    Real gamma = alpha*a(i,j,k)
-                        + dhx * (bX(i+1,j,k,n) + bX(i,j,k,n))
-                        + dhy * (bY(i,j+1,k,n) + bY(i,j,k,n));
-
-                    Real rho =  dhx * (bX(i+1,j,k,n)*phi(i+1,j,k,n)
-                                     + bX(i  ,j,k,n)*phi(i-1,j,k,n))
-                              + dhy * (bY(i,j+1,k,n)*phi(i,j+1,k,n)
-                                     + bY(i,j  ,k,n)*phi(i,j-1,k,n));
-
-                    Real delta = dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf2)
-                        +        dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf3);
-
-                    Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                    phi(i,j,k,n) += res/(gamma-delta);
+                Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
+                Real oxm = -bX(i,j,k,n)*cf0;
+                Real sxm =  bX(i,j,k,n);
+                if (apxm != Real(0.0) && apxm != Real(1.0)) {
+                    Real fcx = ebdata.get<EBData_t::fcx>(i,j,k);
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
+                    Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxm = (Real(1.0)-fracy)*fxm +
+                                   fracy *bX(i,jj,k,n)*(phi(i,jj,k,n)-phi(i-1,jj,k,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxm = (Real(1.0)-fracy)*(             -phi(i-1,j,k,n)) +
+                                   fracy *(phi(i,jj,k,n)-phi(i-1,jj,k,n));
+                        fxm *= bX(i,j,k,n);
+                    }
+                    oxm = Real(0.0);
+                    sxm = (Real(1.0)-fracy)*sxm;
                 }
-                else
-                {
-                    Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
-                    Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k);
-                    Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k);
-                    Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k);
-                    Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k);
 
-                    Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
-                    Real oxm = -bX(i,j,k,n)*cf0;
-                    Real sxm =  bX(i,j,k,n);
-                    if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                        Real fcx = ebdata.get<EBData_t::fcx>(i,j,k);
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
-                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxm = (Real(1.0)-fracy)*fxm +
-                                       fracy *bX(i,jj,k,n)*(phi(i,jj,k,n)-phi(i-1,jj,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxm = (Real(1.0)-fracy)*(             -phi(i-1,j,k,n)) +
-                                       fracy *(phi(i,jj,k,n)-phi(i-1,jj,k,n));
-                            fxm *= bX(i,j,k,n);
-                        }
-                        oxm = Real(0.0);
-                        sxm = (Real(1.0)-fracy)*sxm;
+                Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
+                Real oxp =  bX(i+1,j,k,n)*cf2;
+                Real sxp = -bX(i+1,j,k,n);
+                if (apxp != Real(0.0) && apxp != Real(1.0)) {
+                    Real fcx = ebdata.get<EBData_t::fcx>(i+1,j,k);
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
+                    Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxp = (Real(1.0)-fracy)*fxp +
+                                   fracy *bX(i+1,jj,k,n)*(phi(i+1,jj,k,n)-phi(i,jj,k,n));
                     }
-
-                    Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
-                    Real oxp =  bX(i+1,j,k,n)*cf2;
-                    Real sxp = -bX(i+1,j,k,n);
-                    if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                        Real fcx = ebdata.get<EBData_t::fcx>(i+1,j,k);
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
-                        Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxp = (Real(1.0)-fracy)*fxp +
-                                       fracy *bX(i+1,jj,k,n)*(phi(i+1,jj,k,n)-phi(i,jj,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxp = (Real(1.0)-fracy)*(phi(i+1,j,k,n)               ) +
-                                       fracy *(phi(i+1,jj,k,n)-phi(i,jj,k,n));
-                            fxp *= bX(i+1,j,k,n);
-                        }
-                        oxp = Real(0.0);
-                        sxp = (Real(1.0)-fracy)*sxp;
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxp = (Real(1.0)-fracy)*(phi(i+1,j,k,n)               ) +
+                                   fracy *(phi(i+1,jj,k,n)-phi(i,jj,k,n));
+                        fxp *= bX(i+1,j,k,n);
                     }
-
-                    Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
-                    Real oym = -bY(i,j,k,n)*cf1;
-                    Real sym =  bY(i,j,k,n);
-                    if (apym != Real(0.0) && apym != Real(1.0)) {
-                        Real fcy = ebdata.get<EBData_t::fcy>(i,j,k);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
-                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fym = (Real(1.0)-fracx)*fym +
-                                       fracx *bY(ii,j,k,n)*(phi(ii,j,k,n)-phi(ii,j-1,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fym = (Real(1.0)-fracx)*(             -phi( i,j-1,k,n)) +
-                                       fracx *(phi(ii,j,k,n)-phi(ii,j-1,k,n));
-                            fym *= bY(i,j,k,n);
-                        }
-
-                        oym = Real(0.0);
-                        sym = (Real(1.0)-fracx)*sym;
-                    }
-
-                    Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
-                    Real oyp =  bY(i,j+1,k,n)*cf3;
-                    Real syp = -bY(i,j+1,k,n);
-                    if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                        Real fcy = ebdata.get<EBData_t::fcy>(i,j+1,k);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
-                        Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fyp = (Real(1.0)-fracx)*fyp +
-                                       fracx*bY(ii,j+1,k,n)*(phi(ii,j+1,k,n)-phi(ii,j,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fyp = (Real(1.0)-fracx)*(phi(i,j+1,k,n)               )+
-                                       fracx *(phi(ii,j+1,k,n)-phi(ii,j,k,n));
-                            fyp *= bY(i,j+1,k,n);
-                        }
-                        oyp = Real(0.0);
-                        syp = (Real(1.0)-fracx)*syp;
-                    }
-
-                    Real vfrcinv = (Real(1.0)/kappa);
-                    Real gamma = alpha*a(i,j,k) + vfrcinv *
-                        (dhx*(apxm*sxm-apxp*sxp) +
-                         dhy*(apym*sym-apyp*syp));
-                    Real rho = -vfrcinv *
-                        (dhx*(apxm*fxm-apxp*fxp) +
-                         dhy*(apym*fym-apyp*fyp));
-
-                    Real delta = -vfrcinv *
-                        (dhx*(apxm*oxm-apxp*oxp) +
-                         dhy*(apym*oym-apyp*oyp));
-
-                    if (is_dirichlet) {
-                        Real dapx = (apxm-apxp)*dx[1];
-                        Real dapy = (apym-apyp)*dx[0];
-                        Real anorm = std::hypot(dapx,dapy);
-                        Real anorminv = Real(1.0)/anorm;
-                        Real anrmx = dapx * anorminv;
-                        Real anrmy = dapy * anorminv;
-
-                        Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
-                        Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
-                        Real dx_eb = get_dx_eb(kappa);
-
-                        Real dg, gx, gy, sx, sy;
-                        if (std::abs(anrmx) > std::abs(anrmy)) {
-                            dg = dx_eb / std::abs(anrmx);
-                        } else {
-                            dg = dx_eb / std::abs(anrmy);
-                        }
-                        gx = bctx - dg*anrmx;
-                        gy = bcty - dg*anrmy;
-                        sx = std::copysign(Real(1.0),anrmx);
-                        sy = std::copysign(Real(1.0),anrmy);
-
-                        int ii = i - static_cast<int>(sx);
-                        int jj = j - static_cast<int>(sy);
-
-                        Real phig_gamma = (Real(1.0) + gx*sx + gy*sy + gx*gy*sx*sy);
-                        Real phig = (    - gx*sx         - gx*gy*sx*sy) * phi(ii,j ,k,n)
-                            +       (            - gy*sy - gx*gy*sx*sy) * phi(i ,jj,k,n)
-                            +       (                    + gx*gy*sx*sy) * phi(ii,jj,k,n);
-
-                        // In gsrb we are always in residual-correction form so phib = 0
-                        Real dphidn =  (    -phig)/dg;
-
-                        Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
-
-                        Real feb = dphidn * ba * beb(i,j,k,n);
-                        rho += -vfrcinv*(-dh)*feb;
-
-                        Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
-                        gamma += vfrcinv*(-dh)*feb_gamma;
-                    }
-
-                    Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                    phi(i,j,k,n) += res/(gamma-delta);
+                    oxp = Real(0.0);
+                    sxp = (Real(1.0)-fracy)*sxp;
                 }
+
+                Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
+                Real oym = -bY(i,j,k,n)*cf1;
+                Real sym =  bY(i,j,k,n);
+                if (apym != Real(0.0) && apym != Real(1.0)) {
+                    Real fcy = ebdata.get<EBData_t::fcy>(i,j,k);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
+                    Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fym = (Real(1.0)-fracx)*fym +
+                                   fracx *bY(ii,j,k,n)*(phi(ii,j,k,n)-phi(ii,j-1,k,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fym = (Real(1.0)-fracx)*(             -phi( i,j-1,k,n)) +
+                                   fracx *(phi(ii,j,k,n)-phi(ii,j-1,k,n));
+                        fym *= bY(i,j,k,n);
+                    }
+
+                    oym = Real(0.0);
+                    sym = (Real(1.0)-fracx)*sym;
+                }
+
+                Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
+                Real oyp =  bY(i,j+1,k,n)*cf3;
+                Real syp = -bY(i,j+1,k,n);
+                if (apyp != Real(0.0) && apyp != Real(1.0)) {
+                    Real fcy = ebdata.get<EBData_t::fcy>(i,j+1,k);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
+                    Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fyp = (Real(1.0)-fracx)*fyp +
+                                   fracx*bY(ii,j+1,k,n)*(phi(ii,j+1,k,n)-phi(ii,j,k,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fyp = (Real(1.0)-fracx)*(phi(i,j+1,k,n)               )+
+                                   fracx *(phi(ii,j+1,k,n)-phi(ii,j,k,n));
+                        fyp *= bY(i,j+1,k,n);
+                    }
+                    oyp = Real(0.0);
+                    syp = (Real(1.0)-fracx)*syp;
+                }
+
+                Real vfrcinv = (Real(1.0)/kappa);
+                Real gamma = alpha*a(i,j,k) + vfrcinv *
+                    (dhx*(apxm*sxm-apxp*sxp) +
+                     dhy*(apym*sym-apyp*syp));
+                Real rho = -vfrcinv *
+                    (dhx*(apxm*fxm-apxp*fxp) +
+                     dhy*(apym*fym-apyp*fyp));
+
+                Real delta = -vfrcinv *
+                    (dhx*(apxm*oxm-apxp*oxp) +
+                     dhy*(apym*oym-apyp*oyp));
+
+                if (is_dirichlet) {
+                    Real dapx = (apxm-apxp)*dx[1];
+                    Real dapy = (apym-apyp)*dx[0];
+                    Real anorm = std::hypot(dapx,dapy);
+                    Real anorminv = Real(1.0)/anorm;
+                    Real anrmx = dapx * anorminv;
+                    Real anrmy = dapy * anorminv;
+
+                    Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
+                    Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
+                    Real dx_eb = get_dx_eb(kappa);
+
+                    Real dg, gx, gy, sx, sy;
+                    if (std::abs(anrmx) > std::abs(anrmy)) {
+                        dg = dx_eb / std::abs(anrmx);
+                    } else {
+                        dg = dx_eb / std::abs(anrmy);
+                    }
+                    gx = bctx - dg*anrmx;
+                    gy = bcty - dg*anrmy;
+                    sx = std::copysign(Real(1.0),anrmx);
+                    sy = std::copysign(Real(1.0),anrmy);
+
+                    int ii = i - static_cast<int>(sx);
+                    int jj = j - static_cast<int>(sy);
+
+                    Real phig_gamma = (Real(1.0) + gx*sx + gy*sy + gx*gy*sx*sy);
+                    Real phig = (    - gx*sx         - gx*gy*sx*sy) * phi(ii,j ,k,n)
+                        +       (            - gy*sy - gx*gy*sx*sy) * phi(i ,jj,k,n)
+                        +       (                    + gx*gy*sx*sy) * phi(ii,jj,k,n);
+
+                    // In gsrb we are always in residual-correction form so phib = 0
+                    Real dphidn =  (    -phig)/dg;
+
+                    Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
+
+                    Real feb = dphidn * ba * beb(i,j,k,n);
+                    rho += -vfrcinv*(-dh)*feb;
+
+                    Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
+                    gamma += vfrcinv*(-dh)*feb_gamma;
+                }
+
+                Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+                phi(i,j,k,n) += res/(gamma-delta);
             }
         }
-    });
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -543,7 +543,7 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_gsrb (Box const& box,
+void mlebabeclap_gsrb (int i, int j, int k, int n,
                        Array4<Real> const& phi, Array4<Real const> const& rhs,
                        Real alpha, Array4<Real const> const& a,
                        Real dhx, Real dhy, Real dhz,
@@ -560,343 +560,332 @@ void mlebabeclap_gsrb (Box const& box,
                        Array4<const int> const& ccm, Array4<Real const> const& beb,
                        EBData const& ebdata,
                        bool is_dirichlet, bool beta_on_centroid, bool phi_on_centroid,
-                       Box const& vbox, int redblack, int ncomp) noexcept
+                       Box const& vbox, int redblack) noexcept
 {
     constexpr auto omega = Real(1.15);
 
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-//    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
-    // amrex::Loop here causes gcc 8 to crash.
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-    for (int n = 0; n < ncomp; ++n) {
-    for (int k = lo.z; k <= hi.z; ++k) {
-    for (int j = lo.y; j <= hi.y; ++j) {
-    for (int i = lo.x; i <= hi.x; ++i)
+    if ((i+j+k+redblack) % 2 == 0)
     {
-        if ((i+j+k+redblack) % 2 == 0)
+        auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
+        if (flag.isCovered())
         {
-            auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
-            if (flag.isCovered())
+            phi(i,j,k,n) = Real(0.0);
+        }
+        else
+        {
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
+                ? f0(vlo.x,j,k,n) : Real(0.0);
+            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
+                ? f1(i,vlo.y,k,n) : Real(0.0);
+            Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
+                ? f2(i,j,vlo.z,n) : Real(0.0);
+            Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
+                ? f3(vhi.x,j,k,n) : Real(0.0);
+            Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
+                ? f4(i,vhi.y,k,n) : Real(0.0);
+            Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
+                ? f5(i,j,vhi.z,n) : Real(0.0);
+
+            if (flag.isRegular())
             {
-                phi(i,j,k,n) = Real(0.0);
+                Real gamma = alpha*a(i,j,k)
+                    + dhx*(bX(i+1,j,k,n) + bX(i,j,k,n))
+                    + dhy*(bY(i,j+1,k,n) + bY(i,j,k,n))
+                    + dhz*(bZ(i,j,k+1,n) + bZ(i,j,k,n));
+
+                Real rho = dhx*(bX(i+1,j  ,k  ,n)*phi(i+1,j  ,k  ,n) +
+                                bX(i  ,j  ,k  ,n)*phi(i-1,j  ,k  ,n))
+                    +      dhy*(bY(i  ,j+1,k  ,n)*phi(i  ,j+1,k  ,n) +
+                                bY(i  ,j  ,k  ,n)*phi(i  ,j-1,k  ,n))
+                    +      dhz*(bZ(i  ,j  ,k+1,n)*phi(i  ,j  ,k+1,n) +
+                                bZ(i  ,j  ,k  ,n)*phi(i  ,j  ,k-1,n));
+
+                Real delta = dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
+                    +        dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf4)
+                    +        dhz*(bZ(i,j,k,n)*cf2 + bZ(i,j,k+1,n)*cf5);
+
+                Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+                phi(i,j,k,n) += omega*res/(gamma-delta);
             }
             else
             {
-                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                    ? f0(vlo.x,j,k,n) : Real(0.0);
-                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                    ? f1(i,vlo.y,k,n) : Real(0.0);
-                Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                    ? f2(i,j,vlo.z,n) : Real(0.0);
-                Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                    ? f3(vhi.x,j,k,n) : Real(0.0);
-                Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                    ? f4(i,vhi.y,k,n) : Real(0.0);
-                Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                    ? f5(i,j,vhi.z,n) : Real(0.0);
+                Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
+                Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k  );
+                Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k  );
+                Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k  );
+                Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k  );
+                Real apzm = ebdata.get<EBData_t::apz>(i  ,j  ,k  );
+                Real apzp = ebdata.get<EBData_t::apz>(i  ,j  ,k+1);
 
-                if (flag.isRegular())
-                {
-                    Real gamma = alpha*a(i,j,k)
-                        + dhx*(bX(i+1,j,k,n) + bX(i,j,k,n))
-                        + dhy*(bY(i,j+1,k,n) + bY(i,j,k,n))
-                        + dhz*(bZ(i,j,k+1,n) + bZ(i,j,k,n));
+                Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
+                Real oxm = -bX(i,j,k,n)*cf0;
+                Real sxm =  bX(i,j,k,n);
+                if (apxm != Real(0.0) && apxm != Real(1.0)) {
+                    auto fcx0 = ebdata.get<EBData_t::fcx>(i,j,k,0);
+                    auto fcx1 = ebdata.get<EBData_t::fcx>(i,j,k,1);
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx0));
+                    int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx1));
+                    Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
+                        ? std::abs(fcx0) : Real(0.0);
+                    Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk))
+                        ? std::abs(fcx1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxm
+                             +     fracy *(Real(1.0)-fracz)*bX(i,jj,k ,n)*(phi(i,jj,k ,n)-phi(i-1,jj,k ,n))
+                             +(Real(1.0)-fracy)*     fracz *bX(i,j ,kk,n)*(phi(i,j ,kk,n)-phi(i-1,j ,kk,n))
+                             +     fracy *     fracz *bX(i,jj,kk,n)*(phi(i,jj,kk,n)-phi(i-1,jj,kk,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(              -phi(i-1, j, k,n))
+                             +     fracy *(Real(1.0)-fracz)*(phi(i,jj,k ,n)-phi(i-1,jj, k,n))
+                             +(Real(1.0)-fracy)*     fracz *(phi(i,j ,kk,n)-phi(i-1, j,kk,n))
+                             +     fracy *     fracz *(phi(i,jj,kk,n)-phi(i-1,jj,kk,n));
+                        fxm *= bX(i,j,k,n);
 
-                    Real rho = dhx*(bX(i+1,j  ,k  ,n)*phi(i+1,j  ,k  ,n) +
-                                    bX(i  ,j  ,k  ,n)*phi(i-1,j  ,k  ,n))
-                        +      dhy*(bY(i  ,j+1,k  ,n)*phi(i  ,j+1,k  ,n) +
-                                    bY(i  ,j  ,k  ,n)*phi(i  ,j-1,k  ,n))
-                        +      dhz*(bZ(i  ,j  ,k+1,n)*phi(i  ,j  ,k+1,n) +
-                                    bZ(i  ,j  ,k  ,n)*phi(i  ,j  ,k-1,n));
-
-                    Real delta = dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
-                        +        dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf4)
-                        +        dhz*(bZ(i,j,k,n)*cf2 + bZ(i,j,k+1,n)*cf5);
-
-                    Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                    phi(i,j,k,n) += omega*res/(gamma-delta);
+                    }
+                    oxm = Real(0.0);
+                    sxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*sxm;
                 }
-                else
-                {
-                    Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
-                    Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k  );
-                    Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k  );
-                    Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k  );
-                    Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k  );
-                    Real apzm = ebdata.get<EBData_t::apz>(i  ,j  ,k  );
-                    Real apzp = ebdata.get<EBData_t::apz>(i  ,j  ,k+1);
 
-                    Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
-                    Real oxm = -bX(i,j,k,n)*cf0;
-                    Real sxm =  bX(i,j,k,n);
-                    if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                        auto fcx0 = ebdata.get<EBData_t::fcx>(i,j,k,0);
-                        auto fcx1 = ebdata.get<EBData_t::fcx>(i,j,k,1);
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx0));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx1));
-                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
-                            ? std::abs(fcx0) : Real(0.0);
-                        Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk))
-                            ? std::abs(fcx1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxm
-                                 +     fracy *(Real(1.0)-fracz)*bX(i,jj,k ,n)*(phi(i,jj,k ,n)-phi(i-1,jj,k ,n))
-                                 +(Real(1.0)-fracy)*     fracz *bX(i,j ,kk,n)*(phi(i,j ,kk,n)-phi(i-1,j ,kk,n))
-                                 +     fracy *     fracz *bX(i,jj,kk,n)*(phi(i,jj,kk,n)-phi(i-1,jj,kk,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(              -phi(i-1, j, k,n))
-                                 +     fracy *(Real(1.0)-fracz)*(phi(i,jj,k ,n)-phi(i-1,jj, k,n))
-                                 +(Real(1.0)-fracy)*     fracz *(phi(i,j ,kk,n)-phi(i-1, j,kk,n))
-                                 +     fracy *     fracz *(phi(i,jj,kk,n)-phi(i-1,jj,kk,n));
-                            fxm *= bX(i,j,k,n);
+                Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
+                Real oxp =  bX(i+1,j,k,n)*cf3;
+                Real sxp = -bX(i+1,j,k,n);
+                if (apxp != Real(0.0) && apxp != Real(1.0)) {
+                    auto fcx0 = ebdata.get<EBData_t::fcx>(i+1,j,k,0);
+                    auto fcx1 = ebdata.get<EBData_t::fcx>(i+1,j,k,1);
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx0));
+                    int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx1));
+                    Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
+                        ? std::abs(fcx0) : Real(0.0);
+                    Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk))
+                        ? std::abs(fcx1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxp
+                              +    fracy *(Real(1.0)-fracz)*bX(i+1,jj,k ,n)*(phi(i+1,jj,k ,n)-phi(i,jj,k ,n))
+                             +(Real(1.0)-fracy)*     fracz *bX(i+1,j ,kk,n)*(phi(i+1,j ,kk,n)-phi(i,j ,kk,n))
+                             +     fracy *     fracz *bX(i+1,jj,kk,n)*(phi(i+1,jj,kk,n)-phi(i,jj,kk,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(phi(i+1, j, k,n)               ) +
+                                   fracy *(Real(1.0)-fracz)*(phi(i+1,jj, k,n)-phi(i,jj, k,n)) +
+                                   fracz *(Real(1.0)-fracy)*(phi(i+1, j,kk,n)-phi(i, j,kk,n)) +
+                                   fracy *     fracz *(phi(i+1,jj,kk,n)-phi(i,jj,kk,n));
+                        fxp *= bX(i+1,j,k,n);
 
-                        }
-                        oxm = Real(0.0);
-                        sxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*sxm;
                     }
 
-                    Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
-                    Real oxp =  bX(i+1,j,k,n)*cf3;
-                    Real sxp = -bX(i+1,j,k,n);
-                    if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                        auto fcx0 = ebdata.get<EBData_t::fcx>(i+1,j,k,0);
-                        auto fcx1 = ebdata.get<EBData_t::fcx>(i+1,j,k,1);
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx0));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx1));
-                        Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
-                            ? std::abs(fcx0) : Real(0.0);
-                        Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk))
-                            ? std::abs(fcx1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxp
-                                  +    fracy *(Real(1.0)-fracz)*bX(i+1,jj,k ,n)*(phi(i+1,jj,k ,n)-phi(i,jj,k ,n))
-                                 +(Real(1.0)-fracy)*     fracz *bX(i+1,j ,kk,n)*(phi(i+1,j ,kk,n)-phi(i,j ,kk,n))
-                                 +     fracy *     fracz *bX(i+1,jj,kk,n)*(phi(i+1,jj,kk,n)-phi(i,jj,kk,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(phi(i+1, j, k,n)               ) +
-                                       fracy *(Real(1.0)-fracz)*(phi(i+1,jj, k,n)-phi(i,jj, k,n)) +
-                                       fracz *(Real(1.0)-fracy)*(phi(i+1, j,kk,n)-phi(i, j,kk,n)) +
-                                       fracy *     fracz *(phi(i+1,jj,kk,n)-phi(i,jj,kk,n));
-                            fxp *= bX(i+1,j,k,n);
-
-                        }
-
-                        oxp = Real(0.0);
-                        sxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*sxp;
-                    }
-
-                    Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
-                    Real oym = -bY(i,j,k,n)*cf1;
-                    Real sym =  bY(i,j,k,n);
-                    if (apym != Real(0.0) && apym != Real(1.0)) {
-                        auto fcy0 = ebdata.get<EBData_t::fcy>(i,j,k,0);
-                        auto fcy1 = ebdata.get<EBData_t::fcy>(i,j,k,1);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
-                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
-                            ? std::abs(fcy0) : Real(0.0);
-                        Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk))
-                            ? std::abs(fcy1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fym
-                                +      fracx *(Real(1.0)-fracz)*bY(ii,j,k ,n)*(phi(ii,j,k ,n)-phi(ii,j-1,k ,n))
-                                + (Real(1.0)-fracx)*     fracz *bY(i ,j,kk,n)*(phi(i ,j,kk,n)-phi(i ,j-1,kk,n))
-                                +      fracx *     fracz *bY(ii,j,kk,n)*(phi(ii,j,kk,n)-phi(ii,j-1,kk,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(              -phi( i,j-1, k,n))
-                                +      fracx *(Real(1.0)-fracz)*(phi(ii,j,k ,n)-phi(ii,j-1, k,n))
-                                + (Real(1.0)-fracx)*     fracz *(phi(i ,j,kk,n)-phi( i,j-1,kk,n))
-                                +      fracx *     fracz *(phi(ii,j,kk,n)-phi(ii,j-1,kk,n));
-                            fym *= bY(i,j,k,n);
-
-                        }
-                        oym = Real(0.0);
-                        sym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*sym;
-                    }
-
-                    Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
-                    Real oyp =  bY(i,j+1,k,n)*cf4;
-                    Real syp = -bY(i,j+1,k,n);
-                    if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                        auto fcy0 = ebdata.get<EBData_t::fcy>(i,j+1,k,0);
-                        auto fcy1 = ebdata.get<EBData_t::fcy>(i,j+1,k,1);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
-                        Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
-                            ? std::abs(fcy0) : Real(0.0);
-                        Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk))
-                            ? std::abs(fcy1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fyp
-                                +      fracx *(Real(1.0)-fracz)*bY(ii,j+1,k ,n)*(phi(ii,j+1,k ,n)-phi(ii,j,k ,n))
-                                + (Real(1.0)-fracx)*     fracz *bY(i ,j+1,kk,n)*(phi(i ,j+1,kk,n)-phi(i ,j,kk,n))
-                                +      fracx *     fracz *bY(ii,j+1,kk,n)*(phi(ii,j+1,kk,n)-phi(ii,j,kk,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(phi( i,j+1, k,n)               )
-                                +      fracx *(Real(1.0)-fracz)*(phi(ii,j+1, k,n)-phi(ii,j, k,n))
-                                + (Real(1.0)-fracx)*     fracz *(phi( i,j+1,kk,n)-phi( i,j,kk,n))
-                                +      fracx *     fracz *(phi(ii,j+1,kk,n)-phi(ii,j,kk,n));
-                            fyp *= bY(i,j+1,k,n);
-
-                        }
-                        oyp = Real(0.0);
-                        syp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*syp;
-                    }
-
-                    Real fzm = -bZ(i,j,k,n)*phi(i,j,k-1,n);
-                    Real ozm = -bZ(i,j,k,n)*cf2;
-                    Real szm =  bZ(i,j,k,n);
-                    if (apzm != Real(0.0) && apzm != Real(1.0)) {
-                        auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k,0);
-                        auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k,1);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
-                        Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k))
-                            ? std::abs(fcz0) : Real(0.0);
-                        Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k))
-                            ? std::abs(fcz1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzm
-                                 +     fracx *(Real(1.0)-fracy)*bZ(ii, j,k,n)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
-                                 +(Real(1.0)-fracx)*     fracy *bZ( i,jj,k,n)*(phi( i,jj,k,n)-phi( i,jj,k-1,n))
-                                 +     fracx *     fracy *bZ(ii,jj,k,n)*(phi(ii,jj,k,n)-phi(ii,jj,k-1,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(              -phi( i, j,k-1,n))
-                                +      fracx *(Real(1.0)-fracy)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
-                                + (Real(1.0)-fracx)*     fracy *(phi( i,jj,k,n)-phi(i ,jj,k-1,n))
-                                +      fracx *     fracy *(phi(ii,jj,k,n)-phi(ii,jj,k-1,n));
-                            fzm *= bZ(i,j,k,n);
-
-                        }
-                        ozm = Real(0.0);
-                        szm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*szm;
-                    }
-
-                    Real fzp =  bZ(i,j,k+1,n)*phi(i,j,k+1,n);
-                    Real ozp =  bZ(i,j,k+1,n)*cf5;
-                    Real szp = -bZ(i,j,k+1,n);
-                    if (apzp != Real(0.0) && apzp != Real(1.0)) {
-                        auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k+1,0);
-                        auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k+1,1);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
-                        Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1))
-                            ? std::abs(fcz0) : Real(0.0);
-                        Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1))
-                            ? std::abs(fcz1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzp
-                                +      fracx *(Real(1.0)-fracy)*bZ(ii,j ,k+1,n)*(phi(ii,j ,k+1,n)-phi(ii,j ,k,n))
-                                + (Real(1.0)-fracx)*     fracy *bZ(i ,jj,k+1,n)*(phi(i ,jj,k+1,n)-phi(i ,jj,k,n))
-                                +      fracx *     fracy *bZ(ii,jj,k+1,n)*(phi(ii,jj,k+1,n)-phi(ii,jj,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(phi( i, j,k+1,n)               )
-                                +      fracx *(Real(1.0)-fracy)*(phi(ii, j,k+1,n)-phi(ii, j,k,n))
-                                + (Real(1.0)-fracx)*     fracy *(phi( i,jj,k+1,n)-phi( i,jj,k,n))
-                                +      fracx *     fracy *(phi(ii,jj,k+1,n)-phi(ii,jj,k,n));
-                            fzp *= bZ(i,j,k+1,n);
-
-                        }
-                        ozp = Real(0.0);
-                        szp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*szp;
-                    }
-
-                    Real vfrcinv = Real(1.0)/kappa;
-                    Real gamma = alpha*a(i,j,k) + vfrcinv *
-                        (dhx*(apxm*sxm-apxp*sxp) +
-                         dhy*(apym*sym-apyp*syp) +
-                         dhz*(apzm*szm-apzp*szp));
-
-                    Real rho = -vfrcinv *
-                        (dhx*(apxm*fxm-apxp*fxp) +
-                         dhy*(apym*fym-apyp*fyp) +
-                         dhz*(apzm*fzm-apzp*fzp));
-
-                    Real delta = -vfrcinv *
-                        (dhx*(apxm*oxm-apxp*oxp) +
-                         dhy*(apym*oym-apyp*oyp) +
-                         dhz*(apzm*ozm-apzp*ozp));
-
-                    if (is_dirichlet) {
-                        Real dapx = apxm-apxp;
-                        Real dapy = apym-apyp;
-                        Real dapz = apzm-apzp;
-                        Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
-                        Real anorminv = Real(1.0)/anorm;
-                        Real anrmx = dapx * anorminv;
-                        Real anrmy = dapy * anorminv;
-                        Real anrmz = dapz * anorminv;
-                        Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
-                        Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
-                        Real bctz = ebdata.get<EBData_t::bndrycent>(i,j,k,2);
-                        Real dx_eb = get_dx_eb(kappa);
-
-                        Real dg = dx_eb / amrex::max(std::abs(anrmx),std::abs(anrmy),
-                                                     std::abs(anrmz));
-
-                        Real gx = bctx - dg*anrmx;
-                        Real gy = bcty - dg*anrmy;
-                        Real gz = bctz - dg*anrmz;
-                        Real sx = std::copysign(Real(1.0),anrmx);
-                        Real sy = std::copysign(Real(1.0),anrmy);
-                        Real sz = std::copysign(Real(1.0),anrmz);
-                        int ii = i - static_cast<int>(sx);
-                        int jj = j - static_cast<int>(sy);
-                        int kk = k - static_cast<int>(sz);
-
-                        gx *= sx;
-                        gy *= sy;
-                        gz *= sz;
-                        Real gxy = gx*gy;
-                        Real gxz = gx*gz;
-                        Real gyz = gy*gz;
-                        Real gxyz = gx*gy*gz;
-                        Real phig_gamma = (Real(1.0)+gx+gy+gz+gxy+gxz+gyz+gxyz);
-                        Real phig = (-gz - gxz - gyz - gxyz) * phi(i,j,kk,n)
-                            + (-gy - gxy - gyz - gxyz) * phi(i,jj,k,n)
-                            + (gyz + gxyz) * phi(i,jj,kk,n)
-                            + (-gx - gxy - gxz - gxyz) * phi(ii,j,k,n)
-                            + (gxz + gxyz) * phi(ii,j,kk,n)
-                            + (gxy + gxyz) * phi(ii,jj,k,n)
-                            + (-gxyz) * phi(ii,jj,kk,n);
-
-                        Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
-
-                        Real dphidn    = (    -phig)/dg;
-                        Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
-                        gamma += vfrcinv*(-dhx)*feb_gamma;
-                        Real feb = dphidn * ba * beb(i,j,k,n);
-                        rho += -vfrcinv*(-dhx)*feb;
-                    }
-
-                    Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                    phi(i,j,k,n) += omega*res/(gamma-delta);
+                    oxp = Real(0.0);
+                    sxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*sxp;
                 }
+
+                Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
+                Real oym = -bY(i,j,k,n)*cf1;
+                Real sym =  bY(i,j,k,n);
+                if (apym != Real(0.0) && apym != Real(1.0)) {
+                    auto fcy0 = ebdata.get<EBData_t::fcy>(i,j,k,0);
+                    auto fcy1 = ebdata.get<EBData_t::fcy>(i,j,k,1);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
+                    int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
+                    Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
+                        ? std::abs(fcy0) : Real(0.0);
+                    Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk))
+                        ? std::abs(fcy1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fym
+                            +      fracx *(Real(1.0)-fracz)*bY(ii,j,k ,n)*(phi(ii,j,k ,n)-phi(ii,j-1,k ,n))
+                            + (Real(1.0)-fracx)*     fracz *bY(i ,j,kk,n)*(phi(i ,j,kk,n)-phi(i ,j-1,kk,n))
+                            +      fracx *     fracz *bY(ii,j,kk,n)*(phi(ii,j,kk,n)-phi(ii,j-1,kk,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(              -phi( i,j-1, k,n))
+                            +      fracx *(Real(1.0)-fracz)*(phi(ii,j,k ,n)-phi(ii,j-1, k,n))
+                            + (Real(1.0)-fracx)*     fracz *(phi(i ,j,kk,n)-phi( i,j-1,kk,n))
+                            +      fracx *     fracz *(phi(ii,j,kk,n)-phi(ii,j-1,kk,n));
+                        fym *= bY(i,j,k,n);
+
+                    }
+                    oym = Real(0.0);
+                    sym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*sym;
+                }
+
+                Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
+                Real oyp =  bY(i,j+1,k,n)*cf4;
+                Real syp = -bY(i,j+1,k,n);
+                if (apyp != Real(0.0) && apyp != Real(1.0)) {
+                    auto fcy0 = ebdata.get<EBData_t::fcy>(i,j+1,k,0);
+                    auto fcy1 = ebdata.get<EBData_t::fcy>(i,j+1,k,1);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
+                    int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
+                    Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
+                        ? std::abs(fcy0) : Real(0.0);
+                    Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk))
+                        ? std::abs(fcy1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fyp
+                            +      fracx *(Real(1.0)-fracz)*bY(ii,j+1,k ,n)*(phi(ii,j+1,k ,n)-phi(ii,j,k ,n))
+                            + (Real(1.0)-fracx)*     fracz *bY(i ,j+1,kk,n)*(phi(i ,j+1,kk,n)-phi(i ,j,kk,n))
+                            +      fracx *     fracz *bY(ii,j+1,kk,n)*(phi(ii,j+1,kk,n)-phi(ii,j,kk,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(phi( i,j+1, k,n)               )
+                            +      fracx *(Real(1.0)-fracz)*(phi(ii,j+1, k,n)-phi(ii,j, k,n))
+                            + (Real(1.0)-fracx)*     fracz *(phi( i,j+1,kk,n)-phi( i,j,kk,n))
+                            +      fracx *     fracz *(phi(ii,j+1,kk,n)-phi(ii,j,kk,n));
+                        fyp *= bY(i,j+1,k,n);
+
+                    }
+                    oyp = Real(0.0);
+                    syp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*syp;
+                }
+
+                Real fzm = -bZ(i,j,k,n)*phi(i,j,k-1,n);
+                Real ozm = -bZ(i,j,k,n)*cf2;
+                Real szm =  bZ(i,j,k,n);
+                if (apzm != Real(0.0) && apzm != Real(1.0)) {
+                    auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k,0);
+                    auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k,1);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
+                    Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k))
+                        ? std::abs(fcz0) : Real(0.0);
+                    Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k))
+                        ? std::abs(fcz1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzm
+                             +     fracx *(Real(1.0)-fracy)*bZ(ii, j,k,n)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
+                             +(Real(1.0)-fracx)*     fracy *bZ( i,jj,k,n)*(phi( i,jj,k,n)-phi( i,jj,k-1,n))
+                             +     fracx *     fracy *bZ(ii,jj,k,n)*(phi(ii,jj,k,n)-phi(ii,jj,k-1,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(              -phi( i, j,k-1,n))
+                            +      fracx *(Real(1.0)-fracy)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
+                            + (Real(1.0)-fracx)*     fracy *(phi( i,jj,k,n)-phi(i ,jj,k-1,n))
+                            +      fracx *     fracy *(phi(ii,jj,k,n)-phi(ii,jj,k-1,n));
+                        fzm *= bZ(i,j,k,n);
+
+                    }
+                    ozm = Real(0.0);
+                    szm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*szm;
+                }
+
+                Real fzp =  bZ(i,j,k+1,n)*phi(i,j,k+1,n);
+                Real ozp =  bZ(i,j,k+1,n)*cf5;
+                Real szp = -bZ(i,j,k+1,n);
+                if (apzp != Real(0.0) && apzp != Real(1.0)) {
+                    auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k+1,0);
+                    auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k+1,1);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
+                    Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1))
+                        ? std::abs(fcz0) : Real(0.0);
+                    Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1))
+                        ? std::abs(fcz1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzp
+                            +      fracx *(Real(1.0)-fracy)*bZ(ii,j ,k+1,n)*(phi(ii,j ,k+1,n)-phi(ii,j ,k,n))
+                            + (Real(1.0)-fracx)*     fracy *bZ(i ,jj,k+1,n)*(phi(i ,jj,k+1,n)-phi(i ,jj,k,n))
+                            +      fracx *     fracy *bZ(ii,jj,k+1,n)*(phi(ii,jj,k+1,n)-phi(ii,jj,k,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(phi( i, j,k+1,n)               )
+                            +      fracx *(Real(1.0)-fracy)*(phi(ii, j,k+1,n)-phi(ii, j,k,n))
+                            + (Real(1.0)-fracx)*     fracy *(phi( i,jj,k+1,n)-phi( i,jj,k,n))
+                            +      fracx *     fracy *(phi(ii,jj,k+1,n)-phi(ii,jj,k,n));
+                        fzp *= bZ(i,j,k+1,n);
+
+                    }
+                    ozp = Real(0.0);
+                    szp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*szp;
+                }
+
+                Real vfrcinv = Real(1.0)/kappa;
+                Real gamma = alpha*a(i,j,k) + vfrcinv *
+                    (dhx*(apxm*sxm-apxp*sxp) +
+                     dhy*(apym*sym-apyp*syp) +
+                     dhz*(apzm*szm-apzp*szp));
+
+                Real rho = -vfrcinv *
+                    (dhx*(apxm*fxm-apxp*fxp) +
+                     dhy*(apym*fym-apyp*fyp) +
+                     dhz*(apzm*fzm-apzp*fzp));
+
+                Real delta = -vfrcinv *
+                    (dhx*(apxm*oxm-apxp*oxp) +
+                     dhy*(apym*oym-apyp*oyp) +
+                     dhz*(apzm*ozm-apzp*ozp));
+
+                if (is_dirichlet) {
+                    Real dapx = apxm-apxp;
+                    Real dapy = apym-apyp;
+                    Real dapz = apzm-apzp;
+                    Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
+                    Real anorminv = Real(1.0)/anorm;
+                    Real anrmx = dapx * anorminv;
+                    Real anrmy = dapy * anorminv;
+                    Real anrmz = dapz * anorminv;
+                    Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
+                    Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
+                    Real bctz = ebdata.get<EBData_t::bndrycent>(i,j,k,2);
+                    Real dx_eb = get_dx_eb(kappa);
+
+                    Real dg = dx_eb / amrex::max(std::abs(anrmx),std::abs(anrmy),
+                                                 std::abs(anrmz));
+
+                    Real gx = bctx - dg*anrmx;
+                    Real gy = bcty - dg*anrmy;
+                    Real gz = bctz - dg*anrmz;
+                    Real sx = std::copysign(Real(1.0),anrmx);
+                    Real sy = std::copysign(Real(1.0),anrmy);
+                    Real sz = std::copysign(Real(1.0),anrmz);
+                    int ii = i - static_cast<int>(sx);
+                    int jj = j - static_cast<int>(sy);
+                    int kk = k - static_cast<int>(sz);
+
+                    gx *= sx;
+                    gy *= sy;
+                    gz *= sz;
+                    Real gxy = gx*gy;
+                    Real gxz = gx*gz;
+                    Real gyz = gy*gz;
+                    Real gxyz = gx*gy*gz;
+                    Real phig_gamma = (Real(1.0)+gx+gy+gz+gxy+gxz+gyz+gxyz);
+                    Real phig = (-gz - gxz - gyz - gxyz) * phi(i,j,kk,n)
+                        + (-gy - gxy - gyz - gxyz) * phi(i,jj,k,n)
+                        + (gyz + gxyz) * phi(i,jj,kk,n)
+                        + (-gx - gxy - gxz - gxyz) * phi(ii,j,k,n)
+                        + (gxz + gxyz) * phi(ii,j,kk,n)
+                        + (gxy + gxyz) * phi(ii,jj,k,n)
+                        + (-gxyz) * phi(ii,jj,kk,n);
+
+                    Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
+
+                    Real dphidn    = (    -phig)/dg;
+                    Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
+                    gamma += vfrcinv*(-dhx)*feb_gamma;
+                    Real feb = dphidn * ba * beb(i,j,k,n);
+                    rho += -vfrcinv*(-dhx)*feb;
+                }
+
+                Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+                phi(i,j,k,n) += omega*res/(gamma-delta);
             }
         }
-    }}}}
-//    });
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -318,9 +318,9 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
 
             if (phi_on_centroid) { amrex::Abort("phi_on_centroid is still a WIP"); }
 
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( vbx, thread_box,
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( vbx, nc, i, j, k, n,
             {
-                mlebabeclap_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
+                mlebabeclap_gsrb(i, j, k, n, solnfab, rhsfab, alpha, afab,
                                  AMREX_D_DECL(dhx, dhy, dhz),
                                  AMREX_2D_ONLY_ARGS(dh,h)
                                  AMREX_D_DECL(bxfab,byfab,bzfab),
@@ -330,7 +330,7 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
                                  AMREX_D_DECL(f1fab,f3fab,f5fab),
                                  ccmfab, bebfab, ebdata,
                                  is_eb_dirichlet, beta_on_centroid, phi_on_centroid,
-                                 vbx, redblack, nc);
+                                 vbx, redblack);
             });
             if (has_overset) {
                 Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);


### PR DESCRIPTION
## Summary

Rewrites `mlebabeclap_gsrb` (2D and 3D) from a `Box`-based kernel that loops internally
into a per-cell `(i,j,k,n)` kernel, and calls it from `MLEBABecLap::Fsmooth` through
`AMREX_HOST_DEVICE_PARALLEL_FOR_4D` instead of `AMREX_LAUNCH_HOST_DEVICE_LAMBDA`.

In 3D this also removes the hand-written quadruple `for` loop and the
`// amrex::Loop here causes gcc 8 to crash.` workaround that went with it, since there is
no longer a loop inside the kernel at all.

The arithmetic is untouched: only the loop wrapper is removed and the body re-indented.
The kernel already took its EB geometry as an `EBData`, so no argument rework was needed
beyond dropping `Box const& box` / `int ncomp` in favour of `(i,j,k,n)`. Red/black
Gauss-Seidel only writes cells of one parity and only reads neighbours of the other, so
the switch from a sequential `amrex::Loop` to a concurrent `ParallelFor` introduces no
ordering dependence. Results are bitwise unchanged.

## Additional background

This is part of the ongoing split of the stale WIP #4922 ("GPU specific kernels for
MLEBABecLap"), as requested there; it supersedes the `mlebabeclap_gsrb` part of #4922.
The templating on `T` that #4922 also introduced has been dropped, per the review comment
on that PR, and #4922's change of `dhx` from `m_b_scalar/(h[0]*h[0])` to
`m_b_scalar*dxinv[0]*dxinv[0]` has deliberately been left out so that the answers stay
bit-for-bit the same.

This PR is independent of the `mlebabeclap_adotx` / `mlebabeclap_adotx_centroid` PRs
(different kernels, different function in `AMReX_MLEBABecLap_F.cpp`) and can be merged in
any order relative to them. The `(i,j,k,n)` form is the prerequisite for a later PR that
adds a fused (`MultiFab`-wide `ParallelFor`) GPU path for `Fsmooth`; that follow-up is not
included here.

Testing (all commands run from the repo root unless noted):

* `cmake -S . -B build-split -DAMReX_SPACEDIM=3 -DAMReX_EB=ON -DAMReX_LINEAR_SOLVERS_EM=OFF -DAMReX_ENABLE_TESTS=ON -DAMReX_TEST_TYPE=Small -DAMReX_MPI=ON -DCMAKE_BUILD_TYPE=Release`
  then `cmake --build build-split -j8` and `ctest --test-dir build-split --output-on-failure`
  &rarr; builds clean, 9/9 tests pass. A 2D library build
  (`-DAMReX_SPACEDIM=2 -DAMReX_EB=ON`) also builds clean.
* `Tests/LinearSolvers/CellEB`, `make -j8 COMP=llvm USE_MPI=FALSE DIM=3` and `DIM=2`,
  run over seven configurations (`sphere`, `sphere` + `eb_is_dirichlet=1`, `rotated_box`,
  `two_spheres`, `flower`, two-level `sphere`, periodic `sphere`; `n_cell=64`,
  `verbose=2`). This test drives the V-cycle, so `Fsmooth` is called on every level.
  The MLMG/BiCGStab residual histories and the initial/final max, 1- and 2-norm residuals
  are **bitwise identical** to `development` in both 2D and 3D.
* CUDA build on an NVIDIA RTX A5000 (CUDA 13.2, gcc 11.4):
  `Tests/LinearSolvers/CellEB`, `make -j8 COMP=gnu USE_MPI=FALSE USE_CUDA=TRUE CUDA_ARCH=86 DIM=3`,
  same seven configurations. MLMG iteration counts are identical to `development`
  (9, 12, 11, 3, 11, 28, 11); the residual values differ only at the level of the
  run-to-run nondeterminism of the *unmodified* binary (GPU reductions are not
  bit-reproducible), and all solves converge to `resid/resid0 ~ 1e-13`.

* The same CellEB matrix was re-run on Linux/gcc 11.4 (`make -j8 COMP=gnu USE_MPI=FALSE`,
  `DIM=3` and `DIM=2`) against a `development` build in a sibling worktree: residual
  histories again **bitwise identical** in both dimensions.

### Performance

Neither timing changed measurably; this PR is a refactor, not an optimisation.

CPU, `Tests/LinearSolvers/CellEB` `main3d.gnu.TEST.ex`
(`make -j8 COMP=gnu USE_MPI=FALSE DIM=3`, gcc 11.4, single rank),
`inputs n_cell=128 eb2.geom_type=sphere eb_is_dirichlet=1 verbose=1`.
All binaries were built first and then timed **interleaved** in the same session
(3 reps each) on a shared machine, so the absolute numbers are inflated but the
comparison is fair. Best of 3, MLMG `Timers: Solve` [s]:

| grids | `development` | this PR |
| --- | --- | --- |
| `max_grid_size=32` | 4.284 | 4.280 |
| `max_grid_size=64` | 4.534 | 4.597 |

GPU (NVIDIA RTX A5000, CUDA 13.2,
`make -j8 COMP=gnu USE_MPI=FALSE USE_CUDA=TRUE CUDA_ARCH=86 DIM=3`), same test at
`n_cell=256`, again built up front and timed interleaved, best of 3:

| grids | `development` | this PR |
| --- | --- | --- |
| `max_grid_size=32` (512 boxes) | 1.085 | 1.062 |
| `max_grid_size=64` (64 boxes)  | 0.834 | 0.806 |

MLMG converged in the same number of iterations in every one of these runs.

Also worth noting for this one: the CPU path changes from a sequential `amrex::Loop` inside the kernel to `AMREX_HOST_DEVICE_PARALLEL_FOR_4D`, and `vlo`/`vhi` are now recomputed per cell rather than per box. Neither shows up in the timings above.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate

P.S Generated using Claude Code 