### PR TITLE
Replace deprecated `#pragma omp master` with `#pragma omp masked`

### DIFF
--- a/Src/Base/AMReX_BLProfiler.cpp
+++ b/Src/Base/AMReX_BLProfiler.cpp
@@ -306,7 +306,7 @@ void BLProfiler::PStop() {
 
 void BLProfiler::start() {
 #ifdef AMREX_USE_OMP
-#pragma omp master
+#pragma omp masked
 #endif
 {
   bltelapsed = 0.0;
@@ -341,7 +341,7 @@ void BLProfiler::start() {
 
 void BLProfiler::stop() {
 #ifdef AMREX_USE_OMP
-#pragma omp master
+#pragma omp masked
 #endif
 {
   double tDiff(amrex::second() - bltstart);

--- a/Src/Base/AMReX_FabArrayBase.cpp
+++ b/Src/Base/AMReX_FabArrayBase.cpp
@@ -2362,7 +2362,7 @@ FabArrayBase::getTileArray (const IntVect& tilesize) const
 #endif
         }
 #ifdef AMREX_USE_OMP
-#pragma omp master
+#pragma omp masked
 #endif
         {
             ++(p->nuse);

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -267,7 +267,7 @@ MFIter::Finalize ()
     }
 
 #ifdef AMREX_USE_OMP
-#pragma omp master
+#pragma omp masked
 #endif
     {
         depth = 0;
@@ -278,7 +278,7 @@ void
 MFIter::Initialize ()
 {
 #ifdef AMREX_USE_OMP
-#pragma omp master
+#pragma omp masked
 #endif
     {
         ++depth;

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -164,7 +164,7 @@ while ( false )
                 if (omp_in_parallel()) {
                     #pragma omp barrier
                 }
-                #pragma omp master
+                #pragma omp masked
 #endif
                 {
 #if defined(BL_USE_MPI3)

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -136,14 +136,14 @@ TinyProfiler::start ()
     memory_start();
 
 #ifdef AMREX_USE_OMP
-#pragma omp master
+#pragma omp masked
 #endif
     {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(stats.empty(), "TinyProfiler cannot be started twice");
     }
 
 #ifdef AMREX_USE_OMP
-#pragma omp master
+#pragma omp masked
 #endif
     if (!regionstack.empty()) {
 
@@ -197,7 +197,7 @@ TinyProfiler::stop ()
     memory_stop();
 
 #ifdef AMREX_USE_OMP
-#pragma omp master
+#pragma omp masked
 #endif
     if (!stats.empty()) {
 


### PR DESCRIPTION
## Summary

This PR replaces occurrences of  ` #pragma omp master` with `#pragma omp masked` , as the former is deprecated is deprecated in OpenMP 5.1 . `masked` is more general than `master` (it's possible to specify a `filter` argument), but without additional arguments the two constructs behave in the same way:  https://www.openmp.org/spec-html/5.1/openmpse16.html .

## Additional background

Today I compiled WarpX with `g++ 16.2` and I got several warnings about the deprecation of ` #pragma omp master` . I've checked that with the replacement introduced by this PR in AMReX the warnings disappear and WarpX compiles successfully. I haven't performed other tests.

## Checklist

The proposed changes:
- [X] fix a bug or incorrect behavior in AMReX [[**it was not really a bug, just a deprecated construct.**]]
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate

