### PR TITLE
Implement MLEBNodeFDLaplacian::fillIJMatrix and fillRHS

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_K.H
@@ -205,6 +205,176 @@ void mlebndfdlap_grad_z (Box const& b, Array4<Real> const& pz, Array4<Real const
 }
 #endif
 
+
+#if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
+
+namespace ebnodefdlap_detail {
+
+//! One assembled matrix row.  Entry 0 is the diagonal, the rest are neighbors.
+struct Row
+{
+    static constexpr int nmax = 2*AMREX_SPACEDIM+1;
+    int n = 0;
+    Real val[nmax] = {};
+    Dim3 node[nmax] = {};
+};
+
+/**
+ * \brief sigma averaged onto the face shared by a node and one of its neighbors.
+ *
+ * The face is made up of the 2^(AMREX_SPACEDIM-1) cells that touch both nodes.
+ * With EB the average is volume weighted, matching Fapply.
+ *
+ * \param idim face normal direction
+ * \param side 0 for the low-side neighbor, 1 for the high-side neighbor
+ */
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+Real face_sigma (int i, int j, int k, int idim, int side, bool has_eb,
+                 Array4<Real const> const& sig, Array4<Real const> const& vfrc) noexcept
+{
+    Real num = Real(0.0);
+    Real den = Real(0.0);
+    for (int c = 0; c < (1 << (AMREX_SPACEDIM-1)); ++c) {
+        int off[3] = {0,0,0};
+        int bit = 0;
+        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+            if (d == idim) {
+                off[d] = side - 1;
+            } else {
+                off[d] = ((c >> bit) & 1) - 1;
+                ++bit;
+            }
+        }
+        int const ii = i + off[0];
+        int const jj = j + off[1];
+        int const kk = k + off[2];
+        Real const w = has_eb ? vfrc(ii,jj,kk) : Real(1.0);
+        num += sig(ii,jj,kk) * w;
+        den += w;
+    }
+    return num / den;
+}
+
+}
+
+/**
+ * \brief Assemble one row of the bottom-level MLEBNodeFDLaplacian matrix.
+ *
+ * The row must reproduce MLEBNodeFDLaplacian::Fapply with homogeneous boundary
+ * data, because MLMG's bottom solve works on the residual correction.  Nodes
+ * that are not part of the linear system (Dirichlet, EB covered, or owned by
+ * another box) have an invalid \p gid and their columns are dropped, which is
+ * the same as using a zero value there.  A node outside a Neumann boundary is
+ * folded onto its mirror image, matching what MLNodeLinOp::applyBC puts into
+ * those ghost cells.
+ *
+ * \param gid         global node ids, invalid (max) outside the linear system
+ * \param has_eb      whether this box has cut cells
+ * \param has_sig     whether sigma is given as a MultiFab
+ * \param bcoef       sigma_d / dx_d^2 per direction
+ * \param ndlo, ndhi  bounds of the nodal domain
+ * \param reflect_lo  whether the low-side domain BC mirrors ghost nodes
+ * \param reflect_hi  whether the high-side domain BC mirrors ghost nodes
+ */
+template <typename AtomicInt>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+ebnodefdlap_detail::Row
+mlebndfdlap_ijmat_row (int i, int j, int k,
+                       Array4<AtomicInt const> const& gid,
+                       bool has_eb, bool has_sig,
+                       GpuArray<Real,AMREX_SPACEDIM> const& bcoef,
+                       Array4<Real const> const& sig,
+                       Array4<Real const> const& vfrc,
+                       Array4<Real const> const& levset,
+                       GpuArray<Array4<Real const>,AMREX_SPACEDIM> const& ec,
+                       Dim3 const& ndlo, Dim3 const& ndhi,
+                       GpuArray<bool,AMREX_SPACEDIM> const& reflect_lo,
+                       GpuArray<bool,AMREX_SPACEDIM> const& reflect_hi) noexcept
+{
+    constexpr auto gidmax = std::numeric_limits<AtomicInt>::max();
+
+    Real diag = Real(0.0);
+    Real scale = Real(1.0);
+    Real coef[2*AMREX_SPACEDIM] = {};
+    bool used[2*AMREX_SPACEDIM] = {};
+
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        int const di = (idim == 0) ? 1 : 0;
+        int const dj = (idim == 1) ? 1 : 0;
+        int const dk = (idim == 2) ? 1 : 0;
+
+        Real hp = Real(1.0);
+        Real hm = Real(1.0);
+        bool cut_lo = false;
+        bool cut_hi = false;
+        if (has_eb) {
+            Real const ecp = ec[idim](i,j,k);
+            Real const ecm = ec[idim](i-di,j-dj,k-dk);
+            hp = (ecp == Real(1.0)) ? Real(1.0) : (Real(1.0) + Real(2.0)*ecp);
+            hm = (ecm == Real(1.0)) ? Real(1.0) : (Real(1.0) - Real(2.0)*ecm);
+            cut_hi = (levset(i+di,j+dj,k+dk) >= Real(0.0));
+            cut_lo = (levset(i-di,j-dj,k-dk) >= Real(0.0));
+            scale = amrex::min(scale, hm, hp);
+        }
+
+        Real const fac = bcoef[idim] * Real(2.0) / (hp+hm);
+
+        int const nd = (idim == 0) ? i : ((idim == 1) ? j : k);
+        int const dlo = (idim == 0) ? ndlo.x : ((idim == 1) ? ndlo.y : ndlo.z);
+        int const dhi = (idim == 0) ? ndhi.x : ((idim == 1) ? ndhi.y : ndhi.z);
+
+        for (int side = 0; side < 2; ++side) {
+            Real const s = has_sig
+                ? ebnodefdlap_detail::face_sigma(i,j,k,idim,side,has_eb,sig,vfrc)
+                : Real(1.0);
+            if ((side == 0) ? cut_lo : cut_hi) {
+                // The neighbor is covered, so it only contributes a Dirichlet
+                // value, which is zero here.
+                diag -= s * fac / ((side == 0) ? hm : hp);
+            } else {
+                diag -= s * fac;
+                int ii = (side == 0) ? i-di : i+di;
+                int jj = (side == 0) ? j-dj : j+dj;
+                int kk = (side == 0) ? k-dk : k+dk;
+                int slot = 2*idim + side;
+                bool const outside = (side == 0) ? (nd-1 < dlo) : (nd+1 > dhi);
+                bool const reflect = (side == 0) ? reflect_lo[idim] : reflect_hi[idim];
+                if (outside && reflect) {
+                    ii = (side == 0) ? i+di : i-di;
+                    jj = (side == 0) ? j+dj : j-dj;
+                    kk = (side == 0) ? k+dk : k-dk;
+                    slot = 2*idim + (1-side);
+                }
+                if (gid(ii,jj,kk) < gidmax) {
+                    coef[slot] += s * fac;
+                    used[slot] = true;
+                }
+            }
+        }
+    }
+
+    ebnodefdlap_detail::Row row;
+    row.val[0] = diag * scale;
+    row.node[0] = Dim3{i,j,k};
+    row.n = 1;
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        int const di = (idim == 0) ? 1 : 0;
+        int const dj = (idim == 1) ? 1 : 0;
+        int const dk = (idim == 2) ? 1 : 0;
+        for (int side = 0; side < 2; ++side) {
+            int const slot = 2*idim + side;
+            if (used[slot]) {
+                row.val[row.n] = coef[slot] * scale;
+                row.node[row.n] = (side == 0) ? Dim3{i-di,j-dj,k-dk}
+                                              : Dim3{i+di,j+dj,k+dk};
+                ++row.n;
+            }
+        }
+    }
+    return row;
+}
+
+#endif
 }
 
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLap_K.H
@@ -355,7 +355,7 @@ mlebndfdlap_ijmat_row (int i, int j, int k,
 
     ebnodefdlap_detail::Row row;
     row.val[0] = diag * scale;
-    row.node[0] = Dim3{i,j,k};
+    row.node[0] = Dim3{.x=i, .y=j, .z=k};
     row.n = 1;
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         int const di = (idim == 0) ? 1 : 0;
@@ -365,8 +365,8 @@ mlebndfdlap_ijmat_row (int i, int j, int k,
             int const slot = 2*idim + side;
             if (used[slot]) {
                 row.val[row.n] = coef[slot] * scale;
-                row.node[row.n] = (side == 0) ? Dim3{i-di,j-dj,k-dk}
-                                              : Dim3{i+di,j+dj,k+dk};
+                row.node[row.n] = (side == 0) ? Dim3{.x=i-di, .y=j-dj, .z=k-dk}
+                                              : Dim3{.x=i+di, .y=j+dj, .z=k+dk};
                 ++row.n;
             }
         }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -2,6 +2,7 @@
 #include <AMReX_MLEBNodeFDLap_K.H>
 #include <AMReX_MLNodeLinOp_K.H>
 #include <AMReX_MLNodeTensorLap_K.H>
+#include <AMReX_Scan.H>
 #include <AMReX_MultiFabUtil.H>
 
 #ifdef AMREX_USE_EB
@@ -746,21 +747,149 @@ MLEBNodeFDLaplacian::compGrad (int amrlev, const Array<MultiFab*,AMREX_SPACEDIM>
 
 #if defined(AMREX_USE_HYPRE) && (AMREX_SPACEDIM > 1)
 void
-MLEBNodeFDLaplacian::fillIJMatrix (MFIter const& /*mfi*/,
-                                   Array4<HypreNodeLap::AtomicInt const> const& /*gid*/,
-                                   Array4<int const> const& /*lid*/,
-                                   HypreNodeLap::Int* /*ncols*/,
-                                   HypreNodeLap::Int* /*cols*/,
-                                   Real* /*mat*/) const
+MLEBNodeFDLaplacian::fillIJMatrix (MFIter const& mfi,
+                                   Array4<HypreNodeLap::AtomicInt const> const& gid,
+                                   Array4<int const> const& lid,
+                                   HypreNodeLap::Int* ncols,
+                                   HypreNodeLap::Int* cols,
+                                   Real* mat) const
 {
-    amrex::Abort("MLEBNodeFDLaplacian::fillIJMatrix: todo");
+    const int amrlev = 0;
+    const int mglev  = m_num_mg_levels[amrlev]-1;
+
+#if (AMREX_SPACEDIM == 2)
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_rz,
+        "MLEBNodeFDLaplacian::fillIJMatrix: RZ is not supported yet");
+#endif
+
+    const Geometry& geom = m_geom[amrlev][mglev];
+    const auto dxinv = geom.InvCellSizeArray();
+    const GpuArray<Real,AMREX_SPACEDIM> bcoef
+        {AMREX_D_DECL(m_sigma[0]*dxinv[0]*dxinv[0],
+                      m_sigma[1]*dxinv[1]*dxinv[1],
+                      m_sigma[2]*dxinv[2]*dxinv[2])};
+
+    const Box& nddom = amrex::surroundingNodes(geom.Domain());
+    const auto ndlo = amrex::lbound(nddom);
+    const auto ndhi = amrex::ubound(nddom);
+
+    const auto lobc = LoBC();
+    const auto hibc = HiBC();
+    GpuArray<bool,AMREX_SPACEDIM> reflect_lo{};
+    GpuArray<bool,AMREX_SPACEDIM> reflect_hi{};
+    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+        reflect_lo[idim] = (lobc[idim] == LinOpBCType::Neumann ||
+                            lobc[idim] == LinOpBCType::inflow);
+        reflect_hi[idim] = (hibc[idim] == LinOpBCType::Neumann ||
+                            hibc[idim] == LinOpBCType::inflow);
+    }
+
+    const bool has_sig = m_has_sigma_mf;
+    Array4<Real const> sig{};
+    if (has_sig) {
+        sig = m_sigma_mf[amrlev][mglev]->const_array(mfi);
+    }
+
+    bool has_eb = false;
+    Array4<Real const> levset{};
+    Array4<Real const> vfrc{};
+    GpuArray<Array4<Real const>,AMREX_SPACEDIM> ec{};
+#ifdef AMREX_USE_EB
+    const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][mglev].get());
+    if (factory) {
+        Array<const MultiCutFab*,AMREX_SPACEDIM> const& edgecent = factory->getEdgeCent();
+        has_eb = edgecent[0] && edgecent[0]->ok(mfi);
+        if (has_eb) {
+            AMREX_D_TERM(ec[0] = edgecent[0]->const_array(mfi);,
+                         ec[1] = edgecent[1]->const_array(mfi);,
+                         ec[2] = edgecent[2]->const_array(mfi));
+            levset = factory->getLevelSet().const_array(mfi);
+            vfrc = factory->getVolFrac().const_array(mfi);
+        }
+    }
+#endif
+
+    const Box& ndbx = mfi.validbox();
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE
+        (ndbx.numPts()*(2*AMREX_SPACEDIM+1) <
+         static_cast<Long>(std::numeric_limits<int>::max()),
+         "The Box is too big.  We could use Long here, but it would be much slower.");
+
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        const auto blo = amrex::lbound(ndbx);
+        const auto blen = amrex::length(ndbx);
+        const int npts = static_cast<int>(ndbx.numPts());
+        Scan::PrefixSum<int>
+            (npts,
+             [=] AMREX_GPU_DEVICE (int offset) noexcept -> int
+             {
+                 int const k = offset / (blen.x*blen.y);
+                 int const j = (offset - k*blen.x*blen.y) / blen.x;
+                 int const i = offset - k*blen.x*blen.y - j*blen.x;
+                 if (lid(i+blo.x,j+blo.y,k+blo.z) < 0) { return 0; }
+                 return mlebndfdlap_ijmat_row(i+blo.x, j+blo.y, k+blo.z, gid,
+                                              has_eb, has_sig, bcoef, sig, vfrc,
+                                              levset, ec, ndlo, ndhi,
+                                              reflect_lo, reflect_hi).n;
+             },
+             [=] AMREX_GPU_DEVICE (int offset, int ps) noexcept
+             {
+                 int const k = offset / (blen.x*blen.y);
+                 int const j = (offset - k*blen.x*blen.y) / blen.x;
+                 int const i = offset - k*blen.x*blen.y - j*blen.x;
+                 int const row_lid = lid(i+blo.x,j+blo.y,k+blo.z);
+                 if (row_lid < 0) { return; }
+                 auto const& row = mlebndfdlap_ijmat_row
+                     (i+blo.x, j+blo.y, k+blo.z, gid, has_eb, has_sig, bcoef,
+                      sig, vfrc, levset, ec, ndlo, ndhi, reflect_lo, reflect_hi);
+                 ncols[row_lid] = row.n;
+                 for (int n = 0; n < row.n; ++n) {
+                     cols[ps+n] = static_cast<HypreNodeLap::Int>
+                         (gid(row.node[n].x, row.node[n].y, row.node[n].z));
+                     mat[ps+n] = row.val[n];
+                 }
+             },
+             Scan::Type::exclusive);
+    } else
+#endif
+    {
+        // The nodes are visited in the same order in which local ids were
+        // assigned, so the rows come out sorted by local id.
+        int nelems = 0;
+        amrex::LoopOnCpu(ndbx, [&] (int i, int j, int k) noexcept
+        {
+            if (lid(i,j,k) >= 0) {
+                auto const& row = mlebndfdlap_ijmat_row(i, j, k, gid, has_eb, has_sig,
+                                                        bcoef, sig, vfrc, levset, ec,
+                                                        ndlo, ndhi, reflect_lo, reflect_hi);
+                ncols[lid(i,j,k)] = row.n;
+                for (int n = 0; n < row.n; ++n) {
+                    cols[nelems] = static_cast<HypreNodeLap::Int>
+                        (gid(row.node[n].x, row.node[n].y, row.node[n].z));
+                    mat[nelems] = row.val[n];
+                    ++nelems;
+                }
+            }
+        });
+    }
 }
 
 void
-MLEBNodeFDLaplacian::fillRHS (MFIter const& /*mfi*/, Array4<int const> const& /*lid*/,
-                              Real* /*rhs*/, Array4<Real const> const& /*bfab*/) const
+MLEBNodeFDLaplacian::fillRHS (MFIter const& mfi, Array4<int const> const& lid,
+                              Real* rhs, Array4<Real const> const& bfab) const
 {
-    amrex::Abort("MLEBNodeFDLaplacian::fillRHS: todo");
+    // Unlike MLNodeLaplacian, this is a finite-difference operator, so nodes on
+    // a Neumann boundary need no volume factor here.  fillIJMatrix folds the
+    // ghost node onto its mirror image instead.
+    const Box& bx = mfi.validbox();
+    AMREX_HOST_DEVICE_PARALLEL_FOR_3D(bx, i, j, k,
+    {
+        if (lid(i,j,k) >= 0) {
+            rhs[lid(i,j,k)] = bfab(i,j,k);
+        }
+    });
 }
 #endif
 

--- a/Tests/LinearSolvers/NodeEBFDLap/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodeEBFDLap/CMakeLists.txt
@@ -1,0 +1,17 @@
+if ( (NOT AMReX_EB) OR (NOT AMReX_HYPRE) OR (NOT AMReX_LINEAR_SOLVERS_EM) )
+   return()
+endif ()
+
+foreach(D IN LISTS AMReX_SPACEDIM)
+    if (D EQUAL 1)
+       continue()
+    endif ()
+
+    set(_sources main.cpp)
+    set(_input_files inputs_${D}d)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/LinearSolvers/NodeEBFDLap/GNUmakefile
+++ b/Tests/LinearSolvers/NodeEBFDLap/GNUmakefile
@@ -1,0 +1,33 @@
+
+DEBUG = FALSE
+
+TEST = TRUE
+USE_ASSERTION = TRUE
+
+USE_EB = TRUE
+
+USE_MPI  = TRUE
+USE_OMP  = FALSE
+
+USE_HYPRE  = TRUE
+USE_PETSC  = FALSE
+
+
+COMP = llvm
+
+DIM = 3
+
+AMREX_HOME = ../../..
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+include ./Make.package
+
+Pdirs := Base Boundary AmrCore
+Pdirs += EB
+Pdirs += LinearSolvers/MLMG
+
+Ppack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
+
+include $(Ppack)
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/LinearSolvers/NodeEBFDLap/Make.package
+++ b/Tests/LinearSolvers/NodeEBFDLap/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/LinearSolvers/NodeEBFDLap/inputs_2d
+++ b/Tests/LinearSolvers/NodeEBFDLap/inputs_2d
@@ -1,0 +1,17 @@
+n_cell = 32
+max_grid_size = 16
+
+# Let the hypre bottom solve do all of the work.  That makes this the sharpest
+# possible test of the matrix assembled by MLEBNodeFDLaplacian::fillIJMatrix.
+max_coarsening_level = 0
+
+verbose = 0
+bottom_verbose = 0
+
+use_sigma_mf = 1
+phi_eb = 1.0
+
+eb2.geom_type = sphere
+eb2.sphere_radius = 0.23
+eb2.sphere_center = 0.5 0.5
+eb2.sphere_has_fluid_inside = 0

--- a/Tests/LinearSolvers/NodeEBFDLap/inputs_3d
+++ b/Tests/LinearSolvers/NodeEBFDLap/inputs_3d
@@ -1,0 +1,17 @@
+n_cell = 32
+max_grid_size = 16
+
+# Let the hypre bottom solve do all of the work.  That makes this the sharpest
+# possible test of the matrix assembled by MLEBNodeFDLaplacian::fillIJMatrix.
+max_coarsening_level = 0
+
+verbose = 0
+bottom_verbose = 0
+
+use_sigma_mf = 1
+phi_eb = 1.0
+
+eb2.geom_type = sphere
+eb2.sphere_radius = 0.23
+eb2.sphere_center = 0.5 0.5 0.5
+eb2.sphere_has_fluid_inside = 0

--- a/Tests/LinearSolvers/NodeEBFDLap/main.cpp
+++ b/Tests/LinearSolvers/NodeEBFDLap/main.cpp
@@ -1,0 +1,180 @@
+//
+// Solves del dot (sigma grad phi) = rhs with MLEBNodeFDLaplacian and compares
+// the solution obtained with the hypre bottom solver against the one obtained
+// with the native bottom solver.  Set max_coarsening_level = 0 to make the
+// bottom solve do all of the work, which is the sharpest test of the matrix
+// assembled by MLEBNodeFDLaplacian::fillIJMatrix.
+//
+
+#include <AMReX.H>
+#include <AMReX_EB2.H>
+#include <AMReX_EBFabFactory.H>
+#include <AMReX_MLEBNodeFDLaplacian.H>
+#include <AMReX_MLMG.H>
+#include <AMReX_MultiFabUtil.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_PlotFileUtil.H>
+
+using namespace amrex;
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+    {
+        int n_cell = 64;
+        int max_grid_size = 32;
+        int max_coarsening_level = 0;
+        int verbose = 1;
+        int bottom_verbose = 0;
+        int use_sigma_mf = 1;
+        int plot = 0;
+        Real phi_eb = 1.0;
+        Real reltol = 1.e-11;
+        Real bottom_reltol = 1.e-9;
+        Real max_rel_diff = 1.e-12;
+        Vector<int> periodic{AMREX_D_DECL(0,0,0)};
+        {
+            ParmParse pp;
+            pp.queryarr("periodic", periodic, 0, AMREX_SPACEDIM);
+            pp.query("n_cell", n_cell);
+            pp.query("max_grid_size", max_grid_size);
+            pp.query("max_coarsening_level", max_coarsening_level);
+            pp.query("verbose", verbose);
+            pp.query("bottom_verbose", bottom_verbose);
+            pp.query("use_sigma_mf", use_sigma_mf);
+            pp.query("phi_eb", phi_eb);
+            pp.query("reltol", reltol);
+            pp.query("bottom_reltol", bottom_reltol);
+            pp.query("plot", plot);
+            pp.query("max_rel_diff", max_rel_diff);
+        }
+
+        Box const domain(IntVect(0), IntVect(n_cell-1));
+        RealBox const rb({AMREX_D_DECL(0.,0.,0.)}, {AMREX_D_DECL(1.,1.,1.)});
+        Array<int,AMREX_SPACEDIM> is_periodic{};
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            is_periodic[idim] = periodic[idim];
+        }
+        Geometry const geom(domain, rb, CoordSys::cartesian, is_periodic);
+
+        BoxArray grids(domain);
+        grids.maxSize(max_grid_size);
+        DistributionMapping const dmap(grids);
+
+        EB2::Build(geom, 0, max_coarsening_level);
+        auto factory = makeEBFabFactory(geom, grids, dmap, {2,2,2}, EBSupport::full);
+
+        BoxArray const& nba = amrex::convert(grids, IntVect(1));
+
+        // A smooth, strictly positive sigma so that the variable coefficient
+        // path is exercised.
+        MultiFab sigma(grids, dmap, 1, 1, MFInfo(), *factory);
+        // Use whole wavenumbers so that sigma and the source stay single valued
+        // when a direction is periodic.
+        Real const twopi = Real(2.0)*Real(3.14159265358979323846);
+        auto const dx = geom.CellSizeArray();
+        auto const problo = geom.ProbLoArray();
+        for (MFIter mfi(sigma); mfi.isValid(); ++mfi) {
+            Array4<Real> const& s = sigma.array(mfi);
+            amrex::ParallelFor(mfi.growntilebox(), [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                AMREX_D_TERM(Real const x = problo[0] + (i+Real(0.5))*dx[0];,
+                             Real const y = problo[1] + (j+Real(0.5))*dx[1];,
+                             Real const z = problo[2] + (k+Real(0.5))*dx[2];)
+                s(i,j,k) = Real(1.0) + Real(0.5)*std::sin(twopi*x)
+                    * AMREX_D_TERM(Real(1.0), *std::cos(Real(2.0)*twopi*y), *std::sin(twopi*z));
+            });
+        }
+        sigma.FillBoundary(geom.periodicity());
+
+        MultiFab rhs(nba, dmap, 1, 0);
+        for (MFIter mfi(rhs); mfi.isValid(); ++mfi) {
+            Array4<Real> const& r = rhs.array(mfi);
+            amrex::ParallelFor(mfi.tilebox(), [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                AMREX_D_TERM(Real const x = problo[0] + i*dx[0];,
+                             Real const y = problo[1] + j*dx[1];,
+                             Real const z = problo[2] + k*dx[2];)
+                r(i,j,k) = std::sin(twopi*x)
+                    * AMREX_D_TERM(Real(1.0), *std::cos(Real(3.0)*twopi*y), *std::cos(Real(2.0)*twopi*z));
+            });
+        }
+
+        // Mix the boundary conditions so that both the Dirichlet nodes (which
+        // are left out of the linear system) and the Neumann nodes (whose ghost
+        // node is folded onto its mirror image) are covered.
+        Array<LinOpBCType,AMREX_SPACEDIM> lobc
+            {AMREX_D_DECL(LinOpBCType::Neumann, LinOpBCType::Dirichlet, LinOpBCType::Neumann)};
+        Array<LinOpBCType,AMREX_SPACEDIM> hibc
+            {AMREX_D_DECL(LinOpBCType::Dirichlet, LinOpBCType::Neumann, LinOpBCType::Dirichlet)};
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (geom.isPeriodic(idim)) {
+                lobc[idim] = LinOpBCType::Periodic;
+                hibc[idim] = LinOpBCType::Periodic;
+            }
+        }
+
+        auto do_solve = [&] (BottomSolver bottom_solver, MultiFab& sol)
+        {
+            LPInfo info;
+            info.setMaxCoarseningLevel(max_coarsening_level);
+
+            MLEBNodeFDLaplacian linop({geom}, {grids}, {dmap}, info,
+                                      {static_cast<EBFArrayBoxFactory const*>(factory.get())});
+            linop.setDomainBC(lobc, hibc);
+            linop.setEBDirichlet(phi_eb);
+            if (use_sigma_mf) {
+                linop.setSigma(0, sigma);
+            } else {
+                linop.setSigma({AMREX_D_DECL(Real(1.0), Real(1.5), Real(0.7))});
+            }
+
+            MLMG mlmg(linop);
+            mlmg.setVerbose(verbose);
+            mlmg.setBottomVerbose(bottom_verbose);
+            mlmg.setBottomSolver(bottom_solver);
+            mlmg.setBottomTolerance(bottom_reltol);
+            mlmg.setBottomMaxIter(1000);
+
+            MultiFab rhs_copy(nba, dmap, 1, 0);
+            MultiFab::Copy(rhs_copy, rhs, 0, 0, 1, 0);
+
+            sol.define(nba, dmap, 1, 1);
+            sol.setVal(0.0);
+            return mlmg.solve({&sol}, {&rhs_copy}, reltol, Real(0.0));
+        };
+
+        MultiFab sol_native;
+        MultiFab sol_hypre;
+
+        amrex::Print() << "\n==== native bottom solver ====\n";
+        Real const err_native = do_solve(BottomSolver::bicgstab, sol_native);
+
+        amrex::Print() << "\n==== hypre bottom solver ====\n";
+        Real const err_hypre = do_solve(BottomSolver::hypre, sol_hypre);
+
+        MultiFab diff(nba, dmap, 1, 0);
+        MultiFab::Copy(diff, sol_hypre, 0, 0, 1, 0);
+        MultiFab::Subtract(diff, sol_native, 0, 0, 1, 0);
+        Real const dmax = diff.norminf();
+        Real const smax = sol_native.norminf(0, 0);
+
+        amrex::Print() << "\nfinal residual: native = " << err_native
+                       << ", hypre = " << err_hypre << "\n"
+                       << "max |phi|              = " << smax << "\n"
+                       << "max |phi_hypre - phi|  = " << dmax << "\n"
+                       << "relative difference    = " << dmax/smax << std::endl;
+
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dmax <= max_rel_diff*smax,
+            "The hypre bottom solver did not reproduce the native solution");
+
+        if (plot) {
+            MultiFab plotmf(nba, dmap, 3, 0);
+            MultiFab::Copy(plotmf, sol_native, 0, 0, 1, 0);
+            MultiFab::Copy(plotmf, sol_hypre , 0, 1, 1, 0);
+            MultiFab::Copy(plotmf, diff      , 0, 2, 1, 0);
+            WriteSingleLevelPlotfile("plot", plotmf, {"phi_native","phi_hypre","diff"}, geom, 0.0, 0);
+        }
+    }
+    amrex::Finalize();
+}


### PR DESCRIPTION
These were stubs that aborted, so the hypre bottom solver could not be used with MLEBNodeFDLaplacian.  The assembled row reproduces Fapply with homogeneous boundary data, which is what MLMG's bottom solve needs since it works on the residual correction:

* Cut cells use the same Shortley-Weller distances and row scaling as Fapply. A covered neighbor drops out of the row and only contributes to the diagonal, matching the zero EB value that Fsmooth also assumes.
* sigma given as a MultiFab is averaged onto the faces, volume weighted where there are cut cells.
* Nodes left out of the linear system (Dirichlet, covered, or owned by another box) are recognized by an invalid gid and their columns are dropped.
* A node outside a Neumann boundary is folded onto its mirror image, which is what MLNodeLinOp::applyBC puts into those ghost cells.  Unlike MLNodeLaplacian this is a finite-difference operator, so fillRHS needs no half-volume factor at Neumann nodes.

RZ still aborts.

Tests/LinearSolvers/NodeEBFDLap solves the same problem with the native and the hypre bottom solver and compares.  With max_coarsening_level = 0 the bottom solve does all of the work, so the two solutions can only agree if the assembled matrix is right; they agree to 1e-16 relative in 2D and 3D, with and without cut cells, with constant and variable sigma, and for periodic, Dirichlet and Neumann domain boundaries.

## Summary

## Additional background

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [x] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
