### PR TITLE
EB state redistribution: Fix Itracker abort with vfrac fallback

### DIFF
--- a/Src/EB/AMReX_EB_StateRedistItracker.cpp
+++ b/Src/EB/AMReX_EB_StateRedistItracker.cpp
@@ -65,11 +65,6 @@ MakeITracker ( Box const& bx,
     {
        if (vfrac(i,j,k) > 0.0 && vfrac(i,j,k) < target_volfrac)
        {
-           // Variables for vfrac fallback - initialized here but only populated if needed
-           bool select_by_vfrac = false;
-           Real second_vfrac = Real(-1.0);
-           int second_idx = -1;
-
            Real apnorm, apnorm_inv;
            const Real dapx = apx(i+1,j  ,k  ) - apx(i,j,k);
            const Real dapy = apy(i  ,j+1,k  ) - apy(i,j,k);
@@ -122,6 +117,11 @@ MakeITracker ( Box const& bx,
            int ioff = imap[itracker(i,j,k,1)];
            int joff = jmap[itracker(i,j,k,1)];
 
+           // Variables for vfrac fallback
+           bool select_by_vfrac = false;
+           Real second_vfrac = Real(-1.0);
+           int second_idx = -1;
+           
            // Sanity check - if selected neighbor is covered, use vfrac fallback
            if (vfrac(i+ioff,j+joff,k) == 0.)
            {

--- a/Src/EB/AMReX_EB_StateRedistItracker.cpp
+++ b/Src/EB/AMReX_EB_StateRedistItracker.cpp
@@ -65,6 +65,12 @@ MakeITracker ( Box const& bx,
     {
        if (vfrac(i,j,k) > 0.0 && vfrac(i,j,k) < target_volfrac)
        {
+           // Track whether we used vfrac fallback for first neighbor
+           // Store second neighbor info at lambda scope for later use
+           bool first_nbr_by_vfrac = false;
+           Real second_vfrac = Real(-1.0);
+           int second_idx = -1;
+
            Real apnorm, apnorm_inv;
            const Real dapx = apx(i+1,j  ,k  ) - apx(i,j,k);
            const Real dapy = apy(i  ,j+1,k  ) - apy(i,j,k);
@@ -117,9 +123,50 @@ MakeITracker ( Box const& bx,
            int ioff = imap[itracker(i,j,k,1)];
            int joff = jmap[itracker(i,j,k,1)];
 
-           // Sanity check
-           if (vfrac(i+ioff,j+joff,k) == 0.) {
-               amrex::Abort(" Trying to merge with covered cell");
+           // Sanity check - if selected neighbor is covered, use vfrac fallback
+           if (vfrac(i+ioff,j+joff,k) == 0.)
+           {
+               // X-direction: default to +x, override if -x is better
+               Real vfrac_x = (xdir_pls_ok) ? vfrac(i+1,j,k) : Real(-1.0);
+               int idx_x = 5;
+               if (xdir_mns_ok && vfrac(i-1,j,k) > vfrac_x) {
+                   vfrac_x = vfrac(i-1,j,k);
+                   idx_x = 4;
+               }
+
+               // Y-direction: default to +y, override if -y is better
+               Real vfrac_y = (ydir_pls_ok) ? vfrac(i,j+1,k) : Real(-1.0);
+               int idx_y = 7;
+               if (ydir_mns_ok && vfrac(i,j-1,k) > vfrac_y) {
+                   vfrac_y = vfrac(i,j-1,k);
+                   idx_y = 2;
+               }
+
+               // Select largest (first) and second-largest
+               int first_idx;
+               Real first_vfrac;
+               if (vfrac_x >= vfrac_y) {
+                   first_idx = idx_x;
+                   first_vfrac = vfrac_x;
+                   second_idx = idx_y;
+                   second_vfrac = vfrac_y;
+               } else {
+                   first_idx = idx_y;
+                   first_vfrac = vfrac_y;
+                   second_idx = idx_x;
+                   second_vfrac = vfrac_x;
+               }
+
+               // Validate first neighbor has vfrac > 0
+               if (first_vfrac <= 0.0) {
+                   amrex::Abort("Trying to merge with covered cell - all cardinal neighbors are also covered or outside domain");
+               }
+
+               itracker(i,j,k,1) = first_idx;
+               first_nbr_by_vfrac = true;
+
+               ioff = imap[first_idx];
+               joff = jmap[first_idx];
            }
 
            Real sum_vol = vfrac(i,j,k) + vfrac(i+ioff,j+joff,k);
@@ -135,9 +182,21 @@ MakeITracker ( Box const& bx,
            // If the merged cell isn't large enough, we try to merge in the other direction
            if (sum_vol < target_volfrac || nx_eq_ny)
            {
-               // Original offset was in y-direction, so we will add to the x-direction
-               // Note that if we can't because it would go outside the domain, we don't
-               if (ioff == 0) {
+               // If first neighbor was selected by vfrac, use second-best vfrac candidate for second neighbor
+               if (first_nbr_by_vfrac && second_vfrac > 0.0)
+               {
+                   itracker(i,j,k,2) = second_idx;
+                   itracker(i,j,k,0) += 1;
+                   int ioff2 = imap[second_idx];
+                   int joff2 = jmap[second_idx];
+                   sum_vol += vfrac(i+ioff2,j+joff2,k);
+               }
+               else if (!first_nbr_by_vfrac)
+               {
+                   // Original normal-based perpendicular selection logic
+                   // Original offset was in y-direction, so we will add to the x-direction
+                   // Note that if we can't because it would go outside the domain, we don't
+                   if (ioff == 0) {
                    if (nx >= 0 && xdir_pls_ok)
                    {
                        itracker(i,j,k,2) = 5;
@@ -162,23 +221,24 @@ MakeITracker ( Box const& bx,
                        itracker(i,j,k,2) = 2;
                        itracker(i,j,k,0) += 1;
                    }
-               }
+                   }
 
-               if (itracker(i,j,k,0) > 1)
-               {
-                   // (i+ioff2,j+joff2) is in the nbhd of (i,j)
-                   int ioff2 = imap[itracker(i,j,k,2)];
-                   int joff2 = jmap[itracker(i,j,k,2)];
+                   if (itracker(i,j,k,0) > 1)
+                   {
+                       // (i+ioff2,j+joff2) is in the nbhd of (i,j)
+                       int ioff2 = imap[itracker(i,j,k,2)];
+                       int joff2 = jmap[itracker(i,j,k,2)];
 
-                   sum_vol += vfrac(i+ioff2,j+joff2,k);
+                       sum_vol += vfrac(i+ioff2,j+joff2,k);
 #if 0
-                   if (debug_verbose > 0)
-                       amrex::Print() << "Cell " << IntVect(i,j) << " with volfrac " << vfrac(i,j,k) <<
-                                         " trying to ALSO merge with " << IntVect(i+ioff2,j+joff2) <<
-                                         " with volfrac " << vfrac(i+ioff2,j+joff2,k) <<
-                                          " to get new sum_vol " <<  sum_vol << '\n';
+                       if (debug_verbose > 0)
+                           amrex::Print() << "Cell " << IntVect(i,j) << " with volfrac " << vfrac(i,j,k) <<
+                                             " trying to ALSO merge with " << IntVect(i+ioff2,j+joff2) <<
+                                             " with volfrac " << vfrac(i+ioff2,j+joff2,k) <<
+                                              " to get new sum_vol " <<  sum_vol << '\n';
 #endif
-               }
+                   }
+               }  // end else if (!first_nbr_by_vfrac)
            }
 
            // Now we merge in the corner direction if we have already claimed two
@@ -289,6 +349,12 @@ MakeITracker ( Box const& bx,
     {
        if (vfrac(i,j,k) > 0.0 && vfrac(i,j,k) < target_volfrac)
        {
+           // Track whether we used vfrac fallback for first neighbor
+           // Store second neighbor info at lambda scope for later use
+           bool first_nbr_by_vfrac = false;
+           Real second_vfrac = Real(-1.0);
+           int second_idx = -1;
+
            Real apnorm, apnorm_inv;
            const Real dapx = apx(i+1,j  ,k  ) - apx(i,j,k);
            const Real dapy = apy(i  ,j+1,k  ) - apy(i,j,k);
@@ -381,11 +447,97 @@ MakeITracker ( Box const& bx,
            int joff = jmap[itracker(i,j,k,1)];
            int koff = kmap[itracker(i,j,k,1)];
 
-           // Sanity check
+           // Sanity check - if selected neighbor is covered, use vfrac fallback
            if (vfrac(i+ioff,j+joff,k+koff) == 0.)
            {
-               // amrex::Print() << "Cell " << IntVect(i,j,k) << " is trying to merge with cell " << IntVect(i+ioff,j+joff,k+koff) << '\n';
-               amrex::Abort(" Trying to merge with covered cell");
+               // For each direction, get best neighbor's vfrac and index
+               // Use if-statements for optimal GPU performance
+
+               // X-direction: default to +x, override if -x is better
+               Real vfrac_x = (xdir_pls_ok) ? vfrac(i+1,j,k) : Real(-1.0);
+               int idx_x = 5;
+               if (xdir_mns_ok && vfrac(i-1,j,k) > vfrac_x) {  // Strict > means +x wins ties
+                   vfrac_x = vfrac(i-1,j,k);
+                   idx_x = 4;
+               }
+
+               // Y-direction: default to +y, override if -y is better
+               Real vfrac_y = (ydir_pls_ok) ? vfrac(i,j+1,k) : Real(-1.0);
+               int idx_y = 7;
+               if (ydir_mns_ok && vfrac(i,j-1,k) > vfrac_y) {
+                   vfrac_y = vfrac(i,j-1,k);
+                   idx_y = 2;
+               }
+
+               // Z-direction: default to +z, override if -z is better
+               Real vfrac_z = (zdir_pls_ok) ? vfrac(i,j,k+1) : Real(-1.0);
+               int idx_z = 22;
+               if (zdir_mns_ok && vfrac(i,j,k-1) > vfrac_z) {
+                   vfrac_z = vfrac(i,j,k-1);
+                   idx_z = 13;
+               }
+
+               // Find largest and second-largest, storing to lambda-scope variables
+               int first_idx;
+               Real first_vfrac;
+
+               if (vfrac_x >= vfrac_y && vfrac_x >= vfrac_z) {
+                   // X is largest
+                   first_idx = idx_x;
+                   first_vfrac = vfrac_x;
+                   if (vfrac_y >= vfrac_z) {
+                       second_idx = idx_y;
+                       second_vfrac = vfrac_y;
+                   } else {
+                       second_idx = idx_z;
+                       second_vfrac = vfrac_z;
+                   }
+               } else if (vfrac_y >= vfrac_z) {
+                   // Y is largest
+                   first_idx = idx_y;
+                   first_vfrac = vfrac_y;
+                   if (vfrac_x >= vfrac_z) {
+                       second_idx = idx_x;
+                       second_vfrac = vfrac_x;
+                   } else {
+                       second_idx = idx_z;
+                       second_vfrac = vfrac_z;
+                   }
+               } else {
+                   // Z is largest
+                   first_idx = idx_z;
+                   first_vfrac = vfrac_z;
+                   if (vfrac_x >= vfrac_y) {
+                       second_idx = idx_x;
+                       second_vfrac = vfrac_x;
+                   } else {
+                       second_idx = idx_y;
+                       second_vfrac = vfrac_y;
+                   }
+               }
+
+               // Validate first neighbor has vfrac > 0
+               if (first_vfrac <= 0.0) {
+                   amrex::Abort("Trying to merge with covered cell - all cardinal neighbors are also covered or outside domain");
+               }
+
+               // Update itracker with vfrac-selected neighbor
+               itracker(i,j,k,1) = first_idx;
+               first_nbr_by_vfrac = true;
+
+               // Recompute offsets with new selection
+               ioff = imap[first_idx];
+               joff = jmap[first_idx];
+               koff = kmap[first_idx];
+
+#if 0
+               if (debug_print) {
+                   amrex::Print() << "Cell " << IntVect(i,j,k) << " with vfrac " << vfrac(i,j,k)
+                                  << " using vfrac fallback. Selected neighbor " << first_idx
+                                  << " at " << IntVect(i+ioff,j+joff,k+koff)
+                                  << " with vfrac " << first_vfrac << '\n';
+               }
+#endif
            }
 
            Real sum_vol = vfrac(i,j,k) + vfrac(i+ioff,j+joff,k+koff);
@@ -408,8 +560,31 @@ MakeITracker ( Box const& bx,
 
            if ( (sum_vol < target_volfrac) || just_broke_symmetry )
            {
-               // Original offset was in x-direction
-               if (joff == 0 && koff == 0)
+               // If first neighbor was selected by vfrac, use second-best vfrac candidate for second neighbor
+               if (first_nbr_by_vfrac && second_vfrac > 0.0)  // Check vfrac validity directly
+               {
+                   itracker(i,j,k,2) = second_idx;
+                   itracker(i,j,k,0) += 1;
+
+                   int ioff2 = imap[second_idx];
+                   int joff2 = jmap[second_idx];
+                   int koff2 = kmap[second_idx];
+                   sum_vol += vfrac(i+ioff2,j+joff2,k+koff2);
+
+#if 0
+                   if (debug_print) {
+                       amrex::Print() << "Cell " << IntVect(i,j,k)
+                                      << " also merging with second-best vfrac neighbor " << second_idx
+                                      << " at " << IntVect(i+ioff2,j+joff2,k+koff2)
+                                      << " with vfrac " << second_vfrac << '\n';
+                   }
+#endif
+               }
+               else if (!first_nbr_by_vfrac)
+               {
+                   // Original normal-based perpendicular selection logic
+                   // Original offset was in x-direction
+                   if (joff == 0 && koff == 0)
                {
                    if (nx_eq_ny) {
                        itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
@@ -448,22 +623,23 @@ MakeITracker ( Box const& bx,
                    }
                }
 
-               // (i,j,k) merges with at least two cells now
-               itracker(i,j,k,0) += 1;
+                   // (i,j,k) merges with at least two cells now
+                   itracker(i,j,k,0) += 1;
 
-               // (i+ioff2,j+joff2,k+koff2) is in the nbhd of (i,j,k)
-               int ioff2 = imap[itracker(i,j,k,2)];
-               int joff2 = jmap[itracker(i,j,k,2)];
-               int koff2 = kmap[itracker(i,j,k,2)];
+                   // (i+ioff2,j+joff2,k+koff2) is in the nbhd of (i,j,k)
+                   int ioff2 = imap[itracker(i,j,k,2)];
+                   int joff2 = jmap[itracker(i,j,k,2)];
+                   int koff2 = kmap[itracker(i,j,k,2)];
 
-               sum_vol += vfrac(i+ioff2,j+joff2,k+koff2);
+                   sum_vol += vfrac(i+ioff2,j+joff2,k+koff2);
 #if 0
-               if (debug_print)
-                   amrex::Print() << "Cell " << IntVect(i,j,k) << " with volfrac " << vfrac(i,j,k) <<
-                                     " trying to ALSO merge with " << IntVect(i+ioff2,j+joff2,k+koff2) <<
-                                     " with volfrac " << vfrac(i+ioff2,j+joff2,k+koff2) <<
-                                      " to get new sum_vol " <<  sum_vol << '\n';
+                   if (debug_print)
+                       amrex::Print() << "Cell " << IntVect(i,j,k) << " with volfrac " << vfrac(i,j,k) <<
+                                         " trying to ALSO merge with " << IntVect(i+ioff2,j+joff2,k+koff2) <<
+                                         " with volfrac " << vfrac(i+ioff2,j+joff2,k+koff2) <<
+                                          " to get new sum_vol " <<  sum_vol << '\n';
 #endif
+               }  // end else if (!first_nbr_by_vfrac)
            }
 
            // If the merged cell has merged in two directions, we now merge in the corner direction within the current plane

--- a/Src/EB/AMReX_EB_StateRedistItracker.cpp
+++ b/Src/EB/AMReX_EB_StateRedistItracker.cpp
@@ -121,7 +121,7 @@ MakeITracker ( Box const& bx,
            bool select_by_vfrac = false;
            Real second_vfrac = Real(-1.0);
            int second_idx = -1;
-           
+
            // Sanity check - if selected neighbor is covered, use vfrac fallback
            if (vfrac(i+ioff,j+joff,k) == 0.)
            {

--- a/Src/EB/AMReX_EB_StateRedistItracker.cpp
+++ b/Src/EB/AMReX_EB_StateRedistItracker.cpp
@@ -194,30 +194,30 @@ MakeITracker ( Box const& bx,
                    // Original offset was in y-direction, so we will add to the x-direction
                    // Note that if we can't because it would go outside the domain, we don't
                    if (ioff == 0) {
-                   if (nx >= 0 && xdir_pls_ok)
-                   {
-                       itracker(i,j,k,2) = 5;
-                       itracker(i,j,k,0) += 1;
-                   }
-                   else if (nx <= 0 && xdir_mns_ok)
-                   {
-                       itracker(i,j,k,2) = 4;
-                       itracker(i,j,k,0) += 1;
-                   }
+                       if (nx >= 0 && xdir_pls_ok)
+                       {
+                           itracker(i,j,k,2) = 5;
+                           itracker(i,j,k,0) += 1;
+                       }
+                       else if (nx <= 0 && xdir_mns_ok)
+                       {
+                           itracker(i,j,k,2) = 4;
+                           itracker(i,j,k,0) += 1;
+                       }
 
-               // Original offset was in x-direction, so we will add to the y-direction
-               // Note that if we can't because it would go outside the domain, we don't
-               } else {
-                   if (ny >= 0 && ydir_pls_ok)
-                   {
-                       itracker(i,j,k,2) = 7;
-                       itracker(i,j,k,0) += 1;
-                   }
-                   else if (ny <= 0 && ydir_mns_ok)
-                   {
-                       itracker(i,j,k,2) = 2;
-                       itracker(i,j,k,0) += 1;
-                   }
+                   // Original offset was in x-direction, so we will add to the y-direction
+                   // Note that if we can't because it would go outside the domain, we don't
+                   } else {
+                       if (ny >= 0 && ydir_pls_ok)
+                       {
+                           itracker(i,j,k,2) = 7;
+                           itracker(i,j,k,0) += 1;
+                       }
+                       else if (ny <= 0 && ydir_mns_ok)
+                       {
+                           itracker(i,j,k,2) = 2;
+                           itracker(i,j,k,0) += 1;
+                       }
                    }
 
                    if (itracker(i,j,k,0) > 1)
@@ -557,43 +557,43 @@ MakeITracker ( Box const& bx,
                    // Original normal-based perpendicular selection logic
                    // Original offset was in x-direction
                    if (joff == 0 && koff == 0)
-               {
-                   if (nx_eq_ny) {
-                       itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
-                   } else if (nx_eq_nz) {
-                       itracker(i,j,k,2) = (nz > 0) ? 22 : 13;
-                   } else if ( (std::abs(ny) > std::abs(nz)) ) {
-                       itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
-                   } else {
-                       itracker(i,j,k,2) = (nz > 0) ? 22 : 13;
-                   }
+                   {
+                       if (nx_eq_ny) {
+                           itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
+                       } else if (nx_eq_nz) {
+                           itracker(i,j,k,2) = (nz > 0) ? 22 : 13;
+                       } else if ( (std::abs(ny) > std::abs(nz)) ) {
+                           itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
+                       } else {
+                           itracker(i,j,k,2) = (nz > 0) ? 22 : 13;
+                       }
 
-               // Original offset was in y-direction
-               } else if (ioff == 0 && koff == 0)
-               {
-                   if (nx_eq_ny) {
-                       itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
-                   } else if (ny_eq_nz) {
-                       itracker(i,j,k,2) = (nz > 0) ? 22 : 13;
-                   } else if ( (std::abs(nx) > std::abs(nz)) ) {
-                       itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
-                   } else {
-                       itracker(i,j,k,2) = (nz > 0) ? 22 : 13;
-                   }
+                   // Original offset was in y-direction
+                   } else if (ioff == 0 && koff == 0)
+                   {
+                       if (nx_eq_ny) {
+                           itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
+                       } else if (ny_eq_nz) {
+                           itracker(i,j,k,2) = (nz > 0) ? 22 : 13;
+                       } else if ( (std::abs(nx) > std::abs(nz)) ) {
+                           itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
+                       } else {
+                           itracker(i,j,k,2) = (nz > 0) ? 22 : 13;
+                       }
 
-               // Original offset was in z-direction
-               } else if (ioff == 0 && joff == 0)
-               {
-                   if (nx_eq_nz) {
-                       itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
-                   } else if (ny_eq_nz) {
-                       itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
-                   } else if ( (std::abs(nx) > std::abs(ny)) ) {
-                       itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
-                   } else {
-                       itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
+                   // Original offset was in z-direction
+                   } else if (ioff == 0 && joff == 0)
+                   {
+                       if (nx_eq_nz) {
+                           itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
+                       } else if (ny_eq_nz) {
+                           itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
+                       } else if ( (std::abs(nx) > std::abs(ny)) ) {
+                           itracker(i,j,k,2) = (nx > 0) ? 5 : 4;
+                       } else {
+                           itracker(i,j,k,2) = (ny > 0) ? 7 : 2;
+                       }
                    }
-               }
 
                    // (i,j,k) merges with at least two cells now
                    itracker(i,j,k,0) += 1;

--- a/Src/EB/AMReX_EB_StateRedistItracker.cpp
+++ b/Src/EB/AMReX_EB_StateRedistItracker.cpp
@@ -159,7 +159,7 @@ MakeITracker ( Box const& bx,
                }
 
                itracker(i,j,k,1) = first_idx;
-               
+
                ioff = imap[first_idx];
                joff = jmap[first_idx];
 

--- a/Src/EB/AMReX_EB_StateRedistItracker.cpp
+++ b/Src/EB/AMReX_EB_StateRedistItracker.cpp
@@ -65,9 +65,8 @@ MakeITracker ( Box const& bx,
     {
        if (vfrac(i,j,k) > 0.0 && vfrac(i,j,k) < target_volfrac)
        {
-           // Track whether we used vfrac fallback for first neighbor
-           // Store second neighbor info at lambda scope for later use
-           bool first_nbr_by_vfrac = false;
+           // Variables for vfrac fallback - initialized here but only populated if needed
+           bool select_by_vfrac = false;
            Real second_vfrac = Real(-1.0);
            int second_idx = -1;
 
@@ -126,7 +125,6 @@ MakeITracker ( Box const& bx,
            // Sanity check - if selected neighbor is covered, use vfrac fallback
            if (vfrac(i+ioff,j+joff,k) == 0.)
            {
-               // X-direction: default to +x, override if -x is better
                Real vfrac_x = (xdir_pls_ok) ? vfrac(i+1,j,k) : Real(-1.0);
                int idx_x = 5;
                if (xdir_mns_ok && vfrac(i-1,j,k) > vfrac_x) {
@@ -134,7 +132,6 @@ MakeITracker ( Box const& bx,
                    idx_x = 4;
                }
 
-               // Y-direction: default to +y, override if -y is better
                Real vfrac_y = (ydir_pls_ok) ? vfrac(i,j+1,k) : Real(-1.0);
                int idx_y = 7;
                if (ydir_mns_ok && vfrac(i,j-1,k) > vfrac_y) {
@@ -142,7 +139,7 @@ MakeITracker ( Box const& bx,
                    idx_y = 2;
                }
 
-               // Select largest (first) and second-largest
+               // Select largest and second-largest vfrac
                int first_idx;
                Real first_vfrac;
                if (vfrac_x >= vfrac_y) {
@@ -157,16 +154,16 @@ MakeITracker ( Box const& bx,
                    second_vfrac = vfrac_x;
                }
 
-               // Validate first neighbor has vfrac > 0
                if (first_vfrac <= 0.0) {
                    amrex::Abort("Trying to merge with covered cell - all cardinal neighbors are also covered or outside domain");
                }
 
                itracker(i,j,k,1) = first_idx;
-               first_nbr_by_vfrac = true;
-
+               
                ioff = imap[first_idx];
                joff = jmap[first_idx];
+
+               select_by_vfrac = true;
            }
 
            Real sum_vol = vfrac(i,j,k) + vfrac(i+ioff,j+joff,k);
@@ -183,7 +180,7 @@ MakeITracker ( Box const& bx,
            if (sum_vol < target_volfrac || nx_eq_ny)
            {
                // If first neighbor was selected by vfrac, use second-best vfrac candidate for second neighbor
-               if (first_nbr_by_vfrac && second_vfrac > 0.0)
+               if (select_by_vfrac && second_vfrac > 0.0)
                {
                    itracker(i,j,k,2) = second_idx;
                    itracker(i,j,k,0) += 1;
@@ -191,7 +188,7 @@ MakeITracker ( Box const& bx,
                    int joff2 = jmap[second_idx];
                    sum_vol += vfrac(i+ioff2,j+joff2,k);
                }
-               else if (!first_nbr_by_vfrac)
+               else if (!select_by_vfrac)
                {
                    // Original normal-based perpendicular selection logic
                    // Original offset was in y-direction, so we will add to the x-direction
@@ -238,7 +235,7 @@ MakeITracker ( Box const& bx,
                                               " to get new sum_vol " <<  sum_vol << '\n';
 #endif
                    }
-               }  // end else if (!first_nbr_by_vfrac)
+               }  // end else if (!select_by_vfrac)
            }
 
            // Now we merge in the corner direction if we have already claimed two
@@ -349,12 +346,6 @@ MakeITracker ( Box const& bx,
     {
        if (vfrac(i,j,k) > 0.0 && vfrac(i,j,k) < target_volfrac)
        {
-           // Track whether we used vfrac fallback for first neighbor
-           // Store second neighbor info at lambda scope for later use
-           bool first_nbr_by_vfrac = false;
-           Real second_vfrac = Real(-1.0);
-           int second_idx = -1;
-
            Real apnorm, apnorm_inv;
            const Real dapx = apx(i+1,j  ,k  ) - apx(i,j,k);
            const Real dapy = apy(i  ,j+1,k  ) - apy(i,j,k);
@@ -447,13 +438,14 @@ MakeITracker ( Box const& bx,
            int joff = jmap[itracker(i,j,k,1)];
            int koff = kmap[itracker(i,j,k,1)];
 
+           // Variables for vfrac fallback
+           bool select_by_vfrac = false;
+           Real second_vfrac = Real(-1.0);
+           int second_idx = -1;
+
            // Sanity check - if selected neighbor is covered, use vfrac fallback
            if (vfrac(i+ioff,j+joff,k+koff) == 0.)
            {
-               // For each direction, get best neighbor's vfrac and index
-               // Use if-statements for optimal GPU performance
-
-               // X-direction: default to +x, override if -x is better
                Real vfrac_x = (xdir_pls_ok) ? vfrac(i+1,j,k) : Real(-1.0);
                int idx_x = 5;
                if (xdir_mns_ok && vfrac(i-1,j,k) > vfrac_x) {  // Strict > means +x wins ties
@@ -461,7 +453,6 @@ MakeITracker ( Box const& bx,
                    idx_x = 4;
                }
 
-               // Y-direction: default to +y, override if -y is better
                Real vfrac_y = (ydir_pls_ok) ? vfrac(i,j+1,k) : Real(-1.0);
                int idx_y = 7;
                if (ydir_mns_ok && vfrac(i,j-1,k) > vfrac_y) {
@@ -469,7 +460,6 @@ MakeITracker ( Box const& bx,
                    idx_y = 2;
                }
 
-               // Z-direction: default to +z, override if -z is better
                Real vfrac_z = (zdir_pls_ok) ? vfrac(i,j,k+1) : Real(-1.0);
                int idx_z = 22;
                if (zdir_mns_ok && vfrac(i,j,k-1) > vfrac_z) {
@@ -477,7 +467,7 @@ MakeITracker ( Box const& bx,
                    idx_z = 13;
                }
 
-               // Find largest and second-largest, storing to lambda-scope variables
+               // Find largest and second-largest vfrac
                int first_idx;
                Real first_vfrac;
 
@@ -516,28 +506,18 @@ MakeITracker ( Box const& bx,
                    }
                }
 
-               // Validate first neighbor has vfrac > 0
                if (first_vfrac <= 0.0) {
                    amrex::Abort("Trying to merge with covered cell - all cardinal neighbors are also covered or outside domain");
                }
 
-               // Update itracker with vfrac-selected neighbor
+               // Update itracker and offsets
                itracker(i,j,k,1) = first_idx;
-               first_nbr_by_vfrac = true;
 
-               // Recompute offsets with new selection
                ioff = imap[first_idx];
                joff = jmap[first_idx];
                koff = kmap[first_idx];
 
-#if 0
-               if (debug_print) {
-                   amrex::Print() << "Cell " << IntVect(i,j,k) << " with vfrac " << vfrac(i,j,k)
-                                  << " using vfrac fallback. Selected neighbor " << first_idx
-                                  << " at " << IntVect(i+ioff,j+joff,k+koff)
-                                  << " with vfrac " << first_vfrac << '\n';
-               }
-#endif
+               select_by_vfrac = true;
            }
 
            Real sum_vol = vfrac(i,j,k) + vfrac(i+ioff,j+joff,k+koff);
@@ -561,7 +541,7 @@ MakeITracker ( Box const& bx,
            if ( (sum_vol < target_volfrac) || just_broke_symmetry )
            {
                // If first neighbor was selected by vfrac, use second-best vfrac candidate for second neighbor
-               if (first_nbr_by_vfrac && second_vfrac > 0.0)  // Check vfrac validity directly
+               if (select_by_vfrac && second_vfrac > 0.0)
                {
                    itracker(i,j,k,2) = second_idx;
                    itracker(i,j,k,0) += 1;
@@ -571,16 +551,8 @@ MakeITracker ( Box const& bx,
                    int koff2 = kmap[second_idx];
                    sum_vol += vfrac(i+ioff2,j+joff2,k+koff2);
 
-#if 0
-                   if (debug_print) {
-                       amrex::Print() << "Cell " << IntVect(i,j,k)
-                                      << " also merging with second-best vfrac neighbor " << second_idx
-                                      << " at " << IntVect(i+ioff2,j+joff2,k+koff2)
-                                      << " with vfrac " << second_vfrac << '\n';
-                   }
-#endif
                }
-               else if (!first_nbr_by_vfrac)
+               else if (!select_by_vfrac)
                {
                    // Original normal-based perpendicular selection logic
                    // Original offset was in x-direction
@@ -639,7 +611,7 @@ MakeITracker ( Box const& bx,
                                          " with volfrac " << vfrac(i+ioff2,j+joff2,k+koff2) <<
                                           " to get new sum_vol " <<  sum_vol << '\n';
 #endif
-               }  // end else if (!first_nbr_by_vfrac)
+               }  // end else if (!select_by_vfrac)
            }
 
            // If the merged cell has merged in two directions, we now merge in the corner direction within the current plane

--- a/Src/EB/AMReX_EB_StateRedistribute.cpp
+++ b/Src/EB/AMReX_EB_StateRedistribute.cpp
@@ -154,11 +154,11 @@ MLStateRedistribute ( Box const& bx, int ncomp,
                             qt(i,j,k,i_nbor) = fac * U_in(r,s,t,n) * vfrac(r,s,t) / nbhd_vol(i,j,k);
                             Qhat(i,j,k,n) += qt(i,j,k,i_nbor);
                         }
-                        else
-                        {
-                            // Neighbor outside domain_per_grown contributes zero
-                            qt(i,j,k,i_nbor) = 0.0;
-                        }
+                        // else
+                        // {
+                        //     // Neighbor outside domain_per_grown contributes zero
+                        //     qt(i,j,k,i_nbor) = 0.0;
+                        // }
                     }
                 }
             } else {

--- a/Src/EB/AMReX_EB_StateRedistribute.cpp
+++ b/Src/EB/AMReX_EB_StateRedistribute.cpp
@@ -154,6 +154,11 @@ MLStateRedistribute ( Box const& bx, int ncomp,
                             qt(i,j,k,i_nbor) = fac * U_in(r,s,t,n) * vfrac(r,s,t) / nbhd_vol(i,j,k);
                             Qhat(i,j,k,n) += qt(i,j,k,i_nbor);
                         }
+                        else
+                        {
+                            // Neighbor outside domain_per_grown contributes zero
+                            qt(i,j,k,i_nbor) = 0.0;
+                        }
                     }
                 }
             } else {

--- a/Src/EB/AMReX_EB_StateRedistribute.cpp
+++ b/Src/EB/AMReX_EB_StateRedistribute.cpp
@@ -154,11 +154,6 @@ MLStateRedistribute ( Box const& bx, int ncomp,
                             qt(i,j,k,i_nbor) = fac * U_in(r,s,t,n) * vfrac(r,s,t) / nbhd_vol(i,j,k);
                             Qhat(i,j,k,n) += qt(i,j,k,i_nbor);
                         }
-                        // else
-                        // {
-                        //     // Neighbor outside domain_per_grown contributes zero
-                        //     qt(i,j,k,i_nbor) = 0.0;
-                        // }
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary

This PR adds a volume-fraction-based fallback pathway in the `itracker` construction for EB state redistribution when the original normal-based neighbor selection fails.

## Problem

- State redistribution merges cutcells with neighbors to achieve target volume. Currently, neighbors are selected based on the EB normal direction, and the selected local indices are stored in `itracker` array. This is a geometrically reasonable approach when the normal vector accurately represents local EB topology.
- However, when the EB is poorly resolved or cells have limited connectivity (e.g., cells near the tip of a narrow canyon), the normal-based selection can point to a covered cell (vfrac=0). The current code aborts in this situation with `Abort: Trying to merge with covered cell`.
- This stops simulations even when valid merge targets exist in other directions.

## Solution

- This PR adds a fallback selection strategy that activates only when the normal-based method fails.
- The additional selection method chooses the primary and secondary merge target with the largest volume fraction.
- The implementation has no impact on existing simulations, because it preserves the original normal-based logic when it succeeds.

## Validation

- Tested on an ERF application with complex urban geometry. This enables redistribution in previously-aborting cases.

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
