### PR TITLE
Index-based mlebabeclap_adotx_centroid kernel

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -163,17 +163,14 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
+void mlebabeclap_adotx (int i, int j, int k, int n, Array4<Real> const& y,
                         Array4<Real const> const& x, Array4<Real const> const& a,
                         Array4<Real const> const& bX, Array4<Real const> const& bY,
-                        Array4<const int> const& ccm, Array4<EBCellFlag const> const& flag,
-                        Array4<Real const> const& vfrc, Array4<Real const> const& apx,
-                        Array4<Real const> const& apy, Array4<Real const> const& fcx,
-                        Array4<Real const> const& fcy, Array4<Real const> const& ba,
-                        Array4<Real const> const& bc, Array4<Real const> const& beb,
+                        Array4<const int> const& ccm, EBData const& ebdata,
+                        Array4<Real const> const& beb,
                         bool is_dirichlet, Array4<Real const> const& phieb,
                         bool is_inhomog, GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                        Real alpha, Real beta, int ncomp,
+                        Real alpha, Real beta,
                         bool beta_on_centroid, bool phi_on_centroid) noexcept
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
@@ -184,120 +181,126 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
     bool beta_on_center = !(beta_on_centroid);
     bool  phi_on_center = !( phi_on_centroid);
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    auto const& flag = ebdata.get<EBData_t::cellflag>();
+    auto const& vfrc = ebdata.get<EBData_t::volfrac>();
+    auto const& apx  = ebdata.get<EBData_t::apx>();
+    auto const& apy  = ebdata.get<EBData_t::apy>();
+    auto const& fcx  = ebdata.get<EBData_t::fcx>();
+    auto const& fcy  = ebdata.get<EBData_t::fcy>();
+    auto const& ba   = ebdata.get<EBData_t::bndryarea>();
+    auto const& bc   = ebdata.get<EBData_t::bndrycent>();
+
+    if (flag(i,j,k).isCovered())
     {
-        if (flag(i,j,k).isCovered())
-        {
-            y(i,j,k,n) = Real(0.0);
+        y(i,j,k,n) = Real(0.0);
+    }
+    else if (flag(i,j,k).isRegular())
+    {
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+            - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                   - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+            - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                   - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)));
+    }
+    else
+    {
+        Real kappa = vfrc(i,j,k);
+        Real apxm = apx(i,j,k);
+        Real apxp = apx(i+1,j,k);
+        Real apym = apy(i,j,k);
+        Real apyp = apy(i,j+1,k);
+
+        Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
+        if (apxm != Real(0.0) && apxm != Real(1.0)) {
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i,j,k)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k)) : Real(0.0);
+            if (beta_on_center && phi_on_center) {
+               fxm = (Real(1.0)-fracy)*fxm + fracy*bX(i,jj,k,n)*(x(i,jj,k,n)-x(i-1,jj,k,n));
+            } else if (beta_on_centroid && phi_on_center) {
+               fxm = bX(i,j,k,n) * ( (Real(1.0)-fracy)*(x(i, j,k,n)-x(i-1, j,k,n))
+                                       + fracy  *(x(i,jj,k,n)-x(i-1,jj,k,n)) );
+            }
         }
-        else if (flag(i,j,k).isRegular())
-        {
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                       - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                       - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)));
+
+        Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
+        if (apxp != Real(0.0) && apxp != Real(1.0)) {
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k)));
+            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k)) : Real(0.0);
+            if (beta_on_center && phi_on_center) {
+                fxp = (Real(1.0)-fracy)*fxp + fracy*bX(i+1,jj,k,n)*(x(i+1,jj,k,n)-x(i,jj,k,n));
+            } else if (beta_on_centroid && phi_on_center) {
+                fxp = bX(i+1,j,k,n) * ( (Real(1.0)-fracy)*(x(i+1, j,k,n)-x(i, j,k,n))
+                                           + fracy *(x(i+1,jj,k,n)-x(i,jj,k,n)) );
+            }
         }
-        else
-        {
-            Real kappa = vfrc(i,j,k);
-            Real apxm = apx(i,j,k);
-            Real apxp = apx(i+1,j,k);
-            Real apym = apy(i,j,k);
-            Real apyp = apy(i,j+1,k);
 
-            Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
-            if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i,j,k)));
-                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k)) : Real(0.0);
-                if (beta_on_center && phi_on_center) {
-                   fxm = (Real(1.0)-fracy)*fxm + fracy*bX(i,jj,k,n)*(x(i,jj,k,n)-x(i-1,jj,k,n));
-                } else if (beta_on_centroid && phi_on_center) {
-                   fxm = bX(i,j,k,n) * ( (Real(1.0)-fracy)*(x(i, j,k,n)-x(i-1, j,k,n))
-                                           + fracy  *(x(i,jj,k,n)-x(i-1,jj,k,n)) );
-                }
+        Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
+        if (apym != Real(0.0) && apym != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k)) : Real(0.0);
+            if (beta_on_center && phi_on_center) {
+                fym = (Real(1.0)-fracx)*fym + fracx*bY(ii,j,k,n)*(x(ii,j,k,n)-x(ii,j-1,k,n));
+            } else if (beta_on_centroid && phi_on_center) {
+                fym = bY(i,j,k,n) * ( (Real(1.0)-fracx)*(x( i,j,k,n)-x( i,j-1,k,n))
+                                         + fracx *(x(ii,j,k,n)-x(ii,j-1,k,n)) );
             }
-
-            Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
-            if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k)));
-                Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k)) : Real(0.0);
-                if (beta_on_center && phi_on_center) {
-                    fxp = (Real(1.0)-fracy)*fxp + fracy*bX(i+1,jj,k,n)*(x(i+1,jj,k,n)-x(i,jj,k,n));
-                } else if (beta_on_centroid && phi_on_center) {
-                    fxp = bX(i+1,j,k,n) * ( (Real(1.0)-fracy)*(x(i+1, j,k,n)-x(i, j,k,n))
-                                               + fracy *(x(i+1,jj,k,n)-x(i,jj,k,n)) );
-                }
-            }
-
-            Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
-            if (apym != Real(0.0) && apym != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k)));
-                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k)) : Real(0.0);
-                if (beta_on_center && phi_on_center) {
-                    fym = (Real(1.0)-fracx)*fym + fracx*bY(ii,j,k,n)*(x(ii,j,k,n)-x(ii,j-1,k,n));
-                } else if (beta_on_centroid && phi_on_center) {
-                    fym = bY(i,j,k,n) * ( (Real(1.0)-fracx)*(x( i,j,k,n)-x( i,j-1,k,n))
-                                             + fracx *(x(ii,j,k,n)-x(ii,j-1,k,n)) );
-                }
-            }
-
-            Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
-            if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k)));
-                Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k)) : Real(0.0);
-                if (beta_on_center && phi_on_center) {
-                    fyp = (Real(1.0)-fracx)*fyp + fracx*bY(ii,j+1,k,n)*(x(ii,j+1,k,n)-x(ii,j,k,n));
-                } else if (beta_on_centroid && phi_on_center) {
-                    fyp = bY(i,j+1,k,n) * ( (Real(1.0)-fracx)*(x( i,j+1,k,n)-x( i,j,k,n))
-                                               + fracx *(x(ii,j+1,k,n)-x(ii,j,k,n)) );
-                }
-            }
-
-            Real feb = Real(0.0);
-            if (is_dirichlet) {
-                Real dapx = (apxm-apxp)/dxinv[1];
-                Real dapy = (apym-apyp)/dxinv[0];
-                Real anorm = std::hypot(dapx,dapy);
-                Real anorminv = Real(1.0)/anorm;
-                Real anrmx = dapx * anorminv;
-                Real anrmy = dapy * anorminv;
-
-                Real phib = is_inhomog ? phieb(i,j,k,n) : Real(0.0);
-
-                Real bctx = bc(i,j,k,0);
-                Real bcty = bc(i,j,k,1);
-                Real dx_eb = get_dx_eb(kappa);
-
-                Real dg, gx, gy, sx, sy;
-                if (std::abs(anrmx) > std::abs(anrmy)) {
-                    dg = dx_eb / std::abs(anrmx);
-                } else {
-                    dg = dx_eb / std::abs(anrmy);
-                }
-                gx = (bctx - dg*anrmx);
-                gy = (bcty - dg*anrmy);
-                sx = std::copysign(Real(1.0),anrmx);
-                sy = std::copysign(Real(1.0),anrmy);
-
-                int ii = i - static_cast<int>(sx);
-                int jj = j - static_cast<int>(sy);
-
-                Real phig = (Real(1.0) + gx*sx + gy*sy + gx*gy*sx*sy) * x(i ,j ,k,n)
-                    +       (    - gx*sx         - gx*gy*sx*sy) * x(ii,j ,k,n)
-                    +       (            - gy*sy - gx*gy*sx*sy) * x(i ,jj,k,n)
-                    +       (                    + gx*gy*sx*sy) * x(ii,jj,k,n) ;
-
-                Real dphidn = (phib-phig) / dg;
-
-                feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
-            }
-
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
-                (dhx*(apxm*fxm-apxp*fxp) +
-                 dhy*(apym*fym-apyp*fyp) - dh*feb);
         }
-    });
+
+        Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
+        if (apyp != Real(0.0) && apyp != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k)) : Real(0.0);
+            if (beta_on_center && phi_on_center) {
+                fyp = (Real(1.0)-fracx)*fyp + fracx*bY(ii,j+1,k,n)*(x(ii,j+1,k,n)-x(ii,j,k,n));
+            } else if (beta_on_centroid && phi_on_center) {
+                fyp = bY(i,j+1,k,n) * ( (Real(1.0)-fracx)*(x( i,j+1,k,n)-x( i,j,k,n))
+                                           + fracx *(x(ii,j+1,k,n)-x(ii,j,k,n)) );
+            }
+        }
+
+        Real feb = Real(0.0);
+        if (is_dirichlet) {
+            Real dapx = (apxm-apxp)/dxinv[1];
+            Real dapy = (apym-apyp)/dxinv[0];
+            Real anorm = std::hypot(dapx,dapy);
+            Real anorminv = Real(1.0)/anorm;
+            Real anrmx = dapx * anorminv;
+            Real anrmy = dapy * anorminv;
+
+            Real phib = is_inhomog ? phieb(i,j,k,n) : Real(0.0);
+
+            Real bctx = bc(i,j,k,0);
+            Real bcty = bc(i,j,k,1);
+            Real dx_eb = get_dx_eb(kappa);
+
+            Real dg, gx, gy, sx, sy;
+            if (std::abs(anrmx) > std::abs(anrmy)) {
+                dg = dx_eb / std::abs(anrmx);
+            } else {
+                dg = dx_eb / std::abs(anrmy);
+            }
+            gx = (bctx - dg*anrmx);
+            gy = (bcty - dg*anrmy);
+            sx = std::copysign(Real(1.0),anrmx);
+            sy = std::copysign(Real(1.0),anrmy);
+
+            int ii = i - static_cast<int>(sx);
+            int jj = j - static_cast<int>(sy);
+
+            Real phig = (Real(1.0) + gx*sx + gy*sy + gx*gy*sx*sy) * x(i ,j ,k,n)
+                +       (    - gx*sx         - gx*gy*sx*sy) * x(ii,j ,k,n)
+                +       (            - gy*sy - gx*gy*sx*sy) * x(i ,jj,k,n)
+                +       (                    + gx*gy*sx*sy) * x(ii,jj,k,n) ;
+
+            Real dphidn = (phib-phig) / dg;
+
+            feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
+        }
+
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
+            (dhx*(apxm*fxm-apxp*fxp) +
+             dhy*(apym*fym-apyp*fyp) - dh*feb);
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -8,158 +8,161 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
+void mlebabeclap_adotx_centroid (int i, int j, int k, int n, Array4<Real> const& y,
                         Array4<Real const> const& x, Array4<Real const> const& a,
                         Array4<Real const> const& bX, Array4<Real const> const& bY,
-                        Array4<EBCellFlag const> const& flag,
-                        Array4<Real const> const& vfrc,
-                        Array4<Real const> const& apx, Array4<Real const> const& apy,
-                        Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                        Array4<Real const> const& ccent, Array4<Real const> const& ba,
-                        Array4<Real const> const& bcent, Array4<Real const> const& beb,
+                        EBData const& ebdata,
+                        Array4<Real const> const& beb,
                         Array4<Real const> const& phieb,
                         const int& domlo_x,    const int& domlo_y,
                         const int& domhi_x,    const int& domhi_y,
                         const bool& on_x_face, const bool& on_y_face,
                         bool is_eb_dirichlet, bool is_eb_inhomog,
                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                        Real alpha, Real beta, int ncomp) noexcept
+                        Real alpha, Real beta) noexcept
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
     Real dhy = beta*dxinv[1]*dxinv[1];
     Real dh  = beta*dxinv[0]*dxinv[1];
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    auto const& flag  = ebdata.get<EBData_t::cellflag>();
+    auto const& vfrc  = ebdata.get<EBData_t::volfrac>();
+    auto const& apx   = ebdata.get<EBData_t::apx>();
+    auto const& apy   = ebdata.get<EBData_t::apy>();
+    auto const& fcx   = ebdata.get<EBData_t::fcx>();
+    auto const& fcy   = ebdata.get<EBData_t::fcy>();
+    auto const& ccent = ebdata.get<EBData_t::centroid>();
+    auto const& ba    = ebdata.get<EBData_t::bndryarea>();
+    auto const& bcent = ebdata.get<EBData_t::bndrycent>();
+
+    if (flag(i,j,k).isCovered())
     {
-        if (flag(i,j,k).isCovered())
+        y(i,j,k,n) = Real(0.0);
+    }
+    else if (flag(i,j,k).isRegular() &&
+            ((flag(i-1,j  ,k).isRegular() && flag(i+1,j  ,k).isRegular() &&
+             flag(i  ,j-1,k).isRegular() && flag(i  ,j+1,k).isRegular()) ))
+    {
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+            - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                   - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+            - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                   - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)));
+
+
+    }
+    else
+    {
+        Real kappa = vfrc(i,j,k);
+        Real apxm = apx(i,j,k);
+        Real apxp = apx(i+1,j,k);
+        Real apym = apy(i,j,k);
+        Real apyp = apy(i,j+1,k);
+
+        // First get EB-aware slope that doesn't know about extdir
+        bool needs_bdry_stencil = (i <= domlo_x) || (i >= domhi_x) ||
+                                  (j <= domlo_y) || (j >= domhi_y);
+
+        // if phi_on_centroid -- A second order least squares fit is used
+        // to approximate the slope on the high and low faces. Note that if
+        // any of the three cells --e.g., (i-1,j), (i,j), or (i-1,j)-- are
+        // cut, then the least squares fit is needed. This is a bit more than
+        // is actually needed for most cases but it will return the correct
+        // value in all cases.
+
+        Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
+        if ( (apxm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0)) )
         {
-            y(i,j,k,n) = Real(0.0);
+            Real yloc_on_xface = fcx(i,j,k);
+
+            if(needs_bdry_stencil) {
+
+              fxm = grad_x_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      yloc_on_xface,is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face, domlo_x, domhi_x,
+                                                      on_y_face, domlo_y, domhi_y);
+
+            } else {
+              fxm = grad_x_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                               yloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
+            }
+            fxm *= bX(i,j,k,n);
         }
-        else if (flag(i,j,k).isRegular() &&
-                ((flag(i-1,j  ,k).isRegular() && flag(i+1,j  ,k).isRegular() &&
-                 flag(i  ,j-1,k).isRegular() && flag(i  ,j+1,k).isRegular()) ))
+
+        Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
+        if ( (apxp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0)) ) {
+            Real yloc_on_xface = fcx(i+1,j,k,0);
+            if(needs_bdry_stencil) {
+              fxp = grad_x_of_phi_on_centroids_extdir(i+1,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      yloc_on_xface,is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face, domlo_x, domhi_x,
+                                                      on_y_face, domlo_y, domhi_y);
+
+            } else {
+              fxp = grad_x_of_phi_on_centroids(i+1,j,k,n,x,phieb,flag,ccent,bcent,
+                                               yloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
+            }
+            fxp *= bX(i+1,j,k,n);
+
+        }
+
+        Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
+        if ( (apym != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0)) ) {
+            Real xloc_on_yface = fcy(i,j,k,0);
+
+            if(needs_bdry_stencil) {
+
+              fym = grad_y_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_yface,is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face, domlo_x, domhi_x,
+                                                      on_y_face, domlo_y, domhi_y);
+
+            } else {
+              fym = grad_y_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                               xloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
+            }
+            fym *= bY(i,j,k,n);
+        }
+
+        Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
+        if ( (apyp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0)) ) {
+            Real xloc_on_yface = fcy(i,j+1,k,0);
+            if(needs_bdry_stencil) {
+              fyp = grad_y_of_phi_on_centroids_extdir(i,j+1,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_yface,is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face, domlo_x, domhi_x,
+                                                      on_y_face, domlo_y, domhi_y);
+
+            } else {
+              fyp = grad_y_of_phi_on_centroids(i,j+1,k,n,x,phieb,flag,ccent,bcent,
+                                               xloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
+            }
+            fyp *= bY(i,j+1,k,n);
+        }
+
+        Real feb = Real(0.0);
+        if (is_eb_dirichlet && flag(i,j,k).isSingleValued())
         {
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                       - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                       - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)));
+            Real dapx = (apxm-apxp)/dxinv[1];
+            Real dapy = (apym-apyp)/dxinv[0];
+            Real anorm = std::hypot(dapx,dapy);
+            Real anorminv = Real(1.0)/anorm;
+            Real anrmx = dapx * anorminv;
+            Real anrmy = dapy * anorminv;
 
 
+            feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                     anrmx,anrmy,is_eb_inhomog,
+                                                     on_x_face, domlo_x, domhi_x,
+                                                     on_y_face, domlo_y, domhi_y);
+
+            feb *= ba(i,j,k) * beb(i,j,k,n);
         }
-        else
-        {
-            Real kappa = vfrc(i,j,k);
-            Real apxm = apx(i,j,k);
-            Real apxp = apx(i+1,j,k);
-            Real apym = apy(i,j,k);
-            Real apyp = apy(i,j+1,k);
-
-            // First get EB-aware slope that doesn't know about extdir
-            bool needs_bdry_stencil = (i <= domlo_x) || (i >= domhi_x) ||
-                                      (j <= domlo_y) || (j >= domhi_y);
-
-            // if phi_on_centroid -- A second order least squares fit is used
-            // to approximate the slope on the high and low faces. Note that if
-            // any of the three cells --e.g., (i-1,j), (i,j), or (i-1,j)-- are
-            // cut, then the least squares fit is needed. This is a bit more than
-            // is actually needed for most cases but it will return the correct
-            // value in all cases.
-
-            Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
-            if ( (apxm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0)) )
-            {
-                Real yloc_on_xface = fcx(i,j,k);
-
-                if(needs_bdry_stencil) {
-
-                  fxm = grad_x_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          yloc_on_xface,is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face, domlo_x, domhi_x,
-                                                          on_y_face, domlo_y, domhi_y);
-
-                } else {
-                  fxm = grad_x_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                   yloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
-                }
-                fxm *= bX(i,j,k,n);
-            }
-
-            Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
-            if ( (apxp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0)) ) {
-                Real yloc_on_xface = fcx(i+1,j,k,0);
-                if(needs_bdry_stencil) {
-                  fxp = grad_x_of_phi_on_centroids_extdir(i+1,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          yloc_on_xface,is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face, domlo_x, domhi_x,
-                                                          on_y_face, domlo_y, domhi_y);
-
-                } else {
-                  fxp = grad_x_of_phi_on_centroids(i+1,j,k,n,x,phieb,flag,ccent,bcent,
-                                                   yloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
-                }
-                fxp *= bX(i+1,j,k,n);
-
-            }
-
-            Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
-            if ( (apym != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0)) ) {
-                Real xloc_on_yface = fcy(i,j,k,0);
-
-                if(needs_bdry_stencil) {
-
-                  fym = grad_y_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_yface,is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face, domlo_x, domhi_x,
-                                                          on_y_face, domlo_y, domhi_y);
-
-                } else {
-                  fym = grad_y_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                   xloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
-                }
-                fym *= bY(i,j,k,n);
-            }
-
-            Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
-            if ( (apyp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0)) ) {
-                Real xloc_on_yface = fcy(i,j+1,k,0);
-                if(needs_bdry_stencil) {
-                  fyp = grad_y_of_phi_on_centroids_extdir(i,j+1,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_yface,is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face, domlo_x, domhi_x,
-                                                          on_y_face, domlo_y, domhi_y);
-
-                } else {
-                  fyp = grad_y_of_phi_on_centroids(i,j+1,k,n,x,phieb,flag,ccent,bcent,
-                                                   xloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
-                }
-                fyp *= bY(i,j+1,k,n);
-            }
-
-            Real feb = Real(0.0);
-            if (is_eb_dirichlet && flag(i,j,k).isSingleValued())
-            {
-                Real dapx = (apxm-apxp)/dxinv[1];
-                Real dapy = (apym-apyp)/dxinv[0];
-                Real anorm = std::hypot(dapx,dapy);
-                Real anorminv = Real(1.0)/anorm;
-                Real anrmx = dapx * anorminv;
-                Real anrmy = dapy * anorminv;
 
 
-                feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                         anrmx,anrmy,is_eb_inhomog,
-                                                         on_x_face, domlo_x, domhi_x,
-                                                         on_y_face, domlo_y, domhi_y);
-
-                feb *= ba(i,j,k) * beb(i,j,k,n);
-            }
-
-
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
-                (dhx*(apxm*fxm-apxp*fxp) + dhy*(apym*fym-apyp*fyp) - dh*feb);
-        }
-    });
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
+            (dhx*(apxm*fxm-apxp*fxp) + dhy*(apym*fym-apyp*fyp) - dh*feb);
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -8,208 +8,212 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
+void mlebabeclap_adotx_centroid (int i, int j, int k, int n, Array4<Real> const& y,
                         Array4<Real const> const& x, Array4<Real const> const& a,
                         Array4<Real const> const& bX, Array4<Real const> const& bY,
                         Array4<Real const> const& bZ,
-                        Array4<EBCellFlag const> const& flag,
-                        Array4<Real const> const& vfrc, Array4<Real const> const& apx,
-                        Array4<Real const> const& apy, Array4<Real const> const& apz,
-                        Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                        Array4<Real const> const& fcz,
-                        Array4<Real const> const& ccent, Array4<Real const> const& ba,
-                        Array4<Real const> const& bcent, Array4<Real const> const& beb,
+                        EBData const& ebdata,
+                        Array4<Real const> const& beb,
                         Array4<Real const> const& phieb,
                         const int& domlo_x, const int& domlo_y, const int& domlo_z,
                         const int& domhi_x, const int& domhi_y, const int& domhi_z,
                         const bool& on_x_face, const bool& on_y_face, const bool& on_z_face,
                         bool is_eb_dirichlet, bool is_eb_inhomog,
                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                        Real alpha, Real beta, int ncomp) noexcept
+                        Real alpha, Real beta) noexcept
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
     Real dhy = beta*dxinv[1]*dxinv[1];
     Real dhz = beta*dxinv[2]*dxinv[2];
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    auto const& flag  = ebdata.get<EBData_t::cellflag>();
+    auto const& vfrc  = ebdata.get<EBData_t::volfrac>();
+    auto const& apx   = ebdata.get<EBData_t::apx>();
+    auto const& apy   = ebdata.get<EBData_t::apy>();
+    auto const& apz   = ebdata.get<EBData_t::apz>();
+    auto const& fcx   = ebdata.get<EBData_t::fcx>();
+    auto const& fcy   = ebdata.get<EBData_t::fcy>();
+    auto const& fcz   = ebdata.get<EBData_t::fcz>();
+    auto const& ccent = ebdata.get<EBData_t::centroid>();
+    auto const& ba    = ebdata.get<EBData_t::bndryarea>();
+    auto const& bcent = ebdata.get<EBData_t::bndrycent>();
+
+    if (flag(i,j,k).isCovered())
     {
-        if (flag(i,j,k).isCovered())
-        {
-            y(i,j,k,n) = Real(0.0);
+        y(i,j,k,n) = Real(0.0);
+    }
+    else if (flag(i,j,k).isRegular() &&
+             ((flag(i-1,j  ,k  ).isRegular() && flag(i+1,j  ,k  ).isRegular() &&
+              flag(i  ,j-1,k  ).isRegular() && flag(i  ,j+1,k  ).isRegular() &&
+              flag(i  ,j  ,k-1).isRegular() && flag(i  ,j  ,k+1).isRegular()) ))
+    {
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+            - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                    -bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+            - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                    -bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
+            - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
+                    -bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
+    }
+    else
+    {
+        Real kappa = vfrc(i,j,k);
+        Real apxm = apx(i,j,k);
+        Real apxp = apx(i+1,j,k);
+        Real apym = apy(i,j,k);
+        Real apyp = apy(i,j+1,k);
+        Real apzm = apz(i,j,k);
+        Real apzp = apz(i,j,k+1);
+
+        // First get EB-aware slope that doesn't know about extdir
+        bool needs_bdry_stencil = (i <= domlo_x) || (i >= domhi_x) ||
+                                  (j <= domlo_y) || (j >= domhi_y) ||
+                                  (k <= domlo_z) || (k >= domhi_z);
+
+        Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
+        if ( (apxm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0)) ) {
+            Real yloc_on_xface = fcx(i,j,k,0);
+            Real zloc_on_xface = fcx(i,j,k,1);
+
+            if(needs_bdry_stencil) {
+              fxm = grad_x_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      yloc_on_xface,zloc_on_xface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fxm = grad_x_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                             yloc_on_xface,zloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fxm *= bX(i,j,k,n);
         }
-        else if (flag(i,j,k).isRegular() &&
-                 ((flag(i-1,j  ,k  ).isRegular() && flag(i+1,j  ,k  ).isRegular() &&
-                  flag(i  ,j-1,k  ).isRegular() && flag(i  ,j+1,k  ).isRegular() &&
-                  flag(i  ,j  ,k-1).isRegular() && flag(i  ,j  ,k+1).isRegular()) ))
-        {
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                        -bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                        -bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
-                - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
-                        -bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
+
+        Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
+        if ( (apxp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0)) ) {
+            Real yloc_on_xface = fcx(i+1,j,k,0);
+            Real zloc_on_xface = fcx(i+1,j,k,1);
+
+            if(needs_bdry_stencil) {
+              fxp = grad_x_of_phi_on_centroids_extdir(i+1,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      yloc_on_xface,zloc_on_xface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fxp = grad_x_of_phi_on_centroids(i+1,j,k,n,x,phieb,flag,ccent,bcent,
+                                             yloc_on_xface,zloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fxp *= bX(i+1,j,k,n);
         }
-        else
-        {
-            Real kappa = vfrc(i,j,k);
-            Real apxm = apx(i,j,k);
-            Real apxp = apx(i+1,j,k);
-            Real apym = apy(i,j,k);
-            Real apyp = apy(i,j+1,k);
-            Real apzm = apz(i,j,k);
-            Real apzp = apz(i,j,k+1);
 
-            // First get EB-aware slope that doesn't know about extdir
-            bool needs_bdry_stencil = (i <= domlo_x) || (i >= domhi_x) ||
-                                      (j <= domlo_y) || (j >= domhi_y) ||
-                                      (k <= domlo_z) || (k >= domhi_z);
+        Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
+        if ( (apym != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0)) ) {
+            Real xloc_on_yface = fcy(i,j,k,0);
+            Real zloc_on_yface = fcy(i,j,k,1);
 
-            Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
-            if ( (apxm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0)) ) {
-                Real yloc_on_xface = fcx(i,j,k,0);
-                Real zloc_on_xface = fcx(i,j,k,1);
-
-                if(needs_bdry_stencil) {
-                  fxm = grad_x_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          yloc_on_xface,zloc_on_xface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fxm = grad_x_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                 yloc_on_xface,zloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fxm *= bX(i,j,k,n);
+            if(needs_bdry_stencil) {
+              fym = grad_y_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_yface,zloc_on_yface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fym = grad_y_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                             xloc_on_yface,zloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
             }
 
-            Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
-            if ( (apxp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0)) ) {
-                Real yloc_on_xface = fcx(i+1,j,k,0);
-                Real zloc_on_xface = fcx(i+1,j,k,1);
-
-                if(needs_bdry_stencil) {
-                  fxp = grad_x_of_phi_on_centroids_extdir(i+1,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          yloc_on_xface,zloc_on_xface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fxp = grad_x_of_phi_on_centroids(i+1,j,k,n,x,phieb,flag,ccent,bcent,
-                                                 yloc_on_xface,zloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fxp *= bX(i+1,j,k,n);
-            }
-
-            Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
-            if ( (apym != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0)) ) {
-                Real xloc_on_yface = fcy(i,j,k,0);
-                Real zloc_on_yface = fcy(i,j,k,1);
-
-                if(needs_bdry_stencil) {
-                  fym = grad_y_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_yface,zloc_on_yface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fym = grad_y_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                 xloc_on_yface,zloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fym *= bY(i,j,k,n);
-            }
-
-            Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
-            if ( (apyp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0)) ) {
-                Real xloc_on_yface = fcy(i,j+1,k,0);
-                Real zloc_on_yface = fcy(i,j+1,k,1);
-
-                if(needs_bdry_stencil) {
-                  fyp = grad_y_of_phi_on_centroids_extdir(i,j+1,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_yface,zloc_on_yface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fyp = grad_y_of_phi_on_centroids(i,j+1,k,n,x,phieb,flag,ccent,bcent,
-                                                 xloc_on_yface,zloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fyp *= bY(i,j+1,k,n);
-            }
-
-            Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
-            if ( (apzm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j,k-1) != Real(1.0) || vfrc(i,j,k+1) != Real(1.0)) ) {
-                Real xloc_on_zface = fcz(i,j,k,0);
-                Real yloc_on_zface = fcz(i,j,k,1);
-
-                if(needs_bdry_stencil) {
-                  fzm = grad_z_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_zface,yloc_on_zface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fzm = grad_z_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                 xloc_on_zface,yloc_on_zface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fzm *= bZ(i,j,k,n);
-            }
-
-            Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
-            if ( (apzp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j,k+1) != Real(1.0)  || vfrc(i,j,k-1) != Real(1.0)) ) {
-                Real xloc_on_zface = fcz(i,j,k+1,0);
-                Real yloc_on_zface = fcz(i,j,k+1,1);
-
-                if(needs_bdry_stencil) {
-                  fzp = grad_z_of_phi_on_centroids_extdir(i,j,k+1,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_zface,yloc_on_zface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fzp = grad_z_of_phi_on_centroids(i,j,k+1,n,x,phieb,flag,ccent,bcent,
-                                                 xloc_on_zface,yloc_on_zface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fzp *= bZ(i,j,k+1,n);
-            }
-
-            Real feb = Real(0.0);
-            if (is_eb_dirichlet && flag(i,j,k).isSingleValued()) {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
-                Real dapz = apzm-apzp;
-                Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
-                Real anorminv = Real(1.0)/anorm;
-                Real anrmx = dapx * anorminv;
-                Real anrmy = dapy * anorminv;
-                Real anrmz = dapz * anorminv;
-
-                feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                         anrmx,anrmy,anrmz,is_eb_inhomog,
-                                                         on_x_face,domlo_x,domhi_x,
-                                                         on_y_face,domlo_y,domhi_y,
-                                                         on_z_face,domlo_z,domhi_z);
-                feb *= ba(i,j,k) * beb(i,j,k,n);
-            }
-
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
-                (dhx*(apxm*fxm - apxp*fxp) +
-                 dhy*(apym*fym - apyp*fyp) +
-                 dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
+            fym *= bY(i,j,k,n);
         }
-    });
+
+        Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
+        if ( (apyp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0)) ) {
+            Real xloc_on_yface = fcy(i,j+1,k,0);
+            Real zloc_on_yface = fcy(i,j+1,k,1);
+
+            if(needs_bdry_stencil) {
+              fyp = grad_y_of_phi_on_centroids_extdir(i,j+1,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_yface,zloc_on_yface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fyp = grad_y_of_phi_on_centroids(i,j+1,k,n,x,phieb,flag,ccent,bcent,
+                                             xloc_on_yface,zloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fyp *= bY(i,j+1,k,n);
+        }
+
+        Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
+        if ( (apzm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j,k-1) != Real(1.0) || vfrc(i,j,k+1) != Real(1.0)) ) {
+            Real xloc_on_zface = fcz(i,j,k,0);
+            Real yloc_on_zface = fcz(i,j,k,1);
+
+            if(needs_bdry_stencil) {
+              fzm = grad_z_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_zface,yloc_on_zface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fzm = grad_z_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                             xloc_on_zface,yloc_on_zface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fzm *= bZ(i,j,k,n);
+        }
+
+        Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
+        if ( (apzp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j,k+1) != Real(1.0)  || vfrc(i,j,k-1) != Real(1.0)) ) {
+            Real xloc_on_zface = fcz(i,j,k+1,0);
+            Real yloc_on_zface = fcz(i,j,k+1,1);
+
+            if(needs_bdry_stencil) {
+              fzp = grad_z_of_phi_on_centroids_extdir(i,j,k+1,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_zface,yloc_on_zface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fzp = grad_z_of_phi_on_centroids(i,j,k+1,n,x,phieb,flag,ccent,bcent,
+                                             xloc_on_zface,yloc_on_zface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fzp *= bZ(i,j,k+1,n);
+        }
+
+        Real feb = Real(0.0);
+        if (is_eb_dirichlet && flag(i,j,k).isSingleValued()) {
+            Real dapx = apxm-apxp;
+            Real dapy = apym-apyp;
+            Real dapz = apzm-apzp;
+            Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
+            Real anorminv = Real(1.0)/anorm;
+            Real anrmx = dapx * anorminv;
+            Real anrmy = dapy * anorminv;
+            Real anrmz = dapz * anorminv;
+
+            feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                     anrmx,anrmy,anrmz,is_eb_inhomog,
+                                                     on_x_face,domlo_x,domhi_x,
+                                                     on_y_face,domlo_y,domhi_y,
+                                                     on_z_face,domlo_z,domhi_z);
+            feb *= ba(i,j,k) * beb(i,j,k,n);
+        }
+
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
+            (dhx*(apxm*fxm - apxp*fxp) +
+             dhy*(apym*fym - apyp*fyp) +
+             dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -213,19 +213,14 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
+void mlebabeclap_adotx (int i, int j, int k, int n, Array4<Real> const& y,
                         Array4<Real const> const& x, Array4<Real const> const& a,
                         Array4<Real const> const& bX, Array4<Real const> const& bY,
                         Array4<Real const> const& bZ, Array4<const int> const& ccm,
-                        Array4<EBCellFlag const> const& flag,
-                        Array4<Real const> const& vfrc, Array4<Real const> const& apx,
-                        Array4<Real const> const& apy, Array4<Real const> const& apz,
-                        Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                        Array4<Real const> const& fcz, Array4<Real const> const& ba,
-                        Array4<Real const> const& bc, Array4<Real const> const& beb,
+                        EBData const& ebdata, Array4<Real const> const& beb,
                         bool is_dirichlet, Array4<Real const> const& phieb,
                         bool is_inhomog, GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                        Real alpha, Real beta, int ncomp,
+                        Real alpha, Real beta,
                         bool beta_on_centroid, bool phi_on_centroid) noexcept
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
@@ -235,232 +230,240 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
     bool beta_on_center = !(beta_on_centroid);
     bool  phi_on_center = !( phi_on_centroid);
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    auto const& flag = ebdata.get<EBData_t::cellflag>();
+    auto const& vfrc = ebdata.get<EBData_t::volfrac>();
+    auto const& apx  = ebdata.get<EBData_t::apx>();
+    auto const& apy  = ebdata.get<EBData_t::apy>();
+    auto const& apz  = ebdata.get<EBData_t::apz>();
+    auto const& fcx  = ebdata.get<EBData_t::fcx>();
+    auto const& fcy  = ebdata.get<EBData_t::fcy>();
+    auto const& fcz  = ebdata.get<EBData_t::fcz>();
+    auto const& ba   = ebdata.get<EBData_t::bndryarea>();
+    auto const& bc   = ebdata.get<EBData_t::bndrycent>();
+
+    if (flag(i,j,k).isCovered())
     {
-        if (flag(i,j,k).isCovered())
-        {
-            y(i,j,k,n) = Real(0.0);
+        y(i,j,k,n) = Real(0.0);
+    }
+    else if (flag(i,j,k).isRegular())
+    {
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+            - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                    -bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+            - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                    -bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
+            - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
+                    -bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
+    }
+    else
+    {
+        Real kappa = vfrc(i,j,k);
+        Real apxm = apx(i,j,k);
+        Real apxp = apx(i+1,j,k);
+        Real apym = apy(i,j,k);
+        Real apyp = apy(i,j+1,k);
+        Real apzm = apz(i,j,k);
+        Real apzp = apz(i,j,k+1);
+
+        Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
+        if (apxm != Real(0.0) && apxm != Real(1.0)) {
+            int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,1)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : Real(0.0);
+            Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxm +
+                    fracy*(Real(1.0)-fracz)*bX(i,jj,k ,n)*(x(i,jj,k ,n)-x(i-1,jj,k ,n)) +
+                    fracz*(Real(1.0)-fracy)*bX(i,j ,kk,n)*(x(i,j ,kk,n)-x(i-1,j ,kk,n)) +
+                    fracy*     fracz *bX(i,jj,kk,n)*(x(i,jj,kk,n)-x(i-1,jj,kk,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(x(i, j, k,n)-x(i-1, j, k,n)) +
+                           fracy *(Real(1.0)-fracz)*(x(i,jj, k,n)-x(i-1,jj, k,n)) +
+                           fracz *(Real(1.0)-fracy)*(x(i, j,kk,n)-x(i-1, j,kk,n)) +
+                           fracy *     fracz *(x(i,jj,kk,n)-x(i-1,jj,kk,n));
+                fxm *= bX(i,j,k,n);
+            }
         }
-        else if (flag(i,j,k).isRegular())
-        {
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                        -bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                        -bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
-                - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
-                        -bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
+
+        Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
+        if (apxp != Real(0.0) && apxp != Real(1.0)) {
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,1)));
+            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k,0)) : Real(0.0);
+            Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? std::abs(fcx(i+1,j,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxp +
+                    fracy*(Real(1.0)-fracz)*bX(i+1,jj,k ,n)*(x(i+1,jj,k ,n)-x(i,jj,k ,n)) +
+                    fracz*(Real(1.0)-fracy)*bX(i+1,j ,kk,n)*(x(i+1,j ,kk,n)-x(i,j ,kk,n)) +
+                    fracy*     fracz *bX(i+1,jj,kk,n)*(x(i+1,jj,kk,n)-x(i,jj,kk,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(x(i+1, j, k,n)-x(i, j, k,n)) +
+                           fracy *(Real(1.0)-fracz)*(x(i+1,jj, k,n)-x(i,jj, k,n)) +
+                           fracz *(Real(1.0)-fracy)*(x(i+1, j,kk,n)-x(i, j,kk,n)) +
+                           fracy *     fracz *(x(i+1,jj,kk,n)-x(i,jj,kk,n));
+                fxp *= bX(i+1,j,k,n);
+
+            }
         }
-        else
-        {
-            Real kappa = vfrc(i,j,k);
-            Real apxm = apx(i,j,k);
-            Real apxp = apx(i+1,j,k);
-            Real apym = apy(i,j,k);
-            Real apyp = apy(i,j+1,k);
-            Real apzm = apz(i,j,k);
-            Real apzp = apz(i,j,k+1);
 
-            Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
-            if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,0)));
-                int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,1)));
-                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : Real(0.0);
-                Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxm +
-                        fracy*(Real(1.0)-fracz)*bX(i,jj,k ,n)*(x(i,jj,k ,n)-x(i-1,jj,k ,n)) +
-                        fracz*(Real(1.0)-fracy)*bX(i,j ,kk,n)*(x(i,j ,kk,n)-x(i-1,j ,kk,n)) +
-                        fracy*     fracz *bX(i,jj,kk,n)*(x(i,jj,kk,n)-x(i-1,jj,kk,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(x(i, j, k,n)-x(i-1, j, k,n)) +
-                               fracy *(Real(1.0)-fracz)*(x(i,jj, k,n)-x(i-1,jj, k,n)) +
-                               fracz *(Real(1.0)-fracy)*(x(i, j,kk,n)-x(i-1, j,kk,n)) +
-                               fracy *     fracz *(x(i,jj,kk,n)-x(i-1,jj,kk,n));
-                    fxm *= bX(i,j,k,n);
-                }
+        Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
+        if (apym != Real(0.0) && apym != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,1)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : Real(0.0);
+            Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fym +
+                    fracx*(Real(1.0)-fracz)*bY(ii,j,k ,n)*(x(ii,j,k ,n)-x(ii,j-1,k ,n)) +
+                    fracz*(Real(1.0)-fracx)*bY(i ,j,kk,n)*(x(i ,j,kk,n)-x(i ,j-1,kk,n)) +
+                    fracx*     fracz *bY(ii,j,kk,n)*(x(ii,j,kk,n)-x(ii,j-1,kk,n));
             }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(x( i,j, k,n)-x( i,j-1, k,n)) +
+                           fracx *(Real(1.0)-fracz)*(x(ii,j, k,n)-x(ii,j-1, k,n)) +
+                           fracz *(Real(1.0)-fracx)*(x(i ,j,kk,n)-x( i,j-1,kk,n)) +
+                           fracx *     fracz *(x(ii,j,kk,n)-x(ii,j-1,kk,n));
+                fym *= bY(i,j,k,n);
 
-            Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
-            if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,0)));
-                int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,1)));
-                Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k,0)) : Real(0.0);
-                Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? std::abs(fcx(i+1,j,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxp +
-                        fracy*(Real(1.0)-fracz)*bX(i+1,jj,k ,n)*(x(i+1,jj,k ,n)-x(i,jj,k ,n)) +
-                        fracz*(Real(1.0)-fracy)*bX(i+1,j ,kk,n)*(x(i+1,j ,kk,n)-x(i,j ,kk,n)) +
-                        fracy*     fracz *bX(i+1,jj,kk,n)*(x(i+1,jj,kk,n)-x(i,jj,kk,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(x(i+1, j, k,n)-x(i, j, k,n)) +
-                               fracy *(Real(1.0)-fracz)*(x(i+1,jj, k,n)-x(i,jj, k,n)) +
-                               fracz *(Real(1.0)-fracy)*(x(i+1, j,kk,n)-x(i, j,kk,n)) +
-                               fracy *     fracz *(x(i+1,jj,kk,n)-x(i,jj,kk,n));
-                    fxp *= bX(i+1,j,k,n);
-
-                }
             }
-
-            Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
-            if (apym != Real(0.0) && apym != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,0)));
-                int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,1)));
-                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : Real(0.0);
-                Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fym +
-                        fracx*(Real(1.0)-fracz)*bY(ii,j,k ,n)*(x(ii,j,k ,n)-x(ii,j-1,k ,n)) +
-                        fracz*(Real(1.0)-fracx)*bY(i ,j,kk,n)*(x(i ,j,kk,n)-x(i ,j-1,kk,n)) +
-                        fracx*     fracz *bY(ii,j,kk,n)*(x(ii,j,kk,n)-x(ii,j-1,kk,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(x( i,j, k,n)-x( i,j-1, k,n)) +
-                               fracx *(Real(1.0)-fracz)*(x(ii,j, k,n)-x(ii,j-1, k,n)) +
-                               fracz *(Real(1.0)-fracx)*(x(i ,j,kk,n)-x( i,j-1,kk,n)) +
-                               fracx *     fracz *(x(ii,j,kk,n)-x(ii,j-1,kk,n));
-                    fym *= bY(i,j,k,n);
-
-                }
-            }
-
-            Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
-            if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,0)));
-                int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,1)));
-                Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k,0)) : Real(0.0);
-                Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? std::abs(fcy(i,j+1,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fyp +
-                        fracx*(Real(1.0)-fracz)*bY(ii,j+1,k ,n)*(x(ii,j+1,k ,n)-x(ii,j,k ,n)) +
-                        fracz*(Real(1.0)-fracx)*bY(i ,j+1,kk,n)*(x(i ,j+1,kk,n)-x(i ,j,kk,n)) +
-                        fracx*     fracz *bY(ii,j+1,kk,n)*(x(ii,j+1,kk,n)-x(ii,j,kk,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(x( i,j+1, k,n)-x( i,j, k,n)) +
-                               fracx *(Real(1.0)-fracz)*(x(ii,j+1, k,n)-x(ii,j, k,n)) +
-                               fracz *(Real(1.0)-fracx)*(x( i,j+1,kk,n)-x( i,j,kk,n)) +
-                               fracx *     fracz *(x(ii,j+1,kk,n)-x(ii,j,kk,n));
-                    fyp *= bY(i,j+1,k,n);
-
-                }
-            }
-
-            Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
-            if (apzm != Real(0.0) && apzm != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,0)));
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,1)));
-                Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : Real(0.0);
-                Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzm +
-                        fracx*(Real(1.0)-fracy)*bZ(ii,j ,k,n)*(x(ii,j ,k,n)-x(ii,j ,k-1,n)) +
-                        fracy*(Real(1.0)-fracx)*bZ(i ,jj,k,n)*(x(i ,jj,k,n)-x(i ,jj,k-1,n)) +
-                        fracx*     fracy *bZ(ii,jj,k,n)*(x(ii,jj,k,n)-x(ii,jj,k-1,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(x( i, j,k,n)-x( i, j,k-1,n)) +
-                               fracx *(Real(1.0)-fracy)*(x(ii, j,k,n)-x(ii, j,k-1,n)) +
-                               fracy *(Real(1.0)-fracx)*(x( i,jj,k,n)-x( i,jj,k-1,n)) +
-                               fracx *     fracy *(x(ii,jj,k,n)-x(ii,jj,k-1,n));
-                    fzm *= bZ(i,j,k,n);
-
-                }
-            }
-
-            Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
-            if (apzp != Real(0.0) && apzp != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,0)));
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,1)));
-                Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? std::abs(fcz(i,j,k+1,0)) : Real(0.0);
-                Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? std::abs(fcz(i,j,k+1,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzp +
-                        fracx*(Real(1.0)-fracy)*bZ(ii,j ,k+1,n)*(x(ii,j ,k+1,n)-x(ii,j ,k,n)) +
-                        fracy*(Real(1.0)-fracx)*bZ(i ,jj,k+1,n)*(x(i ,jj,k+1,n)-x(i ,jj,k,n)) +
-                        fracx*     fracy *bZ(ii,jj,k+1,n)*(x(ii,jj,k+1,n)-x(ii,jj,k,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(x( i, j,k+1,n)-x( i, j,k,n)) +
-                               fracx *(Real(1.0)-fracy)*(x(ii, j,k+1,n)-x(ii, j,k,n)) +
-                               fracy *(Real(1.0)-fracx)*(x( i,jj,k+1,n)-x( i,jj,k,n)) +
-                               fracx *     fracy *(x(ii,jj,k+1,n)-x(ii,jj,k,n));
-                    fzp *= bZ(i,j,k+1,n);
-
-                }
-            }
-
-            Real feb = Real(0.0);
-            if (is_dirichlet) {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
-                Real dapz = apzm-apzp;
-                Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
-                Real anorminv = Real(1.0)/anorm;
-                Real anrmx = dapx * anorminv;
-                Real anrmy = dapy * anorminv;
-                Real anrmz = dapz * anorminv;
-
-                Real phib = is_inhomog ? phieb(i,j,k,n) : Real(0.0);
-
-                Real bctx = bc(i,j,k,0);
-                Real bcty = bc(i,j,k,1);
-                Real bctz = bc(i,j,k,2);
-                Real dx_eb = get_dx_eb(kappa);
-
-                Real dg = dx_eb / amrex::max(std::abs(anrmx), std::abs(anrmy),
-                                             std::abs(anrmz));
-                Real gx = bctx - dg*anrmx;
-                Real gy = bcty - dg*anrmy;
-                Real gz = bctz - dg*anrmz;
-                Real sx = std::copysign(Real(1.0),anrmx);
-                Real sy = std::copysign(Real(1.0),anrmy);
-                Real sz = std::copysign(Real(1.0),anrmz);
-                int ii = i - static_cast<int>(sx);
-                int jj = j - static_cast<int>(sy);
-                int kk = k - static_cast<int>(sz);
-
-                gx = sx*gx;
-                gy = sy*gy;
-                gz = sz*gz;
-                Real gxy = gx*gy;
-                Real gxz = gx*gz;
-                Real gyz = gy*gz;
-                Real gxyz = gx*gy*gz;
-                Real phig = (Real(1.0)+gx+gy+gz+gxy+gxz+gyz+gxyz) * x(i ,j ,k ,n)
-                    +       (-gz - gxz - gyz - gxyz)        * x(i ,j ,kk,n)
-                    +       (-gy - gxy - gyz - gxyz)        * x(i ,jj,k ,n)
-                    +       (gyz + gxyz)                    * x(i ,jj,kk,n)
-                    +       (-gx - gxy - gxz - gxyz)        * x(ii,j ,k ,n)
-                    +       (gxz + gxyz)                    * x(ii,j ,kk,n)
-                    +       (gxy + gxyz)                    * x(ii,jj,k ,n)
-                    +       (-gxyz)                         * x(ii,jj,kk,n);
-
-                Real dphidn = (phib-phig)/dg;
-
-                feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
-            }
-
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
-                (dhx*(apxm*fxm - apxp*fxp) +
-                 dhy*(apym*fym - apyp*fyp) +
-                 dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
         }
-    });
+
+        Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
+        if (apyp != Real(0.0) && apyp != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,0)));
+            int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,1)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k,0)) : Real(0.0);
+            Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? std::abs(fcy(i,j+1,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fyp +
+                    fracx*(Real(1.0)-fracz)*bY(ii,j+1,k ,n)*(x(ii,j+1,k ,n)-x(ii,j,k ,n)) +
+                    fracz*(Real(1.0)-fracx)*bY(i ,j+1,kk,n)*(x(i ,j+1,kk,n)-x(i ,j,kk,n)) +
+                    fracx*     fracz *bY(ii,j+1,kk,n)*(x(ii,j+1,kk,n)-x(ii,j,kk,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(x( i,j+1, k,n)-x( i,j, k,n)) +
+                           fracx *(Real(1.0)-fracz)*(x(ii,j+1, k,n)-x(ii,j, k,n)) +
+                           fracz *(Real(1.0)-fracx)*(x( i,j+1,kk,n)-x( i,j,kk,n)) +
+                           fracx *     fracz *(x(ii,j+1,kk,n)-x(ii,j,kk,n));
+                fyp *= bY(i,j+1,k,n);
+
+            }
+        }
+
+        Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
+        if (apzm != Real(0.0) && apzm != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,0)));
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,1)));
+            Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : Real(0.0);
+            Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzm +
+                    fracx*(Real(1.0)-fracy)*bZ(ii,j ,k,n)*(x(ii,j ,k,n)-x(ii,j ,k-1,n)) +
+                    fracy*(Real(1.0)-fracx)*bZ(i ,jj,k,n)*(x(i ,jj,k,n)-x(i ,jj,k-1,n)) +
+                    fracx*     fracy *bZ(ii,jj,k,n)*(x(ii,jj,k,n)-x(ii,jj,k-1,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(x( i, j,k,n)-x( i, j,k-1,n)) +
+                           fracx *(Real(1.0)-fracy)*(x(ii, j,k,n)-x(ii, j,k-1,n)) +
+                           fracy *(Real(1.0)-fracx)*(x( i,jj,k,n)-x( i,jj,k-1,n)) +
+                           fracx *     fracy *(x(ii,jj,k,n)-x(ii,jj,k-1,n));
+                fzm *= bZ(i,j,k,n);
+
+            }
+        }
+
+        Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
+        if (apzp != Real(0.0) && apzp != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,0)));
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,1)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? std::abs(fcz(i,j,k+1,0)) : Real(0.0);
+            Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? std::abs(fcz(i,j,k+1,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzp +
+                    fracx*(Real(1.0)-fracy)*bZ(ii,j ,k+1,n)*(x(ii,j ,k+1,n)-x(ii,j ,k,n)) +
+                    fracy*(Real(1.0)-fracx)*bZ(i ,jj,k+1,n)*(x(i ,jj,k+1,n)-x(i ,jj,k,n)) +
+                    fracx*     fracy *bZ(ii,jj,k+1,n)*(x(ii,jj,k+1,n)-x(ii,jj,k,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(x( i, j,k+1,n)-x( i, j,k,n)) +
+                           fracx *(Real(1.0)-fracy)*(x(ii, j,k+1,n)-x(ii, j,k,n)) +
+                           fracy *(Real(1.0)-fracx)*(x( i,jj,k+1,n)-x( i,jj,k,n)) +
+                           fracx *     fracy *(x(ii,jj,k+1,n)-x(ii,jj,k,n));
+                fzp *= bZ(i,j,k+1,n);
+
+            }
+        }
+
+        Real feb = Real(0.0);
+        if (is_dirichlet) {
+            Real dapx = apxm-apxp;
+            Real dapy = apym-apyp;
+            Real dapz = apzm-apzp;
+            Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
+            Real anorminv = Real(1.0)/anorm;
+            Real anrmx = dapx * anorminv;
+            Real anrmy = dapy * anorminv;
+            Real anrmz = dapz * anorminv;
+
+            Real phib = is_inhomog ? phieb(i,j,k,n) : Real(0.0);
+
+            Real bctx = bc(i,j,k,0);
+            Real bcty = bc(i,j,k,1);
+            Real bctz = bc(i,j,k,2);
+            Real dx_eb = get_dx_eb(kappa);
+
+            Real dg = dx_eb / amrex::max(std::abs(anrmx), std::abs(anrmy),
+                                         std::abs(anrmz));
+            Real gx = bctx - dg*anrmx;
+            Real gy = bcty - dg*anrmy;
+            Real gz = bctz - dg*anrmz;
+            Real sx = std::copysign(Real(1.0),anrmx);
+            Real sy = std::copysign(Real(1.0),anrmy);
+            Real sz = std::copysign(Real(1.0),anrmz);
+            int ii = i - static_cast<int>(sx);
+            int jj = j - static_cast<int>(sy);
+            int kk = k - static_cast<int>(sz);
+
+            gx = sx*gx;
+            gy = sy*gy;
+            gz = sz*gz;
+            Real gxy = gx*gy;
+            Real gxz = gx*gz;
+            Real gyz = gy*gz;
+            Real gxyz = gx*gy*gz;
+            Real phig = (Real(1.0)+gx+gy+gz+gxy+gxz+gyz+gxyz) * x(i ,j ,k ,n)
+                +       (-gz - gxz - gyz - gxyz)        * x(i ,j ,kk,n)
+                +       (-gy - gxy - gyz - gxyz)        * x(i ,jj,k ,n)
+                +       (gyz + gxyz)                    * x(i ,jj,kk,n)
+                +       (-gx - gxy - gxz - gxyz)        * x(ii,j ,k ,n)
+                +       (gxz + gxyz)                    * x(ii,j ,kk,n)
+                +       (gxy + gxyz)                    * x(ii,jj,k ,n)
+                +       (-gxyz)                         * x(ii,jj,kk,n);
+
+            Real dphidn = (phib-phig)/dg;
+
+            feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
+        }
+
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
+            (dhx*(apxm*fxm - apxp*fxp) +
+             dhy*(apym*fym - apyp*fyp) +
+             dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -130,7 +130,9 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                 amrex::ignore_unused(AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
                                      AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
                                      AMREX_D_DECL(extdir_x, extdir_y, extdir_z));
-                amrex::ignore_unused(ccfab);
+                amrex::ignore_unused(ccfab, flagfab, vfracfab, bafab, bcfab,
+                                     AMREX_D_DECL(apxfab,apyfab,apzfab),
+                                     AMREX_D_DECL(fcxfab,fcyfab,fczfab));
 #else
                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
                {
@@ -147,18 +149,17 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                });
 #endif
             } else {
-               AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
-               {
-                   mlebabeclap_adotx(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
-                                     ccmfab, flagfab, vfracfab,
-                                     AMREX_D_DECL(apxfab,apyfab,apzfab),
-                                     AMREX_D_DECL(fcxfab,fcyfab,fczfab),
-                                     bafab, bcfab, bebfab,
-                                     is_eb_dirichlet,
-                                     phiebfab,
-                                     is_eb_inhomog, dxinvarr,
-                                     ascalar, bscalar, ncomp, beta_on_centroid, phi_on_centroid);
-               });
+                auto const& ebdata = factory->getEBData(mfi);
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
+                {
+                    mlebabeclap_adotx(i, j, k, n, yfab, xfab, afab,
+                                      AMREX_D_DECL(bxfab,byfab,bzfab),
+                                      ccmfab, ebdata, bebfab,
+                                      is_eb_dirichlet,
+                                      phiebfab,
+                                      is_eb_inhomog, dxinvarr,
+                                      ascalar, bscalar, beta_on_centroid, phi_on_centroid);
+                });
             }
             if (has_overset) {
                 Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -23,14 +23,6 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
 
     const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
     const FabArray<EBCellFlagFab>* flags = (factory) ? &(factory->getMultiEBCellFlagFab()) : nullptr;
-    const MultiFab* vfrac = (factory) ? &(factory->getVolFrac()) : nullptr;
-    auto area = (factory) ? factory->getAreaFrac()
-        : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
-    auto fcent = (factory) ? factory->getFaceCent()
-        : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
-    const MultiCutFab* barea = (factory) ? &(factory->getBndryArea()) : nullptr;
-    const MultiCutFab* bcent = (factory) ? &(factory->getBndryCent()) : nullptr;
-    const auto *const  ccent = (factory) ? &(factory->getCentroid()) : nullptr;
 
     const bool is_eb_dirichlet =  isEBDirichlet();
     const bool is_eb_inhomog = m_is_eb_inhomog && (!this->m_precond_mode);
@@ -99,17 +91,7 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
             }
         } else {
             Array4<int const> const& ccmfab = ccmask.const_array(mfi);
-            Array4<EBCellFlag const> const& flagfab = flags->const_array(mfi);
-            Array4<Real const> const& vfracfab = vfrac->const_array(mfi);
-            AMREX_D_TERM(Array4<Real const> const& apxfab = area[0]->const_array(mfi);,
-                         Array4<Real const> const& apyfab = area[1]->const_array(mfi);,
-                         Array4<Real const> const& apzfab = area[2]->const_array(mfi););
-            AMREX_D_TERM(Array4<Real const> const& fcxfab = fcent[0]->const_array(mfi);,
-                         Array4<Real const> const& fcyfab = fcent[1]->const_array(mfi);,
-                         Array4<Real const> const& fczfab = fcent[2]->const_array(mfi););
-            Array4<Real const> const& bafab = barea->const_array(mfi);
-            Array4<Real const> const& bcfab = bcent->const_array(mfi);
-            Array4<Real const> const& ccfab = ccent->const_array(mfi);
+            auto const& ebdata = factory->getEBData(mfi);
             Array4<Real const> const& bebfab = (is_eb_dirichlet)
                 ? m_eb_b_coeffs[amrlev][mglev]->const_array(mfi) : foo;
             Array4<Real const> const& phiebfab = (is_eb_dirichlet && is_eb_inhomog)
@@ -130,26 +112,20 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                 amrex::ignore_unused(AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
                                      AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
                                      AMREX_D_DECL(extdir_x, extdir_y, extdir_z));
-                amrex::ignore_unused(ccfab, flagfab, vfracfab, bafab, bcfab,
-                                     AMREX_D_DECL(apxfab,apyfab,apzfab),
-                                     AMREX_D_DECL(fcxfab,fcyfab,fczfab));
 #else
-               AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
-               {
-                   mlebabeclap_adotx_centroid(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
-                                     flagfab, vfracfab,
-                                     AMREX_D_DECL(apxfab,apyfab,apzfab),
-                                     AMREX_D_DECL(fcxfab,fcyfab,fczfab),
-                                     ccfab, bafab, bcfab, bebfab, phiebfab,
-                                     AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
-                                     AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
-                                     AMREX_D_DECL(extdir_x, extdir_y, extdir_z),
-                                     is_eb_dirichlet, is_eb_inhomog, dxinvarr,
-                                     ascalar, bscalar, ncomp);
-               });
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
+                {
+                    mlebabeclap_adotx_centroid(i, j, k, n, yfab, xfab, afab,
+                                      AMREX_D_DECL(bxfab,byfab,bzfab),
+                                      ebdata, bebfab, phiebfab,
+                                      AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
+                                      AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
+                                      AMREX_D_DECL(extdir_x, extdir_y, extdir_z),
+                                      is_eb_dirichlet, is_eb_inhomog, dxinvarr,
+                                      ascalar, bscalar);
+                });
 #endif
             } else {
-                auto const& ebdata = factory->getEBData(mfi);
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
                 {
                     mlebabeclap_adotx(i, j, k, n, yfab, xfab, afab,


### PR DESCRIPTION
## Summary

Rewrites `mlebabeclap_adotx_centroid` (2D and 3D) from a `Box`-based kernel that loops
internally (`amrex::Loop(box, ncomp, ...)`) into a per-cell `(i,j,k,n)` kernel, and
replaces its eleven separate EB `Array4` arguments (`flag`, `vfrc`, `apx/apy/apz`,
`fcx/fcy/fcz`, `ccent`, `ba`, `bcent`) with the existing `EBData` view.

`MLEBABecLap::Fapply` now calls it through `AMREX_HOST_DEVICE_PARALLEL_FOR_4D` and gets
all EB geometry from `factory->getEBData(mfi)`, which lets the `getVolFrac()` /
`getAreaFrac()` / `getFaceCent()` / `getBndryArea()` / `getBndryCent()` / `getCentroid()`
lookups at the top of `Fapply` be dropped entirely.

The arithmetic inside the kernel is untouched: the loop wrapper is removed and the body is
only re-indented, and the EB arrays are re-bound to identically named local references
(`auto const& ccent = ebdata.get<EBData_t::centroid>();` etc.), so the expressions are
character for character the same. Results are bitwise unchanged.

## Additional background

This is part of the ongoing split of the stale WIP #4922 ("GPU specific kernels for
MLEBABecLap"), as requested there; it supersedes the `mlebabeclap_adotx_centroid` part of
#4922. The templating on `T` that #4922 also introduced has been dropped, per the review
comment on that PR.

**This PR is stacked on top of the `mlebabeclap_adotx` PR** (branch
`ankithadas:MLEBABecLap-Adotx-Index`) because both edit the same block of
`MLEBABecLap::Fapply`; please merge that one first. The diff shown here against
`development` therefore contains that commit as well.

Testing (all commands run from the repo root unless noted):

* `cmake -S . -B build-split -DAMReX_SPACEDIM=3 -DAMReX_EB=ON -DAMReX_LINEAR_SOLVERS_EM=OFF -DAMReX_ENABLE_TESTS=ON -DAMReX_TEST_TYPE=Small -DAMReX_MPI=ON -DCMAKE_BUILD_TYPE=Release`
  then `cmake --build build-split -j8` and `ctest --test-dir build-split --output-on-failure`
  &rarr; builds clean, 9/9 tests pass. A 2D library build
  (`-DAMReX_SPACEDIM=2 -DAMReX_EB=ON`) also builds clean.
* `Tests/LinearSolvers/LeastSquares` is the test that actually exercises this kernel: it
  calls `MLEBABecLap::setPhiOnCentroid()` and then `MLMG::apply()`. Built with
  `make -j8 COMP=llvm USE_MPI=FALSE DIM=2` and `DIM=3`, and run on
  `inputs.2d.base`, `inputs.2d.askew-x`, `inputs.2d.fullyrotated`,
  `inputs.2d.trianglewave`, `inputs.3d.poiseuille.askew-all` and
  `inputs.3d.poiseuille.aligned.xy-x`. The resulting plotfiles are **byte for byte
  identical** to those produced by `development` (`diff -r` over all six).
* `Tests/LinearSolvers/CellEB`, `make -j8 COMP=llvm USE_MPI=FALSE DIM=3` and `DIM=2`,
  seven configurations (`sphere`, `sphere` + `eb_is_dirichlet=1`, `rotated_box`,
  `two_spheres`, `flower`, two-level `sphere`, periodic `sphere`; `n_cell=64`,
  `verbose=2`): MLMG/BiCGStab residual histories and final residual norms are bitwise
  identical to `development`.
* CUDA build on an NVIDIA RTX A5000 (CUDA 13.2, gcc 11.4):
  `Tests/LinearSolvers/CellEB`, `make -j8 COMP=gnu USE_MPI=FALSE USE_CUDA=TRUE CUDA_ARCH=86 DIM=3`.
  MLMG iteration counts are identical to `development` (9, 12, 11, 3, 11, 28, 11); the
  residual values differ only at the level of the run-to-run nondeterminism of the
  *unmodified* binary (GPU reductions are not bit-reproducible).

* The same CellEB matrix was re-run on Linux/gcc 11.4 (`make -j8 COMP=gnu USE_MPI=FALSE`,
  `DIM=3` and `DIM=2`) against a `development` build in a sibling worktree: residual
  histories again **bitwise identical** in both dimensions.

### Performance

Neither timing changed measurably; this PR is a refactor, not an optimisation.

CPU, `Tests/LinearSolvers/CellEB` `main3d.gnu.TEST.ex`
(`make -j8 COMP=gnu USE_MPI=FALSE DIM=3`, gcc 11.4, single rank),
`inputs n_cell=128 eb2.geom_type=sphere eb_is_dirichlet=1 verbose=1`.
All binaries were built first and then timed **interleaved** in the same session
(3 reps each) on a shared machine, so the absolute numbers are inflated but the
comparison is fair. Best of 3, MLMG `Timers: Solve` [s]:

| grids | `development` | this PR |
| --- | --- | --- |
| `max_grid_size=32` | 4.284 | 4.325 |
| `max_grid_size=64` | 4.534 | 4.553 |

GPU (NVIDIA RTX A5000, CUDA 13.2,
`make -j8 COMP=gnu USE_MPI=FALSE USE_CUDA=TRUE CUDA_ARCH=86 DIM=3`), same test at
`n_cell=256`, again built up front and timed interleaved, best of 3:

| grids | `development` | this PR |
| --- | --- | --- |
| `max_grid_size=32` (512 boxes) | 1.085 | 1.083 |
| `max_grid_size=64` (64 boxes)  | 0.834 | 0.824 |

MLMG converged in the same number of iterations in every one of these runs.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate

P.S Generated using Claude Code 