### PR TITLE
Skip empty MPI_Testall

### DIFF
--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -529,7 +529,9 @@ Test (MPI_Request& request, int& flag, MPI_Status& status)
 void
 Test (Vector<MPI_Request>& request, int& flag, Vector<MPI_Status>& status)
 {
-    BL_MPI_REQUIRE( MPI_Testall(request.size(), request.data(), &flag, status.data()) );
+    if (!request.empty()) {
+        BL_MPI_REQUIRE( MPI_Testall(request.size(), request.data(), &flag, status.data()) );
+    }
 }
 
 void


### PR DESCRIPTION
Avoids the `MPI_Testall` for empty request vectors.

This was observed to improve performance in an MLMG case where the bottom solver only used one MPI rank (the whole simulation used four ranks). In this case, the bottom solver did not emit MPI requests and it is not needed to call `MPI_Testall`.
