### PR TITLE
Tuple: Silence `modernize-pass-by-value`

### DIFF
--- a/Src/Base/AMReX_Tuple.H
+++ b/Src/Base/AMReX_Tuple.H
@@ -29,6 +29,12 @@ struct gpu_tuple_element
     AMREX_GPU_HOST_DEVICE
     constexpr gpu_tuple_element () requires (std::is_default_constructible_v<T>) {} // NOLINT
 
+    // This overload is what catches arguments the forwarding constructor below
+    // cannot deduce, a braced initializer list above all. Everything else, both
+    // lvalues and rvalues of T, already goes there. Taking this one by value
+    // would therefore add a move for exactly those callers while saving a copy
+    // for nobody.
+    // NOLINTNEXTLINE(modernize-pass-by-value)
     explicit constexpr gpu_tuple_element (T const& a_value)
         : m_value(a_value)
         {}


### PR DESCRIPTION
## Summary

`clang-tidy`'s `modernize-pass-by-value` fires on `detail::gpu_tuple_element`'s constructor and asks for the argument to be taken by value and moved. Following that advice would be a pessimization here. This adds a `NOLINTNEXTLINE` with the reasoning written down, because it is not obvious from the code.

## Why by value is wrong here

The forwarding constructor immediately below already takes everything that can be deduced — lvalues and rvalues of `T` alike. The const-reference overload is reached only by arguments it *cannot* deduce, a braced initializer list above all:

```cpp
struct P { int a, b; };

P p{1,2};
E<P> a(p);        // forwarding constructor
E<P> b(P{3,4});   // forwarding constructor
E<P> c({5,6});    // this one -- U cannot be deduced from a braced-init-list
```

(verified by instrumenting the two constructors and running the three cases)

So taking it by value would add a move for exactly the callers this overload exists to serve, and save a copy for nobody, since rvalues never reach it. Removing the overload instead is not an option either — the braced-init case would stop compiling.

## Why it is showing up now

Nothing changed in `AMReX_Tuple.H`. The SIMD CI job runs `clang-tidy` over ccache *misses*, so which headers get linted depends on what was recompiled. A change to a widely included header — https://github.com/AMReX-Codes/amrex/pull/5644 touches `AMReX_Math.H` — pulls `AMReX_Tuple.H` into the linted set and the finding appears. It is pre-existing on `development` and unrelated to that work, which is why it is split out here: this is a two-line comment change that can be reviewed on its own, and #5644 can rebase on it afterwards.

## Testing

```
clang-tidy-21 --config-file=.clang-tidy --header-filter='.*AMReX.*'
```
over `Tests/SIMD/main.cpp` and `Tests/Particles/ParticleReduceSIMD/main.cpp`: `modernize-pass-by-value` findings across all AMReX headers go from 1 to 0, and this was the only one. `AMReX_Tuple.H` still compiles and behaves the same (`amrex::makeTuple` with scalar and aggregate members).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
