### PR TITLE
BLProfiler: give each BL_PROFILE_REGION a unique variable name

### DIFF
--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -419,7 +419,10 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_PROFILE_ADD_STEP(snum)  amrex::BLProfiler::AddStep(snum);
 #define BL_PROFILE_SET_RUN_TIME(rtime)  amrex::BLProfiler::SetRunTime(rtime);
 
-#define BL_PROFILE_REGION(rname) amrex::BLProfileRegion bl_profile_region_##vname((rname));
+#define BL_PROFILE_REGION(rname)                                      \
+    AMREX_WARNING_PUSH_COUNTER                                       \
+    amrex::BLProfileRegion BL_PROFILE_PASTE(bl_profile_region_, __COUNTER__)((rname)); \
+    AMREX_WARNING_POP
 
 #define BL_PROFILE_REGION_START(rname) amrex::BLProfiler::RegionStart(rname);
 #define BL_PROFILE_REGION_STOP(rname)  amrex::BLProfiler::RegionStop(rname);
@@ -504,7 +507,10 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_PROFILE_INIT_PARAMS(ptl,wall,wfabs)
 #define BL_PROFILE_ADD_STEP(snum)
 #define BL_PROFILE_SET_RUN_TIME(rtime)
-#define BL_PROFILE_REGION(rname)          amrex::TinyProfileRegion tiny_profile_region_##vname((rname))
+#define BL_PROFILE_REGION(rname)                                      \
+    AMREX_WARNING_PUSH_COUNTER                                       \
+    amrex::TinyProfileRegion BL_PROFILE_PASTE(tiny_profile_region_, __COUNTER__)((rname)); \
+    AMREX_WARNING_POP
 #define BL_PROFILE_REGION_START(rname)
 #define BL_PROFILE_REGION_STOP(rname)
 //#define BL_PROFILE_REGION_START(rname)    amrex::TinyProfiler::StartRegion(rname)


### PR DESCRIPTION
Both definitions of BL_PROFILE_REGION take a parameter named rname but pasted the token vname, which is not a parameter, so every expansion produced the same identifier: bl_profile_region_vname for the full profiler and tiny_profile_region_vname for the tiny one. Two regions in the same scope therefore failed to compile with a redefinition error. It looks like a copy-paste leftover from BL_PROFILE_VAR(fname, vname).

Pasting rname would not work either, since the argument is a string literal, so use `__COUNTER__` through BL_PROFILE_PASTE the way BL_PROFILE already does.
