### PR TITLE
FFT: expose OpenBCSolver's spectral Green's function

### DIFF
--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -75,7 +75,7 @@ public:
      * setGreensFunction(). Since solve() only reads the spectral Green's function, one
      * moved in this way needs no further preparation.
      *
-     * \note In two-d mode this is an alias of the Green's function R2C's spectral data.
+     * \note In 2D, this is an alias of the Green's function R2C's spectral data.
      *       Callers may write through it, but must not swap or otherwise re-seat it,
      *       because a later setGreensFunction() writes into the aliased array.
      *

--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -67,6 +67,29 @@ public:
      */
     [[nodiscard]] IntVect const& PaddedLength () const { return m_padded_length; }
 
+    /**
+     * \brief Access the spectral Green's function held by this solver.
+     *
+     * This lets a caller keep its own set of Green's functions and move them into and
+     * out of the solver, for instance with std::swap, instead of recomputing them with
+     * setGreensFunction(). Since solve() only reads the spectral Green's function, one
+     * moved in this way needs no further preparation.
+     *
+     * \note In two-d mode this is an alias of the Green's function R2C's spectral data.
+     *       Callers may write through it, but must not swap or otherwise re-seat it,
+     *       because a later setGreensFunction() writes into the aliased array.
+     *
+     * \return The spectral Green's function.
+     */
+    [[nodiscard]] cMF& greensFunctionFFT () noexcept { return m_G_fft; }
+
+    /**
+     * \brief Access the spectral Green's function held by this solver.
+     *
+     * \return The spectral Green's function.
+     */
+    [[nodiscard]] cMF const& greensFunctionFFT () const noexcept { return m_G_fft; }
+
 private:
     static IntVect make_padded_length (Box const& domain, Info const& info);
     static Box make_grown_domain (Box const& domain, IntVect const& padded_len,


### PR DESCRIPTION
`OpenBCSolver` rebuilds its spectral Green's function whenever `setGreensFunction()` is called, and there is no way to hand it one that was built earlier. Add `greensFunctionFFT()` accessors so a caller can keep its own set and move them into and out of the solver with `std::swap` rather than recomputing. `solve()` only reads the spectral Green's function, and `prepare_openbc()` concerns the R2C plans rather than the Green's function values, so one moved in this way needs no further preparation.

The one caveat, documented at the accessor: in 2D, `m_G_fft` is an alias of the Green's function R2C's spectral data, which a later `setGreensFunction()` writes into. Callers may write through the reference there, but must not swap or otherwise re-seat it.

Additive only, so nothing changes for existing users. Exercised downstream in BLAST-WarpX/warpx#7178 & https://github.com/BLAST-ImpactX/impactx/pull/1621, where reusing Green's functions this way reproduces rebuilding them bit for bit, and where it takes an accelerating beam simulation from 100 Green's function builds to 10.

- [x] 🤖 Generated with [Claude Code](https://claude.com/claude-code)
- [x] tested with ABLASTR/WarpX and ImpactX
- [x] manually self-reviewed
