### PR TITLE
Fix `Random()` returning 1.0f & add `RandomPositive`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ endif ()
 set_mininum_compiler_version(CXX GNU 11.0)
 set_mininum_compiler_version(CXX Clang 14.0)
 set_mininum_compiler_version(CXX AppleClang 14.0)
-set_mininum_compiler_version(CXX MSVC 19.34)
+set_mininum_compiler_version(CXX MSVC 19.44)
 
 #
 # Set CMAKE_<LANG>_FLAGS_<CONFIG> if not already defined

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -3412,6 +3412,126 @@ The downside of this is we have to use :fortran:`pointer` instead of
 pass the Fortran pointer to a procedure with explicit array argument
 to get rid of the pointerness completely.
 
+.. _sec:basics:random:
+
+Random Numbers
+==============
+
+AMReX provides a set of pseudo-random number generators.  Most come in two
+overloads: one that takes no arguments, for use on the host, and one that takes
+a :cpp:`RandomEngine` and can be called from inside a GPU kernel.  The engine is
+supplied by :cpp:`ParallelForRNG`, the random-number variant of
+:cpp:`ParallelFor`:
+
+.. highlight:: c++
+
+::
+
+    amrex::ParallelForRNG(N,
+    [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+    {
+        p[i] = amrex::Random(engine);
+    });
+
+The generators are thread safe.  With OpenMP, each thread draws from its own
+independent generator.  The seed can be set with
+:cpp:`amrex::ResetRandomSeed(cpu_seed, gpu_seed)`.
+
+The uniform generators and their intervals
+------------------------------------------
+
+There are two uniform generators on the unit interval, and which one you want
+depends on what you do with the result:
+
+.. table::
+   :align: center
+
+   +----------------------------------+------------+-----------------------------------------+
+   | Function                         | Interval   | Use for                                 |
+   +==================================+============+=========================================+
+   | :cpp:`amrex::Random()`           | ``[0,1)``  | indices, positions within a cell,       |
+   |                                  |            | rejection tests                         |
+   +----------------------------------+------------+-----------------------------------------+
+   | :cpp:`amrex::RandomPositive()`   | ``(0,1]``  | anything singular at zero:              |
+   |                                  |            | ``log(u)``, ``1/u``, ``pow(u,-a)``      |
+   +----------------------------------+------------+-----------------------------------------+
+
+Both endpoints matter in practice, and each generator excludes the one that is
+dangerous for its intended use.
+
+:cpp:`amrex::Random` excludes the upper endpoint, so that
+:cpp:`int(N*amrex::Random())` is always a valid index into an array of length
+``N`` -- the product cannot round up to ``N``.  It *includes* zero.
+
+Note that the guarantee is on the value :cpp:`amrex::Random` returns, not on
+whatever is computed from it.  Arithmetic downstream can still round onto a
+boundary: :cpp:`problo + amrex::Random()*dx` may evaluate to exactly the upper
+face of the cell, since the rounded sum can land there even though the draw is
+strictly below one.  Code that needs a coordinate strictly inside the cell must
+guard the final value, not just the draw.
+
+:cpp:`amrex::RandomPositive` excludes the lower endpoint, so that the result can
+be passed straight to a function that is singular at zero:
+
+.. highlight:: c++
+
+::
+
+    // exponential distribution with mean tau
+    amrex::Real const t = -tau * std::log(amrex::RandomPositive(engine));
+
+    // power law with exponent -a
+    amrex::Real const x = std::pow(amrex::RandomPositive(engine), -a);
+
+There is no accuracy or performance penalty for picking the interval that fits
+the use case: whichever one you ask for is obtained from the underlying
+generator by relocating at most a single endpoint, never by arithmetic.  Both
+guarantees therefore hold in single and double precision, and under every
+floating-point mode AMReX may be built with, including ``-ffast-math`` /
+``--use_fast_math`` and flush-to-zero.
+
+.. warning::
+
+   Do **not** write :cpp:`1 - amrex::Random()` to obtain a non-zero value; draw
+   from :cpp:`amrex::RandomPositive` instead.  The two are not equivalent: the
+   subtraction costs an arithmetic operation and discards resolution, since it
+   is exact only above ``0.5`` and collapses smaller values onto a coarse
+   grid.
+
+Other distributions
+-------------------
+
+.. table::
+   :align: center
+
+   +--------------------------------------------------+------------------------------------------+
+   | Function                                         | Distribution                             |
+   +==================================================+==========================================+
+   | :cpp:`amrex::RandomNormal(mean, stddev)`         | normal                                   |
+   +--------------------------------------------------+------------------------------------------+
+   | :cpp:`amrex::RandomPoisson(lambda)`              | Poisson                                  |
+   +--------------------------------------------------+------------------------------------------+
+   | :cpp:`amrex::RandomGamma(alpha, beta)`           | Gamma                                    |
+   +--------------------------------------------------+------------------------------------------+
+   | :cpp:`amrex::Random_int(n)`                      | uniform integer on ``[0,n-1]``           |
+   +--------------------------------------------------+------------------------------------------+
+   | :cpp:`amrex::Random_long(n)`                     | uniform long on ``[0,n-1]``, host only   |
+   +--------------------------------------------------+------------------------------------------+
+
+To fill an array rather than draw one value at a time, use
+:cpp:`amrex::FillRandom(p, N)` for the uniform distribution and
+:cpp:`amrex::FillRandomNormal(p, N, mean, stddev)` for the normal distribution.
+
+.. note::
+
+   :cpp:`amrex::FillRandom` does not give the same interval on every backend
+   the way :cpp:`amrex::Random` and :cpp:`amrex::RandomPositive` do.  It is
+   ``[0,1)`` on the CPU, but the GPU paths hand back whatever the vendor bulk
+   generator produces -- nominally ``[0,1)`` with SYCL and ``(0,1]`` with CUDA
+   and HIP -- so code that depends on either endpoint should guard the values
+   it reads back, or draw with :cpp:`amrex::Random` /
+   :cpp:`amrex::RandomPositive` instead.
+
 Abort, Assertion and Backtrace
 ==============================
 

--- a/Docs/sphinx_documentation/source/Basics.rst
+++ b/Docs/sphinx_documentation/source/Basics.rst
@@ -3449,8 +3449,8 @@ depends on what you do with the result:
    +----------------------------------+------------+-----------------------------------------+
    | Function                         | Interval   | Use for                                 |
    +==================================+============+=========================================+
-   | :cpp:`amrex::Random()`           | ``[0,1)``  | indices, positions within a cell,       |
-   |                                  |            | rejection tests                         |
+   | :cpp:`amrex::Random()`           | ``[0,1)``  | positions within a cell, rejection      |
+   |                                  |            | tests, general uniform sampling         |
    +----------------------------------+------------+-----------------------------------------+
    | :cpp:`amrex::RandomPositive()`   | ``(0,1]``  | anything singular at zero:              |
    |                                  |            | ``log(u)``, ``1/u``, ``pow(u,-a)``      |
@@ -3459,16 +3459,14 @@ depends on what you do with the result:
 Both endpoints matter in practice, and each generator excludes the one that is
 dangerous for its intended use.
 
-:cpp:`amrex::Random` excludes the upper endpoint, so that
-:cpp:`int(N*amrex::Random())` is always a valid index into an array of length
-``N`` -- the product cannot round up to ``N``.  It *includes* zero.
+:cpp:`amrex::Random` excludes the upper endpoint and *includes* zero.
 
 Note that the guarantee is on the value :cpp:`amrex::Random` returns, not on
 whatever is computed from it.  Arithmetic downstream can still round onto a
 boundary: :cpp:`problo + amrex::Random()*dx` may evaluate to exactly the upper
 face of the cell, since the rounded sum can land there even though the draw is
-strictly below one.  Code that needs a coordinate strictly inside the cell must
-guard the final value, not just the draw.
+strictly below one.  Code that needs a value strictly inside a range must
+therefore guard the result of the computation, not rely on the draw alone.
 
 :cpp:`amrex::RandomPositive` excludes the lower endpoint, so that the result can
 be passed straight to a function that is singular at zero:

--- a/Docs/sphinx_documentation/source/BuildingAMReX_Chapter.rst
+++ b/Docs/sphinx_documentation/source/BuildingAMReX_Chapter.rst
@@ -29,7 +29,7 @@ The minimum toolchain versions we target for C++20 builds are:
 
 * GCC 11 or newer (for both host builds and CUDA host compilers).
 * LLVM Clang 14 or newer, including AppleClang 14 on macOS.
-* Microsoft Visual Studio 2022 (MSVC 19.34 / 17.4) or newer.
+* Microsoft Visual Studio 2022 (MSVC 19.44 / 17.14) or newer.
 * NVIDIA CUDA Toolkit 12.2 or newer.
 * AMD ROCm/HIP 6.0 or newer.
 * Intel oneAPI DPC++ 2025.2 or newer.

--- a/Docs/sphinx_documentation/source/Faq.rst
+++ b/Docs/sphinx_documentation/source/Faq.rst
@@ -130,7 +130,12 @@ Are they thread safe with MPI and OpenMP?
 
 **A.** (Thread safe) Yes, :cpp:`amrex::Random()` is thread safe. When OpenMP is on,
 each thread will have its own dedicated Random Number Generator that
-is totally independent of the others.
+is totally independent of the others. See :ref:`sec:basics:random` for the
+available generators, how to set the seed, and how to draw random numbers
+inside a GPU kernel. Note in particular that :cpp:`amrex::Random()` returns a
+value in ``[0,1)`` and can therefore return zero; use
+:cpp:`amrex::RandomPositive()`, which returns a value in ``(0,1]``, whenever
+the result is passed to something singular at zero such as ``std::log``.
 
 |
 

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -38,9 +38,15 @@ namespace amrex
     Real clamp_below_one (Real v) noexcept
     {
         // The constexpr equivalent of std::nextafter(Real(1), Real(0)), which
-        // is not available in device code.
+        // is not available in device code.  That this really is the immediate
+        // predecessor of one follows from the two assertions below: it is less
+        // than one, and the midpoint between it and one already rounds to one,
+        // so no Real lies in between.  Tests/Base/Random additionally checks it
+        // against std::nextafter itself on the host.
         constexpr Real almost_one
             = Real(1) - Real(0.5)*std::numeric_limits<Real>::epsilon();
+        static_assert(almost_one < Real(1));
+        static_assert(Real(1) - Real(0.25)*std::numeric_limits<Real>::epsilon() == Real(1));
         // No generator produces NaN, but note this maps it to almost_one
         // rather than propagating it, since the comparison is false for NaN.
         return (v < almost_one) ? v : almost_one;

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -22,6 +22,12 @@ namespace amrex
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real one_to_zero (Real v) noexcept { return (v == Real(1)) ? Real(0) : v; }
 
+    //! Convert a [0,1) draw to the left-open (0,1] the same way.  Note that
+    //! this is also correct if the generator reaches 1.0 in violation of its
+    //! own contract, since 1.0 is in range here.
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real zero_to_one (Real v) noexcept { return (v == Real(0)) ? Real(1) : v; }
+
     //! Clamp a value into the half-open unit interval [0,1) by pulling an
     //! exact 1.0 down to the largest representable Real below one.  Used
     //! where the generator is natively [0,1) and only needs guarding against
@@ -52,12 +58,11 @@ namespace amrex
     *
     *  \note Since 0.0 is included, the result must not be passed unguarded
     *  to a function that is singular at zero, such as std::log or std::pow
-    *  with a negative exponent.  Note that `1 - amrex::Random()` is \b not
-    *  a way around that: it costs an arithmetic operation and discards
+    *  with a negative exponent.  Draw from amrex::RandomPositive for those
+    *  cases rather than deriving a value with `1 - amrex::Random()`, which is
+    *  \b not equivalent: it costs an arithmetic operation and discards
     *  resolution, because the subtraction is exact only above 0.5 and
-    *  collapses smaller values onto a coarse grid.  Before the upper bound
-    *  above was guaranteed it was unsafe as well, evaluating to exactly 0.0
-    *  whenever Random() returned exactly 1.0.
+    *  collapses smaller values onto a coarse grid.
     *
     */
     Real Random ();
@@ -96,6 +101,98 @@ namespace amrex
         AMREX_IF_ON_HOST((
                 amrex::ignore_unused(random_engine);
                 return Random();
+        ))
+#endif
+    }
+
+    /**
+    * \ingroup amrex_utilities
+    * \brief Generate a pseudo-random real from uniform distribution,
+    *  excluding zero
+    *
+    *  Generates one pseudorandom real number from a uniform
+    *  distribution between 0.0 and 1.0 (0.0 excluded, 1.0 included).
+    *
+    *  This is the counterpart to amrex::Random for samplers that are
+    *  singular at zero, for example
+    *
+    *  \code{.cpp}
+    *      // exponential distribution with mean tau
+    *      Real const t = -tau * std::log(amrex::RandomPositive(engine));
+    *
+    *      // power law with exponent -a
+    *      Real const x = std::pow(amrex::RandomPositive(engine), -a);
+    *  \endcode
+    *
+    *  Prefer this over deriving a non-zero value from amrex::Random by hand
+    *  with `1 - amrex::Random()`, which is lossier for no benefit.  See the
+    *  note on amrex::Random.
+    *
+    *  \note If all you need is a normally distributed value, use
+    *  amrex::RandomNormal rather than a hand-rolled Box-Muller transform on
+    *  top of this function.  It is faster (on GPU it is the vendor's own
+    *  normal generator, and it does not consume two uniforms per deviate) and
+    *  it never touches std::log, so it is unaffected by the endpoint issue
+    *  described above.  Box-Muller written out by hand is only worthwhile
+    *  when the radial variable itself is needed, for instance to truncate a
+    *  Gaussian at a given number of sigma by inverting the radial CDF, or to
+    *  draw an isotropic direction by normalizing a vector of deviates.
+    *
+    *
+    *  There is no accuracy or performance penalty for choosing this interval
+    *  over the half-open [0,1) of amrex::Random.  On CUDA/HIP it is the
+    *  native interval of the underlying generator, so the value is returned
+    *  as drawn; on the host and with SYCL the generator is natively [0,1) and
+    *  only its zero endpoint is relocated to one.  No arithmetic is performed
+    *  on any path, so no resolution is lost and there is nothing that a
+    *  floating-point mode could change: the exclusion of zero holds under
+    *  -ffast-math / --use_fast_math and flush-to-zero alike, because it is
+    *  established by a comparison rather than by a computed bound.
+    *
+    *  The smallest value that can be returned is in every case the smallest
+    *  positive value of the underlying generator, and is therefore
+    *  backend-dependent: roughly 2^-33 in single precision with curand,
+    *  2^-32 with rocrand, and the granularity of the standard library's
+    *  distribution on the host, which for a 32-bit engine is 2^-32 in single
+    *  precision and 2^-64 in double.  All of these are normal numbers, so
+    *  flush-to-zero cannot reach them.
+    *
+    *  \see amrex::Random, amrex::RandomNormal
+    */
+    Real RandomPositive ();
+
+    /// \ingroup amrex_utilities
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real RandomPositive (RandomEngine const& random_engine)
+    {
+#if defined (__SYCL_DEVICE_ONLY__)
+        // oneMKL draws from [0,1); relocating the zero endpoint converts that
+        // to (0,1] with no arithmetic, and stays correct even if the
+        // generator reaches its own upper bound, since 1.0 is in range here
+        mkl::rng::device::uniform<Real> distr;
+        return random_util::zero_to_one(mkl::rng::device::generate(distr, *random_engine.engine));
+#else
+        // (0,1] is the native interval of hiprand/curand, so unlike Random()
+        // this needs no endpoint relocated and no clamp: the draw is
+        // returned exactly as the generator produced it.
+#ifdef BL_USE_FLOAT
+        AMREX_IF_ON_DEVICE((
+                AMREX_HIP_OR_CUDA(
+                        return hiprand_uniform(random_engine.rand_state); ,
+                        return curand_uniform(random_engine.rand_state);
+                )
+        ))
+#else
+        AMREX_IF_ON_DEVICE((
+                AMREX_HIP_OR_CUDA(
+                        return hiprand_uniform_double(random_engine.rand_state); ,
+                        return curand_uniform_double(random_engine.rand_state);
+                )
+        ))
+#endif
+        AMREX_IF_ON_HOST((
+                amrex::ignore_unused(random_engine);
+                return RandomPositive();
         ))
 #endif
     }
@@ -193,7 +290,7 @@ namespace amrex
             } while (v <= 0.0_rt);
 
             v = v * v * v;
-            u = amrex::Random(random_engine);
+            u = amrex::RandomPositive(random_engine); // std::log(u) below
 
             if (u < 1.0_rt - 0.0331_rt * x * x * x * x) {
                 break;
@@ -215,9 +312,9 @@ namespace amrex
     *  Generates one real number (single or double)
     *  extracted from a Gamma distribution, given the Real parameters alpha and beta.
     *  alpha and beta must both be > 0.
-    *  The CPU version of this function relies on the Standard Template Library
-    *  The GPU version of this function relies is implemented in terms of Random
-    *  and RandomNormal.
+    *  The CPU version of this function relies on the Standard Template Library.
+    *  The GPU version is implemented in terms of amrex::RandomPositive and
+    *  amrex::RandomNormal.
     *
     */
     Real RandomGamma (Real alpha, Real beta);
@@ -232,7 +329,7 @@ namespace amrex
         AMREX_IF_ON_DEVICE((
         if (alpha < 1)
         {
-            Real u = amrex::Random(random_engine);
+            Real u = amrex::RandomPositive(random_engine); // std::pow(u, 1/alpha) below
             return amrex::random_util::RandomGamma_alpha_ge_1(1.0_rt + alpha, beta, random_engine) * std::pow(u, 1.0_rt / alpha);
         } else {
             return amrex::random_util::RandomGamma_alpha_ge_1(alpha, beta, random_engine);
@@ -294,11 +391,13 @@ namespace amrex
 
     //! \ingroup amrex_utilities
     //! Fill random numbers from uniform distribution.  The interval is not
-    //! uniform across backends the way amrex::Random is: it is [0,1) on the
-    //! CPU, but the GPU paths hand back whatever the vendor bulk generator
-    //! produces, nominally [0,1) for SYCL and (0,1] for CUDA and HIP.  Code
-    //! that depends on either endpoint should guard the values it reads back,
-    //! or draw with amrex::Random instead.
+    //! uniform across backends the way amrex::Random and amrex::RandomPositive
+    //! are: it is [0,1) on the CPU, but the GPU paths hand back whatever the
+    //! vendor bulk generator produces, nominally [0,1) for SYCL and (0,1] for
+    //! CUDA and HIP.  Code that depends on either endpoint should guard the
+    //! values it reads back, or draw with amrex::Random / amrex::RandomPositive
+    //! instead.
+    void FillRandom (Real* p, Long N);
 
     //! \ingroup amrex_utilities
     //! Fill random numbers from normal distribution

--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -12,12 +12,52 @@
 
 namespace amrex
 {
+    /// \cond DOXYGEN_IGNORE
+    namespace random_util {
+
+    //! Convert a (0,1] draw to the documented half-open [0,1) by relocating
+    //! the single endpoint that is out of range.  This is the whole interval
+    //! conversion: no arithmetic is involved, so nothing can be reassociated,
+    //! contracted or flushed, and no resolution is lost.
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real one_to_zero (Real v) noexcept { return (v == Real(1)) ? Real(0) : v; }
+
+    //! Clamp a value into the half-open unit interval [0,1) by pulling an
+    //! exact 1.0 down to the largest representable Real below one.  Used
+    //! where the generator is natively [0,1) and only needs guarding against
+    //! reaching its own upper bound; unlike one_to_zero this does not raise
+    //! the probability of returning zero.  A comparison rather than
+    //! arithmetic, so it holds under every floating-point mode.
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    Real clamp_below_one (Real v) noexcept
+    {
+        // The constexpr equivalent of std::nextafter(Real(1), Real(0)), which
+        // is not available in device code.
+        constexpr Real almost_one
+            = Real(1) - Real(0.5)*std::numeric_limits<Real>::epsilon();
+        // No generator produces NaN, but note this maps it to almost_one
+        // rather than propagating it, since the comparison is false for NaN.
+        return (v < almost_one) ? v : almost_one;
+    }
+
+    }
+    /// \endcond
+
     /**
     * \ingroup amrex_utilities
     * \brief Generate a psuedo-random real from uniform distribution
     *
     *  Generates one pseudorandom real number from a uniform
-    *  distribution between 0.0 and 1.0 (0.0 included, 1.0 excluded)
+    *  distribution between 0.0 and 1.0 (0.0 included, 1.0 excluded).
+    *
+    *  \note Since 0.0 is included, the result must not be passed unguarded
+    *  to a function that is singular at zero, such as std::log or std::pow
+    *  with a negative exponent.  Note that `1 - amrex::Random()` is \b not
+    *  a way around that: it costs an arithmetic operation and discards
+    *  resolution, because the subtraction is exact only above 0.5 and
+    *  collapses smaller values onto a coarse grid.  Before the upper bound
+    *  above was guaranteed it was unsafe as well, evaluating to exactly 0.0
+    *  whenever Random() returned exactly 1.0.
     *
     */
     Real Random ();
@@ -27,21 +67,29 @@ namespace amrex
     Real Random (RandomEngine const& random_engine)
     {
 #if defined (__SYCL_DEVICE_ONLY__)
+        // clamped for the same reason as the host path: the documented [0,1)
+        // of the vendor generator is not a bound we want to depend on
         mkl::rng::device::uniform<Real> distr;
-        return mkl::rng::device::generate(distr, *random_engine.engine);
+        return random_util::clamp_below_one(mkl::rng::device::generate(distr, *random_engine.engine));
 #else
+        // hiprand/curand draw from (0,1].  Relocating the single endpoint
+        // that is out of range converts that to the documented [0,1) exactly,
+        // with no arithmetic.  Subtracting from one would also convert the
+        // interval, but not exactly: for a draw below half an ULP of one,
+        // `1 - draw` rounds back up to 1.0, and the subtraction additionally
+        // collapses every value below 0.5 onto a 2^-24 grid.
 #ifdef BL_USE_FLOAT
         AMREX_IF_ON_DEVICE((
                 AMREX_HIP_OR_CUDA(
-                        return 1.0f - hiprand_uniform(random_engine.rand_state); ,
-                        return 1.0f - curand_uniform(random_engine.rand_state);
+                        return random_util::one_to_zero(hiprand_uniform(random_engine.rand_state)); ,
+                        return random_util::one_to_zero(curand_uniform(random_engine.rand_state));
                 )
         ))
 #else
         AMREX_IF_ON_DEVICE((
                 AMREX_HIP_OR_CUDA(
-                        return 1.0 - hiprand_uniform_double(random_engine.rand_state); ,
-                        return 1.0 - curand_uniform_double(random_engine.rand_state);
+                        return random_util::one_to_zero(hiprand_uniform_double(random_engine.rand_state)); ,
+                        return random_util::one_to_zero(curand_uniform_double(random_engine.rand_state));
                 )
         ))
 #endif
@@ -245,9 +293,12 @@ namespace amrex
     ULong Random_long (ULong n); // [0,n-1]
 
     //! \ingroup amrex_utilities
-    //! Fill random numbers from uniform distribution.  The range is [0,1)
-    //! for CPU and SYCl, and (0,1] for CUADA and HIP.
-    void FillRandom (Real* p, Long N);
+    //! Fill random numbers from uniform distribution.  The interval is not
+    //! uniform across backends the way amrex::Random is: it is [0,1) on the
+    //! CPU, but the GPU paths hand back whatever the vendor bulk generator
+    //! produces, nominally [0,1) for SYCL and (0,1] for CUDA and HIP.  Code
+    //! that depends on either endpoint should guard the values it reads back,
+    //! or draw with amrex::Random instead.
 
     //! \ingroup amrex_utilities
     //! Fill random numbers from normal distribution

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -147,6 +147,16 @@ Real Random ()
     return random_util::clamp_below_one(distribution(generators[tid]));
 }
 
+Real RandomPositive ()
+{
+    // Relocating the zero endpoint converts [0,1) to (0,1] with no arithmetic.
+    // Note this needs no clamp: unlike Random(), it stays correct even when the
+    // distribution reaches 1.0 as described above, because 1.0 is in range here.
+    std::uniform_real_distribution<Real> distribution(0.0, 1.0);
+    int tid = OpenMP::get_thread_num();
+    return random_util::zero_to_one(distribution(generators[tid]));
+}
+
 unsigned int RandomPoisson (Real lambda)
 {
     std::poisson_distribution<unsigned int> distribution(lambda);

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -130,11 +130,21 @@ Real RandomNormal (Real mean, Real stddev)
     return distribution(generators[tid]);
 }
 
+// std::uniform_real_distribution is specified as [0,1), but that bound is not
+// something to depend on: it is built on std::generate_canonical, whose C++20
+// specification is defective -- LWG 2524 -- in that the quotient it forms can
+// round up to exactly 1.0.  In single precision with a 32-bit engine,
+// (2^32-1)/2^32 rounds to 1.0f.  Implementations are free to clamp and the
+// ones AMReX currently supports do (MSVC only since it implemented P0952R2 in
+// 2024, microsoft/STL#1074), but nothing in the standard AMReX targets
+// requires it.  Clamp rather than trust it: that makes the interval of
+// Random() a property of AMReX instead of a property of whichever standard
+// library happens to be in use.
 Real Random ()
 {
     std::uniform_real_distribution<Real> distribution(0.0, 1.0);
     int tid = OpenMP::get_thread_num();
-    return distribution(generators[tid]);
+    return random_util::clamp_below_one(distribution(generators[tid]));
 }
 
 unsigned int RandomPoisson (Real lambda)
@@ -292,10 +302,12 @@ void FillRandom (Real* p, Long N)
     event.wait();
 
 #else
+    // clamped for the same reason as Random(): std::uniform_real_distribution
+    // may reach its upper bound (LWG 2524), so [0,1) is not free here either
     std::uniform_real_distribution<Real> distribution(Real(0.0), Real(1.0));
     auto& gen = generators[OpenMP::get_thread_num()];
     for (Long i = 0; i < N; ++i) {
-        p[i] = distribution(gen);
+        p[i] = random_util::clamp_below_one(distribution(gen));
     }
 #endif
 }

--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -133,11 +133,10 @@ Real RandomNormal (Real mean, Real stddev)
 // std::uniform_real_distribution is specified as [0,1), but that bound is not
 // something to depend on: it is built on std::generate_canonical, whose C++20
 // specification is defective -- LWG 2524 -- in that the quotient it forms can
-// round up to exactly 1.0.  In single precision with a 32-bit engine,
-// (2^32-1)/2^32 rounds to 1.0f.  Implementations are free to clamp and the
-// ones AMReX currently supports do (MSVC only since it implemented P0952R2 in
-// 2024, microsoft/STL#1074), but nothing in the standard AMReX targets
-// requires it.  Clamp rather than trust it: that makes the interval of
+// round up to exactly 1.0f in single precision. Implementations are free to clamp
+// and the ones AMReX currently supports do, including MSVC (fixed
+// P0952R2 in 2024 via microsoft/STL#1074).  Since this is a C++20 defect, we
+// clamp rather than trust it: that makes the interval of
 // Random() a property of AMReX instead of a property of whichever standard
 // library happens to be in use.
 Real Random ()

--- a/Tests/Base/Random/CMakeLists.txt
+++ b/Tests/Base/Random/CMakeLists.txt
@@ -1,0 +1,9 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources     main.cpp)
+    set(_input_files)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Base/Random/GNUmakefile
+++ b/Tests/Base/Random/GNUmakefile
@@ -1,0 +1,24 @@
+AMREX_HOME ?= ../../..
+
+DEBUG	= TRUE
+
+DIM	= 3
+
+COMP    = gcc
+
+USE_MPI   = FALSE
+USE_OMP   = FALSE
+USE_CUDA  = FALSE
+USE_HIP   = FALSE
+USE_SYCL  = FALSE
+
+BL_NO_FORT = TRUE
+
+TINY_PROFILE = FALSE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Base/Random/Make.package
+++ b/Tests/Base/Random/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Base/Random/main.cpp
+++ b/Tests/Base/Random/main.cpp
@@ -1,6 +1,5 @@
 #include <AMReX.H>
 #include <AMReX_Gpu.H>
-#include <AMReX_Math.H>
 #include <AMReX_Print.H>
 #include <AMReX_Random.H>
 
@@ -115,8 +114,13 @@ void test_engine_intervals ()
 
         Real const g1 = amrex::RandomGamma(Real(2.5), Real(1.0), engine);
         Real const g2 = amrex::RandomGamma(Real(0.4), Real(1.0), engine); // alpha < 1 branch
-        if (!(g1 > Real(0) && amrex::Math::isfinite(g1)) ||
-            !(g2 > Real(0) && amrex::Math::isfinite(g2))) {
+        // Finiteness is expressed as a comparison rather than with
+        // amrex::Math::isfinite, which is std::isfinite outside SYCL and is a
+        // host-only function to nvcc when MSVC is the host compiler.  Both a
+        // NaN and an infinity fail `x <= max()`, so this is the same test.
+        constexpr Real real_max = std::numeric_limits<Real>::max();
+        if (!(g1 > Real(0) && g1 <= real_max) ||
+            !(g2 > Real(0) && g2 <= real_max)) {
             Gpu::Atomic::AddNoRet(p_bad_gamma, Long(1));
         }
     });

--- a/Tests/Base/Random/main.cpp
+++ b/Tests/Base/Random/main.cpp
@@ -1,5 +1,6 @@
 #include <AMReX.H>
 #include <AMReX_Gpu.H>
+#include <AMReX_Math.H>
 #include <AMReX_Print.H>
 #include <AMReX_Random.H>
 
@@ -86,9 +87,10 @@ void test_host_intervals ()
 // deterministic: the endpoints are rare enough that it would take far more
 // draws than this to hit one, so it guards against a wholesale breakage of a
 // path rather than against a regression at the endpoint itself -- that is what
-// test_endpoint_guard above is for. RandomGamma is included because it
-// consumes RandomPositive internally and would return a non-finite value if a
-// zero ever reached its std::log.
+// test_endpoint_guard above is for. RandomGamma provides smoke coverage for
+// both shape branches. The alpha < 1 branch would return zero if its
+// multiplicative uniform draw were zero. Both results must be positive and
+// finite.
 void test_engine_intervals ()
 {
     Long const N = 2000000;
@@ -113,7 +115,8 @@ void test_engine_intervals ()
 
         Real const g1 = amrex::RandomGamma(Real(2.5), Real(1.0), engine);
         Real const g2 = amrex::RandomGamma(Real(0.4), Real(1.0), engine); // alpha < 1 branch
-        if (!(g1 > Real(0)) || !(g2 > Real(0))) {
+        if (!(g1 > Real(0) && amrex::Math::isfinite(g1)) ||
+            !(g2 > Real(0) && amrex::Math::isfinite(g2))) {
             Gpu::Atomic::AddNoRet(p_bad_gamma, Long(1));
         }
     });

--- a/Tests/Base/Random/main.cpp
+++ b/Tests/Base/Random/main.cpp
@@ -1,0 +1,137 @@
+#include <AMReX.H>
+#include <AMReX_Gpu.H>
+#include <AMReX_Print.H>
+#include <AMReX_Random.H>
+
+#include <cstdint>
+#include <limits>
+#include <random>
+
+using namespace amrex;
+
+namespace {
+
+// A URBG pinned to its maximum output: the input that drives
+// std::uniform_real_distribution hardest towards its excluded upper bound.
+// LWG 2524 notes that std::generate_canonical may return exactly 1.0, because
+// the quotient it forms can round up. Every standard library AMReX currently
+// supports clamps instead (MSVC since it implemented P0952R2 in VS 2022
+// 17.12), so on those this returns the largest value below one rather than one
+// itself -- but nothing in the standard AMReX targets requires that, which is
+// why Random() does not depend on it.
+struct MaxEngine
+{
+    using result_type = std::uint32_t;
+    static constexpr result_type min () { return 0; }
+    static constexpr result_type max () { return std::numeric_limits<std::uint32_t>::max(); }
+    result_type operator() () { return max(); }
+};
+
+// The interval conversions that amrex::Random and amrex::RandomPositive apply
+// to a raw draw must hold the documented intervals for every input, including
+// the endpoints. These checks are deterministic: the endpoints are far too
+// rare to reach by sampling, so they are fed in directly.
+void test_endpoint_guard ()
+{
+    // Whatever the standard library hands back for the hardest input, the
+    // guard must leave it inside [0,1).
+    MaxEngine engine;
+    std::uniform_real_distribution<Real> distribution(0.0, 1.0);
+    Real const raw = distribution(engine);
+    Real const guarded = random_util::clamp_below_one(raw);
+    AMREX_ALWAYS_ASSERT(guarded < Real(1));
+    AMREX_ALWAYS_ASSERT(guarded >= Real(0));
+
+    // The clamp must be a no-op on every value that is already in range.
+    AMREX_ALWAYS_ASSERT(random_util::clamp_below_one(Real(0)) == Real(0));
+    AMREX_ALWAYS_ASSERT(random_util::clamp_below_one(Real(0.5)) == Real(0.5));
+    Real const below_one = Real(1) - Real(0.5)*std::numeric_limits<Real>::epsilon();
+    AMREX_ALWAYS_ASSERT(random_util::clamp_below_one(below_one) == below_one);
+
+    // The clamped upper bound is the largest Real below one, so nothing is
+    // needlessly discarded.
+    AMREX_ALWAYS_ASSERT(random_util::clamp_below_one(Real(1)) == below_one);
+
+    // The interval conversions relocate exactly one endpoint and leave every
+    // other value untouched, so they cannot lose resolution.
+    AMREX_ALWAYS_ASSERT(random_util::one_to_zero(Real(1)) == Real(0));   // (0,1] -> [0,1)
+    AMREX_ALWAYS_ASSERT(random_util::one_to_zero(below_one) == below_one);
+    AMREX_ALWAYS_ASSERT(random_util::one_to_zero(Real(0.5)) == Real(0.5));
+
+    AMREX_ALWAYS_ASSERT(random_util::zero_to_one(Real(0)) == Real(1));   // [0,1) -> (0,1]
+    AMREX_ALWAYS_ASSERT(random_util::zero_to_one(below_one) == below_one);
+    AMREX_ALWAYS_ASSERT(random_util::zero_to_one(Real(0.5)) == Real(0.5));
+
+    // zero_to_one needs no clamp of its own: even a draw of exactly 1.0, which
+    // would violate the generator's own [0,1) contract, is inside (0,1].
+    AMREX_ALWAYS_ASSERT(random_util::zero_to_one(Real(1)) > Real(0));
+    AMREX_ALWAYS_ASSERT(random_util::zero_to_one(Real(1)) <= Real(1));
+    AMREX_ALWAYS_ASSERT(random_util::zero_to_one(raw) > Real(0));
+}
+
+// The intervals themselves, over the host generators.
+void test_host_intervals ()
+{
+    for (int i = 0; i < 1000000; ++i) {
+        Real const r = amrex::Random();
+        AMREX_ALWAYS_ASSERT(r >= Real(0) && r < Real(1));
+
+        Real const p = amrex::RandomPositive();
+        AMREX_ALWAYS_ASSERT(p > Real(0) && p <= Real(1));
+    }
+}
+
+// The same intervals through the RandomEngine overloads, which on a GPU build
+// runs the device code paths. Note this part is statistical, not
+// deterministic: the endpoints are rare enough that it would take far more
+// draws than this to hit one, so it guards against a wholesale breakage of a
+// path rather than against a regression at the endpoint itself -- that is what
+// test_endpoint_guard above is for. RandomGamma is included because it
+// consumes RandomPositive internally and would return a non-finite value if a
+// zero ever reached its std::log.
+void test_engine_intervals ()
+{
+    Long const N = 2000000;
+
+    Gpu::DeviceScalar<Long> d_bad_random(0), d_bad_positive(0), d_bad_gamma(0);
+    Long* p_bad_random   = d_bad_random.dataPtr();
+    Long* p_bad_positive = d_bad_positive.dataPtr();
+    Long* p_bad_gamma    = d_bad_gamma.dataPtr();
+
+    amrex::ParallelForRNG(N,
+    [=] AMREX_GPU_DEVICE (Long, RandomEngine const& engine) noexcept
+    {
+        Real const r = amrex::Random(engine);
+        if (!(r >= Real(0) && r < Real(1))) {
+            Gpu::Atomic::AddNoRet(p_bad_random, Long(1));
+        }
+
+        Real const p = amrex::RandomPositive(engine);
+        if (!(p > Real(0) && p <= Real(1))) {
+            Gpu::Atomic::AddNoRet(p_bad_positive, Long(1));
+        }
+
+        Real const g1 = amrex::RandomGamma(Real(2.5), Real(1.0), engine);
+        Real const g2 = amrex::RandomGamma(Real(0.4), Real(1.0), engine); // alpha < 1 branch
+        if (!(g1 > Real(0)) || !(g2 > Real(0))) {
+            Gpu::Atomic::AddNoRet(p_bad_gamma, Long(1));
+        }
+    });
+    Gpu::streamSynchronize();
+
+    AMREX_ALWAYS_ASSERT(d_bad_random.dataValue() == 0);
+    AMREX_ALWAYS_ASSERT(d_bad_positive.dataValue() == 0);
+    AMREX_ALWAYS_ASSERT(d_bad_gamma.dataValue() == 0);
+}
+
+}
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+    test_endpoint_guard();
+    test_host_intervals();
+    test_engine_intervals();
+    amrex::Print() << "SUCCESS\n";
+    amrex::Finalize();
+}

--- a/Tests/Base/Random/main.cpp
+++ b/Tests/Base/Random/main.cpp
@@ -3,6 +3,7 @@
 #include <AMReX_Print.H>
 #include <AMReX_Random.H>
 
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <random>
@@ -45,7 +46,13 @@ void test_endpoint_guard ()
     // The clamp must be a no-op on every value that is already in range.
     AMREX_ALWAYS_ASSERT(random_util::clamp_below_one(Real(0)) == Real(0));
     AMREX_ALWAYS_ASSERT(random_util::clamp_below_one(Real(0.5)) == Real(0.5));
+    // Check the constant the clamp is built on against std::nextafter, which
+    // is what it is meant to reproduce but cannot call in device code. Doing
+    // this here rather than in the header is the point: it is an independent
+    // check on every platform CI builds for, not the same expression twice.
     Real const below_one = Real(1) - Real(0.5)*std::numeric_limits<Real>::epsilon();
+    AMREX_ALWAYS_ASSERT(below_one == std::nextafter(Real(1), Real(0)));
+
     AMREX_ALWAYS_ASSERT(random_util::clamp_below_one(below_one) == below_one);
 
     // The clamped upper bound is the largest Real below one, so nothing is

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -105,6 +105,7 @@ endfunction ()
 if (AMReX_TEST_TYPE STREQUAL "Small")
 
    add_subdirectory("Base/TrackedVector")
+   add_subdirectory("Base/Random")
    add_subdirectory("Base/RealBox")
    add_subdirectory("Base/CompensatedSum")
 


### PR DESCRIPTION
Fixes #5638.

**What was achieved.** `amrex::Random()` is documented as `[0,1)` but could return exactly `1.0` — on CUDA/HIP because `1 - curand_uniform()` rounds back up for a tiny draw (~3e-8 per call in single precision), and on the host because `std::uniform_real_distribution` is permitted to reach its upper bound (LWG 2524). Both endpoints are now obtained by **relocating a single endpoint of the underlying generator rather than by arithmetic**, which is exact by construction and cheaper. Adds **`amrex::RandomPositive()`**, a uniform real in `(0,1]`, for samplers singular at zero (`-log(u)`, `pow(u,-a)`, Box-Muller) — user code previously wrote `1 - amrex::Random()`, which is *not* a valid guard since it evaluates to exactly `0.0` in single precision. `RandomGamma` now uses it; both are documented in a new "Random Numbers" section of the user's guide.

**What was tested.** New `Tests/Base/Random` in CTest: a deterministic maximal-URBG case (the endpoints are far too rare to sample), the endpoint behaviour of the interval conversions, interval assertions through the `RandomEngine` overloads, and `RandomGamma` finiteness — validated by breaking a guard on purpose to confirm it fails. Passes on CPU (9/9, Small) and single-precision CUDA. On an A2000 the original bug reproduces at **109 violations in 3.9e9 draws** (predicted ~118) and goes to **0**; chi-square over 1024 bins is clean for both generators (z = +0.28 and −0.00). Both precision branches compile clean under IEEE and `--use_fast_math -ftz=true`.

A third commit pins the **MSVC minimum to 19.44 (VS 2022 17.14)**, up from an untested 19.34 — see the details block.

**Does it break user interfaces?** The API is purely additive — one new function, no signature or default changed. **`Random()` does return different values on GPU for a given engine state**, because the interval conversion is no longer `1 - c`, so GPU results and any checksums taken from them will shift. This is not a distribution change: `P(== 0)` is unchanged and chi-square is indistinguishable. CPU streams are unaffected.

<details>
<summary>Details, corner cases, and rejected ideas</summary>

### The clamp constant

Used on the host and SYCL paths, where the native interval is already `[0,1)` and only the vendor defect needs guarding. It is `1 - eps/2`, exactly `std::nextafter(Real(1), Real(0))` in both precisions (verified for `float` and `double`, with and without `-ffast-math`). Being `constexpr`, it works in device code where `std::nextafter` is unavailable — so neither workaround discussed in #5638 is needed: not `1 - epsilon` (2 ULPs below one, needlessly discarding a representable value), and not a host-computed value stashed in `RandomEngine`. Incidentally, libstdc++ already clamps a maximal URBG to exactly this value.

### Safety under all math modes

Both guarantees hold however AMReX is built, because no path performs arithmetic on the draw: every interval is established by a **comparison**, so there is nothing to reassociate, contract or flush. `almost_one` is exactly representable, so constant folding is stable, and the smallest value `RandomPositive()` can return is a **normal** number in both precisions. Verified: all GPU results are byte-identical under `-O3` and `--use_fast_math -ftz=true`.

### Does any of this perturb uniformity?

No. In every case only a single endpoint value is affected and every other value passes through bit-for-bit unchanged, so the distribution restricted to the documented interval is untouched.

- **The GPU remap** relocates `2^-25` of mass from `1.0`, which was never in contract, to `0.0` — which is exactly where the old `1 - c` form put it too, so `P(Random() == 0)` is unchanged at ~`2^-25` (measured: 3.75e-08 over 4e8 draws).
- **The host/SYCL clamp** moves `2^-25` of mass by one ULP, bounding any moment shift by `2^-49` (~2e-15).
- **`RandomPositive`** performs no relocation at all on CUDA/HIP, and on host/SYCL moves `P(u == 0)` onto `1.0` (measured `P(RandomPositive() == 1)` = 2.5e-08).

Measured chi-square over 1024 bins at 4e8 draws in single precision on GPU: `Random()` z = +0.28, `RandomPositive()` z = −0.00. The engine stream is untouched in all cases — no extra draws are consumed and engine state is not altered.

One corner case on the record: under the GPU remap the atom at exactly `0.0` sits next to the generator's fine `~2^-32` grid, so zero is locally overweighted relative to its immediate neighbours, where under `1 - c` the grid near zero was a uniform `2^-24`. `P(== 0)` is identical either way and this is invisible at any binning coarser than ULP scale, but it is the one respect in which the remap's distribution is less locally regular.

### Why the interval conversion is an endpoint remap, not `1 - c`

`(c == 1) ? 0 : c` converts `(0,1]` to `[0,1)` exactly, because the two intervals differ in precisely one endpoint. Subtracting from one also converts the interval, but not exactly, and costs more:

- for a draw below half an ULP of one, `1 - draw` rounds back up to `1.0` — the bug;
- `1 - draw` is exact by Sterbenz above `0.5`, which collapses every returned value below `0.5` onto a `2^-24` grid. So the old form could not return anything between `0` and `2^-24`, discarding roughly nine bits for small values. The remap keeps the generator's own `~2^-33` floor (measured: smallest positive `5.8e-10` vs `6.0e-08`).
- it is one comparison instead of a subtract plus a guard.

Measured over 3.93e9 draws, the two are statistically indistinguishable (chi-square 1089.6 vs 1089.2) and have identical `P(== 0)`, so the resolution and cost are gained for nothing. The cost is that every GPU draw changes value, which is called out above.

An endpoint-only variant that keeps the flip — `v = 1 - c; return (v == 1) ? 0 : v;` — would have preserved GPU streams (differing in only 111 draws in 3.9e9), but it **doubles** `P(Random() == 0)` (5.59e-08 vs 2.77e-08), and zero is the endpoint that makes `std::log(u)` infinite. That is also why the host and SYCL paths, which need only a defect guard rather than an interval conversion, *clamp* instead of relocating: clamping does not raise the probability of returning zero. Full analysis with measurements in [this comment](https://github.com/AMReX-Codes/amrex/pull/5643#issuecomment-5414475212).

### Why not just `amrex::RandomNormal` for the Box-Muller case?

For a plain normal deviate, yes — the guide's distribution table lists it directly below, and the doxygen carries a `\see`. Not a coincidence that it is unaffected: `curand_uniform` excludes zero *precisely because* curand's own normal generator needs `log(u)`; the `1 - c` flip discarded exactly the property the vendor put there on purpose. Hand-written Box-Muller still earns its place when the **radial variable itself** is needed — a radially truncated Gaussian (rejection on `RandomNormal` would be an unbounded loop with divergent warps, variable draw counts, and a *square* rather than *circular* cut), or an isotropic direction from a normalized vector of deviates.

### Pinning the MSVC minimum (third commit)

The declared floor was MSVC 19.34 (VS 2022 17.4, Nov 2022), but nothing exercises it. Since AMReX requires C++20, the Windows toolchains it is actually built with are much newer:

- **CI**: the `windows-2022` and `windows-latest` images currently provide **MSVC 19.44.35228** and **19.51.36252**. So 19.44 is the oldest MSVC any test has ever run against.
- **conda-forge**: the `amrex` feedstock, and the downstream `warpx` and `impactx` feedstocks, all build Windows with the `vs2022` compiler package (`c_stdlib: vs`, no lower pin), so distributed binaries are not built with anything older either.

Raised to 19.44 in `CMakeLists.txt` and `BuildingAMReX_Chapter.rst` so the claim matches what is verified. Note this is a **policy change**, not a consequence of the RNG work — happy to split it out or pick a different number. The natural alternative is **19.42 (VS 17.12)**, the first release containing the `generate_canonical` fix — less aggressive, though still untested. Note the tested floor is a moving target: `windows-2022` is on its final servicing baseline and `windows-latest` has already moved to VS 2026, so this number will need revisiting when that image retires.

This also corrected the framing of the host clamp. An earlier revision justified it by "MSVC 19.34 is defective and is supported"; with the floor at 19.44 every supported standard library clamps already. The clamp stays, but for the accurate reason: **the C++20 wording itself does not guarantee the bound** (LWG 2524; MSVC only conformed once it implemented P0952R2 in VS 2022 17.12 = MSVC 19.42, so the whole of the old 19.34–19.41 window is affected and none of the new one is). The interval should be a property of AMReX, not of whichever standard library is in use.

### Known limitations

- The deterministic test pins the *guard* rather than `Random()` itself, because there is no URBG injection point; it catches a regression in the guard or its constant, but the call-site coverage remains statistical. A seam for injecting an engine would fix that — out of scope here, happy to add.
- `Random()`'s interval is a guarantee about the returned value, not about expressions computed from it: `problo + Random()*dx` can still round onto the upper cell face (verified in both precisions). Noted in the guide.
- `FillRandom` remains backend-dependent. Its CPU path is now clamped (free — already looping), but the GPU paths forward to vendor *bulk* generators where a guarantee needs a full extra pass over the array. Documented accurately rather than papered over.
- Naming is bikesheddable: `RandomPositive` fits the `Random*` prefix, `RandomNonZero` reads more literally.
- A `(0,1)` variant excluding *both* endpoints would additionally serve logistic/Cauchy inversion, at the cost of a clamp on every backend. Left out.

### Downstream

ImpactX BLAST-ImpactX/impactx#1627 can drop its `amrex::max(u1, numeric_limits::min())` clamps in favour of `RandomPositive`; WarpX has four sites that want it (`SampleGaussianFluxDistribution.H:49`, `InjectorMomentum.H:320,322`, `DefaultInitialization.H:71`).

</details>

## To Do

- [x] draft 🤖 Generated with [Claude Code](https://claude.com/claude-code)
- [x] self-review
- [x] LLM-based review
- [x] final self-review






