### PR TITLE
SYCL: give each device RNG engine its own window of the Philox stream

### DIFF
--- a/Src/Base/AMReX_Random.cpp
+++ b/Src/Base/AMReX_Random.cpp
@@ -57,8 +57,21 @@ void ResizeRandomSeed (amrex::ULong gpu_seed)
 
 #ifdef AMREX_USE_SYCL
 
+    // oneMKL initializes engine id of an engine_descriptor as
+    // Engine{seed, id*offset}.  With an offset of 1, all N engines would be
+    // the same philox4x32x10 stream shifted by one element per engine, so the
+    // k-th draw of work-item t would equal the (k-1)-th draw of work-item t+1,
+    // and random fields would be correlated across neighboring work-items and
+    // successive kernels.  Give every engine its own window of the stream
+    // instead, in the spirit of the distinct curand/hiprand subsequences
+    // below.  Philox skip-ahead is counter arithmetic, so the size of the
+    // offset does not matter for the cost of initialization.
+    constexpr ULong elements_per_engine = ULong(1) << 36;
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE
+        (static_cast<ULong>(N) <= std::numeric_limits<ULong>::max() / elements_per_engine,
+         "ResizeRandomSeed: too many RNG engines for the per-engine offset");
     rand_engine_descr = new sycl_rng_descr
-        (Gpu::Device::streamQueue(), sycl::range<1>(N), gpu_seed, 1);
+        (Gpu::Device::streamQueue(), sycl::range<1>(N), gpu_seed, elements_per_engine);
 
     gpu_rand_generator = new std::remove_pointer_t<decltype(gpu_rand_generator)>
         (Gpu::Device::streamQueue(), gpu_seed+1234ULL);


### PR DESCRIPTION
ResizeRandomSeed built the oneMKL engine_descriptor with an offset of 1. oneMKL initializes engine id as Engine{seed, id*offset}, so all N per-work-item engines were the same philox4x32x10 stream shifted by one element per engine: the k-th draw of work-item t equaled the (k-1)-th draw of work-item t+1, across kernel launches. Any kernel that draws more than one number per work-item therefore produced random fields that were correlated between neighboring work-items in a fixed space-time pattern.

Tests/StochasticHeatEquation, which draws two numbers per face per step, measured the equilibrium temperature variance about 24% low on the Intel PVC CI job (64.2 vs 84.97), while CPU and CUDA runs with the same inputs land within a few percent for every seed. A CPU emulation of the offset-1 engine layout reproduces the deficit, and the same emulation with non-overlapping windows does not.

Use an offset of 2^36 elements per engine, in the spirit of the distinct curand/hiprand subsequences used on CUDA and HIP, and check that N * offset cannot overflow. Philox skip-ahead is counter arithmetic, so the larger offset does not change the cost of initialization.
