### PR TITLE
Fix OpenBC when multiple levels are fully refined

### DIFF
--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -919,6 +919,11 @@ Distributions", R. A. James, 1977, Journal of Computational Physics, 25,
                 const Vector<MultiFab const*>& a_rhs,
                  Real a_tol_rel, Real a_tol_abs);
 
+The solver supports hierarchies containing fully refined intermediate AMR
+levels.  It adds source-free support cells outside the original domain as
+needed to preserve proper nesting on the enlarged domain used by James's
+method.
+
 
 GMRES
 =====

--- a/Src/LinearSolvers/OpenBC/AMReX_OpenBC.H
+++ b/Src/LinearSolvers/OpenBC/AMReX_OpenBC.H
@@ -200,6 +200,8 @@ private:
     Vector<BoxArray> m_ba_all;
     Vector<DistributionMapping> m_dm_all;
     Vector<Geometry> m_geom_all;
+    Vector<BoxArray> m_ba_support;
+    Vector<DistributionMapping> m_dm_support;
 };
 
 }

--- a/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
+++ b/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
@@ -45,6 +45,10 @@ void OpenBCSolver::define (const Vector<Geometry>& a_geom,
     m_ba_all.resize(nlevels);
     m_dm_all.resize(nlevels);
     m_geom_all.resize(nlevels);
+    m_ba_support.clear();
+    m_ba_support.resize(nlevels);
+    m_dm_support.clear();
+    m_dm_support.resize(nlevels);
 
     Box const domain0 = m_geom[0].Domain();
     m_coarsen_ratio = 8;
@@ -192,6 +196,47 @@ void OpenBCSolver::define (const Vector<Geometry>& a_geom,
         m_ba_all[ilev].shift(offset);
         m_dm_all[ilev] = a_dmap[ilev];
     }
+
+    // The grown level-0 domain turns the original physical boundary into a
+    // coarse/fine boundary. Add source-free parent cells wherever a finer
+    // level would otherwise reach the edge of its parent grids. Using the
+    // multipole coarsening width ensures that this support survives recursive
+    // coarsening through any fully refined intermediate levels.
+    for (int ilev = nlevels-1; ilev > 1; --ilev) {
+        int const clev = ilev-1;
+        IntVect const rr = m_geom[ilev].Domain().length()
+                         / m_geom[clev].Domain().length();
+        BoxArray cba = m_ba_all[ilev];
+        cba.coarsen(rr);
+
+        Box const original_domain = amrex::shift(m_geom[clev].Domain(),
+                                                  m_box_offset[clev]);
+        BoxList support(IndexType::TheCellType());
+        for (int ibox = 0; ibox < cba.size(); ++ibox) {
+            Box const& cbx = cba[ibox];
+            Box needed = amrex::grow(cbx,m_coarsen_ratio) & m_geom_all[clev].Domain();
+            if (needed.ok()) {
+                BoxList const exterior = amrex::boxDiff(needed, original_domain);
+                for (Box const& bx : exterior) {
+                    support.join(m_ba_all[clev].complementIn(bx));
+                }
+            }
+        }
+
+        if (support.size() > 0) {
+            m_ba_support[clev] = BoxArray(std::move(support));
+            m_ba_support[clev].removeOverlap();
+            m_dm_support[clev] = DistributionMapping(m_ba_support[clev]);
+
+            BoxList all_boxes = m_ba_all[clev].boxList();
+            all_boxes.join(m_ba_support[clev].boxList());
+            Vector<int> pmap = m_dm_all[clev].ProcessorMap();
+            Vector<int> const& support_pmap = m_dm_support[clev].ProcessorMap();
+            pmap.insert(pmap.end(), support_pmap.begin(), support_pmap.end());
+            m_ba_all[clev] = BoxArray(std::move(all_boxes));
+            m_dm_all[clev] = DistributionMapping(std::move(pmap));
+        }
+    }
 }
 
 void OpenBCSolver::setVerbose (int v) noexcept
@@ -283,6 +328,8 @@ Real OpenBCSolver::solve (const Vector<MultiFab*>& a_sol,
     const int nboxes0 = static_cast<int>(m_grids[0].size());
     Vector<MultiFab> sol_all(nlevels);
     Vector<MultiFab> rhs_all(nlevels);
+    Vector<MultiFab> sol_support(nlevels);
+    Vector<MultiFab> rhs_support(nlevels);
 
     sol_all[0].define(m_ba_all[0], m_dm_all[0], 1, solg.nGrowVect(),
                       MFInfo().SetAlloc(false));
@@ -314,18 +361,35 @@ Real OpenBCSolver::solve (const Vector<MultiFab*>& a_sol,
     }
 
     for (int ilev = 1; ilev < nlevels; ++ilev) {
+        int const nboxes = static_cast<int>(m_grids[ilev].size());
+        if (!m_ba_support[ilev].empty()) {
+            sol_support[ilev].define(m_ba_support[ilev], m_dm_support[ilev], 1,
+                                      a_sol[ilev]->nGrowVect());
+            rhs_support[ilev].define(m_ba_support[ilev], m_dm_support[ilev], 1,
+                                      a_rhs[ilev]->nGrowVect());
+            sol_support[ilev].setVal(0._rt);
+            rhs_support[ilev].setVal(0._rt);
+        }
+
         sol_all[ilev].define(m_ba_all[ilev], m_dm_all[ilev], 1,
                              a_sol[ilev]->nGrowVect(), MFInfo().SetAlloc(false));
         rhs_all[ilev].define(m_ba_all[ilev], m_dm_all[ilev], 1,
                              a_rhs[ilev]->nGrowVect(), MFInfo().SetAlloc(false));
         for (MFIter mfi(sol_all[ilev]); mfi.isValid(); ++mfi) {
             const int index = mfi.index();
-            auto const& a_sol_fab = (*a_sol[ilev])[index];
-            auto const& a_rhs_fab = (*a_rhs[ilev])[index];
-            FArrayBox solfab(a_sol_fab, amrex::make_alias, 0, 1);
-            FArrayBox rhsfab(a_rhs_fab, amrex::make_alias, 0, 1);
-            solfab.shift(m_box_offset[ilev]);
-            rhsfab.shift(m_box_offset[ilev]);
+            FArrayBox solfab, rhsfab;
+            if (index < nboxes) {
+                solfab = FArrayBox((*a_sol[ilev])[index], amrex::make_alias, 0, 1);
+                rhsfab = FArrayBox((*a_rhs[ilev])[index], amrex::make_alias, 0, 1);
+                solfab.shift(m_box_offset[ilev]);
+                rhsfab.shift(m_box_offset[ilev]);
+            } else {
+                int const support_index = index-nboxes;
+                solfab = FArrayBox(sol_support[ilev][support_index],
+                                   amrex::make_alias, 0, 1);
+                rhsfab = FArrayBox(rhs_support[ilev][support_index],
+                                   amrex::make_alias, 0, 1);
+            }
             sol_all[ilev].setFab(mfi, std::move(solfab));
             rhs_all[ilev].setFab(mfi, std::move(rhsfab));
         }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -125,6 +125,7 @@ if (AMReX_TEST_TYPE STREQUAL "Small")
 
    if (AMReX_LINEAR_SOLVERS)
       add_subdirectory("LinearSolvers/ABecLaplacian_C")
+      add_subdirectory("LinearSolvers/OpenBC")
    endif()
 
    if (AMReX_FFT)

--- a/Tests/LinearSolvers/OpenBC/CMakeLists.txt
+++ b/Tests/LinearSolvers/OpenBC/CMakeLists.txt
@@ -1,0 +1,9 @@
+if (AMReX_LINEAR_SOLVERS_INCFLO AND (3 IN_LIST AMReX_SPACEDIM))
+    set(_sources main.cpp)
+    set(_input_files)
+
+    setup_test(3 _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endif ()

--- a/Tests/LinearSolvers/OpenBC/main.cpp
+++ b/Tests/LinearSolvers/OpenBC/main.cpp
@@ -1,0 +1,78 @@
+#include <AMReX.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_OpenBC.H>
+
+#include <cmath>
+
+using namespace amrex;
+
+namespace {
+
+void solve_fully_refined_hierarchy (int nlevels)
+{
+    constexpr int n_cell = 8;
+
+    Vector<Geometry> geom(nlevels);
+    Vector<BoxArray> grids(nlevels);
+    Vector<DistributionMapping> dmap(nlevels);
+    Vector<MultiFab> phi(nlevels);
+    Vector<MultiFab> rhs(nlevels);
+
+    RealBox const real_box(0._rt, 0._rt, 0._rt, 1._rt, 1._rt, 1._rt);
+    Array<int, AMREX_SPACEDIM> const periodic{0, 0, 0};
+
+    for (int lev = 0; lev < nlevels; ++lev) {
+        int const nc = n_cell * (1 << lev);
+        Box const domain(IntVect(0), IntVect(nc-1));
+        geom[lev].define(domain, real_box, CoordSys::cartesian, periodic);
+
+        grids[lev].define(domain);
+        grids[lev].maxSize(16);
+        dmap[lev].define(grids[lev]);
+
+        phi[lev].define(grids[lev], dmap[lev], 1, 1);
+        rhs[lev].define(grids[lev], dmap[lev], 1, 2);
+        phi[lev].setVal(0._rt);
+        rhs[lev].setVal(0._rt);
+
+        auto const dx = geom[lev].CellSizeArray();
+        auto const problo = geom[lev].ProbLoArray();
+        for (MFIter mfi(rhs[lev]); mfi.isValid(); ++mfi) {
+            Box const& bx = mfi.validbox();
+            auto const& a = rhs[lev].array(mfi);
+            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            {
+                Real const x = problo[0] + (i+0.5_rt)*dx[0] - 0.5_rt;
+                Real const y = problo[1] + (j+0.5_rt)*dx[1] - 0.5_rt;
+                Real const z = problo[2] + (k+0.5_rt)*dx[2] - 0.5_rt;
+                a(i,j,k) = std::exp(-64._rt*(x*x+y*y+z*z));
+            });
+        }
+    }
+
+    LPInfo info;
+    info.setDeterministic(true);
+    OpenBCSolver solver(geom, grids, dmap, info);
+    Real const error = solver.solve(GetVecOfPtrs(phi), GetVecOfConstPtrs(rhs),
+                                    1.e-10_rt, 0._rt);
+    AMREX_ALWAYS_ASSERT(std::isfinite(error));
+
+    for (auto const& mf : phi) {
+        AMREX_ALWAYS_ASSERT(!mf.contains_nan());
+        AMREX_ALWAYS_ASSERT(!mf.contains_inf());
+    }
+}
+
+}
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+    {
+        solve_fully_refined_hierarchy(2);
+        solve_fully_refined_hierarchy(3);
+        solve_fully_refined_hierarchy(4);
+        solve_fully_refined_hierarchy(5);
+    }
+    amrex::Finalize();
+}


### PR DESCRIPTION
## Summary
When multiple AMR levels are fully refined, the OpenBC solver returns a NaN solution. This fixes the way it extends the domain to work in this case.

Fixes https://github.com/AMReX-Codes/amrex/issues/5659.

## Additional background

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
