### PR TITLE
MLMG: sync duplicated nodal DOFs in MLNodeLinOp::applyBC

### DIFF
--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -2000,9 +2000,16 @@ Dot (FabArray<FAB> const& x, int xcomp, int ncomp, IntVect const& nghost, bool l
 }
 
 /**
- * \brief Compute dot product of two FabArrays in region that mask is true
+ * \brief Compute weighted dot product of two FabArrays
  *
- * \param mask   mask
+ * The mask is a weight, not a boolean.  The result is the sum of
+ * `mask * x * y` over the region, so weights other than 0 and 1 are
+ * meaningful; the nodal solvers, for example, use a mask of 1/2 on Neumann
+ * domain boundaries.  A cell whose weight is zero contributes nothing.  The
+ * mask may be an integer or a floating-point FabArray; its values are
+ * converted to the value type of \p x.
+ *
+ * \param mask   weight of each cell
  * \param x      first FabArray
  * \param xcomp  starting component of x
  * \param y      second FabArray
@@ -2011,9 +2018,9 @@ Dot (FabArray<FAB> const& x, int xcomp, int ncomp, IntVect const& nghost, bool l
  * \param nghost number of ghost cells
  * \param local  If true, MPI communication is skipped.
  */
-template <BaseFabType IFAB, BaseFabType FAB>
+template <BaseFabType MFAB, BaseFabType FAB>
 typename FAB::value_type
-Dot (FabArray<IFAB> const& mask, FabArray<FAB> const& x, int xcomp,
+Dot (FabArray<MFAB> const& mask, FabArray<FAB> const& x, int xcomp,
      FabArray<FAB> const& y, int ycomp, int ncomp, IntVect const& nghost,
      bool local = false)
 {
@@ -2073,18 +2080,22 @@ Dot (FabArray<IFAB> const& mask, FabArray<FAB> const& x, int xcomp,
 }
 
 /**
- * \brief Compute dot product of FabArray with itself in region that mask is true
+ * \brief Compute weighted dot product of a FabArray with itself
  *
- * \param mask   mask
+ * The mask is a weight, not a boolean.  The result is the sum of
+ * `mask * x * x` over the region.  See the two-FabArray overload above for
+ * details.
+ *
+ * \param mask   weight of each cell
  * \param x      FabArray
  * \param xcomp  starting component of x
  * \param ncomp  number of components
  * \param nghost number of ghost cells
  * \param local  If true, MPI communication is skipped.
  */
-template <BaseFabType IFAB, BaseFabType FAB>
+template <BaseFabType MFAB, BaseFabType FAB>
 typename FAB::value_type
-Dot (FabArray<IFAB> const& mask, FabArray<FAB> const& x, int xcomp, int ncomp,
+Dot (FabArray<MFAB> const& mask, FabArray<FAB> const& x, int xcomp, int ncomp,
      IntVect const& nghost, bool local = false)
 {
     BL_ASSERT(x.boxArray() == mask.boxArray());

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -633,7 +633,8 @@ MLEBNodeFDLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
         }
     }
 
-    nodalSync(amrlev, mglev, sol);
+    // No nodalSync here.  Every consumer of sol goes through
+    // MLNodeLinOp::applyBC first, and that does FillBoundaryAndSync.
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeABecLaplacian.cpp
@@ -169,7 +169,10 @@ MLNodeABecLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
                                         aarr, barr, dmskarr, dxinvarr);
         }
     }
-    nodalSync(amrlev, mglev, sol);
+    // No nodalSync here.  Every consumer of sol goes through
+    // MLNodeLinOp::applyBC first, and that does FillBoundaryAndSync.  (The
+    // sync in the GPU branch above is not redundant: it reconciles sol
+    // between the m_smooth_num_sweeps sweeps, which no applyBC separates.)
 #endif
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -576,7 +576,8 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
         if (!Gpu::inNoSyncRegion()) {
             Gpu::streamSynchronize();
         }
-        nodalSync(amrlev, mglev, sol);
+        // No nodalSync here.  Every consumer of sol goes through
+        // MLNodeLinOp::applyBC first, and that does FillBoundaryAndSync.
     }
     else
     {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -511,7 +511,7 @@ MLNodeLinOp::applyBC (int amrlev, int mglev, MultiFab& phi, BCMode/* bc_mode*/,
     const Box& nd_domain = amrex::surroundingNodes(geom.Domain());
 
     if (!skip_fillboundary) {
-        phi.FillBoundary(geom.periodicity());
+        phi.FillBoundaryAndSync(geom.periodicity());
     }
 
     if (m_coarsening_strategy == CoarseningStrategy::Sigma)

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -239,7 +239,8 @@ MLNodeTensorLaplacian::smooth (int amrlev, int mglev, MultiFab& sol, const Multi
             Fsmooth(amrlev, mglev, sol, rhs);
             skip_fillboundary = false;
         }
-        nodalSync(amrlev, mglev, sol);
+        // No nodalSync here.  The applyBC above, and the one in every other
+        // consumer of sol, does FillBoundaryAndSync.
     }
 }
 


### PR DESCRIPTION
MLEBNodeFDLaplacian::Fapply picks its kernel per box: cut boxes use mlebndfdlap_adotx_eb, regular boxes mlebndfdlap_adotx.  Same operator, different floating-point expression, so a node shared by a cut box and a regular box ended up with two copies differing by one ulp.  Nothing reconciled them, and the bottom BiCGStab amplified the difference by more than an order of magnitude per iteration until it saturated at the bottom tolerance and the solve stopped converging.  An EB nodal solve that converged with a single box failed once the domain was split into three or more.

applyBC now calls FillBoundaryAndSync instead of FillBoundary, so every operator application starts from data whose duplicated nodes agree.  This fixes all the nodal operators at once and is robust to any other source of asymmetry (FMA contraction, vectorization, GPU).

That makes the trailing nodalSync in the smoothers redundant, so drop it. The one in MLNodeABecLaplacian's GPU sweep loop stays, since no applyBC separates those sweeps.  Iteration counts are unchanged, but nodal results are no longer bitwise identical across box decompositions and rank counts.

Also document that the mask is a weight rather than a boolean.
