### PR TITLE
Warnings: CXX23 Features

### DIFF
--- a/Src/Base/AMReX_BLBackTrace.H
+++ b/Src/Base/AMReX_BLBackTrace.H
@@ -1,6 +1,7 @@
 #ifndef AMREX_BL_BACKTRACE_H_
 #define AMREX_BL_BACKTRACE_H_
 #include <AMReX_Config.H>
+#include <AMReX_Extension.H>
 
 #ifdef AMREX_USE_OMP
 #include <omp.h>
@@ -29,7 +30,10 @@
  *
  * \param S String literal describing the scope (e.g., function name).
  */
-#define BL_BACKTRACE_PUSH( S )  amrex::BLBTer BL_PASTE( bl_bter, __COUNTER__ )( S, __FILE__, __LINE__ )
+#define BL_BACKTRACE_PUSH( S )                                          \
+    AMREX_COUNTER_WARNING_PUSH                                          \
+    amrex::BLBTer BL_PASTE( bl_bter, __COUNTER__ )( S, __FILE__, __LINE__ ) \
+    AMREX_COUNTER_WARNING_POP
 /**
  * \def BL_BACKTRACE_POP()
  * \brief Manually pop the top entry from the backtrace stack.

--- a/Src/Base/AMReX_BLBackTrace.H
+++ b/Src/Base/AMReX_BLBackTrace.H
@@ -31,9 +31,9 @@
  * \param S String literal describing the scope (e.g., function name).
  */
 #define BL_BACKTRACE_PUSH( S )                                          \
-    AMREX_COUNTER_WARNING_PUSH                                          \
+    AMREX_WARNING_PUSH_COUNTER                                          \
     amrex::BLBTer BL_PASTE( bl_bter, __COUNTER__ )( S, __FILE__, __LINE__ ) \
-    AMREX_COUNTER_WARNING_POP
+    AMREX_WARNING_POP
 /**
  * \def BL_BACKTRACE_POP()
  * \brief Manually pop the top entry from the backtrace stack.

--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -2,6 +2,8 @@
 #define BL_PROFILER_H_
 #include <AMReX_Config.H>
 
+#include <AMReX_Extension.H>
+
 #define BL_PROFILE_PASTE2(x, y) x##y
 #define BL_PROFILE_PASTE(x, y) BL_PROFILE_PASTE2(x, y)
 
@@ -484,7 +486,10 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_TINY_PROFILE_MEMORYINITIALIZE()  amrex::TinyProfiler::MemoryInitialize()
 #define BL_TINY_PROFILE_MEMORYFINALIZE()    amrex::TinyProfiler::MemoryFinalize()
 
-#define BL_PROFILE(fname) BL_PROFILE_IMPL(fname, __COUNTER__)
+#define BL_PROFILE(fname)                       \
+    AMREX_COUNTER_WARNING_PUSH                  \
+    BL_PROFILE_IMPL(fname, __COUNTER__)         \
+    AMREX_COUNTER_WARNING_POP
 #define BL_PROFILE_IMPL(funame, counter)  amrex::TinyProfiler BL_PROFILE_PASTE(tiny_profiler_, counter)((funame)); \
     amrex::ignore_unused(BL_PROFILE_PASTE(tiny_profiler_, counter));
 

--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -487,9 +487,9 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_TINY_PROFILE_MEMORYFINALIZE()    amrex::TinyProfiler::MemoryFinalize()
 
 #define BL_PROFILE(fname)                       \
-    AMREX_COUNTER_WARNING_PUSH                  \
+    AMREX_WARNING_PUSH_COUNTER                  \
     BL_PROFILE_IMPL(fname, __COUNTER__)         \
-    AMREX_COUNTER_WARNING_POP
+    AMREX_WARNING_POP
 #define BL_PROFILE_IMPL(funame, counter)  amrex::TinyProfiler BL_PROFILE_PASTE(tiny_profiler_, counter)((funame)); \
     amrex::ignore_unused(BL_PROFILE_PASTE(tiny_profiler_, counter));
 

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -168,6 +168,28 @@
 #define AMREX_UNROLL_LOOP(n)
 #endif
 
+// __COUNTER__
+//
+// __COUNTER__ has been a de-facto extension in all compilers AMReX supports for
+// a very long time, but it was only recently adopted into C2y.  Clang 22 and
+// later therefore diagnose it as a C2y extension under -Wpedantic, even in C++
+// (https://github.com/llvm/llvm-project/issues/196557).  Bracket a use of
+// __COUNTER__ with these macros to silence that diagnostic.  The nested
+// -Wunknown-warning-option suppression keeps older Clang, which does not know
+// -Wc2y-extensions, quiet as well.
+
+#if defined(__clang__)
+#define AMREX_COUNTER_WARNING_PUSH                                        \
+    _Pragma("clang diagnostic push")                                      \
+    _Pragma("clang diagnostic ignored \"-Wunknown-warning-option\"")      \
+    _Pragma("clang diagnostic ignored \"-Wc2y-extensions\"")
+#define AMREX_COUNTER_WARNING_POP                                         \
+    _Pragma("clang diagnostic pop")
+#else
+#define AMREX_COUNTER_WARNING_PUSH
+#define AMREX_COUNTER_WARNING_POP
+#endif
+
 // __attribute__((weak))
 
 #if defined(AMREX_TYPECHECK)
@@ -233,7 +255,15 @@
 //   - MSVC >= 19.20
 //   - nvcc >= 11.1.0
 //   - icx >= 2021.1.2
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(assume)
+//
+// [[assume]] itself is C++23.  Clang >= 19 and GCC >= 13 advertise it through
+// __has_cpp_attribute in older language modes as well, and Clang then diagnoses
+// every use as a C++23 extension under -Wpedantic
+// (-Wc++23-attribute-extensions).  So only take the attribute when the language
+// mode really is C++23 and rely on the compiler-specific spellings below
+// otherwise; they carry the same information to the optimizer.
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(assume) >= 202207L && \
+    defined(__cplusplus) && __cplusplus >= 202302L
 #   define AMREX_ASSUME(ASSUMPTION) [[assume(ASSUMPTION)]]
 #else
 #   if defined(__CUDA_ARCH__) && defined(__CUDACC__)
@@ -242,6 +272,9 @@
 #       define AMREX_ASSUME(ASSUMPTION) __builtin_assume(ASSUMPTION)
 #   elif defined(_MSC_VER)
 #       define AMREX_ASSUME(ASSUMPTION) __assume(ASSUMPTION)
+#   elif defined(__GNUC__) && __GNUC__ >= 13
+        // like [[assume]], this does not evaluate ASSUMPTION
+#       define AMREX_ASSUME(ASSUMPTION) __attribute__((assume(ASSUMPTION)))
 #   elif defined(__GNUC__)
 #       define AMREX_ASSUME(ASSUMPTION) \
             do { if (!(ASSUMPTION)) { __builtin_unreachable(); } } while (0)

--- a/Src/Base/AMReX_Extension.H
+++ b/Src/Base/AMReX_Extension.H
@@ -177,17 +177,22 @@
 // __COUNTER__ with these macros to silence that diagnostic.  The nested
 // -Wunknown-warning-option suppression keeps older Clang, which does not know
 // -Wc2y-extensions, quiet as well.
+//
+// Each AMREX_WARNING_PUSH_* macro silences a specific diagnostic, while the
+// single AMREX_WARNING_POP restores the previous state of whatever was pushed
+// last.  The naming is intentionally asymmetric: the pops are not tied to a
+// particular warning, so pushes and pops must nest, not interleave.
 
 #if defined(__clang__)
-#define AMREX_COUNTER_WARNING_PUSH                                        \
+#define AMREX_WARNING_PUSH_COUNTER                                        \
     _Pragma("clang diagnostic push")                                      \
     _Pragma("clang diagnostic ignored \"-Wunknown-warning-option\"")      \
     _Pragma("clang diagnostic ignored \"-Wc2y-extensions\"")
-#define AMREX_COUNTER_WARNING_POP                                         \
+#define AMREX_WARNING_POP                                                 \
     _Pragma("clang diagnostic pop")
 #else
-#define AMREX_COUNTER_WARNING_PUSH
-#define AMREX_COUNTER_WARNING_POP
+#define AMREX_WARNING_PUSH_COUNTER
+#define AMREX_WARNING_POP
 #endif
 
 // __attribute__((weak))


### PR DESCRIPTION
## Summary

Both Clang and GCC warn when we use CXX23 features already. Supress them and/or use intrinsics for now to silence them.

## Additional background

Seen downstream in WarpX with Clang 22 (counter) and a recent GCC (for assume).

## Checklist

The proposed changes:
- [ ] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
