### PR TITLE
Conduit Blueprint: include runtime SoA particle components

### DIFF
--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
@@ -218,7 +218,10 @@ ParticleTileToBlueprint(const ParticleTile<ParticleType,
     // since these are contiguous arrays
 
     // array real fields
-    for (int i = 0; i < NArrayReal; i++)
+    //
+    // NumRealComps() spans the compile-time components and any added at
+    // runtime with AddRealComp(); GetRealData(i) already resolves both.
+    for (int i = 0; i < soa.NumRealComps(); i++)
     {
         conduit::Node &n_f = n_fields[real_comp_names.at(vname_real_idx)];
         n_f["topology"] = topology_name;
@@ -230,7 +233,7 @@ ParticleTileToBlueprint(const ParticleTile<ParticleType,
     }
 
     // array int fields
-    for (int i = 0; i < NArrayInt; i++)
+    for (int i = 0; i < soa.NumIntComps(); i++)
     {
         conduit::Node &n_f = n_fields[int_comp_names.at(vname_int_idx)];
         n_f["topology"] = topology_name;
@@ -262,11 +265,11 @@ ParticleContainerToBlueprint(const ParticleContainer_impl<ParticleType,
     // for user defined aos and soa values.
 
     if constexpr(ParticleType::is_soa_particle) {
-        BL_ASSERT(real_comp_names.size() == NArrayReal);
-        BL_ASSERT(int_comp_names.size()  == NArrayInt);
+        BL_ASSERT(real_comp_names.size() == std::size_t(pc.NumRealComps()));
+        BL_ASSERT(int_comp_names.size()  == std::size_t(pc.NumIntComps()));
     } else {
-        BL_ASSERT(real_comp_names.size() == (ParticleType::NReal + NArrayReal) );
-        BL_ASSERT(int_comp_names.size()  == (ParticleType::NInt + NArrayInt) );
+        BL_ASSERT(real_comp_names.size() == std::size_t(ParticleType::NReal + pc.NumRealComps()) );
+        BL_ASSERT(int_comp_names.size()  == std::size_t(ParticleType::NInt  + pc.NumIntComps()) );
     }
 
     int num_levels = pc.maxLevel() + 1;

--- a/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
+++ b/Src/Extern/Conduit/AMReX_Conduit_Blueprint_ParticlesI.H
@@ -219,9 +219,16 @@ ParticleTileToBlueprint(const ParticleTile<ParticleType,
 
     // array real fields
     //
-    // NumRealComps() spans the compile-time components and any added at
-    // runtime with AddRealComp(); GetRealData(i) already resolves both.
-    for (int i = 0; i < soa.NumRealComps(); i++)
+    // The number of SoA components to publish is taken from the names the
+    // caller supplied: the AoS names have already been consumed, so whatever
+    // remains describes the SoA. The historical behavior is to name only the
+    // compile-time components. Runtime components are published only when
+    // names are provided for all SoA components.
+    int const n_soa_real = int(real_comp_names.size()) - vname_real_idx;
+    AMREX_ASSERT(n_soa_real == NArrayReal ||
+                 n_soa_real == soa.NumRealComps());
+
+    for (int i = 0; i < n_soa_real; i++)
     {
         conduit::Node &n_f = n_fields[real_comp_names.at(vname_real_idx)];
         n_f["topology"] = topology_name;
@@ -233,7 +240,11 @@ ParticleTileToBlueprint(const ParticleTile<ParticleType,
     }
 
     // array int fields
-    for (int i = 0; i < soa.NumIntComps(); i++)
+    int const n_soa_int = int(int_comp_names.size()) - vname_int_idx;
+    AMREX_ASSERT(n_soa_int == NArrayInt ||
+                 n_soa_int == soa.NumIntComps());
+
+    for (int i = 0; i < n_soa_int; i++)
     {
         conduit::Node &n_f = n_fields[int_comp_names.at(vname_int_idx)];
         n_f["topology"] = topology_name;
@@ -264,12 +275,17 @@ ParticleContainerToBlueprint(const ParticleContainer_impl<ParticleType,
     // validate varnames, which are used to provide field names
     // for user defined aos and soa values.
 
+    // Name every component, or only the compile-time ones.
     if constexpr(ParticleType::is_soa_particle) {
-        BL_ASSERT(real_comp_names.size() == std::size_t(pc.NumRealComps()));
-        BL_ASSERT(int_comp_names.size()  == std::size_t(pc.NumIntComps()));
+        BL_ASSERT(real_comp_names.size() == NArrayReal ||
+                  real_comp_names.size() == pc.NumRealComps());
+        BL_ASSERT(int_comp_names.size()  == NArrayInt ||
+                  int_comp_names.size()  == pc.NumIntComps());
     } else {
-        BL_ASSERT(real_comp_names.size() == std::size_t(ParticleType::NReal + pc.NumRealComps()) );
-        BL_ASSERT(int_comp_names.size()  == std::size_t(ParticleType::NInt  + pc.NumIntComps()) );
+        BL_ASSERT(real_comp_names.size() == (ParticleType::NReal + NArrayReal) ||
+                  real_comp_names.size() == (ParticleType::NReal + pc.NumRealComps()) );
+        BL_ASSERT(int_comp_names.size()  == (ParticleType::NInt  + NArrayInt) ||
+                  int_comp_names.size()  == (ParticleType::NInt  + pc.NumIntComps()) );
     }
 
     int num_levels = pc.maxLevel() + 1;


### PR DESCRIPTION
## Summary

ParticleContainerToBlueprint historically walked only the compile-time SoA components, so any component added at runtime via `AddRealComp`/`AddIntComp` was silently dropped from the Blueprint output.

This change allows runtime SoA components to be published when the caller provides names for all SoA components, while preserving the historical behavior for callers that provide names only for the compile-time components.

Tested with MFIX-Exa against Ascent 0.9.5 / Conduit 0.9.7: runtime components are published with correct names and render correctly.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
