### PR TITLE
EB: mask the covered region when filling face-centered data

### DIFF
--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -156,11 +156,19 @@ public:
         Array<MultiFab,AMREX_SPACEDIM> m_areafrac_fc;
         Array<MultiFab,AMREX_SPACEDIM> m_facecent_fc;
         Array<MultiFab,AMREX_SPACEDIM> m_edgecent_fc;
-        //! Covered region of the refined level, coarsened onto this level. The refined level is
-        //! transient, so it has to be captured here for the fill*FC functions to mask with.
-        //! Note this is NOT the same as Level::m_covered_grids: the refined level resolves the
-        //! body more finely, so its covered region is the larger one once coarsened, and it is
-        //! the one that matches where the face-centered data was actually computed.
+        // Covered region of the refined level, coarsened onto this level. The refined level
+        // is transient, so this has to be captured while it exists. It is not the same as
+        // Level::m_covered_grids: the refined level resolves the body more finely, so once
+        // coarsened its covered region is the larger of the two, and it is the one that
+        // matches where the face-centered data was computed.
+        //
+        // The fill*FC functions apply it before their ParallelCopy, and deliberately do not
+        // shrink it first. A face-centered cell straddles two cell-centered cells, so the
+        // ones on the covered/cut interface may themselves be cut; clearing them here and
+        // letting the copy write over them is correct, because the copy writes exactly where
+        // the face-centered data is valid - the nodal span of the cut boxes, which reaches
+        // the interface and no further. Ordering does the shrinking, so no box has to be
+        // trimmed and two adjacent covered boxes need no special treatment.
         BoxArray m_covered_grids_fc;
         bool m_built = false;
     };

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -156,6 +156,12 @@ public:
         Array<MultiFab,AMREX_SPACEDIM> m_areafrac_fc;
         Array<MultiFab,AMREX_SPACEDIM> m_facecent_fc;
         Array<MultiFab,AMREX_SPACEDIM> m_edgecent_fc;
+        //! Covered region of the refined level, coarsened onto this level. The refined level is
+        //! transient, so it has to be captured here for the fill*FC functions to mask with.
+        //! Note this is NOT the same as Level::m_covered_grids: the refined level resolves the
+        //! body more finely, so its covered region is the larger one once coarsened, and it is
+        //! the one that matches where the face-centered data was actually computed.
+        BoxArray m_covered_grids_fc;
         bool m_built = false;
     };
 
@@ -859,6 +865,10 @@ GShopLevel<G>::buildFCData (G const& gshop, int face_dir, int max_grid_size)
     // The grids are coarsened from the refined level rather than taken from m_grids so that the
     // DistributionMapping stays compatible with the refined data we read below.
     const BoxArray fc_base_grids = amrex::coarsen(refined_cc_level->m_grids, 2);
+    if (!refined_cc_level->m_covered_grids.empty()) {
+        m_fc_data[face_dir]->m_covered_grids_fc =
+            amrex::coarsen(refined_cc_level->m_covered_grids, 2);
+    }
     const DistributionMapping fc_dmap = refined_cc_level->m_dmap;
 
     // Face-centered data provides no level set, so nothing here coarsens one. The multi-cut check

--- a/Src/EB/AMReX_EB2_Level.cpp
+++ b/Src/EB/AMReX_EB2_Level.cpp
@@ -1064,6 +1064,35 @@ Level::fillVolFracFC (MultiFab& vfrac, int face_dir, const Geometry& geom) const
     AMREX_ASSERT(hasFCData(face_dir));
     vfrac.setVal(1.0);
     if (isAllRegular()) { return; }
+
+    // The covered region is masked BEFORE the ParallelCopy below, and is deliberately not
+    // shrunk. A face-centered cell straddles two cell-centered cells, so the ones on the
+    // covered/cut interface may still be cut; clearing them here and letting the copy write
+    // over them is correct, because the copy writes exactly where the face-centered data is
+    // valid - the nodal span of the cut boxes, which reaches the interface and no further.
+    BoxArray const& cov = m_fc_data[face_dir]->m_covered_grids_fc;
+    if (!cov.empty())
+    {
+        BoxArray cov_fc = amrex::convert(cov, vfrac.ixType());
+        const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
+        std::vector<std::pair<int,Box> > isects;
+        for (MFIter mfi(vfrac); mfi.isValid(); ++mfi)
+        {
+            auto const& fab = vfrac.array(mfi);
+            const Box& bx = mfi.fabbox();
+            for (const auto& iv : pshifts) {
+                cov_fc.intersections(bx+iv, isects);
+                for (const auto& is : isects) {
+                    Box const& ibox = is.second-iv;
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_3D(ibox, i, j, k,
+                    {
+                        fab(i,j,k) = 0.0;  // covered
+                    });
+                }
+            }
+        }
+    }
+
     vfrac.ParallelCopy(m_fc_data[face_dir]->m_volfrac_fc, 0, 0, 1, 0, vfrac.nGrow(), geom.periodicity());
 }
 
@@ -1075,6 +1104,37 @@ Level::fillAreaFracFC (Array<MultiFab*,AMREX_SPACEDIM> const& areafrac, int face
         areafrac[idim]->setVal(1.0);
     }
     if (isAllRegular()) { return; }
+    // The covered region is masked BEFORE the ParallelCopy below, and is deliberately not
+    // shrunk. A face-centered cell straddles two cell-centered cells, so the ones on the
+    // covered/cut interface may still be cut; clearing them here and letting the copy write
+    // over them is correct, because the copy writes exactly where the face-centered data is
+    // valid - the nodal span of the cut boxes, which reaches the interface and no further.
+    BoxArray const& cov = m_fc_data[face_dir]->m_covered_grids_fc;
+    if (!cov.empty())
+    {
+        const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
+        std::vector<std::pair<int,Box> > isects;
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            // FC areafrac is cell-typed on the base grids, indexed by the staggered cell
+            BoxArray cov_fc = amrex::convert(cov, areafrac[idim]->ixType());
+            for (MFIter mfi(*areafrac[idim]); mfi.isValid(); ++mfi)
+            {
+                auto const& fab = areafrac[idim]->array(mfi);
+                const Box& bx = mfi.fabbox();
+                for (const auto& iv : pshifts) {
+                    cov_fc.intersections(bx+iv, isects);
+                    for (const auto& is : isects) {
+                        Box const& ibox = is.second-iv;
+                        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(ibox, i, j, k,
+                        {
+                            fab(i,j,k) = 0.0;  // covered
+                        });
+                    }
+                }
+            }
+        }
+    }
+
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         areafrac[idim]->ParallelCopy(m_fc_data[face_dir]->m_areafrac_fc[idim], 0, 0, 1, 0, areafrac[idim]->nGrow(), geom.periodicity());
     }
@@ -1184,6 +1244,36 @@ Level::fillEBCellFlagFC (FabArray<EBCellFlagFab>& cellflag, int face_dir, const 
         return;
     }
 
+    // The covered region is masked BEFORE the ParallelCopy below, and is deliberately not
+    // shrunk. A face-centered cell straddles two cell-centered cells, so the ones on the
+    // covered/cut interface may still be cut; clearing them here and letting the copy write
+    // over them is correct, because the copy writes exactly where the face-centered data is
+    // valid - the nodal span of the cut boxes, which reaches the interface and no further.
+    BoxArray const& cov = m_fc_data[face_dir]->m_covered_grids_fc;
+    if (!cov.empty())
+    {
+        EBCellFlag cov_val = EBCellFlag::TheDefaultCell();
+        cov_val.setCovered();
+        BoxArray cov_fc = amrex::convert(cov, cellflag.ixType());
+        const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
+        std::vector<std::pair<int,Box> > isects;
+        for (MFIter mfi(cellflag); mfi.isValid(); ++mfi)
+        {
+            auto const& a = cellflag.array(mfi);
+            const Box& bx = mfi.fabbox();
+            for (const auto& iv : pshifts) {
+                cov_fc.intersections(bx+iv, isects);
+                for (const auto& is : isects) {
+                    Box const& ibox = is.second-iv;
+                    AMREX_HOST_DEVICE_PARALLEL_FOR_3D(ibox, i, j, k,
+                    {
+                        a(i,j,k) = cov_val;
+                    });
+                }
+            }
+        }
+    }
+
     cellflag.ParallelCopy(m_fc_data[face_dir]->m_cellflag_fc, 0, 0, 1, 0, cellflag.nGrow(), geom.periodicity());
 
     // Set FabType for each fab (similar to fillEBCellFlag)
@@ -1233,6 +1323,36 @@ Level::fillEdgeCentFC (Array<MultiFab*,AMREX_SPACEDIM> const& edgecent, int face
         edgecent[idim]->setVal(0.0);
     }
     if (isAllRegular()) { return; }
+    // The covered region is masked BEFORE the ParallelCopy below, and is deliberately not
+    // shrunk. A face-centered cell straddles two cell-centered cells, so the ones on the
+    // covered/cut interface may still be cut; clearing them here and letting the copy write
+    // over them is correct, because the copy writes exactly where the face-centered data is
+    // valid - the nodal span of the cut boxes, which reaches the interface and no further.
+    BoxArray const& cov = m_fc_data[face_dir]->m_covered_grids_fc;
+    if (!cov.empty())
+    {
+        const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
+        std::vector<std::pair<int,Box> > isects;
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            BoxArray cov_fc = amrex::convert(cov, edgecent[idim]->ixType());
+            for (MFIter mfi(*edgecent[idim]); mfi.isValid(); ++mfi)
+            {
+                auto const& fab = edgecent[idim]->array(mfi);
+                const Box& bx = mfi.fabbox();
+                for (const auto& iv : pshifts) {
+                    cov_fc.intersections(bx+iv, isects);
+                    for (const auto& is : isects) {
+                        Box const& ibox = is.second-iv;
+                        AMREX_HOST_DEVICE_PARALLEL_FOR_3D(ibox, i, j, k,
+                        {
+                            fab(i,j,k) = Real(-1.0);  // covered edges
+                        });
+                    }
+                }
+            }
+        }
+    }
+
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         edgecent[idim]->ParallelCopy(m_fc_data[face_dir]->m_edgecent_fc[idim], 0, 0, 1, 0, edgecent[idim]->nGrow(), geom.periodicity());
     }

--- a/Src/EB/AMReX_EB2_Level.cpp
+++ b/Src/EB/AMReX_EB2_Level.cpp
@@ -1065,16 +1065,16 @@ Level::fillVolFracFC (MultiFab& vfrac, int face_dir, const Geometry& geom) const
     vfrac.setVal(1.0);
     if (isAllRegular()) { return; }
 
-    // The covered region is masked BEFORE the ParallelCopy below, and is deliberately not
-    // shrunk. A face-centered cell straddles two cell-centered cells, so the ones on the
-    // covered/cut interface may still be cut; clearing them here and letting the copy write
-    // over them is correct, because the copy writes exactly where the face-centered data is
-    // valid - the nodal span of the cut boxes, which reaches the interface and no further.
+    // Mask the covered region before the ParallelCopy; see FCData::m_covered_grids_fc.
     BoxArray const& cov = m_fc_data[face_dir]->m_covered_grids_fc;
     if (!cov.empty())
     {
         BoxArray cov_fc = amrex::convert(cov, vfrac.ixType());
         const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        {
         std::vector<std::pair<int,Box> > isects;
         for (MFIter mfi(vfrac); mfi.isValid(); ++mfi)
         {
@@ -1091,6 +1091,7 @@ Level::fillVolFracFC (MultiFab& vfrac, int face_dir, const Geometry& geom) const
                 }
             }
         }
+        }
     }
 
     vfrac.ParallelCopy(m_fc_data[face_dir]->m_volfrac_fc, 0, 0, 1, 0, vfrac.nGrow(), geom.periodicity());
@@ -1104,19 +1105,19 @@ Level::fillAreaFracFC (Array<MultiFab*,AMREX_SPACEDIM> const& areafrac, int face
         areafrac[idim]->setVal(1.0);
     }
     if (isAllRegular()) { return; }
-    // The covered region is masked BEFORE the ParallelCopy below, and is deliberately not
-    // shrunk. A face-centered cell straddles two cell-centered cells, so the ones on the
-    // covered/cut interface may still be cut; clearing them here and letting the copy write
-    // over them is correct, because the copy writes exactly where the face-centered data is
-    // valid - the nodal span of the cut boxes, which reaches the interface and no further.
+    // Mask the covered region before the ParallelCopy; see FCData::m_covered_grids_fc.
     BoxArray const& cov = m_fc_data[face_dir]->m_covered_grids_fc;
     if (!cov.empty())
     {
         const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
-        std::vector<std::pair<int,Box> > isects;
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             // FC areafrac is cell-typed on the base grids, indexed by the staggered cell
             BoxArray cov_fc = amrex::convert(cov, areafrac[idim]->ixType());
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            {
+            std::vector<std::pair<int,Box> > isects;
             for (MFIter mfi(*areafrac[idim]); mfi.isValid(); ++mfi)
             {
                 auto const& fab = areafrac[idim]->array(mfi);
@@ -1131,6 +1132,7 @@ Level::fillAreaFracFC (Array<MultiFab*,AMREX_SPACEDIM> const& areafrac, int face
                         });
                     }
                 }
+            }
             }
         }
     }
@@ -1244,18 +1246,17 @@ Level::fillEBCellFlagFC (FabArray<EBCellFlagFab>& cellflag, int face_dir, const 
         return;
     }
 
-    // The covered region is masked BEFORE the ParallelCopy below, and is deliberately not
-    // shrunk. A face-centered cell straddles two cell-centered cells, so the ones on the
-    // covered/cut interface may still be cut; clearing them here and letting the copy write
-    // over them is correct, because the copy writes exactly where the face-centered data is
-    // valid - the nodal span of the cut boxes, which reaches the interface and no further.
+    // Mask the covered region before the ParallelCopy; see FCData::m_covered_grids_fc.
     BoxArray const& cov = m_fc_data[face_dir]->m_covered_grids_fc;
     if (!cov.empty())
     {
-        EBCellFlag cov_val = EBCellFlag::TheDefaultCell();
-        cov_val.setCovered();
+        auto cov_val = EBCellFlag::TheCoveredCell();
         BoxArray cov_fc = amrex::convert(cov, cellflag.ixType());
         const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+        {
         std::vector<std::pair<int,Box> > isects;
         for (MFIter mfi(cellflag); mfi.isValid(); ++mfi)
         {
@@ -1271,6 +1272,7 @@ Level::fillEBCellFlagFC (FabArray<EBCellFlagFab>& cellflag, int face_dir, const 
                     });
                 }
             }
+        }
         }
     }
 
@@ -1320,21 +1322,21 @@ Level::fillEdgeCentFC (Array<MultiFab*,AMREX_SPACEDIM> const& edgecent, int face
 {
     AMREX_ASSERT(hasFCData(face_dir));
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        edgecent[idim]->setVal(0.0);
+        edgecent[idim]->setVal(1.0);   // 1.0 marks a fully open edge, as in fillEdgeCent
     }
     if (isAllRegular()) { return; }
-    // The covered region is masked BEFORE the ParallelCopy below, and is deliberately not
-    // shrunk. A face-centered cell straddles two cell-centered cells, so the ones on the
-    // covered/cut interface may still be cut; clearing them here and letting the copy write
-    // over them is correct, because the copy writes exactly where the face-centered data is
-    // valid - the nodal span of the cut boxes, which reaches the interface and no further.
+    // Mask the covered region before the ParallelCopy; see FCData::m_covered_grids_fc.
     BoxArray const& cov = m_fc_data[face_dir]->m_covered_grids_fc;
     if (!cov.empty())
     {
         const std::vector<IntVect>& pshifts = geom.periodicity().shiftIntVect();
-        std::vector<std::pair<int,Box> > isects;
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             BoxArray cov_fc = amrex::convert(cov, edgecent[idim]->ixType());
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            {
+            std::vector<std::pair<int,Box> > isects;
             for (MFIter mfi(*edgecent[idim]); mfi.isValid(); ++mfi)
             {
                 auto const& fab = edgecent[idim]->array(mfi);
@@ -1349,6 +1351,7 @@ Level::fillEdgeCentFC (Array<MultiFab*,AMREX_SPACEDIM> const& edgecent, int face
                         });
                     }
                 }
+            }
             }
         }
     }

--- a/Tests/EB/FCFactory/inputs
+++ b/Tests/EB/FCFactory/inputs
@@ -1,6 +1,10 @@
 n_cell = 64
 max_grid_size = 32
 
+# small enough that whole EB boxes fall inside the body, so the level has covered
+# boxes and the covered-region checks below have something to test
+eb2.max_grid_size = 16
+
 sphere_radius = 0.25
 sphere_center = 0.5 0.5 0.5
 sphere_has_fluid_inside = 1

--- a/Tests/EB/FCFactory/main.cpp
+++ b/Tests/EB/FCFactory/main.cpp
@@ -149,6 +149,86 @@ void main_main()
         }
     }
 
+    // Covered regions. With eb2.max_grid_size small enough that whole boxes fall inside the
+    // body, the EB level has covered boxes, and the face-centered data must report them as
+    // covered rather than as regular fluid. A face-centered cell is covered exactly when both
+    // of the cell-centered cells it straddles are, so classify by the cell-centered flags
+    // rather than by the face-centered volume fraction - the failure being guarded against
+    // makes that volume fraction 1, which would hide the very cells at issue.
+    const auto& ccflag = cc_factory->getMultiEBCellFlagFab();
+    for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+        const MultiFab& volfrac_fc = fc_factories[dir]->getVolFrac();
+        const auto& ebflag = fc_factories[dir]->getMultiEBCellFlagFab();
+        auto const& afrac = fc_factories[dir]->getAreaFrac();
+        const IntVect fdir = IntVect::TheDimensionVector(dir);
+
+        ReduceOps<ReduceOpSum,ReduceOpSum,ReduceOpSum,ReduceOpSum> reduce_op;
+        ReduceData<int,int,int,int> reduce_data(reduce_op);
+        using ReduceTuple = typename ReduceData<int,int,int,int>::Type;
+
+        for (MFIter mfi(volfrac_fc); mfi.isValid(); ++mfi) {
+            auto const& vf    = volfrac_fc.const_array(mfi);
+            auto const& flag  = ebflag[mfi].const_array();
+            auto const& cflag = ccflag[mfi].const_array();
+            // the area fractions carry the cell-centered type, so enclosedCells of the
+            // face-centered valid box is exactly their valid range, and those indices are
+            // valid in the face-centered arrays too
+            const Box abx = amrex::enclosedCells(mfi.validbox());
+            const bool have_ap = afrac[0]->ok(mfi);
+            AMREX_D_TERM(auto const& apx = have_ap ? afrac[0]->const_array(mfi) : Array4<Real const>{};,
+                         auto const& apy = have_ap ? afrac[1]->const_array(mfi) : Array4<Real const>{};,
+                         auto const& apz = have_ap ? afrac[2]->const_array(mfi) : Array4<Real const>{};);
+
+            reduce_op.eval(abx, reduce_data,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple {
+                    const IntVect iv{AMREX_D_DECL(i,j,k)};
+                    if (!(cflag(iv-fdir).isCovered() && cflag(iv).isCovered())) {
+                        return {0,0,0,0};
+                    }
+                    int nbad_vf   = (vf(i,j,k) != Real(0.0))     ? 1 : 0;
+                    int nbad_flag = (!flag(i,j,k).isCovered())   ? 1 : 0;
+                    int nbad_ap   = 0;
+                    if (have_ap) {
+                        if (AMREX_D_TERM(apx(i,j,k) != Real(0.0),
+                                      || apy(i,j,k) != Real(0.0),
+                                      || apz(i,j,k) != Real(0.0))) { nbad_ap = 1; }
+                    }
+                    return {1, nbad_vf, nbad_flag, nbad_ap};
+                });
+        }
+
+        auto rv = reduce_data.value();
+        int ncovered  = amrex::get<0>(rv);
+        int nbad_vf   = amrex::get<1>(rv);
+        int nbad_flag = amrex::get<2>(rv);
+        int nbad_ap   = amrex::get<3>(rv);
+        ParallelDescriptor::ReduceIntSum(ncovered);
+        ParallelDescriptor::ReduceIntSum(nbad_vf);
+        ParallelDescriptor::ReduceIntSum(nbad_flag);
+        ParallelDescriptor::ReduceIntSum(nbad_ap);
+
+        if (ncovered == 0) {
+            ++nerrors;
+            amrex::Print() << "ERROR: dir=" << dir << " no covered cells; set eb2.max_grid_size "
+                           << "small enough that whole boxes fall inside the body\n";
+        }
+        if (nbad_vf > 0) {
+            ++nerrors;
+            amrex::Print() << "ERROR: dir=" << dir << " " << nbad_vf << " of " << ncovered
+                           << " covered cells have a nonzero volume fraction\n";
+        }
+        if (nbad_flag > 0) {
+            ++nerrors;
+            amrex::Print() << "ERROR: dir=" << dir << " " << nbad_flag << " of " << ncovered
+                           << " covered cells are not flagged covered\n";
+        }
+        if (nbad_ap > 0) {
+            ++nerrors;
+            amrex::Print() << "ERROR: dir=" << dir << " " << nbad_ap << " of " << ncovered
+                           << " covered cells have a nonzero area fraction\n";
+        }
+    }
+
     // Report
     if (nerrors > 0) {
         amrex::Print() << "FCFactory test FAILED with " << nerrors << " errors\n";


### PR DESCRIPTION
The face-centered data is built from the refined level's cut boxes and its covered region was dropped, so a box lying wholly inside the body kept the regular defaults the fill starts from: volume fraction 1 and a regular flag in the middle of solid.

The covered region has to come from the refined level, coarsened, not from this level: the refined level resolves the body more finely, so its is the larger of the two and the one that matches where the face-centered data was computed.

Mask before the ParallelCopy, and unshrunk. A face-centered cell straddles two cell-centered cells, so one between a covered and a cut cell may itself be cut; the copy writes exactly those faces again and no others.

This addresses issue 1 in #5635.