### PR TITLE
GPU-fused MLEBABecLap Fapply and Fsmooth

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -163,17 +163,14 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
+void mlebabeclap_adotx (int i, int j, int k, int n, Array4<Real> const& y,
                         Array4<Real const> const& x, Array4<Real const> const& a,
                         Array4<Real const> const& bX, Array4<Real const> const& bY,
-                        Array4<const int> const& ccm, Array4<EBCellFlag const> const& flag,
-                        Array4<Real const> const& vfrc, Array4<Real const> const& apx,
-                        Array4<Real const> const& apy, Array4<Real const> const& fcx,
-                        Array4<Real const> const& fcy, Array4<Real const> const& ba,
-                        Array4<Real const> const& bc, Array4<Real const> const& beb,
+                        Array4<const int> const& ccm, EBData const& ebdata,
+                        Array4<Real const> const& beb,
                         bool is_dirichlet, Array4<Real const> const& phieb,
                         bool is_inhomog, GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                        Real alpha, Real beta, int ncomp,
+                        Real alpha, Real beta,
                         bool beta_on_centroid, bool phi_on_centroid) noexcept
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
@@ -184,120 +181,126 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
     bool beta_on_center = !(beta_on_centroid);
     bool  phi_on_center = !( phi_on_centroid);
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    auto const& flag = ebdata.get<EBData_t::cellflag>();
+    auto const& vfrc = ebdata.get<EBData_t::volfrac>();
+    auto const& apx  = ebdata.get<EBData_t::apx>();
+    auto const& apy  = ebdata.get<EBData_t::apy>();
+    auto const& fcx  = ebdata.get<EBData_t::fcx>();
+    auto const& fcy  = ebdata.get<EBData_t::fcy>();
+    auto const& ba   = ebdata.get<EBData_t::bndryarea>();
+    auto const& bc   = ebdata.get<EBData_t::bndrycent>();
+
+    if (flag(i,j,k).isCovered())
     {
-        if (flag(i,j,k).isCovered())
-        {
-            y(i,j,k,n) = Real(0.0);
+        y(i,j,k,n) = Real(0.0);
+    }
+    else if (flag(i,j,k).isRegular())
+    {
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+            - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                   - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+            - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                   - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)));
+    }
+    else
+    {
+        Real kappa = vfrc(i,j,k);
+        Real apxm = apx(i,j,k);
+        Real apxp = apx(i+1,j,k);
+        Real apym = apy(i,j,k);
+        Real apyp = apy(i,j+1,k);
+
+        Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
+        if (apxm != Real(0.0) && apxm != Real(1.0)) {
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i,j,k)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k)) : Real(0.0);
+            if (beta_on_center && phi_on_center) {
+               fxm = (Real(1.0)-fracy)*fxm + fracy*bX(i,jj,k,n)*(x(i,jj,k,n)-x(i-1,jj,k,n));
+            } else if (beta_on_centroid && phi_on_center) {
+               fxm = bX(i,j,k,n) * ( (Real(1.0)-fracy)*(x(i, j,k,n)-x(i-1, j,k,n))
+                                       + fracy  *(x(i,jj,k,n)-x(i-1,jj,k,n)) );
+            }
         }
-        else if (flag(i,j,k).isRegular())
-        {
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                       - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                       - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)));
+
+        Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
+        if (apxp != Real(0.0) && apxp != Real(1.0)) {
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k)));
+            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k)) : Real(0.0);
+            if (beta_on_center && phi_on_center) {
+                fxp = (Real(1.0)-fracy)*fxp + fracy*bX(i+1,jj,k,n)*(x(i+1,jj,k,n)-x(i,jj,k,n));
+            } else if (beta_on_centroid && phi_on_center) {
+                fxp = bX(i+1,j,k,n) * ( (Real(1.0)-fracy)*(x(i+1, j,k,n)-x(i, j,k,n))
+                                           + fracy *(x(i+1,jj,k,n)-x(i,jj,k,n)) );
+            }
         }
-        else
-        {
-            Real kappa = vfrc(i,j,k);
-            Real apxm = apx(i,j,k);
-            Real apxp = apx(i+1,j,k);
-            Real apym = apy(i,j,k);
-            Real apyp = apy(i,j+1,k);
 
-            Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
-            if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i,j,k)));
-                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k)) : Real(0.0);
-                if (beta_on_center && phi_on_center) {
-                   fxm = (Real(1.0)-fracy)*fxm + fracy*bX(i,jj,k,n)*(x(i,jj,k,n)-x(i-1,jj,k,n));
-                } else if (beta_on_centroid && phi_on_center) {
-                   fxm = bX(i,j,k,n) * ( (Real(1.0)-fracy)*(x(i, j,k,n)-x(i-1, j,k,n))
-                                           + fracy  *(x(i,jj,k,n)-x(i-1,jj,k,n)) );
-                }
+        Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
+        if (apym != Real(0.0) && apym != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k)) : Real(0.0);
+            if (beta_on_center && phi_on_center) {
+                fym = (Real(1.0)-fracx)*fym + fracx*bY(ii,j,k,n)*(x(ii,j,k,n)-x(ii,j-1,k,n));
+            } else if (beta_on_centroid && phi_on_center) {
+                fym = bY(i,j,k,n) * ( (Real(1.0)-fracx)*(x( i,j,k,n)-x( i,j-1,k,n))
+                                         + fracx *(x(ii,j,k,n)-x(ii,j-1,k,n)) );
             }
-
-            Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
-            if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k)));
-                Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k)) : Real(0.0);
-                if (beta_on_center && phi_on_center) {
-                    fxp = (Real(1.0)-fracy)*fxp + fracy*bX(i+1,jj,k,n)*(x(i+1,jj,k,n)-x(i,jj,k,n));
-                } else if (beta_on_centroid && phi_on_center) {
-                    fxp = bX(i+1,j,k,n) * ( (Real(1.0)-fracy)*(x(i+1, j,k,n)-x(i, j,k,n))
-                                               + fracy *(x(i+1,jj,k,n)-x(i,jj,k,n)) );
-                }
-            }
-
-            Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
-            if (apym != Real(0.0) && apym != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k)));
-                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k)) : Real(0.0);
-                if (beta_on_center && phi_on_center) {
-                    fym = (Real(1.0)-fracx)*fym + fracx*bY(ii,j,k,n)*(x(ii,j,k,n)-x(ii,j-1,k,n));
-                } else if (beta_on_centroid && phi_on_center) {
-                    fym = bY(i,j,k,n) * ( (Real(1.0)-fracx)*(x( i,j,k,n)-x( i,j-1,k,n))
-                                             + fracx *(x(ii,j,k,n)-x(ii,j-1,k,n)) );
-                }
-            }
-
-            Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
-            if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k)));
-                Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k)) : Real(0.0);
-                if (beta_on_center && phi_on_center) {
-                    fyp = (Real(1.0)-fracx)*fyp + fracx*bY(ii,j+1,k,n)*(x(ii,j+1,k,n)-x(ii,j,k,n));
-                } else if (beta_on_centroid && phi_on_center) {
-                    fyp = bY(i,j+1,k,n) * ( (Real(1.0)-fracx)*(x( i,j+1,k,n)-x( i,j,k,n))
-                                               + fracx *(x(ii,j+1,k,n)-x(ii,j,k,n)) );
-                }
-            }
-
-            Real feb = Real(0.0);
-            if (is_dirichlet) {
-                Real dapx = (apxm-apxp)/dxinv[1];
-                Real dapy = (apym-apyp)/dxinv[0];
-                Real anorm = std::hypot(dapx,dapy);
-                Real anorminv = Real(1.0)/anorm;
-                Real anrmx = dapx * anorminv;
-                Real anrmy = dapy * anorminv;
-
-                Real phib = is_inhomog ? phieb(i,j,k,n) : Real(0.0);
-
-                Real bctx = bc(i,j,k,0);
-                Real bcty = bc(i,j,k,1);
-                Real dx_eb = get_dx_eb(kappa);
-
-                Real dg, gx, gy, sx, sy;
-                if (std::abs(anrmx) > std::abs(anrmy)) {
-                    dg = dx_eb / std::abs(anrmx);
-                } else {
-                    dg = dx_eb / std::abs(anrmy);
-                }
-                gx = (bctx - dg*anrmx);
-                gy = (bcty - dg*anrmy);
-                sx = std::copysign(Real(1.0),anrmx);
-                sy = std::copysign(Real(1.0),anrmy);
-
-                int ii = i - static_cast<int>(sx);
-                int jj = j - static_cast<int>(sy);
-
-                Real phig = (Real(1.0) + gx*sx + gy*sy + gx*gy*sx*sy) * x(i ,j ,k,n)
-                    +       (    - gx*sx         - gx*gy*sx*sy) * x(ii,j ,k,n)
-                    +       (            - gy*sy - gx*gy*sx*sy) * x(i ,jj,k,n)
-                    +       (                    + gx*gy*sx*sy) * x(ii,jj,k,n) ;
-
-                Real dphidn = (phib-phig) / dg;
-
-                feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
-            }
-
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
-                (dhx*(apxm*fxm-apxp*fxp) +
-                 dhy*(apym*fym-apyp*fyp) - dh*feb);
         }
-    });
+
+        Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
+        if (apyp != Real(0.0) && apyp != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k)) : Real(0.0);
+            if (beta_on_center && phi_on_center) {
+                fyp = (Real(1.0)-fracx)*fyp + fracx*bY(ii,j+1,k,n)*(x(ii,j+1,k,n)-x(ii,j,k,n));
+            } else if (beta_on_centroid && phi_on_center) {
+                fyp = bY(i,j+1,k,n) * ( (Real(1.0)-fracx)*(x( i,j+1,k,n)-x( i,j,k,n))
+                                           + fracx *(x(ii,j+1,k,n)-x(ii,j,k,n)) );
+            }
+        }
+
+        Real feb = Real(0.0);
+        if (is_dirichlet) {
+            Real dapx = (apxm-apxp)/dxinv[1];
+            Real dapy = (apym-apyp)/dxinv[0];
+            Real anorm = std::hypot(dapx,dapy);
+            Real anorminv = Real(1.0)/anorm;
+            Real anrmx = dapx * anorminv;
+            Real anrmy = dapy * anorminv;
+
+            Real phib = is_inhomog ? phieb(i,j,k,n) : Real(0.0);
+
+            Real bctx = bc(i,j,k,0);
+            Real bcty = bc(i,j,k,1);
+            Real dx_eb = get_dx_eb(kappa);
+
+            Real dg, gx, gy, sx, sy;
+            if (std::abs(anrmx) > std::abs(anrmy)) {
+                dg = dx_eb / std::abs(anrmx);
+            } else {
+                dg = dx_eb / std::abs(anrmy);
+            }
+            gx = (bctx - dg*anrmx);
+            gy = (bcty - dg*anrmy);
+            sx = std::copysign(Real(1.0),anrmx);
+            sy = std::copysign(Real(1.0),anrmy);
+
+            int ii = i - static_cast<int>(sx);
+            int jj = j - static_cast<int>(sy);
+
+            Real phig = (Real(1.0) + gx*sx + gy*sy + gx*gy*sx*sy) * x(i ,j ,k,n)
+                +       (    - gx*sx         - gx*gy*sx*sy) * x(ii,j ,k,n)
+                +       (            - gy*sy - gx*gy*sx*sy) * x(i ,jj,k,n)
+                +       (                    + gx*gy*sx*sy) * x(ii,jj,k,n) ;
+
+            Real dphidn = (phib-phig) / dg;
+
+            feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
+        }
+
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
+            (dhx*(apxm*fxm-apxp*fxp) +
+             dhy*(apym*fym-apyp*fyp) - dh*feb);
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -368,7 +368,7 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_gsrb (Box const& box,
+void mlebabeclap_gsrb (int i, int j, int k, int n,
                        Array4<Real> const& phi, Array4<Real const> const& rhs,
                        Real alpha, Array4<Real const> const& a,
                        Real dhx, Real dhy, Real dh,
@@ -381,206 +381,203 @@ void mlebabeclap_gsrb (Box const& box,
                        Array4<const int> const& ccm, Array4<Real const> const& beb,
                        EBData const& ebdata,
                        bool is_dirichlet, bool beta_on_centroid, bool phi_on_centroid,
-                       Box const& vbox, int redblack, int ncomp) noexcept
+                       Box const& vbox, int redblack) noexcept
 {
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    if ((i+j+k+redblack) % 2 == 0)
     {
-        if ((i+j+k+redblack) % 2 == 0)
+        auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
+        if (flag.isCovered())
         {
-            auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
-            if (flag.isCovered())
+            phi(i,j,k,n) = Real(0.0);
+        }
+        else
+        {
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
+                ? f0(vlo.x,j,k,n) : Real(0.0);
+            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
+                ? f1(i,vlo.y,k,n) : Real(0.0);
+            Real cf2 = (i == vhi.x && m2(vhi.x+1,j,k) > 0)
+                ? f2(vhi.x,j,k,n) : Real(0.0);
+            Real cf3 = (j == vhi.y && m3(i,vhi.y+1,k) > 0)
+                ? f3(i,vhi.y,k,n) : Real(0.0);
+
+            if (flag.isRegular())
             {
-                phi(i,j,k,n) = Real(0.0);
+                Real gamma = alpha*a(i,j,k)
+                    + dhx * (bX(i+1,j,k,n) + bX(i,j,k,n))
+                    + dhy * (bY(i,j+1,k,n) + bY(i,j,k,n));
+
+                Real rho =  dhx * (bX(i+1,j,k,n)*phi(i+1,j,k,n)
+                                 + bX(i  ,j,k,n)*phi(i-1,j,k,n))
+                          + dhy * (bY(i,j+1,k,n)*phi(i,j+1,k,n)
+                                 + bY(i,j  ,k,n)*phi(i,j-1,k,n));
+
+                Real delta = dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf2)
+                    +        dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf3);
+
+                Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+                phi(i,j,k,n) += res/(gamma-delta);
             }
             else
             {
-                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                    ? f0(vlo.x,j,k,n) : Real(0.0);
-                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                    ? f1(i,vlo.y,k,n) : Real(0.0);
-                Real cf2 = (i == vhi.x && m2(vhi.x+1,j,k) > 0)
-                    ? f2(vhi.x,j,k,n) : Real(0.0);
-                Real cf3 = (j == vhi.y && m3(i,vhi.y+1,k) > 0)
-                    ? f3(i,vhi.y,k,n) : Real(0.0);
+                Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
+                Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k);
+                Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k);
+                Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k);
+                Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k);
 
-                if (flag.isRegular())
-                {
-                    Real gamma = alpha*a(i,j,k)
-                        + dhx * (bX(i+1,j,k,n) + bX(i,j,k,n))
-                        + dhy * (bY(i,j+1,k,n) + bY(i,j,k,n));
-
-                    Real rho =  dhx * (bX(i+1,j,k,n)*phi(i+1,j,k,n)
-                                     + bX(i  ,j,k,n)*phi(i-1,j,k,n))
-                              + dhy * (bY(i,j+1,k,n)*phi(i,j+1,k,n)
-                                     + bY(i,j  ,k,n)*phi(i,j-1,k,n));
-
-                    Real delta = dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf2)
-                        +        dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf3);
-
-                    Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                    phi(i,j,k,n) += res/(gamma-delta);
+                Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
+                Real oxm = -bX(i,j,k,n)*cf0;
+                Real sxm =  bX(i,j,k,n);
+                if (apxm != Real(0.0) && apxm != Real(1.0)) {
+                    Real fcx = ebdata.get<EBData_t::fcx>(i,j,k);
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
+                    Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxm = (Real(1.0)-fracy)*fxm +
+                                   fracy *bX(i,jj,k,n)*(phi(i,jj,k,n)-phi(i-1,jj,k,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxm = (Real(1.0)-fracy)*(             -phi(i-1,j,k,n)) +
+                                   fracy *(phi(i,jj,k,n)-phi(i-1,jj,k,n));
+                        fxm *= bX(i,j,k,n);
+                    }
+                    oxm = Real(0.0);
+                    sxm = (Real(1.0)-fracy)*sxm;
                 }
-                else
-                {
-                    Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
-                    Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k);
-                    Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k);
-                    Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k);
-                    Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k);
 
-                    Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
-                    Real oxm = -bX(i,j,k,n)*cf0;
-                    Real sxm =  bX(i,j,k,n);
-                    if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                        Real fcx = ebdata.get<EBData_t::fcx>(i,j,k);
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
-                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxm = (Real(1.0)-fracy)*fxm +
-                                       fracy *bX(i,jj,k,n)*(phi(i,jj,k,n)-phi(i-1,jj,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxm = (Real(1.0)-fracy)*(             -phi(i-1,j,k,n)) +
-                                       fracy *(phi(i,jj,k,n)-phi(i-1,jj,k,n));
-                            fxm *= bX(i,j,k,n);
-                        }
-                        oxm = Real(0.0);
-                        sxm = (Real(1.0)-fracy)*sxm;
+                Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
+                Real oxp =  bX(i+1,j,k,n)*cf2;
+                Real sxp = -bX(i+1,j,k,n);
+                if (apxp != Real(0.0) && apxp != Real(1.0)) {
+                    Real fcx = ebdata.get<EBData_t::fcx>(i+1,j,k);
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
+                    Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxp = (Real(1.0)-fracy)*fxp +
+                                   fracy *bX(i+1,jj,k,n)*(phi(i+1,jj,k,n)-phi(i,jj,k,n));
                     }
-
-                    Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
-                    Real oxp =  bX(i+1,j,k,n)*cf2;
-                    Real sxp = -bX(i+1,j,k,n);
-                    if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                        Real fcx = ebdata.get<EBData_t::fcx>(i+1,j,k);
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx));
-                        Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxp = (Real(1.0)-fracy)*fxp +
-                                       fracy *bX(i+1,jj,k,n)*(phi(i+1,jj,k,n)-phi(i,jj,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxp = (Real(1.0)-fracy)*(phi(i+1,j,k,n)               ) +
-                                       fracy *(phi(i+1,jj,k,n)-phi(i,jj,k,n));
-                            fxp *= bX(i+1,j,k,n);
-                        }
-                        oxp = Real(0.0);
-                        sxp = (Real(1.0)-fracy)*sxp;
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxp = (Real(1.0)-fracy)*(phi(i+1,j,k,n)               ) +
+                                   fracy *(phi(i+1,jj,k,n)-phi(i,jj,k,n));
+                        fxp *= bX(i+1,j,k,n);
                     }
-
-                    Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
-                    Real oym = -bY(i,j,k,n)*cf1;
-                    Real sym =  bY(i,j,k,n);
-                    if (apym != Real(0.0) && apym != Real(1.0)) {
-                        Real fcy = ebdata.get<EBData_t::fcy>(i,j,k);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
-                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fym = (Real(1.0)-fracx)*fym +
-                                       fracx *bY(ii,j,k,n)*(phi(ii,j,k,n)-phi(ii,j-1,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fym = (Real(1.0)-fracx)*(             -phi( i,j-1,k,n)) +
-                                       fracx *(phi(ii,j,k,n)-phi(ii,j-1,k,n));
-                            fym *= bY(i,j,k,n);
-                        }
-
-                        oym = Real(0.0);
-                        sym = (Real(1.0)-fracx)*sym;
-                    }
-
-                    Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
-                    Real oyp =  bY(i,j+1,k,n)*cf3;
-                    Real syp = -bY(i,j+1,k,n);
-                    if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                        Real fcy = ebdata.get<EBData_t::fcy>(i,j+1,k);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
-                        Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fyp = (Real(1.0)-fracx)*fyp +
-                                       fracx*bY(ii,j+1,k,n)*(phi(ii,j+1,k,n)-phi(ii,j,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fyp = (Real(1.0)-fracx)*(phi(i,j+1,k,n)               )+
-                                       fracx *(phi(ii,j+1,k,n)-phi(ii,j,k,n));
-                            fyp *= bY(i,j+1,k,n);
-                        }
-                        oyp = Real(0.0);
-                        syp = (Real(1.0)-fracx)*syp;
-                    }
-
-                    Real vfrcinv = (Real(1.0)/kappa);
-                    Real gamma = alpha*a(i,j,k) + vfrcinv *
-                        (dhx*(apxm*sxm-apxp*sxp) +
-                         dhy*(apym*sym-apyp*syp));
-                    Real rho = -vfrcinv *
-                        (dhx*(apxm*fxm-apxp*fxp) +
-                         dhy*(apym*fym-apyp*fyp));
-
-                    Real delta = -vfrcinv *
-                        (dhx*(apxm*oxm-apxp*oxp) +
-                         dhy*(apym*oym-apyp*oyp));
-
-                    if (is_dirichlet) {
-                        Real dapx = (apxm-apxp)*dx[1];
-                        Real dapy = (apym-apyp)*dx[0];
-                        Real anorm = std::hypot(dapx,dapy);
-                        Real anorminv = Real(1.0)/anorm;
-                        Real anrmx = dapx * anorminv;
-                        Real anrmy = dapy * anorminv;
-
-                        Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
-                        Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
-                        Real dx_eb = get_dx_eb(kappa);
-
-                        Real dg, gx, gy, sx, sy;
-                        if (std::abs(anrmx) > std::abs(anrmy)) {
-                            dg = dx_eb / std::abs(anrmx);
-                        } else {
-                            dg = dx_eb / std::abs(anrmy);
-                        }
-                        gx = bctx - dg*anrmx;
-                        gy = bcty - dg*anrmy;
-                        sx = std::copysign(Real(1.0),anrmx);
-                        sy = std::copysign(Real(1.0),anrmy);
-
-                        int ii = i - static_cast<int>(sx);
-                        int jj = j - static_cast<int>(sy);
-
-                        Real phig_gamma = (Real(1.0) + gx*sx + gy*sy + gx*gy*sx*sy);
-                        Real phig = (    - gx*sx         - gx*gy*sx*sy) * phi(ii,j ,k,n)
-                            +       (            - gy*sy - gx*gy*sx*sy) * phi(i ,jj,k,n)
-                            +       (                    + gx*gy*sx*sy) * phi(ii,jj,k,n);
-
-                        // In gsrb we are always in residual-correction form so phib = 0
-                        Real dphidn =  (    -phig)/dg;
-
-                        Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
-
-                        Real feb = dphidn * ba * beb(i,j,k,n);
-                        rho += -vfrcinv*(-dh)*feb;
-
-                        Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
-                        gamma += vfrcinv*(-dh)*feb_gamma;
-                    }
-
-                    Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                    phi(i,j,k,n) += res/(gamma-delta);
+                    oxp = Real(0.0);
+                    sxp = (Real(1.0)-fracy)*sxp;
                 }
+
+                Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
+                Real oym = -bY(i,j,k,n)*cf1;
+                Real sym =  bY(i,j,k,n);
+                if (apym != Real(0.0) && apym != Real(1.0)) {
+                    Real fcy = ebdata.get<EBData_t::fcy>(i,j,k);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
+                    Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fym = (Real(1.0)-fracx)*fym +
+                                   fracx *bY(ii,j,k,n)*(phi(ii,j,k,n)-phi(ii,j-1,k,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fym = (Real(1.0)-fracx)*(             -phi( i,j-1,k,n)) +
+                                   fracx *(phi(ii,j,k,n)-phi(ii,j-1,k,n));
+                        fym *= bY(i,j,k,n);
+                    }
+
+                    oym = Real(0.0);
+                    sym = (Real(1.0)-fracx)*sym;
+                }
+
+                Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
+                Real oyp =  bY(i,j+1,k,n)*cf3;
+                Real syp = -bY(i,j+1,k,n);
+                if (apyp != Real(0.0) && apyp != Real(1.0)) {
+                    Real fcy = ebdata.get<EBData_t::fcy>(i,j+1,k);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy));
+                    Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fyp = (Real(1.0)-fracx)*fyp +
+                                   fracx*bY(ii,j+1,k,n)*(phi(ii,j+1,k,n)-phi(ii,j,k,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fyp = (Real(1.0)-fracx)*(phi(i,j+1,k,n)               )+
+                                   fracx *(phi(ii,j+1,k,n)-phi(ii,j,k,n));
+                        fyp *= bY(i,j+1,k,n);
+                    }
+                    oyp = Real(0.0);
+                    syp = (Real(1.0)-fracx)*syp;
+                }
+
+                Real vfrcinv = (Real(1.0)/kappa);
+                Real gamma = alpha*a(i,j,k) + vfrcinv *
+                    (dhx*(apxm*sxm-apxp*sxp) +
+                     dhy*(apym*sym-apyp*syp));
+                Real rho = -vfrcinv *
+                    (dhx*(apxm*fxm-apxp*fxp) +
+                     dhy*(apym*fym-apyp*fyp));
+
+                Real delta = -vfrcinv *
+                    (dhx*(apxm*oxm-apxp*oxp) +
+                     dhy*(apym*oym-apyp*oyp));
+
+                if (is_dirichlet) {
+                    Real dapx = (apxm-apxp)*dx[1];
+                    Real dapy = (apym-apyp)*dx[0];
+                    Real anorm = std::hypot(dapx,dapy);
+                    Real anorminv = Real(1.0)/anorm;
+                    Real anrmx = dapx * anorminv;
+                    Real anrmy = dapy * anorminv;
+
+                    Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
+                    Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
+                    Real dx_eb = get_dx_eb(kappa);
+
+                    Real dg, gx, gy, sx, sy;
+                    if (std::abs(anrmx) > std::abs(anrmy)) {
+                        dg = dx_eb / std::abs(anrmx);
+                    } else {
+                        dg = dx_eb / std::abs(anrmy);
+                    }
+                    gx = bctx - dg*anrmx;
+                    gy = bcty - dg*anrmy;
+                    sx = std::copysign(Real(1.0),anrmx);
+                    sy = std::copysign(Real(1.0),anrmy);
+
+                    int ii = i - static_cast<int>(sx);
+                    int jj = j - static_cast<int>(sy);
+
+                    Real phig_gamma = (Real(1.0) + gx*sx + gy*sy + gx*gy*sx*sy);
+                    Real phig = (    - gx*sx         - gx*gy*sx*sy) * phi(ii,j ,k,n)
+                        +       (            - gy*sy - gx*gy*sx*sy) * phi(i ,jj,k,n)
+                        +       (                    + gx*gy*sx*sy) * phi(ii,jj,k,n);
+
+                    // In gsrb we are always in residual-correction form so phib = 0
+                    Real dphidn =  (    -phig)/dg;
+
+                    Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
+
+                    Real feb = dphidn * ba * beb(i,j,k,n);
+                    rho += -vfrcinv*(-dh)*feb;
+
+                    Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
+                    gamma += vfrcinv*(-dh)*feb_gamma;
+                }
+
+                Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+                phi(i,j,k,n) += res/(gamma-delta);
             }
         }
-    });
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_2D_K.H
@@ -8,158 +8,161 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
+void mlebabeclap_adotx_centroid (int i, int j, int k, int n, Array4<Real> const& y,
                         Array4<Real const> const& x, Array4<Real const> const& a,
                         Array4<Real const> const& bX, Array4<Real const> const& bY,
-                        Array4<EBCellFlag const> const& flag,
-                        Array4<Real const> const& vfrc,
-                        Array4<Real const> const& apx, Array4<Real const> const& apy,
-                        Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                        Array4<Real const> const& ccent, Array4<Real const> const& ba,
-                        Array4<Real const> const& bcent, Array4<Real const> const& beb,
+                        EBData const& ebdata,
+                        Array4<Real const> const& beb,
                         Array4<Real const> const& phieb,
                         const int& domlo_x,    const int& domlo_y,
                         const int& domhi_x,    const int& domhi_y,
                         const bool& on_x_face, const bool& on_y_face,
                         bool is_eb_dirichlet, bool is_eb_inhomog,
                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                        Real alpha, Real beta, int ncomp) noexcept
+                        Real alpha, Real beta) noexcept
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
     Real dhy = beta*dxinv[1]*dxinv[1];
     Real dh  = beta*dxinv[0]*dxinv[1];
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    auto const& flag  = ebdata.get<EBData_t::cellflag>();
+    auto const& vfrc  = ebdata.get<EBData_t::volfrac>();
+    auto const& apx   = ebdata.get<EBData_t::apx>();
+    auto const& apy   = ebdata.get<EBData_t::apy>();
+    auto const& fcx   = ebdata.get<EBData_t::fcx>();
+    auto const& fcy   = ebdata.get<EBData_t::fcy>();
+    auto const& ccent = ebdata.get<EBData_t::centroid>();
+    auto const& ba    = ebdata.get<EBData_t::bndryarea>();
+    auto const& bcent = ebdata.get<EBData_t::bndrycent>();
+
+    if (flag(i,j,k).isCovered())
     {
-        if (flag(i,j,k).isCovered())
+        y(i,j,k,n) = Real(0.0);
+    }
+    else if (flag(i,j,k).isRegular() &&
+            ((flag(i-1,j  ,k).isRegular() && flag(i+1,j  ,k).isRegular() &&
+             flag(i  ,j-1,k).isRegular() && flag(i  ,j+1,k).isRegular()) ))
+    {
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+            - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                   - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+            - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                   - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)));
+
+
+    }
+    else
+    {
+        Real kappa = vfrc(i,j,k);
+        Real apxm = apx(i,j,k);
+        Real apxp = apx(i+1,j,k);
+        Real apym = apy(i,j,k);
+        Real apyp = apy(i,j+1,k);
+
+        // First get EB-aware slope that doesn't know about extdir
+        bool needs_bdry_stencil = (i <= domlo_x) || (i >= domhi_x) ||
+                                  (j <= domlo_y) || (j >= domhi_y);
+
+        // if phi_on_centroid -- A second order least squares fit is used
+        // to approximate the slope on the high and low faces. Note that if
+        // any of the three cells --e.g., (i-1,j), (i,j), or (i-1,j)-- are
+        // cut, then the least squares fit is needed. This is a bit more than
+        // is actually needed for most cases but it will return the correct
+        // value in all cases.
+
+        Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
+        if ( (apxm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0)) )
         {
-            y(i,j,k,n) = Real(0.0);
+            Real yloc_on_xface = fcx(i,j,k);
+
+            if(needs_bdry_stencil) {
+
+              fxm = grad_x_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      yloc_on_xface,is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face, domlo_x, domhi_x,
+                                                      on_y_face, domlo_y, domhi_y);
+
+            } else {
+              fxm = grad_x_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                               yloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
+            }
+            fxm *= bX(i,j,k,n);
         }
-        else if (flag(i,j,k).isRegular() &&
-                ((flag(i-1,j  ,k).isRegular() && flag(i+1,j  ,k).isRegular() &&
-                 flag(i  ,j-1,k).isRegular() && flag(i  ,j+1,k).isRegular()) ))
+
+        Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
+        if ( (apxp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0)) ) {
+            Real yloc_on_xface = fcx(i+1,j,k,0);
+            if(needs_bdry_stencil) {
+              fxp = grad_x_of_phi_on_centroids_extdir(i+1,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      yloc_on_xface,is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face, domlo_x, domhi_x,
+                                                      on_y_face, domlo_y, domhi_y);
+
+            } else {
+              fxp = grad_x_of_phi_on_centroids(i+1,j,k,n,x,phieb,flag,ccent,bcent,
+                                               yloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
+            }
+            fxp *= bX(i+1,j,k,n);
+
+        }
+
+        Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
+        if ( (apym != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0)) ) {
+            Real xloc_on_yface = fcy(i,j,k,0);
+
+            if(needs_bdry_stencil) {
+
+              fym = grad_y_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_yface,is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face, domlo_x, domhi_x,
+                                                      on_y_face, domlo_y, domhi_y);
+
+            } else {
+              fym = grad_y_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                               xloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
+            }
+            fym *= bY(i,j,k,n);
+        }
+
+        Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
+        if ( (apyp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0)) ) {
+            Real xloc_on_yface = fcy(i,j+1,k,0);
+            if(needs_bdry_stencil) {
+              fyp = grad_y_of_phi_on_centroids_extdir(i,j+1,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_yface,is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face, domlo_x, domhi_x,
+                                                      on_y_face, domlo_y, domhi_y);
+
+            } else {
+              fyp = grad_y_of_phi_on_centroids(i,j+1,k,n,x,phieb,flag,ccent,bcent,
+                                               xloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
+            }
+            fyp *= bY(i,j+1,k,n);
+        }
+
+        Real feb = Real(0.0);
+        if (is_eb_dirichlet && flag(i,j,k).isSingleValued())
         {
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                       - bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                       - bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)));
+            Real dapx = (apxm-apxp)/dxinv[1];
+            Real dapy = (apym-apyp)/dxinv[0];
+            Real anorm = std::hypot(dapx,dapy);
+            Real anorminv = Real(1.0)/anorm;
+            Real anrmx = dapx * anorminv;
+            Real anrmy = dapy * anorminv;
 
 
+            feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                     anrmx,anrmy,is_eb_inhomog,
+                                                     on_x_face, domlo_x, domhi_x,
+                                                     on_y_face, domlo_y, domhi_y);
+
+            feb *= ba(i,j,k) * beb(i,j,k,n);
         }
-        else
-        {
-            Real kappa = vfrc(i,j,k);
-            Real apxm = apx(i,j,k);
-            Real apxp = apx(i+1,j,k);
-            Real apym = apy(i,j,k);
-            Real apyp = apy(i,j+1,k);
-
-            // First get EB-aware slope that doesn't know about extdir
-            bool needs_bdry_stencil = (i <= domlo_x) || (i >= domhi_x) ||
-                                      (j <= domlo_y) || (j >= domhi_y);
-
-            // if phi_on_centroid -- A second order least squares fit is used
-            // to approximate the slope on the high and low faces. Note that if
-            // any of the three cells --e.g., (i-1,j), (i,j), or (i-1,j)-- are
-            // cut, then the least squares fit is needed. This is a bit more than
-            // is actually needed for most cases but it will return the correct
-            // value in all cases.
-
-            Real fxm = bX(i,j,k,n) * (x(i,j,k,n)-x(i-1,j,k,n));
-            if ( (apxm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0)) )
-            {
-                Real yloc_on_xface = fcx(i,j,k);
-
-                if(needs_bdry_stencil) {
-
-                  fxm = grad_x_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          yloc_on_xface,is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face, domlo_x, domhi_x,
-                                                          on_y_face, domlo_y, domhi_y);
-
-                } else {
-                  fxm = grad_x_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                   yloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
-                }
-                fxm *= bX(i,j,k,n);
-            }
-
-            Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n)-x(i,j,k,n));
-            if ( (apxp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0)) ) {
-                Real yloc_on_xface = fcx(i+1,j,k,0);
-                if(needs_bdry_stencil) {
-                  fxp = grad_x_of_phi_on_centroids_extdir(i+1,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          yloc_on_xface,is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face, domlo_x, domhi_x,
-                                                          on_y_face, domlo_y, domhi_y);
-
-                } else {
-                  fxp = grad_x_of_phi_on_centroids(i+1,j,k,n,x,phieb,flag,ccent,bcent,
-                                                   yloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
-                }
-                fxp *= bX(i+1,j,k,n);
-
-            }
-
-            Real fym = bY(i,j,k,n)*(x(i,j,k,n)-x(i,j-1,k,n));
-            if ( (apym != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0)) ) {
-                Real xloc_on_yface = fcy(i,j,k,0);
-
-                if(needs_bdry_stencil) {
-
-                  fym = grad_y_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_yface,is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face, domlo_x, domhi_x,
-                                                          on_y_face, domlo_y, domhi_y);
-
-                } else {
-                  fym = grad_y_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                   xloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
-                }
-                fym *= bY(i,j,k,n);
-            }
-
-            Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n)-x(i,j,k,n));
-            if ( (apyp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0)) ) {
-                Real xloc_on_yface = fcy(i,j+1,k,0);
-                if(needs_bdry_stencil) {
-                  fyp = grad_y_of_phi_on_centroids_extdir(i,j+1,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_yface,is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face, domlo_x, domhi_x,
-                                                          on_y_face, domlo_y, domhi_y);
-
-                } else {
-                  fyp = grad_y_of_phi_on_centroids(i,j+1,k,n,x,phieb,flag,ccent,bcent,
-                                                   xloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
-                }
-                fyp *= bY(i,j+1,k,n);
-            }
-
-            Real feb = Real(0.0);
-            if (is_eb_dirichlet && flag(i,j,k).isSingleValued())
-            {
-                Real dapx = (apxm-apxp)/dxinv[1];
-                Real dapy = (apym-apyp)/dxinv[0];
-                Real anorm = std::hypot(dapx,dapy);
-                Real anorminv = Real(1.0)/anorm;
-                Real anrmx = dapx * anorminv;
-                Real anrmy = dapy * anorminv;
 
 
-                feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                         anrmx,anrmy,is_eb_inhomog,
-                                                         on_x_face, domlo_x, domhi_x,
-                                                         on_y_face, domlo_y, domhi_y);
-
-                feb *= ba(i,j,k) * beb(i,j,k,n);
-            }
-
-
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
-                (dhx*(apxm*fxm-apxp*fxp) + dhy*(apym*fym-apyp*fyp) - dh*feb);
-        }
-    });
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
+            (dhx*(apxm*fxm-apxp*fxp) + dhy*(apym*fym-apyp*fyp) - dh*feb);
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -8,208 +8,212 @@
 namespace amrex {
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
+void mlebabeclap_adotx_centroid (int i, int j, int k, int n, Array4<Real> const& y,
                         Array4<Real const> const& x, Array4<Real const> const& a,
                         Array4<Real const> const& bX, Array4<Real const> const& bY,
                         Array4<Real const> const& bZ,
-                        Array4<EBCellFlag const> const& flag,
-                        Array4<Real const> const& vfrc, Array4<Real const> const& apx,
-                        Array4<Real const> const& apy, Array4<Real const> const& apz,
-                        Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                        Array4<Real const> const& fcz,
-                        Array4<Real const> const& ccent, Array4<Real const> const& ba,
-                        Array4<Real const> const& bcent, Array4<Real const> const& beb,
+                        EBData const& ebdata,
+                        Array4<Real const> const& beb,
                         Array4<Real const> const& phieb,
                         const int& domlo_x, const int& domlo_y, const int& domlo_z,
                         const int& domhi_x, const int& domhi_y, const int& domhi_z,
                         const bool& on_x_face, const bool& on_y_face, const bool& on_z_face,
                         bool is_eb_dirichlet, bool is_eb_inhomog,
                         GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                        Real alpha, Real beta, int ncomp) noexcept
+                        Real alpha, Real beta) noexcept
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
     Real dhy = beta*dxinv[1]*dxinv[1];
     Real dhz = beta*dxinv[2]*dxinv[2];
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    auto const& flag  = ebdata.get<EBData_t::cellflag>();
+    auto const& vfrc  = ebdata.get<EBData_t::volfrac>();
+    auto const& apx   = ebdata.get<EBData_t::apx>();
+    auto const& apy   = ebdata.get<EBData_t::apy>();
+    auto const& apz   = ebdata.get<EBData_t::apz>();
+    auto const& fcx   = ebdata.get<EBData_t::fcx>();
+    auto const& fcy   = ebdata.get<EBData_t::fcy>();
+    auto const& fcz   = ebdata.get<EBData_t::fcz>();
+    auto const& ccent = ebdata.get<EBData_t::centroid>();
+    auto const& ba    = ebdata.get<EBData_t::bndryarea>();
+    auto const& bcent = ebdata.get<EBData_t::bndrycent>();
+
+    if (flag(i,j,k).isCovered())
     {
-        if (flag(i,j,k).isCovered())
-        {
-            y(i,j,k,n) = Real(0.0);
+        y(i,j,k,n) = Real(0.0);
+    }
+    else if (flag(i,j,k).isRegular() &&
+             ((flag(i-1,j  ,k  ).isRegular() && flag(i+1,j  ,k  ).isRegular() &&
+              flag(i  ,j-1,k  ).isRegular() && flag(i  ,j+1,k  ).isRegular() &&
+              flag(i  ,j  ,k-1).isRegular() && flag(i  ,j  ,k+1).isRegular()) ))
+    {
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+            - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                    -bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+            - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                    -bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
+            - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
+                    -bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
+    }
+    else
+    {
+        Real kappa = vfrc(i,j,k);
+        Real apxm = apx(i,j,k);
+        Real apxp = apx(i+1,j,k);
+        Real apym = apy(i,j,k);
+        Real apyp = apy(i,j+1,k);
+        Real apzm = apz(i,j,k);
+        Real apzp = apz(i,j,k+1);
+
+        // First get EB-aware slope that doesn't know about extdir
+        bool needs_bdry_stencil = (i <= domlo_x) || (i >= domhi_x) ||
+                                  (j <= domlo_y) || (j >= domhi_y) ||
+                                  (k <= domlo_z) || (k >= domhi_z);
+
+        Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
+        if ( (apxm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0)) ) {
+            Real yloc_on_xface = fcx(i,j,k,0);
+            Real zloc_on_xface = fcx(i,j,k,1);
+
+            if(needs_bdry_stencil) {
+              fxm = grad_x_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      yloc_on_xface,zloc_on_xface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fxm = grad_x_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                             yloc_on_xface,zloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fxm *= bX(i,j,k,n);
         }
-        else if (flag(i,j,k).isRegular() &&
-                 ((flag(i-1,j  ,k  ).isRegular() && flag(i+1,j  ,k  ).isRegular() &&
-                  flag(i  ,j-1,k  ).isRegular() && flag(i  ,j+1,k  ).isRegular() &&
-                  flag(i  ,j  ,k-1).isRegular() && flag(i  ,j  ,k+1).isRegular()) ))
-        {
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                        -bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                        -bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
-                - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
-                        -bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
+
+        Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
+        if ( (apxp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0)) ) {
+            Real yloc_on_xface = fcx(i+1,j,k,0);
+            Real zloc_on_xface = fcx(i+1,j,k,1);
+
+            if(needs_bdry_stencil) {
+              fxp = grad_x_of_phi_on_centroids_extdir(i+1,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      yloc_on_xface,zloc_on_xface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fxp = grad_x_of_phi_on_centroids(i+1,j,k,n,x,phieb,flag,ccent,bcent,
+                                             yloc_on_xface,zloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fxp *= bX(i+1,j,k,n);
         }
-        else
-        {
-            Real kappa = vfrc(i,j,k);
-            Real apxm = apx(i,j,k);
-            Real apxp = apx(i+1,j,k);
-            Real apym = apy(i,j,k);
-            Real apyp = apy(i,j+1,k);
-            Real apzm = apz(i,j,k);
-            Real apzp = apz(i,j,k+1);
 
-            // First get EB-aware slope that doesn't know about extdir
-            bool needs_bdry_stencil = (i <= domlo_x) || (i >= domhi_x) ||
-                                      (j <= domlo_y) || (j >= domhi_y) ||
-                                      (k <= domlo_z) || (k >= domhi_z);
+        Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
+        if ( (apym != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0)) ) {
+            Real xloc_on_yface = fcy(i,j,k,0);
+            Real zloc_on_yface = fcy(i,j,k,1);
 
-            Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
-            if ( (apxm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0)) ) {
-                Real yloc_on_xface = fcx(i,j,k,0);
-                Real zloc_on_xface = fcx(i,j,k,1);
-
-                if(needs_bdry_stencil) {
-                  fxm = grad_x_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          yloc_on_xface,zloc_on_xface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fxm = grad_x_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                 yloc_on_xface,zloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fxm *= bX(i,j,k,n);
+            if(needs_bdry_stencil) {
+              fym = grad_y_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_yface,zloc_on_yface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fym = grad_y_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                             xloc_on_yface,zloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
             }
 
-            Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
-            if ( (apxp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i+1,j,k) != Real(1.0) || vfrc(i-1,j,k) != Real(1.0)) ) {
-                Real yloc_on_xface = fcx(i+1,j,k,0);
-                Real zloc_on_xface = fcx(i+1,j,k,1);
-
-                if(needs_bdry_stencil) {
-                  fxp = grad_x_of_phi_on_centroids_extdir(i+1,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          yloc_on_xface,zloc_on_xface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fxp = grad_x_of_phi_on_centroids(i+1,j,k,n,x,phieb,flag,ccent,bcent,
-                                                 yloc_on_xface,zloc_on_xface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fxp *= bX(i+1,j,k,n);
-            }
-
-            Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
-            if ( (apym != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0)) ) {
-                Real xloc_on_yface = fcy(i,j,k,0);
-                Real zloc_on_yface = fcy(i,j,k,1);
-
-                if(needs_bdry_stencil) {
-                  fym = grad_y_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_yface,zloc_on_yface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fym = grad_y_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                 xloc_on_yface,zloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fym *= bY(i,j,k,n);
-            }
-
-            Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
-            if ( (apyp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0)) ) {
-                Real xloc_on_yface = fcy(i,j+1,k,0);
-                Real zloc_on_yface = fcy(i,j+1,k,1);
-
-                if(needs_bdry_stencil) {
-                  fyp = grad_y_of_phi_on_centroids_extdir(i,j+1,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_yface,zloc_on_yface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fyp = grad_y_of_phi_on_centroids(i,j+1,k,n,x,phieb,flag,ccent,bcent,
-                                                 xloc_on_yface,zloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fyp *= bY(i,j+1,k,n);
-            }
-
-            Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
-            if ( (apzm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j,k-1) != Real(1.0) || vfrc(i,j,k+1) != Real(1.0)) ) {
-                Real xloc_on_zface = fcz(i,j,k,0);
-                Real yloc_on_zface = fcz(i,j,k,1);
-
-                if(needs_bdry_stencil) {
-                  fzm = grad_z_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_zface,yloc_on_zface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fzm = grad_z_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
-                                                 xloc_on_zface,yloc_on_zface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fzm *= bZ(i,j,k,n);
-            }
-
-            Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
-            if ( (apzp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j,k+1) != Real(1.0)  || vfrc(i,j,k-1) != Real(1.0)) ) {
-                Real xloc_on_zface = fcz(i,j,k+1,0);
-                Real yloc_on_zface = fcz(i,j,k+1,1);
-
-                if(needs_bdry_stencil) {
-                  fzp = grad_z_of_phi_on_centroids_extdir(i,j,k+1,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                          xloc_on_zface,yloc_on_zface,
-                                                          is_eb_dirichlet,is_eb_inhomog,
-                                                          on_x_face,domlo_x,domhi_x,
-                                                          on_y_face,domlo_y,domhi_y,
-                                                          on_z_face,domlo_z,domhi_z);
-                } else {
-                  fzp = grad_z_of_phi_on_centroids(i,j,k+1,n,x,phieb,flag,ccent,bcent,
-                                                 xloc_on_zface,yloc_on_zface,is_eb_dirichlet,is_eb_inhomog);
-                }
-
-                fzp *= bZ(i,j,k+1,n);
-            }
-
-            Real feb = Real(0.0);
-            if (is_eb_dirichlet && flag(i,j,k).isSingleValued()) {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
-                Real dapz = apzm-apzp;
-                Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
-                Real anorminv = Real(1.0)/anorm;
-                Real anrmx = dapx * anorminv;
-                Real anrmy = dapy * anorminv;
-                Real anrmz = dapz * anorminv;
-
-                feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
-                                                         anrmx,anrmy,anrmz,is_eb_inhomog,
-                                                         on_x_face,domlo_x,domhi_x,
-                                                         on_y_face,domlo_y,domhi_y,
-                                                         on_z_face,domlo_z,domhi_z);
-                feb *= ba(i,j,k) * beb(i,j,k,n);
-            }
-
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
-                (dhx*(apxm*fxm - apxp*fxp) +
-                 dhy*(apym*fym - apyp*fyp) +
-                 dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
+            fym *= bY(i,j,k,n);
         }
-    });
+
+        Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
+        if ( (apyp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j+1,k) != Real(1.0) || vfrc(i,j-1,k) != Real(1.0)) ) {
+            Real xloc_on_yface = fcy(i,j+1,k,0);
+            Real zloc_on_yface = fcy(i,j+1,k,1);
+
+            if(needs_bdry_stencil) {
+              fyp = grad_y_of_phi_on_centroids_extdir(i,j+1,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_yface,zloc_on_yface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fyp = grad_y_of_phi_on_centroids(i,j+1,k,n,x,phieb,flag,ccent,bcent,
+                                             xloc_on_yface,zloc_on_yface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fyp *= bY(i,j+1,k,n);
+        }
+
+        Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
+        if ( (apzm != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j,k-1) != Real(1.0) || vfrc(i,j,k+1) != Real(1.0)) ) {
+            Real xloc_on_zface = fcz(i,j,k,0);
+            Real yloc_on_zface = fcz(i,j,k,1);
+
+            if(needs_bdry_stencil) {
+              fzm = grad_z_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_zface,yloc_on_zface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fzm = grad_z_of_phi_on_centroids(i,j,k,n,x,phieb,flag,ccent,bcent,
+                                             xloc_on_zface,yloc_on_zface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fzm *= bZ(i,j,k,n);
+        }
+
+        Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
+        if ( (apzp != Real(0.0)) && (vfrc(i,j,k) != Real(1.0) || vfrc(i,j,k+1) != Real(1.0)  || vfrc(i,j,k-1) != Real(1.0)) ) {
+            Real xloc_on_zface = fcz(i,j,k+1,0);
+            Real yloc_on_zface = fcz(i,j,k+1,1);
+
+            if(needs_bdry_stencil) {
+              fzp = grad_z_of_phi_on_centroids_extdir(i,j,k+1,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                      xloc_on_zface,yloc_on_zface,
+                                                      is_eb_dirichlet,is_eb_inhomog,
+                                                      on_x_face,domlo_x,domhi_x,
+                                                      on_y_face,domlo_y,domhi_y,
+                                                      on_z_face,domlo_z,domhi_z);
+            } else {
+              fzp = grad_z_of_phi_on_centroids(i,j,k+1,n,x,phieb,flag,ccent,bcent,
+                                             xloc_on_zface,yloc_on_zface,is_eb_dirichlet,is_eb_inhomog);
+            }
+
+            fzp *= bZ(i,j,k+1,n);
+        }
+
+        Real feb = Real(0.0);
+        if (is_eb_dirichlet && flag(i,j,k).isSingleValued()) {
+            Real dapx = apxm-apxp;
+            Real dapy = apym-apyp;
+            Real dapz = apzm-apzp;
+            Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
+            Real anorminv = Real(1.0)/anorm;
+            Real anrmx = dapx * anorminv;
+            Real anrmy = dapy * anorminv;
+            Real anrmz = dapz * anorminv;
+
+            feb = grad_eb_of_phi_on_centroids_extdir(i,j,k,n,x,phieb,flag,ccent,bcent,vfrc,
+                                                     anrmx,anrmy,anrmz,is_eb_inhomog,
+                                                     on_x_face,domlo_x,domhi_x,
+                                                     on_y_face,domlo_y,domhi_y,
+                                                     on_z_face,domlo_z,domhi_z);
+            feb *= ba(i,j,k) * beb(i,j,k,n);
+        }
+
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
+            (dhx*(apxm*fxm - apxp*fxp) +
+             dhy*(apym*fym - apyp*fyp) +
+             dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -543,7 +543,7 @@ void mlebabeclap_ebflux (int i, int j, int k, int n,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_gsrb (Box const& box,
+void mlebabeclap_gsrb (int i, int j, int k, int n,
                        Array4<Real> const& phi, Array4<Real const> const& rhs,
                        Real alpha, Array4<Real const> const& a,
                        Real dhx, Real dhy, Real dhz,
@@ -560,343 +560,332 @@ void mlebabeclap_gsrb (Box const& box,
                        Array4<const int> const& ccm, Array4<Real const> const& beb,
                        EBData const& ebdata,
                        bool is_dirichlet, bool beta_on_centroid, bool phi_on_centroid,
-                       Box const& vbox, int redblack, int ncomp) noexcept
+                       Box const& vbox, int redblack) noexcept
 {
     constexpr auto omega = Real(1.15);
 
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-//    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
-    // amrex::Loop here causes gcc 8 to crash.
-    const auto lo = amrex::lbound(box);
-    const auto hi = amrex::ubound(box);
-    for (int n = 0; n < ncomp; ++n) {
-    for (int k = lo.z; k <= hi.z; ++k) {
-    for (int j = lo.y; j <= hi.y; ++j) {
-    for (int i = lo.x; i <= hi.x; ++i)
+    if ((i+j+k+redblack) % 2 == 0)
     {
-        if ((i+j+k+redblack) % 2 == 0)
+        auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
+        if (flag.isCovered())
         {
-            auto const flag = ebdata.get<EBData_t::cellflag>(i,j,k);
-            if (flag.isCovered())
+            phi(i,j,k,n) = Real(0.0);
+        }
+        else
+        {
+            Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
+                ? f0(vlo.x,j,k,n) : Real(0.0);
+            Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
+                ? f1(i,vlo.y,k,n) : Real(0.0);
+            Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
+                ? f2(i,j,vlo.z,n) : Real(0.0);
+            Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
+                ? f3(vhi.x,j,k,n) : Real(0.0);
+            Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
+                ? f4(i,vhi.y,k,n) : Real(0.0);
+            Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
+                ? f5(i,j,vhi.z,n) : Real(0.0);
+
+            if (flag.isRegular())
             {
-                phi(i,j,k,n) = Real(0.0);
+                Real gamma = alpha*a(i,j,k)
+                    + dhx*(bX(i+1,j,k,n) + bX(i,j,k,n))
+                    + dhy*(bY(i,j+1,k,n) + bY(i,j,k,n))
+                    + dhz*(bZ(i,j,k+1,n) + bZ(i,j,k,n));
+
+                Real rho = dhx*(bX(i+1,j  ,k  ,n)*phi(i+1,j  ,k  ,n) +
+                                bX(i  ,j  ,k  ,n)*phi(i-1,j  ,k  ,n))
+                    +      dhy*(bY(i  ,j+1,k  ,n)*phi(i  ,j+1,k  ,n) +
+                                bY(i  ,j  ,k  ,n)*phi(i  ,j-1,k  ,n))
+                    +      dhz*(bZ(i  ,j  ,k+1,n)*phi(i  ,j  ,k+1,n) +
+                                bZ(i  ,j  ,k  ,n)*phi(i  ,j  ,k-1,n));
+
+                Real delta = dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
+                    +        dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf4)
+                    +        dhz*(bZ(i,j,k,n)*cf2 + bZ(i,j,k+1,n)*cf5);
+
+                Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+                phi(i,j,k,n) += omega*res/(gamma-delta);
             }
             else
             {
-                Real cf0 = (i == vlo.x && m0(vlo.x-1,j,k) > 0)
-                    ? f0(vlo.x,j,k,n) : Real(0.0);
-                Real cf1 = (j == vlo.y && m1(i,vlo.y-1,k) > 0)
-                    ? f1(i,vlo.y,k,n) : Real(0.0);
-                Real cf2 = (k == vlo.z && m2(i,j,vlo.z-1) > 0)
-                    ? f2(i,j,vlo.z,n) : Real(0.0);
-                Real cf3 = (i == vhi.x && m3(vhi.x+1,j,k) > 0)
-                    ? f3(vhi.x,j,k,n) : Real(0.0);
-                Real cf4 = (j == vhi.y && m4(i,vhi.y+1,k) > 0)
-                    ? f4(i,vhi.y,k,n) : Real(0.0);
-                Real cf5 = (k == vhi.z && m5(i,j,vhi.z+1) > 0)
-                    ? f5(i,j,vhi.z,n) : Real(0.0);
+                Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
+                Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k  );
+                Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k  );
+                Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k  );
+                Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k  );
+                Real apzm = ebdata.get<EBData_t::apz>(i  ,j  ,k  );
+                Real apzp = ebdata.get<EBData_t::apz>(i  ,j  ,k+1);
 
-                if (flag.isRegular())
-                {
-                    Real gamma = alpha*a(i,j,k)
-                        + dhx*(bX(i+1,j,k,n) + bX(i,j,k,n))
-                        + dhy*(bY(i,j+1,k,n) + bY(i,j,k,n))
-                        + dhz*(bZ(i,j,k+1,n) + bZ(i,j,k,n));
+                Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
+                Real oxm = -bX(i,j,k,n)*cf0;
+                Real sxm =  bX(i,j,k,n);
+                if (apxm != Real(0.0) && apxm != Real(1.0)) {
+                    auto fcx0 = ebdata.get<EBData_t::fcx>(i,j,k,0);
+                    auto fcx1 = ebdata.get<EBData_t::fcx>(i,j,k,1);
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx0));
+                    int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx1));
+                    Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
+                        ? std::abs(fcx0) : Real(0.0);
+                    Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk))
+                        ? std::abs(fcx1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxm
+                             +     fracy *(Real(1.0)-fracz)*bX(i,jj,k ,n)*(phi(i,jj,k ,n)-phi(i-1,jj,k ,n))
+                             +(Real(1.0)-fracy)*     fracz *bX(i,j ,kk,n)*(phi(i,j ,kk,n)-phi(i-1,j ,kk,n))
+                             +     fracy *     fracz *bX(i,jj,kk,n)*(phi(i,jj,kk,n)-phi(i-1,jj,kk,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(              -phi(i-1, j, k,n))
+                             +     fracy *(Real(1.0)-fracz)*(phi(i,jj,k ,n)-phi(i-1,jj, k,n))
+                             +(Real(1.0)-fracy)*     fracz *(phi(i,j ,kk,n)-phi(i-1, j,kk,n))
+                             +     fracy *     fracz *(phi(i,jj,kk,n)-phi(i-1,jj,kk,n));
+                        fxm *= bX(i,j,k,n);
 
-                    Real rho = dhx*(bX(i+1,j  ,k  ,n)*phi(i+1,j  ,k  ,n) +
-                                    bX(i  ,j  ,k  ,n)*phi(i-1,j  ,k  ,n))
-                        +      dhy*(bY(i  ,j+1,k  ,n)*phi(i  ,j+1,k  ,n) +
-                                    bY(i  ,j  ,k  ,n)*phi(i  ,j-1,k  ,n))
-                        +      dhz*(bZ(i  ,j  ,k+1,n)*phi(i  ,j  ,k+1,n) +
-                                    bZ(i  ,j  ,k  ,n)*phi(i  ,j  ,k-1,n));
-
-                    Real delta = dhx*(bX(i,j,k,n)*cf0 + bX(i+1,j,k,n)*cf3)
-                        +        dhy*(bY(i,j,k,n)*cf1 + bY(i,j+1,k,n)*cf4)
-                        +        dhz*(bZ(i,j,k,n)*cf2 + bZ(i,j,k+1,n)*cf5);
-
-                    Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                    phi(i,j,k,n) += omega*res/(gamma-delta);
+                    }
+                    oxm = Real(0.0);
+                    sxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*sxm;
                 }
-                else
-                {
-                    Real kappa = ebdata.get<EBData_t::volfrac>(i,j,k);
-                    Real apxm = ebdata.get<EBData_t::apx>(i  ,j  ,k  );
-                    Real apxp = ebdata.get<EBData_t::apx>(i+1,j  ,k  );
-                    Real apym = ebdata.get<EBData_t::apy>(i  ,j  ,k  );
-                    Real apyp = ebdata.get<EBData_t::apy>(i  ,j+1,k  );
-                    Real apzm = ebdata.get<EBData_t::apz>(i  ,j  ,k  );
-                    Real apzp = ebdata.get<EBData_t::apz>(i  ,j  ,k+1);
 
-                    Real fxm = -bX(i,j,k,n)*phi(i-1,j,k,n);
-                    Real oxm = -bX(i,j,k,n)*cf0;
-                    Real sxm =  bX(i,j,k,n);
-                    if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                        auto fcx0 = ebdata.get<EBData_t::fcx>(i,j,k,0);
-                        auto fcx1 = ebdata.get<EBData_t::fcx>(i,j,k,1);
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx0));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx1));
-                        Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k))
-                            ? std::abs(fcx0) : Real(0.0);
-                        Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk))
-                            ? std::abs(fcx1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxm
-                                 +     fracy *(Real(1.0)-fracz)*bX(i,jj,k ,n)*(phi(i,jj,k ,n)-phi(i-1,jj,k ,n))
-                                 +(Real(1.0)-fracy)*     fracz *bX(i,j ,kk,n)*(phi(i,j ,kk,n)-phi(i-1,j ,kk,n))
-                                 +     fracy *     fracz *bX(i,jj,kk,n)*(phi(i,jj,kk,n)-phi(i-1,jj,kk,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(              -phi(i-1, j, k,n))
-                                 +     fracy *(Real(1.0)-fracz)*(phi(i,jj,k ,n)-phi(i-1,jj, k,n))
-                                 +(Real(1.0)-fracy)*     fracz *(phi(i,j ,kk,n)-phi(i-1, j,kk,n))
-                                 +     fracy *     fracz *(phi(i,jj,kk,n)-phi(i-1,jj,kk,n));
-                            fxm *= bX(i,j,k,n);
+                Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
+                Real oxp =  bX(i+1,j,k,n)*cf3;
+                Real sxp = -bX(i+1,j,k,n);
+                if (apxp != Real(0.0) && apxp != Real(1.0)) {
+                    auto fcx0 = ebdata.get<EBData_t::fcx>(i+1,j,k,0);
+                    auto fcx1 = ebdata.get<EBData_t::fcx>(i+1,j,k,1);
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx0));
+                    int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx1));
+                    Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
+                        ? std::abs(fcx0) : Real(0.0);
+                    Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk))
+                        ? std::abs(fcx1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxp
+                              +    fracy *(Real(1.0)-fracz)*bX(i+1,jj,k ,n)*(phi(i+1,jj,k ,n)-phi(i,jj,k ,n))
+                             +(Real(1.0)-fracy)*     fracz *bX(i+1,j ,kk,n)*(phi(i+1,j ,kk,n)-phi(i,j ,kk,n))
+                             +     fracy *     fracz *bX(i+1,jj,kk,n)*(phi(i+1,jj,kk,n)-phi(i,jj,kk,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(phi(i+1, j, k,n)               ) +
+                                   fracy *(Real(1.0)-fracz)*(phi(i+1,jj, k,n)-phi(i,jj, k,n)) +
+                                   fracz *(Real(1.0)-fracy)*(phi(i+1, j,kk,n)-phi(i, j,kk,n)) +
+                                   fracy *     fracz *(phi(i+1,jj,kk,n)-phi(i,jj,kk,n));
+                        fxp *= bX(i+1,j,k,n);
 
-                        }
-                        oxm = Real(0.0);
-                        sxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*sxm;
                     }
 
-                    Real fxp =  bX(i+1,j,k,n)*phi(i+1,j,k,n);
-                    Real oxp =  bX(i+1,j,k,n)*cf3;
-                    Real sxp = -bX(i+1,j,k,n);
-                    if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                        auto fcx0 = ebdata.get<EBData_t::fcx>(i+1,j,k,0);
-                        auto fcx1 = ebdata.get<EBData_t::fcx>(i+1,j,k,1);
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx0));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx1));
-                        Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k))
-                            ? std::abs(fcx0) : Real(0.0);
-                        Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk))
-                            ? std::abs(fcx1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxp
-                                  +    fracy *(Real(1.0)-fracz)*bX(i+1,jj,k ,n)*(phi(i+1,jj,k ,n)-phi(i,jj,k ,n))
-                                 +(Real(1.0)-fracy)*     fracz *bX(i+1,j ,kk,n)*(phi(i+1,j ,kk,n)-phi(i,j ,kk,n))
-                                 +     fracy *     fracz *bX(i+1,jj,kk,n)*(phi(i+1,jj,kk,n)-phi(i,jj,kk,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(phi(i+1, j, k,n)               ) +
-                                       fracy *(Real(1.0)-fracz)*(phi(i+1,jj, k,n)-phi(i,jj, k,n)) +
-                                       fracz *(Real(1.0)-fracy)*(phi(i+1, j,kk,n)-phi(i, j,kk,n)) +
-                                       fracy *     fracz *(phi(i+1,jj,kk,n)-phi(i,jj,kk,n));
-                            fxp *= bX(i+1,j,k,n);
-
-                        }
-
-                        oxp = Real(0.0);
-                        sxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*sxp;
-                    }
-
-                    Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
-                    Real oym = -bY(i,j,k,n)*cf1;
-                    Real sym =  bY(i,j,k,n);
-                    if (apym != Real(0.0) && apym != Real(1.0)) {
-                        auto fcy0 = ebdata.get<EBData_t::fcy>(i,j,k,0);
-                        auto fcy1 = ebdata.get<EBData_t::fcy>(i,j,k,1);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
-                        Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
-                            ? std::abs(fcy0) : Real(0.0);
-                        Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk))
-                            ? std::abs(fcy1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fym
-                                +      fracx *(Real(1.0)-fracz)*bY(ii,j,k ,n)*(phi(ii,j,k ,n)-phi(ii,j-1,k ,n))
-                                + (Real(1.0)-fracx)*     fracz *bY(i ,j,kk,n)*(phi(i ,j,kk,n)-phi(i ,j-1,kk,n))
-                                +      fracx *     fracz *bY(ii,j,kk,n)*(phi(ii,j,kk,n)-phi(ii,j-1,kk,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(              -phi( i,j-1, k,n))
-                                +      fracx *(Real(1.0)-fracz)*(phi(ii,j,k ,n)-phi(ii,j-1, k,n))
-                                + (Real(1.0)-fracx)*     fracz *(phi(i ,j,kk,n)-phi( i,j-1,kk,n))
-                                +      fracx *     fracz *(phi(ii,j,kk,n)-phi(ii,j-1,kk,n));
-                            fym *= bY(i,j,k,n);
-
-                        }
-                        oym = Real(0.0);
-                        sym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*sym;
-                    }
-
-                    Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
-                    Real oyp =  bY(i,j+1,k,n)*cf4;
-                    Real syp = -bY(i,j+1,k,n);
-                    if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                        auto fcy0 = ebdata.get<EBData_t::fcy>(i,j+1,k,0);
-                        auto fcy1 = ebdata.get<EBData_t::fcy>(i,j+1,k,1);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
-                        int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
-                        Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
-                            ? std::abs(fcy0) : Real(0.0);
-                        Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk))
-                            ? std::abs(fcy1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fyp
-                                +      fracx *(Real(1.0)-fracz)*bY(ii,j+1,k ,n)*(phi(ii,j+1,k ,n)-phi(ii,j,k ,n))
-                                + (Real(1.0)-fracx)*     fracz *bY(i ,j+1,kk,n)*(phi(i ,j+1,kk,n)-phi(i ,j,kk,n))
-                                +      fracx *     fracz *bY(ii,j+1,kk,n)*(phi(ii,j+1,kk,n)-phi(ii,j,kk,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(phi( i,j+1, k,n)               )
-                                +      fracx *(Real(1.0)-fracz)*(phi(ii,j+1, k,n)-phi(ii,j, k,n))
-                                + (Real(1.0)-fracx)*     fracz *(phi( i,j+1,kk,n)-phi( i,j,kk,n))
-                                +      fracx *     fracz *(phi(ii,j+1,kk,n)-phi(ii,j,kk,n));
-                            fyp *= bY(i,j+1,k,n);
-
-                        }
-                        oyp = Real(0.0);
-                        syp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*syp;
-                    }
-
-                    Real fzm = -bZ(i,j,k,n)*phi(i,j,k-1,n);
-                    Real ozm = -bZ(i,j,k,n)*cf2;
-                    Real szm =  bZ(i,j,k,n);
-                    if (apzm != Real(0.0) && apzm != Real(1.0)) {
-                        auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k,0);
-                        auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k,1);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
-                        Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k))
-                            ? std::abs(fcz0) : Real(0.0);
-                        Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k))
-                            ? std::abs(fcz1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzm
-                                 +     fracx *(Real(1.0)-fracy)*bZ(ii, j,k,n)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
-                                 +(Real(1.0)-fracx)*     fracy *bZ( i,jj,k,n)*(phi( i,jj,k,n)-phi( i,jj,k-1,n))
-                                 +     fracx *     fracy *bZ(ii,jj,k,n)*(phi(ii,jj,k,n)-phi(ii,jj,k-1,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(              -phi( i, j,k-1,n))
-                                +      fracx *(Real(1.0)-fracy)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
-                                + (Real(1.0)-fracx)*     fracy *(phi( i,jj,k,n)-phi(i ,jj,k-1,n))
-                                +      fracx *     fracy *(phi(ii,jj,k,n)-phi(ii,jj,k-1,n));
-                            fzm *= bZ(i,j,k,n);
-
-                        }
-                        ozm = Real(0.0);
-                        szm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*szm;
-                    }
-
-                    Real fzp =  bZ(i,j,k+1,n)*phi(i,j,k+1,n);
-                    Real ozp =  bZ(i,j,k+1,n)*cf5;
-                    Real szp = -bZ(i,j,k+1,n);
-                    if (apzp != Real(0.0) && apzp != Real(1.0)) {
-                        auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k+1,0);
-                        auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k+1,1);
-                        int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
-                        int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
-                        Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1))
-                            ? std::abs(fcz0) : Real(0.0);
-                        Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1))
-                            ? std::abs(fcz1) : Real(0.0);
-                        if (!beta_on_centroid && !phi_on_centroid)
-                        {
-                            fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzp
-                                +      fracx *(Real(1.0)-fracy)*bZ(ii,j ,k+1,n)*(phi(ii,j ,k+1,n)-phi(ii,j ,k,n))
-                                + (Real(1.0)-fracx)*     fracy *bZ(i ,jj,k+1,n)*(phi(i ,jj,k+1,n)-phi(i ,jj,k,n))
-                                +      fracx *     fracy *bZ(ii,jj,k+1,n)*(phi(ii,jj,k+1,n)-phi(ii,jj,k,n));
-                        }
-                        else if (beta_on_centroid && !phi_on_centroid)
-                        {
-                            fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(phi( i, j,k+1,n)               )
-                                +      fracx *(Real(1.0)-fracy)*(phi(ii, j,k+1,n)-phi(ii, j,k,n))
-                                + (Real(1.0)-fracx)*     fracy *(phi( i,jj,k+1,n)-phi( i,jj,k,n))
-                                +      fracx *     fracy *(phi(ii,jj,k+1,n)-phi(ii,jj,k,n));
-                            fzp *= bZ(i,j,k+1,n);
-
-                        }
-                        ozp = Real(0.0);
-                        szp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*szp;
-                    }
-
-                    Real vfrcinv = Real(1.0)/kappa;
-                    Real gamma = alpha*a(i,j,k) + vfrcinv *
-                        (dhx*(apxm*sxm-apxp*sxp) +
-                         dhy*(apym*sym-apyp*syp) +
-                         dhz*(apzm*szm-apzp*szp));
-
-                    Real rho = -vfrcinv *
-                        (dhx*(apxm*fxm-apxp*fxp) +
-                         dhy*(apym*fym-apyp*fyp) +
-                         dhz*(apzm*fzm-apzp*fzp));
-
-                    Real delta = -vfrcinv *
-                        (dhx*(apxm*oxm-apxp*oxp) +
-                         dhy*(apym*oym-apyp*oyp) +
-                         dhz*(apzm*ozm-apzp*ozp));
-
-                    if (is_dirichlet) {
-                        Real dapx = apxm-apxp;
-                        Real dapy = apym-apyp;
-                        Real dapz = apzm-apzp;
-                        Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
-                        Real anorminv = Real(1.0)/anorm;
-                        Real anrmx = dapx * anorminv;
-                        Real anrmy = dapy * anorminv;
-                        Real anrmz = dapz * anorminv;
-                        Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
-                        Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
-                        Real bctz = ebdata.get<EBData_t::bndrycent>(i,j,k,2);
-                        Real dx_eb = get_dx_eb(kappa);
-
-                        Real dg = dx_eb / amrex::max(std::abs(anrmx),std::abs(anrmy),
-                                                     std::abs(anrmz));
-
-                        Real gx = bctx - dg*anrmx;
-                        Real gy = bcty - dg*anrmy;
-                        Real gz = bctz - dg*anrmz;
-                        Real sx = std::copysign(Real(1.0),anrmx);
-                        Real sy = std::copysign(Real(1.0),anrmy);
-                        Real sz = std::copysign(Real(1.0),anrmz);
-                        int ii = i - static_cast<int>(sx);
-                        int jj = j - static_cast<int>(sy);
-                        int kk = k - static_cast<int>(sz);
-
-                        gx *= sx;
-                        gy *= sy;
-                        gz *= sz;
-                        Real gxy = gx*gy;
-                        Real gxz = gx*gz;
-                        Real gyz = gy*gz;
-                        Real gxyz = gx*gy*gz;
-                        Real phig_gamma = (Real(1.0)+gx+gy+gz+gxy+gxz+gyz+gxyz);
-                        Real phig = (-gz - gxz - gyz - gxyz) * phi(i,j,kk,n)
-                            + (-gy - gxy - gyz - gxyz) * phi(i,jj,k,n)
-                            + (gyz + gxyz) * phi(i,jj,kk,n)
-                            + (-gx - gxy - gxz - gxyz) * phi(ii,j,k,n)
-                            + (gxz + gxyz) * phi(ii,j,kk,n)
-                            + (gxy + gxyz) * phi(ii,jj,k,n)
-                            + (-gxyz) * phi(ii,jj,kk,n);
-
-                        Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
-
-                        Real dphidn    = (    -phig)/dg;
-                        Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
-                        gamma += vfrcinv*(-dhx)*feb_gamma;
-                        Real feb = dphidn * ba * beb(i,j,k,n);
-                        rho += -vfrcinv*(-dhx)*feb;
-                    }
-
-                    Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
-                    phi(i,j,k,n) += omega*res/(gamma-delta);
+                    oxp = Real(0.0);
+                    sxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*sxp;
                 }
+
+                Real fym = -bY(i,j,k,n)*phi(i,j-1,k,n);
+                Real oym = -bY(i,j,k,n)*cf1;
+                Real sym =  bY(i,j,k,n);
+                if (apym != Real(0.0) && apym != Real(1.0)) {
+                    auto fcy0 = ebdata.get<EBData_t::fcy>(i,j,k,0);
+                    auto fcy1 = ebdata.get<EBData_t::fcy>(i,j,k,1);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
+                    int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
+                    Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k))
+                        ? std::abs(fcy0) : Real(0.0);
+                    Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk))
+                        ? std::abs(fcy1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fym
+                            +      fracx *(Real(1.0)-fracz)*bY(ii,j,k ,n)*(phi(ii,j,k ,n)-phi(ii,j-1,k ,n))
+                            + (Real(1.0)-fracx)*     fracz *bY(i ,j,kk,n)*(phi(i ,j,kk,n)-phi(i ,j-1,kk,n))
+                            +      fracx *     fracz *bY(ii,j,kk,n)*(phi(ii,j,kk,n)-phi(ii,j-1,kk,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(              -phi( i,j-1, k,n))
+                            +      fracx *(Real(1.0)-fracz)*(phi(ii,j,k ,n)-phi(ii,j-1, k,n))
+                            + (Real(1.0)-fracx)*     fracz *(phi(i ,j,kk,n)-phi( i,j-1,kk,n))
+                            +      fracx *     fracz *(phi(ii,j,kk,n)-phi(ii,j-1,kk,n));
+                        fym *= bY(i,j,k,n);
+
+                    }
+                    oym = Real(0.0);
+                    sym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*sym;
+                }
+
+                Real fyp =  bY(i,j+1,k,n)*phi(i,j+1,k,n);
+                Real oyp =  bY(i,j+1,k,n)*cf4;
+                Real syp = -bY(i,j+1,k,n);
+                if (apyp != Real(0.0) && apyp != Real(1.0)) {
+                    auto fcy0 = ebdata.get<EBData_t::fcy>(i,j+1,k,0);
+                    auto fcy1 = ebdata.get<EBData_t::fcy>(i,j+1,k,1);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy0));
+                    int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy1));
+                    Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k))
+                        ? std::abs(fcy0) : Real(0.0);
+                    Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk))
+                        ? std::abs(fcy1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fyp
+                            +      fracx *(Real(1.0)-fracz)*bY(ii,j+1,k ,n)*(phi(ii,j+1,k ,n)-phi(ii,j,k ,n))
+                            + (Real(1.0)-fracx)*     fracz *bY(i ,j+1,kk,n)*(phi(i ,j+1,kk,n)-phi(i ,j,kk,n))
+                            +      fracx *     fracz *bY(ii,j+1,kk,n)*(phi(ii,j+1,kk,n)-phi(ii,j,kk,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(phi( i,j+1, k,n)               )
+                            +      fracx *(Real(1.0)-fracz)*(phi(ii,j+1, k,n)-phi(ii,j, k,n))
+                            + (Real(1.0)-fracx)*     fracz *(phi( i,j+1,kk,n)-phi( i,j,kk,n))
+                            +      fracx *     fracz *(phi(ii,j+1,kk,n)-phi(ii,j,kk,n));
+                        fyp *= bY(i,j+1,k,n);
+
+                    }
+                    oyp = Real(0.0);
+                    syp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*syp;
+                }
+
+                Real fzm = -bZ(i,j,k,n)*phi(i,j,k-1,n);
+                Real ozm = -bZ(i,j,k,n)*cf2;
+                Real szm =  bZ(i,j,k,n);
+                if (apzm != Real(0.0) && apzm != Real(1.0)) {
+                    auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k,0);
+                    auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k,1);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
+                    Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k))
+                        ? std::abs(fcz0) : Real(0.0);
+                    Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k))
+                        ? std::abs(fcz1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzm
+                             +     fracx *(Real(1.0)-fracy)*bZ(ii, j,k,n)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
+                             +(Real(1.0)-fracx)*     fracy *bZ( i,jj,k,n)*(phi( i,jj,k,n)-phi( i,jj,k-1,n))
+                             +     fracx *     fracy *bZ(ii,jj,k,n)*(phi(ii,jj,k,n)-phi(ii,jj,k-1,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(              -phi( i, j,k-1,n))
+                            +      fracx *(Real(1.0)-fracy)*(phi(ii, j,k,n)-phi(ii, j,k-1,n))
+                            + (Real(1.0)-fracx)*     fracy *(phi( i,jj,k,n)-phi(i ,jj,k-1,n))
+                            +      fracx *     fracy *(phi(ii,jj,k,n)-phi(ii,jj,k-1,n));
+                        fzm *= bZ(i,j,k,n);
+
+                    }
+                    ozm = Real(0.0);
+                    szm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*szm;
+                }
+
+                Real fzp =  bZ(i,j,k+1,n)*phi(i,j,k+1,n);
+                Real ozp =  bZ(i,j,k+1,n)*cf5;
+                Real szp = -bZ(i,j,k+1,n);
+                if (apzp != Real(0.0) && apzp != Real(1.0)) {
+                    auto fcz0 = ebdata.get<EBData_t::fcz>(i,j,k+1,0);
+                    auto fcz1 = ebdata.get<EBData_t::fcz>(i,j,k+1,1);
+                    int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz0));
+                    int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz1));
+                    Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1))
+                        ? std::abs(fcz0) : Real(0.0);
+                    Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1))
+                        ? std::abs(fcz1) : Real(0.0);
+                    if (!beta_on_centroid && !phi_on_centroid)
+                    {
+                        fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzp
+                            +      fracx *(Real(1.0)-fracy)*bZ(ii,j ,k+1,n)*(phi(ii,j ,k+1,n)-phi(ii,j ,k,n))
+                            + (Real(1.0)-fracx)*     fracy *bZ(i ,jj,k+1,n)*(phi(i ,jj,k+1,n)-phi(i ,jj,k,n))
+                            +      fracx *     fracy *bZ(ii,jj,k+1,n)*(phi(ii,jj,k+1,n)-phi(ii,jj,k,n));
+                    }
+                    else if (beta_on_centroid && !phi_on_centroid)
+                    {
+                        fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(phi( i, j,k+1,n)               )
+                            +      fracx *(Real(1.0)-fracy)*(phi(ii, j,k+1,n)-phi(ii, j,k,n))
+                            + (Real(1.0)-fracx)*     fracy *(phi( i,jj,k+1,n)-phi( i,jj,k,n))
+                            +      fracx *     fracy *(phi(ii,jj,k+1,n)-phi(ii,jj,k,n));
+                        fzp *= bZ(i,j,k+1,n);
+
+                    }
+                    ozp = Real(0.0);
+                    szp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*szp;
+                }
+
+                Real vfrcinv = Real(1.0)/kappa;
+                Real gamma = alpha*a(i,j,k) + vfrcinv *
+                    (dhx*(apxm*sxm-apxp*sxp) +
+                     dhy*(apym*sym-apyp*syp) +
+                     dhz*(apzm*szm-apzp*szp));
+
+                Real rho = -vfrcinv *
+                    (dhx*(apxm*fxm-apxp*fxp) +
+                     dhy*(apym*fym-apyp*fyp) +
+                     dhz*(apzm*fzm-apzp*fzp));
+
+                Real delta = -vfrcinv *
+                    (dhx*(apxm*oxm-apxp*oxp) +
+                     dhy*(apym*oym-apyp*oyp) +
+                     dhz*(apzm*ozm-apzp*ozp));
+
+                if (is_dirichlet) {
+                    Real dapx = apxm-apxp;
+                    Real dapy = apym-apyp;
+                    Real dapz = apzm-apzp;
+                    Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
+                    Real anorminv = Real(1.0)/anorm;
+                    Real anrmx = dapx * anorminv;
+                    Real anrmy = dapy * anorminv;
+                    Real anrmz = dapz * anorminv;
+                    Real bctx = ebdata.get<EBData_t::bndrycent>(i,j,k,0);
+                    Real bcty = ebdata.get<EBData_t::bndrycent>(i,j,k,1);
+                    Real bctz = ebdata.get<EBData_t::bndrycent>(i,j,k,2);
+                    Real dx_eb = get_dx_eb(kappa);
+
+                    Real dg = dx_eb / amrex::max(std::abs(anrmx),std::abs(anrmy),
+                                                 std::abs(anrmz));
+
+                    Real gx = bctx - dg*anrmx;
+                    Real gy = bcty - dg*anrmy;
+                    Real gz = bctz - dg*anrmz;
+                    Real sx = std::copysign(Real(1.0),anrmx);
+                    Real sy = std::copysign(Real(1.0),anrmy);
+                    Real sz = std::copysign(Real(1.0),anrmz);
+                    int ii = i - static_cast<int>(sx);
+                    int jj = j - static_cast<int>(sy);
+                    int kk = k - static_cast<int>(sz);
+
+                    gx *= sx;
+                    gy *= sy;
+                    gz *= sz;
+                    Real gxy = gx*gy;
+                    Real gxz = gx*gz;
+                    Real gyz = gy*gz;
+                    Real gxyz = gx*gy*gz;
+                    Real phig_gamma = (Real(1.0)+gx+gy+gz+gxy+gxz+gyz+gxyz);
+                    Real phig = (-gz - gxz - gyz - gxyz) * phi(i,j,kk,n)
+                        + (-gy - gxy - gyz - gxyz) * phi(i,jj,k,n)
+                        + (gyz + gxyz) * phi(i,jj,kk,n)
+                        + (-gx - gxy - gxz - gxyz) * phi(ii,j,k,n)
+                        + (gxz + gxyz) * phi(ii,j,kk,n)
+                        + (gxy + gxyz) * phi(ii,jj,k,n)
+                        + (-gxyz) * phi(ii,jj,kk,n);
+
+                    Real ba = ebdata.get<EBData_t::bndryarea>(i,j,k);
+
+                    Real dphidn    = (    -phig)/dg;
+                    Real feb_gamma = -phig_gamma/dg * ba * beb(i,j,k,n);
+                    gamma += vfrcinv*(-dhx)*feb_gamma;
+                    Real feb = dphidn * ba * beb(i,j,k,n);
+                    rho += -vfrcinv*(-dhx)*feb;
+                }
+
+                Real res = rhs(i,j,k,n) - (gamma*phi(i,j,k,n) - rho);
+                phi(i,j,k,n) += omega*res/(gamma-delta);
             }
         }
-    }}}}
-//    });
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_3D_K.H
@@ -213,19 +213,14 @@ void mlebabeclap_adotx_centroid (Box const& box, Array4<Real> const& y,
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
+void mlebabeclap_adotx (int i, int j, int k, int n, Array4<Real> const& y,
                         Array4<Real const> const& x, Array4<Real const> const& a,
                         Array4<Real const> const& bX, Array4<Real const> const& bY,
                         Array4<Real const> const& bZ, Array4<const int> const& ccm,
-                        Array4<EBCellFlag const> const& flag,
-                        Array4<Real const> const& vfrc, Array4<Real const> const& apx,
-                        Array4<Real const> const& apy, Array4<Real const> const& apz,
-                        Array4<Real const> const& fcx, Array4<Real const> const& fcy,
-                        Array4<Real const> const& fcz, Array4<Real const> const& ba,
-                        Array4<Real const> const& bc, Array4<Real const> const& beb,
+                        EBData const& ebdata, Array4<Real const> const& beb,
                         bool is_dirichlet, Array4<Real const> const& phieb,
                         bool is_inhomog, GpuArray<Real,AMREX_SPACEDIM> const& dxinv,
-                        Real alpha, Real beta, int ncomp,
+                        Real alpha, Real beta,
                         bool beta_on_centroid, bool phi_on_centroid) noexcept
 {
     Real dhx = beta*dxinv[0]*dxinv[0];
@@ -235,232 +230,240 @@ void mlebabeclap_adotx (Box const& box, Array4<Real> const& y,
     bool beta_on_center = !(beta_on_centroid);
     bool  phi_on_center = !( phi_on_centroid);
 
-    amrex::Loop(box, ncomp, [=] (int i, int j, int k, int n) noexcept
+    auto const& flag = ebdata.get<EBData_t::cellflag>();
+    auto const& vfrc = ebdata.get<EBData_t::volfrac>();
+    auto const& apx  = ebdata.get<EBData_t::apx>();
+    auto const& apy  = ebdata.get<EBData_t::apy>();
+    auto const& apz  = ebdata.get<EBData_t::apz>();
+    auto const& fcx  = ebdata.get<EBData_t::fcx>();
+    auto const& fcy  = ebdata.get<EBData_t::fcy>();
+    auto const& fcz  = ebdata.get<EBData_t::fcz>();
+    auto const& ba   = ebdata.get<EBData_t::bndryarea>();
+    auto const& bc   = ebdata.get<EBData_t::bndrycent>();
+
+    if (flag(i,j,k).isCovered())
     {
-        if (flag(i,j,k).isCovered())
-        {
-            y(i,j,k,n) = Real(0.0);
+        y(i,j,k,n) = Real(0.0);
+    }
+    else if (flag(i,j,k).isRegular())
+    {
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
+            - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
+                    -bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
+            - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
+                    -bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
+            - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
+                    -bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
+    }
+    else
+    {
+        Real kappa = vfrc(i,j,k);
+        Real apxm = apx(i,j,k);
+        Real apxp = apx(i+1,j,k);
+        Real apym = apy(i,j,k);
+        Real apyp = apy(i,j+1,k);
+        Real apzm = apz(i,j,k);
+        Real apzp = apz(i,j,k+1);
+
+        Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
+        if (apxm != Real(0.0) && apxm != Real(1.0)) {
+            int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,1)));
+            Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : Real(0.0);
+            Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxm +
+                    fracy*(Real(1.0)-fracz)*bX(i,jj,k ,n)*(x(i,jj,k ,n)-x(i-1,jj,k ,n)) +
+                    fracz*(Real(1.0)-fracy)*bX(i,j ,kk,n)*(x(i,j ,kk,n)-x(i-1,j ,kk,n)) +
+                    fracy*     fracz *bX(i,jj,kk,n)*(x(i,jj,kk,n)-x(i-1,jj,kk,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(x(i, j, k,n)-x(i-1, j, k,n)) +
+                           fracy *(Real(1.0)-fracz)*(x(i,jj, k,n)-x(i-1,jj, k,n)) +
+                           fracz *(Real(1.0)-fracy)*(x(i, j,kk,n)-x(i-1, j,kk,n)) +
+                           fracy *     fracz *(x(i,jj,kk,n)-x(i-1,jj,kk,n));
+                fxm *= bX(i,j,k,n);
+            }
         }
-        else if (flag(i,j,k).isRegular())
-        {
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n)
-                - dhx * (bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i  ,j,k,n))
-                        -bX(i  ,j,k,n)*(x(i  ,j,k,n) - x(i-1,j,k,n)))
-                - dhy * (bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j  ,k,n))
-                        -bY(i,j  ,k,n)*(x(i,j  ,k,n) - x(i,j-1,k,n)))
-                - dhz * (bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k  ,n))
-                        -bZ(i,j,k  ,n)*(x(i,j,k  ,n) - x(i,j,k-1,n)));
+
+        Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
+        if (apxp != Real(0.0) && apxp != Real(1.0)) {
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,1)));
+            Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k,0)) : Real(0.0);
+            Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? std::abs(fcx(i+1,j,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxp +
+                    fracy*(Real(1.0)-fracz)*bX(i+1,jj,k ,n)*(x(i+1,jj,k ,n)-x(i,jj,k ,n)) +
+                    fracz*(Real(1.0)-fracy)*bX(i+1,j ,kk,n)*(x(i+1,j ,kk,n)-x(i,j ,kk,n)) +
+                    fracy*     fracz *bX(i+1,jj,kk,n)*(x(i+1,jj,kk,n)-x(i,jj,kk,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(x(i+1, j, k,n)-x(i, j, k,n)) +
+                           fracy *(Real(1.0)-fracz)*(x(i+1,jj, k,n)-x(i,jj, k,n)) +
+                           fracz *(Real(1.0)-fracy)*(x(i+1, j,kk,n)-x(i, j,kk,n)) +
+                           fracy *     fracz *(x(i+1,jj,kk,n)-x(i,jj,kk,n));
+                fxp *= bX(i+1,j,k,n);
+
+            }
         }
-        else
-        {
-            Real kappa = vfrc(i,j,k);
-            Real apxm = apx(i,j,k);
-            Real apxp = apx(i+1,j,k);
-            Real apym = apy(i,j,k);
-            Real apyp = apy(i,j+1,k);
-            Real apzm = apz(i,j,k);
-            Real apzp = apz(i,j,k+1);
 
-            Real fxm = bX(i,j,k,n)*(x(i,j,k,n) - x(i-1,j,k,n));
-            if (apxm != Real(0.0) && apxm != Real(1.0)) {
-                int jj = j + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,0)));
-                int kk = k + static_cast<int>(std::copysign(Real(1.0), fcx(i,j,k,1)));
-                Real fracy = (ccm(i-1,jj,k) || ccm(i,jj,k)) ? std::abs(fcx(i,j,k,0)) : Real(0.0);
-                Real fracz = (ccm(i-1,j,kk) || ccm(i,j,kk)) ? std::abs(fcx(i,j,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxm +
-                        fracy*(Real(1.0)-fracz)*bX(i,jj,k ,n)*(x(i,jj,k ,n)-x(i-1,jj,k ,n)) +
-                        fracz*(Real(1.0)-fracy)*bX(i,j ,kk,n)*(x(i,j ,kk,n)-x(i-1,j ,kk,n)) +
-                        fracy*     fracz *bX(i,jj,kk,n)*(x(i,jj,kk,n)-x(i-1,jj,kk,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fxm = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(x(i, j, k,n)-x(i-1, j, k,n)) +
-                               fracy *(Real(1.0)-fracz)*(x(i,jj, k,n)-x(i-1,jj, k,n)) +
-                               fracz *(Real(1.0)-fracy)*(x(i, j,kk,n)-x(i-1, j,kk,n)) +
-                               fracy *     fracz *(x(i,jj,kk,n)-x(i-1,jj,kk,n));
-                    fxm *= bX(i,j,k,n);
-                }
+        Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
+        if (apym != Real(0.0) && apym != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,0)));
+            int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,1)));
+            Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : Real(0.0);
+            Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fym +
+                    fracx*(Real(1.0)-fracz)*bY(ii,j,k ,n)*(x(ii,j,k ,n)-x(ii,j-1,k ,n)) +
+                    fracz*(Real(1.0)-fracx)*bY(i ,j,kk,n)*(x(i ,j,kk,n)-x(i ,j-1,kk,n)) +
+                    fracx*     fracz *bY(ii,j,kk,n)*(x(ii,j,kk,n)-x(ii,j-1,kk,n));
             }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(x( i,j, k,n)-x( i,j-1, k,n)) +
+                           fracx *(Real(1.0)-fracz)*(x(ii,j, k,n)-x(ii,j-1, k,n)) +
+                           fracz *(Real(1.0)-fracx)*(x(i ,j,kk,n)-x( i,j-1,kk,n)) +
+                           fracx *     fracz *(x(ii,j,kk,n)-x(ii,j-1,kk,n));
+                fym *= bY(i,j,k,n);
 
-            Real fxp = bX(i+1,j,k,n)*(x(i+1,j,k,n) - x(i,j,k,n));
-            if (apxp != Real(0.0) && apxp != Real(1.0)) {
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,0)));
-                int kk = k + static_cast<int>(std::copysign(Real(1.0),fcx(i+1,j,k,1)));
-                Real fracy = (ccm(i,jj,k) || ccm(i+1,jj,k)) ? std::abs(fcx(i+1,j,k,0)) : Real(0.0);
-                Real fracz = (ccm(i,j,kk) || ccm(i+1,j,kk)) ? std::abs(fcx(i+1,j,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*fxp +
-                        fracy*(Real(1.0)-fracz)*bX(i+1,jj,k ,n)*(x(i+1,jj,k ,n)-x(i,jj,k ,n)) +
-                        fracz*(Real(1.0)-fracy)*bX(i+1,j ,kk,n)*(x(i+1,j ,kk,n)-x(i,j ,kk,n)) +
-                        fracy*     fracz *bX(i+1,jj,kk,n)*(x(i+1,jj,kk,n)-x(i,jj,kk,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fxp = (Real(1.0)-fracy)*(Real(1.0)-fracz)*(x(i+1, j, k,n)-x(i, j, k,n)) +
-                               fracy *(Real(1.0)-fracz)*(x(i+1,jj, k,n)-x(i,jj, k,n)) +
-                               fracz *(Real(1.0)-fracy)*(x(i+1, j,kk,n)-x(i, j,kk,n)) +
-                               fracy *     fracz *(x(i+1,jj,kk,n)-x(i,jj,kk,n));
-                    fxp *= bX(i+1,j,k,n);
-
-                }
             }
-
-            Real fym = bY(i,j,k,n)*(x(i,j,k,n) - x(i,j-1,k,n));
-            if (apym != Real(0.0) && apym != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,0)));
-                int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j,k,1)));
-                Real fracx = (ccm(ii,j-1,k) || ccm(ii,j,k)) ? std::abs(fcy(i,j,k,0)) : Real(0.0);
-                Real fracz = (ccm(i,j-1,kk) || ccm(i,j,kk)) ? std::abs(fcy(i,j,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fym +
-                        fracx*(Real(1.0)-fracz)*bY(ii,j,k ,n)*(x(ii,j,k ,n)-x(ii,j-1,k ,n)) +
-                        fracz*(Real(1.0)-fracx)*bY(i ,j,kk,n)*(x(i ,j,kk,n)-x(i ,j-1,kk,n)) +
-                        fracx*     fracz *bY(ii,j,kk,n)*(x(ii,j,kk,n)-x(ii,j-1,kk,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fym = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(x( i,j, k,n)-x( i,j-1, k,n)) +
-                               fracx *(Real(1.0)-fracz)*(x(ii,j, k,n)-x(ii,j-1, k,n)) +
-                               fracz *(Real(1.0)-fracx)*(x(i ,j,kk,n)-x( i,j-1,kk,n)) +
-                               fracx *     fracz *(x(ii,j,kk,n)-x(ii,j-1,kk,n));
-                    fym *= bY(i,j,k,n);
-
-                }
-            }
-
-            Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
-            if (apyp != Real(0.0) && apyp != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,0)));
-                int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,1)));
-                Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k,0)) : Real(0.0);
-                Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? std::abs(fcy(i,j+1,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fyp +
-                        fracx*(Real(1.0)-fracz)*bY(ii,j+1,k ,n)*(x(ii,j+1,k ,n)-x(ii,j,k ,n)) +
-                        fracz*(Real(1.0)-fracx)*bY(i ,j+1,kk,n)*(x(i ,j+1,kk,n)-x(i ,j,kk,n)) +
-                        fracx*     fracz *bY(ii,j+1,kk,n)*(x(ii,j+1,kk,n)-x(ii,j,kk,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(x( i,j+1, k,n)-x( i,j, k,n)) +
-                               fracx *(Real(1.0)-fracz)*(x(ii,j+1, k,n)-x(ii,j, k,n)) +
-                               fracz *(Real(1.0)-fracx)*(x( i,j+1,kk,n)-x( i,j,kk,n)) +
-                               fracx *     fracz *(x(ii,j+1,kk,n)-x(ii,j,kk,n));
-                    fyp *= bY(i,j+1,k,n);
-
-                }
-            }
-
-            Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
-            if (apzm != Real(0.0) && apzm != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,0)));
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,1)));
-                Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : Real(0.0);
-                Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzm +
-                        fracx*(Real(1.0)-fracy)*bZ(ii,j ,k,n)*(x(ii,j ,k,n)-x(ii,j ,k-1,n)) +
-                        fracy*(Real(1.0)-fracx)*bZ(i ,jj,k,n)*(x(i ,jj,k,n)-x(i ,jj,k-1,n)) +
-                        fracx*     fracy *bZ(ii,jj,k,n)*(x(ii,jj,k,n)-x(ii,jj,k-1,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(x( i, j,k,n)-x( i, j,k-1,n)) +
-                               fracx *(Real(1.0)-fracy)*(x(ii, j,k,n)-x(ii, j,k-1,n)) +
-                               fracy *(Real(1.0)-fracx)*(x( i,jj,k,n)-x( i,jj,k-1,n)) +
-                               fracx *     fracy *(x(ii,jj,k,n)-x(ii,jj,k-1,n));
-                    fzm *= bZ(i,j,k,n);
-
-                }
-            }
-
-            Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
-            if (apzp != Real(0.0) && apzp != Real(1.0)) {
-                int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,0)));
-                int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,1)));
-                Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? std::abs(fcz(i,j,k+1,0)) : Real(0.0);
-                Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? std::abs(fcz(i,j,k+1,1)) : Real(0.0);
-                if (beta_on_center && phi_on_center)
-                {
-                    fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzp +
-                        fracx*(Real(1.0)-fracy)*bZ(ii,j ,k+1,n)*(x(ii,j ,k+1,n)-x(ii,j ,k,n)) +
-                        fracy*(Real(1.0)-fracx)*bZ(i ,jj,k+1,n)*(x(i ,jj,k+1,n)-x(i ,jj,k,n)) +
-                        fracx*     fracy *bZ(ii,jj,k+1,n)*(x(ii,jj,k+1,n)-x(ii,jj,k,n));
-                }
-                else if (beta_on_centroid && phi_on_center)
-                {
-                    fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(x( i, j,k+1,n)-x( i, j,k,n)) +
-                               fracx *(Real(1.0)-fracy)*(x(ii, j,k+1,n)-x(ii, j,k,n)) +
-                               fracy *(Real(1.0)-fracx)*(x( i,jj,k+1,n)-x( i,jj,k,n)) +
-                               fracx *     fracy *(x(ii,jj,k+1,n)-x(ii,jj,k,n));
-                    fzp *= bZ(i,j,k+1,n);
-
-                }
-            }
-
-            Real feb = Real(0.0);
-            if (is_dirichlet) {
-                Real dapx = apxm-apxp;
-                Real dapy = apym-apyp;
-                Real dapz = apzm-apzp;
-                Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
-                Real anorminv = Real(1.0)/anorm;
-                Real anrmx = dapx * anorminv;
-                Real anrmy = dapy * anorminv;
-                Real anrmz = dapz * anorminv;
-
-                Real phib = is_inhomog ? phieb(i,j,k,n) : Real(0.0);
-
-                Real bctx = bc(i,j,k,0);
-                Real bcty = bc(i,j,k,1);
-                Real bctz = bc(i,j,k,2);
-                Real dx_eb = get_dx_eb(kappa);
-
-                Real dg = dx_eb / amrex::max(std::abs(anrmx), std::abs(anrmy),
-                                             std::abs(anrmz));
-                Real gx = bctx - dg*anrmx;
-                Real gy = bcty - dg*anrmy;
-                Real gz = bctz - dg*anrmz;
-                Real sx = std::copysign(Real(1.0),anrmx);
-                Real sy = std::copysign(Real(1.0),anrmy);
-                Real sz = std::copysign(Real(1.0),anrmz);
-                int ii = i - static_cast<int>(sx);
-                int jj = j - static_cast<int>(sy);
-                int kk = k - static_cast<int>(sz);
-
-                gx = sx*gx;
-                gy = sy*gy;
-                gz = sz*gz;
-                Real gxy = gx*gy;
-                Real gxz = gx*gz;
-                Real gyz = gy*gz;
-                Real gxyz = gx*gy*gz;
-                Real phig = (Real(1.0)+gx+gy+gz+gxy+gxz+gyz+gxyz) * x(i ,j ,k ,n)
-                    +       (-gz - gxz - gyz - gxyz)        * x(i ,j ,kk,n)
-                    +       (-gy - gxy - gyz - gxyz)        * x(i ,jj,k ,n)
-                    +       (gyz + gxyz)                    * x(i ,jj,kk,n)
-                    +       (-gx - gxy - gxz - gxyz)        * x(ii,j ,k ,n)
-                    +       (gxz + gxyz)                    * x(ii,j ,kk,n)
-                    +       (gxy + gxyz)                    * x(ii,jj,k ,n)
-                    +       (-gxyz)                         * x(ii,jj,kk,n);
-
-                Real dphidn = (phib-phig)/dg;
-
-                feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
-            }
-
-            y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
-                (dhx*(apxm*fxm - apxp*fxp) +
-                 dhy*(apym*fym - apyp*fyp) +
-                 dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
         }
-    });
+
+        Real fyp = bY(i,j+1,k,n)*(x(i,j+1,k,n) - x(i,j,k,n));
+        if (apyp != Real(0.0) && apyp != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,0)));
+            int kk = k + static_cast<int>(std::copysign(Real(1.0),fcy(i,j+1,k,1)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j+1,k)) ? std::abs(fcy(i,j+1,k,0)) : Real(0.0);
+            Real fracz = (ccm(i,j,kk) || ccm(i,j+1,kk)) ? std::abs(fcy(i,j+1,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*fyp +
+                    fracx*(Real(1.0)-fracz)*bY(ii,j+1,k ,n)*(x(ii,j+1,k ,n)-x(ii,j,k ,n)) +
+                    fracz*(Real(1.0)-fracx)*bY(i ,j+1,kk,n)*(x(i ,j+1,kk,n)-x(i ,j,kk,n)) +
+                    fracx*     fracz *bY(ii,j+1,kk,n)*(x(ii,j+1,kk,n)-x(ii,j,kk,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fyp = (Real(1.0)-fracx)*(Real(1.0)-fracz)*(x( i,j+1, k,n)-x( i,j, k,n)) +
+                           fracx *(Real(1.0)-fracz)*(x(ii,j+1, k,n)-x(ii,j, k,n)) +
+                           fracz *(Real(1.0)-fracx)*(x( i,j+1,kk,n)-x( i,j,kk,n)) +
+                           fracx *     fracz *(x(ii,j+1,kk,n)-x(ii,j,kk,n));
+                fyp *= bY(i,j+1,k,n);
+
+            }
+        }
+
+        Real fzm = bZ(i,j,k,n)*(x(i,j,k,n) - x(i,j,k-1,n));
+        if (apzm != Real(0.0) && apzm != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,0)));
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k,1)));
+            Real fracx = (ccm(ii,j,k-1) || ccm(ii,j,k)) ? std::abs(fcz(i,j,k,0)) : Real(0.0);
+            Real fracy = (ccm(i,jj,k-1) || ccm(i,jj,k)) ? std::abs(fcz(i,j,k,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzm +
+                    fracx*(Real(1.0)-fracy)*bZ(ii,j ,k,n)*(x(ii,j ,k,n)-x(ii,j ,k-1,n)) +
+                    fracy*(Real(1.0)-fracx)*bZ(i ,jj,k,n)*(x(i ,jj,k,n)-x(i ,jj,k-1,n)) +
+                    fracx*     fracy *bZ(ii,jj,k,n)*(x(ii,jj,k,n)-x(ii,jj,k-1,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fzm = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(x( i, j,k,n)-x( i, j,k-1,n)) +
+                           fracx *(Real(1.0)-fracy)*(x(ii, j,k,n)-x(ii, j,k-1,n)) +
+                           fracy *(Real(1.0)-fracx)*(x( i,jj,k,n)-x( i,jj,k-1,n)) +
+                           fracx *     fracy *(x(ii,jj,k,n)-x(ii,jj,k-1,n));
+                fzm *= bZ(i,j,k,n);
+
+            }
+        }
+
+        Real fzp = bZ(i,j,k+1,n)*(x(i,j,k+1,n) - x(i,j,k,n));
+        if (apzp != Real(0.0) && apzp != Real(1.0)) {
+            int ii = i + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,0)));
+            int jj = j + static_cast<int>(std::copysign(Real(1.0),fcz(i,j,k+1,1)));
+            Real fracx = (ccm(ii,j,k) || ccm(ii,j,k+1)) ? std::abs(fcz(i,j,k+1,0)) : Real(0.0);
+            Real fracy = (ccm(i,jj,k) || ccm(i,jj,k+1)) ? std::abs(fcz(i,j,k+1,1)) : Real(0.0);
+            if (beta_on_center && phi_on_center)
+            {
+                fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*fzp +
+                    fracx*(Real(1.0)-fracy)*bZ(ii,j ,k+1,n)*(x(ii,j ,k+1,n)-x(ii,j ,k,n)) +
+                    fracy*(Real(1.0)-fracx)*bZ(i ,jj,k+1,n)*(x(i ,jj,k+1,n)-x(i ,jj,k,n)) +
+                    fracx*     fracy *bZ(ii,jj,k+1,n)*(x(ii,jj,k+1,n)-x(ii,jj,k,n));
+            }
+            else if (beta_on_centroid && phi_on_center)
+            {
+                fzp = (Real(1.0)-fracx)*(Real(1.0)-fracy)*(x( i, j,k+1,n)-x( i, j,k,n)) +
+                           fracx *(Real(1.0)-fracy)*(x(ii, j,k+1,n)-x(ii, j,k,n)) +
+                           fracy *(Real(1.0)-fracx)*(x( i,jj,k+1,n)-x( i,jj,k,n)) +
+                           fracx *     fracy *(x(ii,jj,k+1,n)-x(ii,jj,k,n));
+                fzp *= bZ(i,j,k+1,n);
+
+            }
+        }
+
+        Real feb = Real(0.0);
+        if (is_dirichlet) {
+            Real dapx = apxm-apxp;
+            Real dapy = apym-apyp;
+            Real dapz = apzm-apzp;
+            Real anorm = std::sqrt(dapx*dapx+dapy*dapy+dapz*dapz);
+            Real anorminv = Real(1.0)/anorm;
+            Real anrmx = dapx * anorminv;
+            Real anrmy = dapy * anorminv;
+            Real anrmz = dapz * anorminv;
+
+            Real phib = is_inhomog ? phieb(i,j,k,n) : Real(0.0);
+
+            Real bctx = bc(i,j,k,0);
+            Real bcty = bc(i,j,k,1);
+            Real bctz = bc(i,j,k,2);
+            Real dx_eb = get_dx_eb(kappa);
+
+            Real dg = dx_eb / amrex::max(std::abs(anrmx), std::abs(anrmy),
+                                         std::abs(anrmz));
+            Real gx = bctx - dg*anrmx;
+            Real gy = bcty - dg*anrmy;
+            Real gz = bctz - dg*anrmz;
+            Real sx = std::copysign(Real(1.0),anrmx);
+            Real sy = std::copysign(Real(1.0),anrmy);
+            Real sz = std::copysign(Real(1.0),anrmz);
+            int ii = i - static_cast<int>(sx);
+            int jj = j - static_cast<int>(sy);
+            int kk = k - static_cast<int>(sz);
+
+            gx = sx*gx;
+            gy = sy*gy;
+            gz = sz*gz;
+            Real gxy = gx*gy;
+            Real gxz = gx*gz;
+            Real gyz = gy*gz;
+            Real gxyz = gx*gy*gz;
+            Real phig = (Real(1.0)+gx+gy+gz+gxy+gxz+gyz+gxyz) * x(i ,j ,k ,n)
+                +       (-gz - gxz - gyz - gxyz)        * x(i ,j ,kk,n)
+                +       (-gy - gxy - gyz - gxyz)        * x(i ,jj,k ,n)
+                +       (gyz + gxyz)                    * x(i ,jj,kk,n)
+                +       (-gx - gxy - gxz - gxyz)        * x(ii,j ,k ,n)
+                +       (gxz + gxyz)                    * x(ii,j ,kk,n)
+                +       (gxy + gxyz)                    * x(ii,jj,k ,n)
+                +       (-gxyz)                         * x(ii,jj,kk,n);
+
+            Real dphidn = (phib-phig)/dg;
+
+            feb = dphidn * ba(i,j,k) * beb(i,j,k,n);
+        }
+
+        y(i,j,k,n) = alpha*a(i,j,k)*x(i,j,k,n) + (Real(1.0)/kappa) *
+            (dhx*(apxm*fxm - apxp*fxp) +
+             dhy*(apym*fym - apyp*fyp) +
+             dhz*(apzm*fzm - apzp*fzp) - dhx*feb);
+    }
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -50,101 +50,164 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
         const bool extdir_y = !(m_geom[amrlev][mglev].isPeriodic(1));,
         const bool extdir_z = !(m_geom[amrlev][mglev].isPeriodic(2)););
 
-    MFItInfo mfi_info;
-    if (Gpu::notInLaunchRegion()) { mfi_info.EnableTiling().SetDynamic(true); }
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion() && out.isFusingCandidate() && factory && !has_overset)
+    {
+        MultiArray4<Real const> fooma;
+        auto const& xma = in.const_arrays();
+        auto const& yma = out.arrays();
+        auto const& ama = acoef.const_arrays();
+        AMREX_D_TERM(auto const& bxma = bxcoef.const_arrays();,
+                     auto const& byma = bycoef.const_arrays();,
+                     auto const& bzma = bzcoef.const_arrays(););
+        auto const& ccmma = ccmask.const_arrays();
+        auto const ebdata_ma = factory->getEBDataArrays();
+        auto const& bebma = (is_eb_dirichlet)
+            ? m_eb_b_coeffs[amrlev][mglev]->const_arrays() : fooma;
+        auto const& phiebma = (is_eb_dirichlet && is_eb_inhomog)
+            ? m_eb_phi[amrlev]->const_arrays() : fooma;
+
+        const bool beta_on_centroid = (m_beta_loc == Location::FaceCentroid);
+        const bool  phi_on_centroid = (m_phi_loc  == Location::CellCentroid);
+        const bool treat_phi_as_on_centroid = (phi_on_centroid && (mglev == 0));
+
+        if (treat_phi_as_on_centroid) {
+#ifdef AMREX_USE_HIP
+            // This causes an abort in HIP 4.5 but works in earlier versions
+            // A follow-up release should fix this.
+            // Error message:
+            //   lld: error: ran out of registers during register allocation
+            amrex::Abort("MLEBABecLap::Fapply: phi on centroid not supported for HIP");
+            amrex::ignore_unused(AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
+                                 AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
+                                 AMREX_D_DECL(extdir_x, extdir_y, extdir_z));
+#else
+            amrex::ParallelFor(out, IntVect(0), ncomp,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+            {
+                mlebabeclap_adotx_centroid(i, j, k, n, yma[box_no], xma[box_no], ama[box_no],
+                                  AMREX_D_DECL(bxma[box_no],byma[box_no],bzma[box_no]),
+                                  ebdata_ma.get(box_no), bebma[box_no], phiebma[box_no],
+                                  AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
+                                  AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
+                                  AMREX_D_DECL(extdir_x, extdir_y, extdir_z),
+                                  is_eb_dirichlet, is_eb_inhomog, dxinvarr,
+                                  ascalar, bscalar);
+            });
+#endif
+        } else {
+            amrex::ParallelFor(out, IntVect(0), ncomp,
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+            {
+                mlebabeclap_adotx(i, j, k, n, yma[box_no], xma[box_no], ama[box_no],
+                                  AMREX_D_DECL(bxma[box_no],byma[box_no],bzma[box_no]),
+                                  ccmma[box_no], ebdata_ma.get(box_no), bebma[box_no],
+                                  is_eb_dirichlet, phiebma[box_no],
+                                  is_eb_inhomog, dxinvarr,
+                                  ascalar, bscalar, beta_on_centroid, phi_on_centroid);
+            });
+        }
+        if (!Gpu::inNoSyncRegion()) { Gpu::streamSynchronize(); }
+    }
+    else
+#endif
+    {
+        MFItInfo mfi_info;
+        if (Gpu::notInLaunchRegion()) { mfi_info.EnableTiling().SetDynamic(true); }
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(out, mfi_info); mfi.isValid(); ++mfi)
-    {
-        const Box& bx = mfi.tilebox();
-        Array4<Real const> const& xfab = in.const_array(mfi);
-        Array4<Real> const& yfab = out.array(mfi);
-        Array4<Real const> const& afab = acoef.const_array(mfi);
-        AMREX_D_TERM(Array4<Real const> const& bxfab = bxcoef.const_array(mfi);,
-                     Array4<Real const> const& byfab = bycoef.const_array(mfi);,
-                     Array4<Real const> const& bzfab = bzcoef.const_array(mfi););
+        for (MFIter mfi(out, mfi_info); mfi.isValid(); ++mfi)
+        {
+            const Box& bx = mfi.tilebox();
+            Array4<Real const> const& xfab = in.const_array(mfi);
+            Array4<Real> const& yfab = out.array(mfi);
+            Array4<Real const> const& afab = acoef.const_array(mfi);
+            AMREX_D_TERM(Array4<Real const> const& bxfab = bxcoef.const_array(mfi);,
+                         Array4<Real const> const& byfab = bycoef.const_array(mfi);,
+                         Array4<Real const> const& bzfab = bzcoef.const_array(mfi););
 
-        auto fabtyp = (flags) ? (*flags)[mfi].getType(bx) : FabType::regular;
+            auto fabtyp = (flags) ? (*flags)[mfi].getType(bx) : FabType::regular;
 
-        if (fabtyp == FabType::covered) {
-            AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
-            {
-                yfab(i,j,k,n) = 0.0;
-            });
-        } else if (fabtyp == FabType::regular) {
-            if (has_overset) {
-                Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
+            if (fabtyp == FabType::covered) {
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
                 {
-                    mlabeclap_adotx_os(i,j,k,n, yfab, xfab, afab,
-                                       AMREX_D_DECL(bxfab,byfab,bzfab),
-                                       osm, dxinvarr, ascalar, bscalar);
+                    yfab(i,j,k,n) = 0.0;
                 });
+            } else if (fabtyp == FabType::regular) {
+                if (has_overset) {
+                    Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
+                    {
+                        mlabeclap_adotx_os(i,j,k,n, yfab, xfab, afab,
+                                           AMREX_D_DECL(bxfab,byfab,bzfab),
+                                           osm, dxinvarr, ascalar, bscalar);
+                    });
+                } else {
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
+                    {
+                        mlabeclap_adotx(i,j,k,n, yfab, xfab, afab,
+                                        AMREX_D_DECL(bxfab,byfab,bzfab),
+                                        dxinvarr, ascalar, bscalar);
+                    });
+                }
             } else {
-                AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
-                {
-                    mlabeclap_adotx(i,j,k,n, yfab, xfab, afab,
-                                    AMREX_D_DECL(bxfab,byfab,bzfab),
-                                    dxinvarr, ascalar, bscalar);
-                });
-            }
-        } else {
-            Array4<int const> const& ccmfab = ccmask.const_array(mfi);
-            auto const& ebdata = factory->getEBData(mfi);
-            Array4<Real const> const& bebfab = (is_eb_dirichlet)
-                ? m_eb_b_coeffs[amrlev][mglev]->const_array(mfi) : foo;
-            Array4<Real const> const& phiebfab = (is_eb_dirichlet && is_eb_inhomog)
-                ? m_eb_phi[amrlev]->const_array(mfi) : foo;
+                Array4<int const> const& ccmfab = ccmask.const_array(mfi);
+                auto const& ebdata = factory->getEBData(mfi);
+                Array4<Real const> const& bebfab = (is_eb_dirichlet)
+                    ? m_eb_b_coeffs[amrlev][mglev]->const_array(mfi) : foo;
+                Array4<Real const> const& phiebfab = (is_eb_dirichlet && is_eb_inhomog)
+                    ? m_eb_phi[amrlev]->const_array(mfi) : foo;
 
-            bool beta_on_centroid = (m_beta_loc == Location::FaceCentroid);
-            bool  phi_on_centroid = (m_phi_loc  == Location::CellCentroid);
+                bool beta_on_centroid = (m_beta_loc == Location::FaceCentroid);
+                bool  phi_on_centroid = (m_phi_loc  == Location::CellCentroid);
 
-            bool treat_phi_as_on_centroid = ( phi_on_centroid && (mglev == 0) );
+                bool treat_phi_as_on_centroid = ( phi_on_centroid && (mglev == 0) );
 
-            if (treat_phi_as_on_centroid) {
+                if (treat_phi_as_on_centroid) {
 #ifdef AMREX_USE_HIP
-                // This causes an abort in HIP 4.5 but works in earlier versions
-                // A follow-up release should fix this.
-                // Error message:
-                //   lld: error: ran out of registers during register allocation
-                amrex::Abort("MLEBABecLap::Fapply: phi on centroid not supported for HIP");
-                amrex::ignore_unused(AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
-                                     AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
-                                     AMREX_D_DECL(extdir_x, extdir_y, extdir_z));
+                    // This causes an abort in HIP 4.5 but works in earlier versions
+                    // A follow-up release should fix this.
+                    // Error message:
+                    //   lld: error: ran out of registers during register allocation
+                    amrex::Abort("MLEBABecLap::Fapply: phi on centroid not supported for HIP");
+                    amrex::ignore_unused(AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
+                                         AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
+                                         AMREX_D_DECL(extdir_x, extdir_y, extdir_z));
 #else
-                AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
-                {
-                    mlebabeclap_adotx_centroid(i, j, k, n, yfab, xfab, afab,
-                                      AMREX_D_DECL(bxfab,byfab,bzfab),
-                                      ebdata, bebfab, phiebfab,
-                                      AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
-                                      AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
-                                      AMREX_D_DECL(extdir_x, extdir_y, extdir_z),
-                                      is_eb_dirichlet, is_eb_inhomog, dxinvarr,
-                                      ascalar, bscalar);
-                });
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
+                    {
+                        mlebabeclap_adotx_centroid(i, j, k, n, yfab, xfab, afab,
+                                          AMREX_D_DECL(bxfab,byfab,bzfab),
+                                          ebdata, bebfab, phiebfab,
+                                          AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
+                                          AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
+                                          AMREX_D_DECL(extdir_x, extdir_y, extdir_z),
+                                          is_eb_dirichlet, is_eb_inhomog, dxinvarr,
+                                          ascalar, bscalar);
+                    });
 #endif
-            } else {
-                AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
-                {
-                    mlebabeclap_adotx(i, j, k, n, yfab, xfab, afab,
-                                      AMREX_D_DECL(bxfab,byfab,bzfab),
-                                      ccmfab, ebdata, bebfab,
-                                      is_eb_dirichlet,
-                                      phiebfab,
-                                      is_eb_inhomog, dxinvarr,
-                                      ascalar, bscalar, beta_on_centroid, phi_on_centroid);
-                });
-            }
-            if (has_overset) {
-                Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
-                AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
-                {
-                    if (osm(i,j,k) == 0) {
-                        yfab(i,j,k,n) = Real(0.0);
-                    }
-                });
+                } else {
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
+                    {
+                        mlebabeclap_adotx(i, j, k, n, yfab, xfab, afab,
+                                          AMREX_D_DECL(bxfab,byfab,bzfab),
+                                          ccmfab, ebdata, bebfab,
+                                          is_eb_dirichlet,
+                                          phiebfab,
+                                          is_eb_inhomog, dxinvarr,
+                                          ascalar, bscalar, beta_on_centroid, phi_on_centroid);
+                    });
+                }
+                if (has_overset) {
+                    Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
+                    {
+                        if (osm(i,j,k) == 0) {
+                            yfab(i,j,k,n) = Real(0.0);
+                        }
+                    });
+                }
             }
         }
     }
@@ -206,117 +269,181 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
 
     Array4<Real const> foo;
 
-    MFItInfo mfi_info;
-    if (Gpu::notInLaunchRegion()) { mfi_info.SetDynamic(true); }
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion() && sol.isFusingCandidate() && factory && !has_overset)
+    {
+        AMREX_ALWAYS_ASSERT(rhs.nGrowVect() == 0);
+
+        MultiArray4<Real const> fooma;
+        auto const& m0ma = mm0.const_arrays();
+        auto const& m1ma = mm1.const_arrays();
+#if (AMREX_SPACEDIM > 1)
+        auto const& m2ma = mm2.const_arrays();
+        auto const& m3ma = mm3.const_arrays();
+#if (AMREX_SPACEDIM > 2)
+        auto const& m4ma = mm4.const_arrays();
+        auto const& m5ma = mm5.const_arrays();
+#endif
+#endif
+        auto const& solma = sol.arrays();
+        auto const& rhsma = rhs.const_arrays();
+        auto const& ama   = acoef.const_arrays();
+        AMREX_D_TERM(auto const& bxma = bxcoef.const_arrays();,
+                     auto const& byma = bycoef.const_arrays();,
+                     auto const& bzma = bzcoef.const_arrays(););
+        auto const& f0ma = f0.const_arrays();
+        auto const& f1ma = f1.const_arrays();
+#if (AMREX_SPACEDIM > 1)
+        auto const& f2ma = f2.const_arrays();
+        auto const& f3ma = f3.const_arrays();
+#if (AMREX_SPACEDIM > 2)
+        auto const& f4ma = f4.const_arrays();
+        auto const& f5ma = f5.const_arrays();
+#endif
+#endif
+        auto const& ccmma = ccmask.const_arrays();
+        auto const ebdata_ma = factory->getEBDataArrays();
+        auto const& bebma = (is_eb_dirichlet)
+            ? m_eb_b_coeffs[amrlev][mglev]->const_arrays() : fooma;
+
+        const bool beta_on_centroid = (m_beta_loc == Location::FaceCentroid);
+        const bool  phi_on_centroid = (m_phi_loc  == Location::CellCentroid);
+
+        if (phi_on_centroid) { amrex::Abort("phi_on_centroid is still a WIP"); }
+
+        amrex::ParallelFor(sol, IntVect(0), nc,
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+        {
+            Box vbx(rhsma[box_no]);
+            mlebabeclap_gsrb(i, j, k, n, solma[box_no], rhsma[box_no], alpha, ama[box_no],
+                             AMREX_D_DECL(dhx, dhy, dhz),
+                             AMREX_2D_ONLY_ARGS(dh,h)
+                             AMREX_D_DECL(bxma[box_no],byma[box_no],bzma[box_no]),
+                             AMREX_D_DECL(m0ma[box_no],m2ma[box_no],m4ma[box_no]),
+                             AMREX_D_DECL(m1ma[box_no],m3ma[box_no],m5ma[box_no]),
+                             AMREX_D_DECL(f0ma[box_no],f2ma[box_no],f4ma[box_no]),
+                             AMREX_D_DECL(f1ma[box_no],f3ma[box_no],f5ma[box_no]),
+                             ccmma[box_no], bebma[box_no], ebdata_ma.get(box_no),
+                             is_eb_dirichlet, beta_on_centroid, phi_on_centroid,
+                             vbx, redblack);
+        });
+        if (!Gpu::inNoSyncRegion()) { Gpu::streamSynchronize(); }
+    }
+    else
+#endif
+    {
+        MFItInfo mfi_info;
+        if (Gpu::notInLaunchRegion()) { mfi_info.SetDynamic(true); }
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(sol, mfi_info);  mfi.isValid(); ++mfi)
-    {
-        const auto& m0 = mm0.array(mfi);
-        const auto& m1 = mm1.array(mfi);
-#if (AMREX_SPACEDIM > 1)
-        const auto& m2 = mm2.array(mfi);
-        const auto& m3 = mm3.array(mfi);
-#if (AMREX_SPACEDIM > 2)
-        const auto& m4 = mm4.array(mfi);
-        const auto& m5 = mm5.array(mfi);
-#endif
-#endif
-
-        const Box& vbx = mfi.validbox();
-        const auto& solnfab = sol.array(mfi);
-        const auto& rhsfab  = rhs.const_array(mfi);
-        const auto& afab    = acoef.const_array(mfi);
-
-        AMREX_D_TERM(const auto& bxfab = bxcoef.const_array(mfi);,
-                     const auto& byfab = bycoef.const_array(mfi);,
-                     const auto& bzfab = bzcoef.const_array(mfi););
-
-        const auto& f0fab = f0.const_array(mfi);
-        const auto& f1fab = f1.const_array(mfi);
-#if (AMREX_SPACEDIM > 1)
-        const auto& f2fab = f2.const_array(mfi);
-        const auto& f3fab = f3.const_array(mfi);
-#if (AMREX_SPACEDIM > 2)
-        const auto& f4fab = f4.const_array(mfi);
-        const auto& f5fab = f5.const_array(mfi);
-#endif
-#endif
-
-        auto fabtyp = (flags) ? (*flags)[mfi].getType(vbx) : FabType::regular;
-
-        if (fabtyp == FabType::covered)
+        for (MFIter mfi(sol, mfi_info);  mfi.isValid(); ++mfi)
         {
-            AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( vbx, nc, i, j, k, n,
+            const auto& m0 = mm0.array(mfi);
+            const auto& m1 = mm1.array(mfi);
+#if (AMREX_SPACEDIM > 1)
+            const auto& m2 = mm2.array(mfi);
+            const auto& m3 = mm3.array(mfi);
+#if (AMREX_SPACEDIM > 2)
+            const auto& m4 = mm4.array(mfi);
+            const auto& m5 = mm5.array(mfi);
+#endif
+#endif
+
+            const Box& vbx = mfi.validbox();
+            const auto& solnfab = sol.array(mfi);
+            const auto& rhsfab  = rhs.const_array(mfi);
+            const auto& afab    = acoef.const_array(mfi);
+
+            AMREX_D_TERM(const auto& bxfab = bxcoef.const_array(mfi);,
+                         const auto& byfab = bycoef.const_array(mfi);,
+                         const auto& bzfab = bzcoef.const_array(mfi););
+
+            const auto& f0fab = f0.const_array(mfi);
+            const auto& f1fab = f1.const_array(mfi);
+#if (AMREX_SPACEDIM > 1)
+            const auto& f2fab = f2.const_array(mfi);
+            const auto& f3fab = f3.const_array(mfi);
+#if (AMREX_SPACEDIM > 2)
+            const auto& f4fab = f4.const_array(mfi);
+            const auto& f5fab = f5.const_array(mfi);
+#endif
+#endif
+
+            auto fabtyp = (flags) ? (*flags)[mfi].getType(vbx) : FabType::regular;
+
+            if (fabtyp == FabType::covered)
             {
-                solnfab(i,j,k,n) = 0.0;
-            });
-        }
-        else if (fabtyp == FabType::regular)
-        {
-            if (has_overset) {
-                Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
-                AMREX_HOST_DEVICE_PARALLEL_FOR_4D(vbx, nc, i, j, k, n,
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( vbx, nc, i, j, k, n,
                 {
-                    abec_gsrb_os(i,j,k,n, solnfab, rhsfab, alpha, afab,
-                                 AMREX_D_DECL(dhx, dhy, dhz),
-                                 AMREX_D_DECL(bxfab, byfab, bzfab),
-                                 AMREX_D_DECL(m0,m2,m4),
-                                 AMREX_D_DECL(m1,m3,m5),
-                                 AMREX_D_DECL(f0fab,f2fab,f4fab),
-                                 AMREX_D_DECL(f1fab,f3fab,f5fab),
-                                 osm, vbx, redblack);
-                });
-            } else {
-                AMREX_HOST_DEVICE_PARALLEL_FOR_4D(vbx, nc, i, j, k, n,
-                {
-                    abec_gsrb(i,j,k,n, solnfab, rhsfab, alpha, afab,
-                              AMREX_D_DECL(dhx, dhy, dhz),
-                              AMREX_D_DECL(bxfab, byfab, bzfab),
-                              AMREX_D_DECL(m0,m2,m4),
-                              AMREX_D_DECL(m1,m3,m5),
-                              AMREX_D_DECL(f0fab,f2fab,f4fab),
-                              AMREX_D_DECL(f1fab,f3fab,f5fab),
-                              vbx, redblack);
+                    solnfab(i,j,k,n) = 0.0;
                 });
             }
-        }
-        else
-        {
-            Array4<int const> const& ccmfab = ccmask.const_array(mfi);
-            Array4<Real const> const& bebfab = (is_eb_dirichlet)
-                ? m_eb_b_coeffs[amrlev][mglev]->const_array(mfi) : foo;
-
-            auto const& ebdata = factory->getEBData(mfi);
-
-            bool beta_on_centroid = (m_beta_loc == Location::FaceCentroid);
-            bool  phi_on_centroid = (m_phi_loc  == Location::CellCentroid);
-
-            if (phi_on_centroid) { amrex::Abort("phi_on_centroid is still a WIP"); }
-
-            AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( vbx, nc, i, j, k, n,
+            else if (fabtyp == FabType::regular)
             {
-                mlebabeclap_gsrb(i, j, k, n, solnfab, rhsfab, alpha, afab,
-                                 AMREX_D_DECL(dhx, dhy, dhz),
-                                 AMREX_2D_ONLY_ARGS(dh,h)
-                                 AMREX_D_DECL(bxfab,byfab,bzfab),
-                                 AMREX_D_DECL(m0,m2,m4),
-                                 AMREX_D_DECL(m1,m3,m5),
-                                 AMREX_D_DECL(f0fab,f2fab,f4fab),
-                                 AMREX_D_DECL(f1fab,f3fab,f5fab),
-                                 ccmfab, bebfab, ebdata,
-                                 is_eb_dirichlet, beta_on_centroid, phi_on_centroid,
-                                 vbx, redblack);
-            });
-            if (has_overset) {
-                Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
-                AMREX_HOST_DEVICE_PARALLEL_FOR_4D(vbx, nc, i, j, k, n,
+                if (has_overset) {
+                    Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D(vbx, nc, i, j, k, n,
+                    {
+                        abec_gsrb_os(i,j,k,n, solnfab, rhsfab, alpha, afab,
+                                     AMREX_D_DECL(dhx, dhy, dhz),
+                                     AMREX_D_DECL(bxfab, byfab, bzfab),
+                                     AMREX_D_DECL(m0,m2,m4),
+                                     AMREX_D_DECL(m1,m3,m5),
+                                     AMREX_D_DECL(f0fab,f2fab,f4fab),
+                                     AMREX_D_DECL(f1fab,f3fab,f5fab),
+                                     osm, vbx, redblack);
+                    });
+                } else {
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D(vbx, nc, i, j, k, n,
+                    {
+                        abec_gsrb(i,j,k,n, solnfab, rhsfab, alpha, afab,
+                                  AMREX_D_DECL(dhx, dhy, dhz),
+                                  AMREX_D_DECL(bxfab, byfab, bzfab),
+                                  AMREX_D_DECL(m0,m2,m4),
+                                  AMREX_D_DECL(m1,m3,m5),
+                                  AMREX_D_DECL(f0fab,f2fab,f4fab),
+                                  AMREX_D_DECL(f1fab,f3fab,f5fab),
+                                  vbx, redblack);
+                    });
+                }
+            }
+            else
+            {
+                Array4<int const> const& ccmfab = ccmask.const_array(mfi);
+                Array4<Real const> const& bebfab = (is_eb_dirichlet)
+                    ? m_eb_b_coeffs[amrlev][mglev]->const_array(mfi) : foo;
+
+                auto const& ebdata = factory->getEBData(mfi);
+
+                bool beta_on_centroid = (m_beta_loc == Location::FaceCentroid);
+                bool  phi_on_centroid = (m_phi_loc  == Location::CellCentroid);
+
+                if (phi_on_centroid) { amrex::Abort("phi_on_centroid is still a WIP"); }
+
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( vbx, nc, i, j, k, n,
                 {
-                    if (((i+j+k+redblack)%2 == 0) && (osm(i,j,k) == 0)) {
-                        solnfab(i,j,k,n) = Real(0.0);
-                    }
+                    mlebabeclap_gsrb(i, j, k, n, solnfab, rhsfab, alpha, afab,
+                                     AMREX_D_DECL(dhx, dhy, dhz),
+                                     AMREX_2D_ONLY_ARGS(dh,h)
+                                     AMREX_D_DECL(bxfab,byfab,bzfab),
+                                     AMREX_D_DECL(m0,m2,m4),
+                                     AMREX_D_DECL(m1,m3,m5),
+                                     AMREX_D_DECL(f0fab,f2fab,f4fab),
+                                     AMREX_D_DECL(f1fab,f3fab,f5fab),
+                                     ccmfab, bebfab, ebdata,
+                                     is_eb_dirichlet, beta_on_centroid, phi_on_centroid,
+                                     vbx, redblack);
                 });
+                if (has_overset) {
+                    Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_4D(vbx, nc, i, j, k, n,
+                    {
+                        if (((i+j+k+redblack)%2 == 0) && (osm(i,j,k) == 0)) {
+                            solnfab(i,j,k,n) = Real(0.0);
+                        }
+                    });
+                }
             }
         }
     }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -130,7 +130,9 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                 amrex::ignore_unused(AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
                                      AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
                                      AMREX_D_DECL(extdir_x, extdir_y, extdir_z));
-                amrex::ignore_unused(ccfab);
+                amrex::ignore_unused(ccfab, flagfab, vfracfab, bafab, bcfab,
+                                     AMREX_D_DECL(apxfab,apyfab,apzfab),
+                                     AMREX_D_DECL(fcxfab,fcyfab,fczfab));
 #else
                AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
                {
@@ -147,18 +149,17 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                });
 #endif
             } else {
-               AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
-               {
-                   mlebabeclap_adotx(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
-                                     ccmfab, flagfab, vfracfab,
-                                     AMREX_D_DECL(apxfab,apyfab,apzfab),
-                                     AMREX_D_DECL(fcxfab,fcyfab,fczfab),
-                                     bafab, bcfab, bebfab,
-                                     is_eb_dirichlet,
-                                     phiebfab,
-                                     is_eb_inhomog, dxinvarr,
-                                     ascalar, bscalar, ncomp, beta_on_centroid, phi_on_centroid);
-               });
+                auto const& ebdata = factory->getEBData(mfi);
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
+                {
+                    mlebabeclap_adotx(i, j, k, n, yfab, xfab, afab,
+                                      AMREX_D_DECL(bxfab,byfab,bzfab),
+                                      ccmfab, ebdata, bebfab,
+                                      is_eb_dirichlet,
+                                      phiebfab,
+                                      is_eb_inhomog, dxinvarr,
+                                      ascalar, bscalar, beta_on_centroid, phi_on_centroid);
+                });
             }
             if (has_overset) {
                 Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -318,9 +318,9 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
 
             if (phi_on_centroid) { amrex::Abort("phi_on_centroid is still a WIP"); }
 
-            AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( vbx, thread_box,
+            AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( vbx, nc, i, j, k, n,
             {
-                mlebabeclap_gsrb(thread_box, solnfab, rhsfab, alpha, afab,
+                mlebabeclap_gsrb(i, j, k, n, solnfab, rhsfab, alpha, afab,
                                  AMREX_D_DECL(dhx, dhy, dhz),
                                  AMREX_2D_ONLY_ARGS(dh,h)
                                  AMREX_D_DECL(bxfab,byfab,bzfab),
@@ -330,7 +330,7 @@ MLEBABecLap::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& rhs,
                                  AMREX_D_DECL(f1fab,f3fab,f5fab),
                                  ccmfab, bebfab, ebdata,
                                  is_eb_dirichlet, beta_on_centroid, phi_on_centroid,
-                                 vbx, redblack, nc);
+                                 vbx, redblack);
             });
             if (has_overset) {
                 Array4<int const> const& osm = m_overset_mask[amrlev][mglev]->const_array(mfi);

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap_F.cpp
@@ -23,14 +23,6 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
 
     const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
     const FabArray<EBCellFlagFab>* flags = (factory) ? &(factory->getMultiEBCellFlagFab()) : nullptr;
-    const MultiFab* vfrac = (factory) ? &(factory->getVolFrac()) : nullptr;
-    auto area = (factory) ? factory->getAreaFrac()
-        : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
-    auto fcent = (factory) ? factory->getFaceCent()
-        : Array<const MultiCutFab*,AMREX_SPACEDIM>{AMREX_D_DECL(nullptr,nullptr,nullptr)};
-    const MultiCutFab* barea = (factory) ? &(factory->getBndryArea()) : nullptr;
-    const MultiCutFab* bcent = (factory) ? &(factory->getBndryCent()) : nullptr;
-    const auto *const  ccent = (factory) ? &(factory->getCentroid()) : nullptr;
 
     const bool is_eb_dirichlet =  isEBDirichlet();
     const bool is_eb_inhomog = m_is_eb_inhomog && (!this->m_precond_mode);
@@ -99,17 +91,7 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
             }
         } else {
             Array4<int const> const& ccmfab = ccmask.const_array(mfi);
-            Array4<EBCellFlag const> const& flagfab = flags->const_array(mfi);
-            Array4<Real const> const& vfracfab = vfrac->const_array(mfi);
-            AMREX_D_TERM(Array4<Real const> const& apxfab = area[0]->const_array(mfi);,
-                         Array4<Real const> const& apyfab = area[1]->const_array(mfi);,
-                         Array4<Real const> const& apzfab = area[2]->const_array(mfi););
-            AMREX_D_TERM(Array4<Real const> const& fcxfab = fcent[0]->const_array(mfi);,
-                         Array4<Real const> const& fcyfab = fcent[1]->const_array(mfi);,
-                         Array4<Real const> const& fczfab = fcent[2]->const_array(mfi););
-            Array4<Real const> const& bafab = barea->const_array(mfi);
-            Array4<Real const> const& bcfab = bcent->const_array(mfi);
-            Array4<Real const> const& ccfab = ccent->const_array(mfi);
+            auto const& ebdata = factory->getEBData(mfi);
             Array4<Real const> const& bebfab = (is_eb_dirichlet)
                 ? m_eb_b_coeffs[amrlev][mglev]->const_array(mfi) : foo;
             Array4<Real const> const& phiebfab = (is_eb_dirichlet && is_eb_inhomog)
@@ -130,26 +112,20 @@ MLEBABecLap::Fapply (int amrlev, int mglev, MultiFab& out, const MultiFab& in) c
                 amrex::ignore_unused(AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
                                      AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
                                      AMREX_D_DECL(extdir_x, extdir_y, extdir_z));
-                amrex::ignore_unused(ccfab, flagfab, vfracfab, bafab, bcfab,
-                                     AMREX_D_DECL(apxfab,apyfab,apzfab),
-                                     AMREX_D_DECL(fcxfab,fcyfab,fczfab));
 #else
-               AMREX_LAUNCH_HOST_DEVICE_LAMBDA ( bx, tbx,
-               {
-                   mlebabeclap_adotx_centroid(tbx, yfab, xfab, afab, AMREX_D_DECL(bxfab,byfab,bzfab),
-                                     flagfab, vfracfab,
-                                     AMREX_D_DECL(apxfab,apyfab,apzfab),
-                                     AMREX_D_DECL(fcxfab,fcyfab,fczfab),
-                                     ccfab, bafab, bcfab, bebfab, phiebfab,
-                                     AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
-                                     AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
-                                     AMREX_D_DECL(extdir_x, extdir_y, extdir_z),
-                                     is_eb_dirichlet, is_eb_inhomog, dxinvarr,
-                                     ascalar, bscalar, ncomp);
-               });
+                AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
+                {
+                    mlebabeclap_adotx_centroid(i, j, k, n, yfab, xfab, afab,
+                                      AMREX_D_DECL(bxfab,byfab,bzfab),
+                                      ebdata, bebfab, phiebfab,
+                                      AMREX_D_DECL(domlo_x, domlo_y, domlo_z),
+                                      AMREX_D_DECL(domhi_x, domhi_y, domhi_z),
+                                      AMREX_D_DECL(extdir_x, extdir_y, extdir_z),
+                                      is_eb_dirichlet, is_eb_inhomog, dxinvarr,
+                                      ascalar, bscalar);
+                });
 #endif
             } else {
-                auto const& ebdata = factory->getEBData(mfi);
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D( bx, ncomp, i, j, k, n,
                 {
                     mlebabeclap_adotx(i, j, k, n, yfab, xfab, afab,


### PR DESCRIPTION
## Summary

Adds fused, `MultiFab`-wide GPU paths to `MLEBABecLap::Fapply` and `MLEBABecLap::Fsmooth`,
so that a whole `MultiFab` is processed by a single `ParallelFor` launch instead of one
launch per box. This is the GPU-performance part of the old WIP #4922.

* `Fapply`: when `Gpu::inLaunchRegion() && out.isFusingCandidate()`, and there is an EB
  factory and no overset mask, a single `amrex::ParallelFor(out, IntVect(0), ncomp, ...)`
  runs `mlebabeclap_adotx` (or `mlebabeclap_adotx_centroid`) over every box, using
  `EBFArrayBoxFactory::getEBDataArrays()` (added in #4929) for the EB geometry.
* `Fsmooth`: likewise a single `amrex::ParallelFor(sol, IntVect(0), nc, ...)` running
  `mlebabeclap_gsrb`, with the valid box recovered as `Box vbx(rhsma[box_no])` guarded by
  `AMREX_ALWAYS_ASSERT(rhs.nGrowVect() == 0)` — the same pattern `MLPoisson::Fsmooth`
  already uses for its fused path.
* The existing `MFIter` loop is kept verbatim as the fallback for CPU builds, for
  non-fusing-candidate `MultiFab`s, for the overset case, and for builds without an EB
  factory.

Because the fused kernel cannot dispatch per box on `FabType`, covered and regular boxes
now go through the EB kernels as well. Those kernels branch per cell on
`EBCellFlag::isCovered()` / `isRegular()`:

* `Fapply`: the regular branch of `mlebabeclap_adotx` is expression-for-expression the
  same as `mlabeclap_adotx`, so regular boxes are bitwise unchanged; covered boxes are set
  to zero exactly as before.
* `Fsmooth`: the regular branch of `mlebabeclap_gsrb` and `abec_gsrb` are algebraically
  the same relaxation (same `omega = 1.15` in 3D, no over-relaxation in 2D) but group the
  final update differently (`omega*res/(gamma-delta)` vs `omega/g_m_d*res`), so regular
  boxes change at roundoff level in the fused GPU path.

Also note that the EB cut-cell arrays reached through `EBData` are only valid on
`FabType::singlevalued` boxes; that is safe here because the kernels only touch them in
the cut-cell branch, which is unreachable on a fully regular or fully covered box.

## Additional background

This is the last piece of the split of the stale WIP #4922 ("GPU specific kernels for
MLEBABecLap"). It **depends on** the preceding index-based-kernel PRs
(`MLEBABecLap-Adotx-Index`, `MLEBABecLap-AdotxCentroid-Index`, `MLEBABecLap-GSRB-Index`)
and should be merged after all three. The equivalent change for `normalize` is #4930.

### Performance

GPU: NVIDIA RTX A5000, CUDA 13.2, gcc 11.4, `Tests/LinearSolvers/CellEB`,
`make -j8 COMP=gnu USE_MPI=FALSE USE_CUDA=TRUE CUDA_ARCH=86 DIM=3`, run as
`./main3d.gnu.TEST.CUDA.ex inputs n_cell=256 max_grid_size=<mgs> eb2.geom_type=sphere
eb_is_dirichlet=1 verbose=1 bottom_verbose=0`. Both binaries were built first and then
timed **interleaved** in one session (3 reps each) so that other load on the shared
machine hits both equally. Best of three, MLMG `Timers: Solve`:

| grids | `development` | this PR | speedup |
| --- | --- | --- | --- |
| `max_grid_size=32` (512 boxes) | 1.085 s | 0.916 s | **1.18x** |
| `max_grid_size=64` (64 boxes)  | 0.834 s | 0.737 s | **1.13x** |

MLMG converged in 11 iterations in every one of these runs, on both `development` and
this branch. The speedup grows with the number of boxes, as expected for kernel-launch
fusion. For reference, the three prerequisite index-based PRs are perf-neutral on GPU in
the same measurement (1.083 / 1.083 / 1.062 s at `max_grid_size=32`).

CPU is unaffected, as expected (the fused path is inside `#ifdef AMREX_USE_GPU`).
`make -j8 COMP=gnu USE_MPI=FALSE DIM=3`, `n_cell=128`, binaries built up front and timed
interleaved on the same (shared, hence inflated) machine, best of three:

| grids | `development` | this PR |
| --- | --- | --- |
| `max_grid_size=32` | 4.284 s | 4.285 s |
| `max_grid_size=64` | 4.534 s | 4.549 s |

### Testing

* CPU, `Tests/LinearSolvers/CellEB`, both `make -j8 COMP=llvm USE_MPI=FALSE DIM=3`/`DIM=2`
  (macOS/clang) and `make -j8 COMP=gnu USE_MPI=FALSE DIM=3`/`DIM=2` (Linux/gcc 11.4),
  over seven configurations (`sphere`, `sphere` + `eb_is_dirichlet=1`, `rotated_box`,
  `two_spheres`, `flower`, two-level `sphere`, periodic `sphere`; `n_cell=64`,
  `verbose=2`) &rarr; MLMG/BiCGStab residual histories **bitwise identical** to
  `development` in both dimensions on both platforms.
* `cmake -S . -B build-split -DAMReX_SPACEDIM=3 -DAMReX_EB=ON -DAMReX_LINEAR_SOLVERS_EM=OFF -DAMReX_ENABLE_TESTS=ON -DAMReX_TEST_TYPE=Small -DAMReX_MPI=ON -DCMAKE_BUILD_TYPE=Release`,
  `cmake --build build-split -j8`, `ctest --test-dir build-split --output-on-failure`
  &rarr; 9/9 pass. A 2D library build (`-DAMReX_SPACEDIM=2 -DAMReX_EB=ON`) is also clean.
* GPU: same CellEB matrix under CUDA. MLMG iteration counts identical to `development`
  (9, 12, 11, 3, 11, 28, 11). Note that GPU runs are not bit-reproducible: the *same
  unmodified binary* gives different residual values run to run (AMReX GPU reductions use
  atomics), and the base-vs-branch spread is the same order as that noise floor.

### Still open / worth a reviewer's eye

* No fused path is taken when an overset mask is present; the per-box loop handles that.
* The fused `Fsmooth` assumes `rhs` has no ghost cells (asserted).
* `m_eb_phi[amrlev]` is indexed by the fused `box_no`, i.e. it is assumed to share `out`'s
  box layout — the same assumption the existing `MFIter` code makes via
  `m_eb_phi[amrlev]->const_array(mfi)`.
* Only tested on a single NVIDIA GPU; no HIP or SYCL testing, and no multi-GPU/MPI run.

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate

P.S Generated using Claude Code 