### PR TITLE
Add GPU-synchronized TinyProfiler timers

### DIFF
--- a/Docs/sphinx_documentation/source/AMReX_Profiling_Tools.rst
+++ b/Docs/sphinx_documentation/source/AMReX_Profiling_Tools.rst
@@ -429,6 +429,41 @@ is isolated in its own group.
 Any timers inside :cpp:`MyFunc_0` and :cpp:`MyFunc_1` are not included in the
 region groupings.
 
+GPU-synchronized TinyProfiler timers
+------------------------------------
+
+GPU kernels normally launch asynchronously, so a host timer does not necessarily
+measure the work launched inside its scope. On GPU builds, TinyProfiler provides
+opt-in variants that synchronize the current AMReX GPU stream immediately before
+recording both the start and stop timestamps:
+
+* :cpp:`BL_PROFILE_GPU_SYNC(name)`
+* :cpp:`BL_PROFILE_VAR_GPU_SYNC(name, variable)`
+* :cpp:`BL_PROFILE_VAR_NS_GPU_SYNC(name, variable)`
+* :cpp:`BL_PROFILE_REGION_GPU_SYNC(name)`
+
+Variables created with :cpp:`BL_PROFILE_VAR_NS_GPU_SYNC` are started and stopped
+with the ordinary :cpp:`BL_PROFILE_VAR_START` and :cpp:`BL_PROFILE_VAR_STOP`
+macros. On CPU builds these four macros are aliases for their ordinary variants.
+They are also ordinary aliases when the full profiler is selected, and are no-ops
+when profiling is disabled.
+
+After any GPU-synchronized timer starts, TinyProfiler uses a focused report for
+the remainder of that AMReX initialization cycle. The focused report contains
+the outermost active timer, timers created by the GPU-synchronized macros, and
+tables created by :cpp:`BL_PROFILE_REGION_GPU_SYNC`. Ordinary nested timers and
+ordinary region tables are still collected in the complete internal statistics,
+but are omitted from focused flushes and the final report. Activation is combined
+across all MPI processes, so every process uses the same report even if only one
+process executes a synchronized timer. Percentages remain relative to the total
+application run time.
+
+The runtime parameter
+``tiny_profiler.device_synchronize_around_region`` remains available and is
+independent of these macros. When enabled, it retains its existing behavior of
+synchronizing all TinyProfiler timer boundaries; it does not by itself activate
+the focused report.
+
 Instrumenting Fortran90 Code
 ============================
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -2074,31 +2074,33 @@ and recommendations for improving the code.  For more information on how to
 use ``nvprof``, see NVIDIA's User's Guide as well as the help web pages of
 your favorite supercomputing facility that uses NVIDIA GPUs.
 
-AMReX's internal profilers currently cannot hook into profiling information
-on the GPU and an efficient way to time and retrieve that information is
-being explored. In the meantime, AMReX's timers can be used to report some
-generic timers that are useful in categorizing an application.
+AMReX's internal profilers do not hook into backend profiling information,
+but TinyProfiler can measure selected GPU scopes by synchronizing the current
+AMReX GPU stream at their timer boundaries.
 
-Due to the asynchronous launching of GPU kernels, any AMReX timers inside of
-asynchronous regions or inside GPU kernels will not measure useful
-information.  However, since the :cpp:`MFIter` synchronizes when being
-destroyed, any timer wrapped around an :cpp:`MFIter` loop will yield a
-consistent timing of the entire set of GPU launches contained within. For
-example:
+Due to asynchronous GPU kernel launches, an ordinary host timer might finish
+before the work launched inside it. Use :cpp:`BL_PROFILE_GPU_SYNC` (or its
+variable and region variants) when a TinyProfiler timer must include work
+launched on the current stream. For example:
 
 .. highlight:: cpp
 
 ::
 
-    BL_PROFILE_VAR("A_NAME", blp);     // Profiling start
+    BL_PROFILE_VAR_GPU_SYNC("A_NAME", blp); // Synchronize, then start timing
     for (MFIter mfi(mf); mfi.isValid(); ++mfi)
     {
         // gpu works
     }
-    BL_PROFILE_STOP(blp);              // Profiling stop
+    BL_PROFILE_VAR_STOP(blp);           // Synchronize, then stop timing
 
-For now, this is the best way to profile GPU codes using ``TinyProfiler``.
-If you require further profiling detail, use ``nvprof``.
+The synchronized macros add synchronization points that are unnecessary for
+correctness and may affect application performance. Once one executes, the
+TinyProfiler report focuses on synchronized timers, synchronized regions, and
+the outermost timer; see :ref:`sec:tiny:profiling` for the complete behavior.
+The runtime parameter ``tiny_profiler.device_synchronize_around_region`` can
+still synchronize every TinyProfiler timer boundary and does not activate this
+focused report. For detailed kernel information, use a backend profiling tool.
 
 
 Performance Tips

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1606,7 +1606,9 @@ enabled.
   synchronization could be misleading. Enabling this parameter can provide
   more accurate measurements. However, the added synchronization points,
   which are unnecessary for correctness, could potentially degrade the
-  performance.
+  performance. This global setting is independent of the selective
+  GPU-synchronized profiling macros described in :ref:`sec:tiny:profiling`;
+  enabling it does not activate their focused report.
 
 .. py:data:: tiny_profiler.enabled
    :type: bool

--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -414,12 +414,17 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_PROFILE_VAR_START(vname) bl_profiler_##vname.start();
 #define BL_PROFILE_VAR_STOP(vname) bl_profiler_##vname.stop();
 
+#define BL_PROFILE_GPU_SYNC(fname) BL_PROFILE(fname)
+#define BL_PROFILE_VAR_GPU_SYNC(fname, vname) BL_PROFILE_VAR(fname, vname)
+#define BL_PROFILE_VAR_NS_GPU_SYNC(fname, vname) BL_PROFILE_VAR_NS(fname, vname)
+
 #define BL_PROFILE_INIT_PARAMS(ptl,wall,wfabs)  \
     amrex::BLProfiler::InitParams(ptl,wall, wfabs);
 #define BL_PROFILE_ADD_STEP(snum)  amrex::BLProfiler::AddStep(snum);
 #define BL_PROFILE_SET_RUN_TIME(rtime)  amrex::BLProfiler::SetRunTime(rtime);
 
 #define BL_PROFILE_REGION(rname) amrex::BLProfileRegion bl_profile_region_##vname((rname));
+#define BL_PROFILE_REGION_GPU_SYNC(rname) BL_PROFILE_REGION(rname)
 
 #define BL_PROFILE_REGION_START(rname) amrex::BLProfiler::RegionStart(rname);
 #define BL_PROFILE_REGION_STOP(rname)  amrex::BLProfiler::RegionStop(rname);
@@ -501,10 +506,29 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_PROFILE_VAR_NS(fname, vname)                   amrex::TinyProfiler tiny_profiler_##vname(fname, false)
 #define BL_PROFILE_VAR_START(vname)                       tiny_profiler_##vname.start()
 #define BL_PROFILE_VAR_STOP(vname)                        tiny_profiler_##vname.stop()
+#ifdef AMREX_USE_GPU
+#define BL_PROFILE_GPU_SYNC(fname)                        \
+    AMREX_WARNING_PUSH_COUNTER                            \
+    BL_PROFILE_GPU_SYNC_IMPL(fname, __COUNTER__)          \
+    AMREX_WARNING_POP
+#define BL_PROFILE_GPU_SYNC_IMPL(funame, counter) amrex::TinyProfiler BL_PROFILE_PASTE(tiny_profiler_, counter)((funame), true, true); \
+    amrex::ignore_unused(BL_PROFILE_PASTE(tiny_profiler_, counter));
+#define BL_PROFILE_VAR_GPU_SYNC(fname, vname)             amrex::TinyProfiler tiny_profiler_##vname((fname), true, true)
+#define BL_PROFILE_VAR_NS_GPU_SYNC(fname, vname)          amrex::TinyProfiler tiny_profiler_##vname((fname), false, true)
+#else
+#define BL_PROFILE_GPU_SYNC(fname)                        BL_PROFILE(fname)
+#define BL_PROFILE_VAR_GPU_SYNC(fname, vname)             BL_PROFILE_VAR(fname, vname)
+#define BL_PROFILE_VAR_NS_GPU_SYNC(fname, vname)          BL_PROFILE_VAR_NS(fname, vname)
+#endif
 #define BL_PROFILE_INIT_PARAMS(ptl,wall,wfabs)
 #define BL_PROFILE_ADD_STEP(snum)
 #define BL_PROFILE_SET_RUN_TIME(rtime)
 #define BL_PROFILE_REGION(rname)          amrex::TinyProfileRegion tiny_profile_region_##vname((rname))
+#ifdef AMREX_USE_GPU
+#define BL_PROFILE_REGION_GPU_SYNC(rname) amrex::TinyProfileRegion tiny_profile_region_gpu_sync_##vname((rname), true)
+#else
+#define BL_PROFILE_REGION_GPU_SYNC(rname) BL_PROFILE_REGION(rname)
+#endif
 #define BL_PROFILE_REGION_START(rname)
 #define BL_PROFILE_REGION_STOP(rname)
 //#define BL_PROFILE_REGION_START(rname)    amrex::TinyProfiler::StartRegion(rname)
@@ -566,10 +590,14 @@ class BLProfiler
 #define BL_PROFILE_VAR_NS(fname, vname)
 #define BL_PROFILE_VAR_START(vname)
 #define BL_PROFILE_VAR_STOP(vname)
+#define BL_PROFILE_GPU_SYNC(fname)
+#define BL_PROFILE_VAR_GPU_SYNC(fname, vname)
+#define BL_PROFILE_VAR_NS_GPU_SYNC(fname, vname)
 #define BL_PROFILE_INIT_PARAMS(ptl,wall,wfabs)
 #define BL_PROFILE_ADD_STEP(snum)
 #define BL_PROFILE_SET_RUN_TIME(rtime)
 #define BL_PROFILE_REGION(rname)
+#define BL_PROFILE_REGION_GPU_SYNC(rname)
 #define BL_PROFILE_REGION_START(rname)
 #define BL_PROFILE_REGION_STOP(rname)
 #define BL_PROFILE_REGION_VAR(fname, rvname)

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -32,8 +32,10 @@ class TinyProfiler
 public:
     explicit TinyProfiler (std::string funcname) noexcept;
     TinyProfiler (std::string funcname, bool start_) noexcept;
+    TinyProfiler (std::string funcname, bool start_, bool gpu_sync_) noexcept;
     explicit TinyProfiler (const char* funcname) noexcept;
     TinyProfiler (const char* funcname, bool start_) noexcept;
+    TinyProfiler (const char* funcname, bool start_, bool gpu_sync_) noexcept;
     ~TinyProfiler ();
 
     TinyProfiler (TinyProfiler const&) = delete;
@@ -63,6 +65,7 @@ public:
     static void DeregisterArena (std::map<std::string, MemStat>& memstats) noexcept;
 
     static void StartRegion (std::string regname) noexcept;
+    static void StartRegion (std::string regname, bool gpu_sync) noexcept;
     static void StopRegion (const std::string& regname) noexcept;
 
     static void PrintCallStack (std::ostream& os);
@@ -77,6 +80,20 @@ private:
         double dtin{0.0};    //!< inclusive dt
         double dtex{0.0};    //!< exclusive dt
     };
+
+    struct TimerKey
+    {
+        std::string name;
+        bool gpu_sync = false;
+
+        bool operator< (TimerKey const& rhs) const noexcept
+        {
+            return std::tie(name, gpu_sync) < std::tie(rhs.name, rhs.gpu_sync);
+        }
+    };
+
+    using RegionStats = std::map<TimerKey, Stats>;
+    using StatsMap = std::map<std::string, RegionStats>;
 
     //! stats across processes
     struct ProcStats
@@ -116,9 +133,11 @@ private:
     };
 
     std::string fname;
+    bool gpu_sync = false;
     bool in_parallel_region = false;
     int global_depth = -1;
     std::vector<Stats*> stats;
+    std::vector<Stats*> selective_stats;
 
     static std::deque<const TinyProfiler*> mem_stack;
 
@@ -134,9 +153,12 @@ private:
     static std::vector<std::string> all_memnames;
 
     static std::vector<std::string> regionstack;
-    static std::vector<std::pair<std::string,bool> > regionstartstack;
+    static std::vector<std::string> selective_regionstack;
+    static std::vector<std::tuple<std::string,bool,bool> > regionstartstack;
     static std::deque<std::tuple<double,double,std::string*> > ttstack;
-    static std::map<std::string,std::map<std::string, Stats> > statsmap;
+    static StatsMap statsmap;
+    static StatsMap selective_statsmap;
+    static bool selective_reporting;
     static double t_init;
     static double t_memory_init;
     static bool device_synchronize_around_region;
@@ -148,7 +170,7 @@ private:
     static std::string output_file;
 
     static std::string const& get_output_file ();
-    static void PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
+    static void PrintStats (RegionStats& regstats, double dt_max,
                             std::ostream* os);
     static void PrintMemStats (std::map<std::string, MemStat>& memstats,
                                std::string const& memname, double dt_max,
@@ -160,6 +182,8 @@ class TinyProfileRegion
 public:
     explicit TinyProfileRegion (std::string a_regname) noexcept;
     explicit TinyProfileRegion (const char* a_regname) noexcept;
+    TinyProfileRegion (std::string a_regname, bool gpu_sync) noexcept;
+    TinyProfileRegion (const char* a_regname, bool gpu_sync) noexcept;
     TinyProfileRegion (TinyProfileRegion const&) = delete;
     TinyProfileRegion (TinyProfileRegion &&) = delete;
     TinyProfileRegion& operator= (TinyProfileRegion const&) = delete;

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -1,5 +1,4 @@
-// We only support BL_PROFILE, BL_PROFILE_VAR, BL_PROFILE_VAR_STOP, BL_PROFILE_VAR_START,
-// BL_PROFILE_VAR_NS, and BL_PROFILE_REGION.
+// TinyProfiler implementation for the BL_PROFILE family of macros.
 
 #include <AMReX_TinyProfiler.H>
 #include <AMReX_ParallelDescriptor.H>
@@ -47,9 +46,12 @@ std::vector<std::map<std::string, MemStat>*> TinyProfiler::all_memstats;
 std::vector<std::string> TinyProfiler::all_memnames;
 
 std::vector<std::string>          TinyProfiler::regionstack;
-std::vector<std::pair<std::string,bool> > TinyProfiler::regionstartstack;
+std::vector<std::string>          TinyProfiler::selective_regionstack;
+std::vector<std::tuple<std::string,bool,bool> > TinyProfiler::regionstartstack;
 std::deque<std::tuple<double,double,std::string*> > TinyProfiler::ttstack;
-std::map<std::string,std::map<std::string, TinyProfiler::Stats> > TinyProfiler::statsmap;
+TinyProfiler::StatsMap TinyProfiler::statsmap;
+TinyProfiler::StatsMap TinyProfiler::selective_statsmap;
+bool TinyProfiler::selective_reporting = false;
 double TinyProfiler::t_init = std::numeric_limits<double>::max();
 double TinyProfiler::t_memory_init = std::numeric_limits<double>::max();
 bool TinyProfiler::device_synchronize_around_region = false;
@@ -111,6 +113,12 @@ TinyProfiler::TinyProfiler (std::string funcname, bool start_) noexcept
     if (start_) { start(); }
 }
 
+TinyProfiler::TinyProfiler (std::string funcname, bool start_, bool gpu_sync_) noexcept
+    : fname(std::move(funcname)), gpu_sync(gpu_sync_)
+{
+    if (start_) { start(); }
+}
+
 TinyProfiler::TinyProfiler (const char* funcname) noexcept
     : fname(funcname)
 {
@@ -119,6 +127,12 @@ TinyProfiler::TinyProfiler (const char* funcname) noexcept
 
 TinyProfiler::TinyProfiler (const char* funcname, bool start_) noexcept
     : fname(funcname)
+{
+    if (start_) { start(); }
+}
+
+TinyProfiler::TinyProfiler (const char* funcname, bool start_, bool gpu_sync_) noexcept
+    : fname(funcname), gpu_sync(gpu_sync_)
 {
     if (start_) { start(); }
 }
@@ -139,7 +153,8 @@ TinyProfiler::start ()
 #pragma omp master
 #endif
     {
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(stats.empty(), "TinyProfiler cannot be started twice");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(stats.empty() && selective_stats.empty(),
+            "TinyProfiler cannot be started twice");
     }
 
 #ifdef AMREX_USE_OMP
@@ -148,12 +163,17 @@ TinyProfiler::start ()
     if (!regionstack.empty()) {
 
 #ifdef AMREX_USE_GPU
-        if (device_synchronize_around_region) {
+        if (gpu_sync || device_synchronize_around_region) {
             amrex::Gpu::streamSynchronize();
         }
 #endif
 
         const double t = amrex::second();
+        bool const outermost = ttstack.empty();
+
+        if (gpu_sync) {
+            selective_reporting = true;
+        }
 
         ttstack.emplace_back(t, 0.0, &fname);
         global_depth = static_cast<int>(ttstack.size());
@@ -169,11 +189,25 @@ TinyProfiler::start ()
         roctxRangePush(fname.c_str());
 #endif
 
+        TimerKey const key{fname, gpu_sync};
         for (auto const& region : regionstack)
         {
-            Stats& st = statsmap[region][fname];
+            Stats& st = statsmap[region][key];
             ++st.depth;
             stats.push_back(&st);
+        }
+
+        if (outermost || gpu_sync) {
+            Stats& st = selective_statsmap[mainregion][key];
+            ++st.depth;
+            selective_stats.push_back(&st);
+        }
+        if (gpu_sync) {
+            for (auto const& region : selective_regionstack) {
+                Stats& st = selective_statsmap[region][key];
+                ++st.depth;
+                selective_stats.push_back(&st);
+            }
         }
 
         if (verbose) {
@@ -202,7 +236,7 @@ TinyProfiler::stop ()
     if (!stats.empty()) {
 
 #ifdef AMREX_USE_GPU
-        if (device_synchronize_around_region) {
+        if (gpu_sync || device_synchronize_around_region) {
             amrex::Gpu::streamSynchronize();
         }
 #endif
@@ -234,6 +268,16 @@ TinyProfiler::stop ()
                 st->dtex += dtex;
             }
 
+            for (Stats* st : selective_stats)
+            {
+                --(st->depth);
+                ++(st->n);
+                if (st->depth == 0) {
+                    st->dtin += dtin;
+                }
+                st->dtex += dtex;
+            }
+
             ttstack.pop_back();
             if (!ttstack.empty()) {
                 std::tuple<double,double,std::string*>& parent = ttstack.back();
@@ -248,6 +292,7 @@ TinyProfiler::stop ()
         }
 
         stats.clear();
+        selective_stats.clear();
 
         if (verbose) {
             std::string whitespace;
@@ -348,6 +393,10 @@ TinyProfiler::memory_free (std::size_t nbytes, MemStat* stat) noexcept
 void
 TinyProfiler::Initialize ()
 {
+    selective_regionstack.clear();
+    selective_statsmap.clear();
+    selective_reporting = false;
+
     {
         amrex::ParmParse pp("tiny_profiler");
         pp.queryAdd("device_synchronize_around_region", device_synchronize_around_region);
@@ -411,8 +460,11 @@ TinyProfiler::Finalize (bool bFlushing)
 
     double t_final = amrex::second();
 
-    // make a local copy so that any functions call after this will not be recorded in the local copy.
-    auto lstatsmap = statsmap;
+    bool use_selective_stats = selective_reporting;
+    ParallelDescriptor::ReduceBoolOr(use_selective_stats);
+
+    // Make a local copy so that timers completed during output are not included.
+    auto lstatsmap = use_selective_stats ? selective_statsmap : statsmap;
 
     int nprocs = ParallelDescriptor::NProcs();
     int ioproc = ParallelDescriptor::IOProcessorNumber();
@@ -455,7 +507,7 @@ TinyProfiler::Finalize (bool bFlushing)
         if (!alreadySynced) {
             for (auto const& s : syncedRegions) {
                 if (!lstatsmap.contains(s)) {
-                    lstatsmap.insert(std::make_pair(s,std::map<std::string,Stats>()));
+                    lstatsmap.insert(std::make_pair(s,RegionStats()));
                 }
             }
         }
@@ -476,9 +528,12 @@ TinyProfiler::Finalize (bool bFlushing)
 
     if (!bFlushing) {
         regionstack.clear();
+        selective_regionstack.clear();
         regionstartstack.clear();
         ttstack.clear();
         statsmap.clear();
+        selective_statsmap.clear();
+        selective_reporting = false;
     }
 }
 
@@ -538,24 +593,29 @@ TinyProfiler::DeregisterArena (std::map<std::string, MemStat>& memstats) noexcep
 }
 
 void
-TinyProfiler::PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
+TinyProfiler::PrintStats (RegionStats& regstats, double dt_max,
                           std::ostream* os)
 {
     // make sure the set of profiled functions is the same on all processes
     {
-        Vector<std::string> localStrings, syncedStrings;
-        bool alreadySynced;
+        for (bool const gpu_sync_key : {false, true}) {
+            Vector<std::string> localStrings, syncedStrings;
+            bool alreadySynced;
 
-        for(auto const& kv : regstats) {
-            localStrings.push_back(kv.first);
-        }
+            for (auto const& kv : regstats) {
+                if (kv.first.gpu_sync == gpu_sync_key) {
+                    localStrings.push_back(kv.first.name);
+                }
+            }
 
-        amrex::SyncStrings(localStrings, syncedStrings, alreadySynced);
+            amrex::SyncStrings(localStrings, syncedStrings, alreadySynced);
 
-        if (! alreadySynced) {  // add the new name
-            for (auto const& s : syncedStrings) {
-                if (!regstats.contains(s)) {
-                    regstats.insert(std::make_pair(s, Stats()));
+            if (!alreadySynced) {
+                for (auto const& s : syncedStrings) {
+                    TimerKey const key{s, gpu_sync_key};
+                    if (!regstats.contains(key)) {
+                        regstats.insert(std::make_pair(key, Stats()));
+                    }
                 }
             }
         }
@@ -606,7 +666,7 @@ TinyProfiler::PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
             pst.navg /= nprocs;
             pst.dtinavg /= nprocs;
             pst.dtexavg /= nprocs;
-            pst.fname = regstat.first;
+            pst.fname = regstat.first.name;
             allprocstats.push_back(pst);
             maxfnamelen = std::max(maxfnamelen, int(pst.fname.size()));
             maxncalls = std::max(maxncalls, pst.nmax);
@@ -973,6 +1033,12 @@ TinyProfiler::PrintMemStats (std::map<std::string, MemStat>& memstats,
 void
 TinyProfiler::StartRegion (std::string regname) noexcept
 {
+    StartRegion(std::move(regname), false);
+}
+
+void
+TinyProfiler::StartRegion (std::string regname, bool gpu_sync_region) noexcept
+{
     if (!enabled) { return; }
 
     bool pushed = false;
@@ -980,7 +1046,15 @@ TinyProfiler::StartRegion (std::string regname) noexcept
         regionstack.emplace_back(regname);
         pushed = true;
     }
-    regionstartstack.emplace_back(std::move(regname), pushed);
+
+    bool selective_pushed = false;
+    if (gpu_sync_region && regname != mainregion &&
+        std::ranges::find(selective_regionstack, regname) == selective_regionstack.end()) {
+        selective_regionstack.emplace_back(regname);
+        selective_pushed = true;
+    }
+
+    regionstartstack.emplace_back(std::move(regname), pushed, selective_pushed);
 }
 
 void
@@ -988,11 +1062,17 @@ TinyProfiler::StopRegion (const std::string& regname) noexcept
 {
     if (!enabled) { return; }
 
-    if (!regionstartstack.empty() && regname == regionstartstack.back().first) {
-        if (regionstartstack.back().second) {
+    if (!regionstartstack.empty() && regname == std::get<0>(regionstartstack.back())) {
+        if (std::get<1>(regionstartstack.back())) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!regionstack.empty() && regname == regionstack.back(),
                 "TinyProfiler regions must be nested with respect to each other");
             regionstack.pop_back();
+        }
+        if (std::get<2>(regionstartstack.back())) {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!selective_regionstack.empty() &&
+                regname == selective_regionstack.back(),
+                "Selective TinyProfiler regions must be nested with respect to each other");
+            selective_regionstack.pop_back();
         }
         regionstartstack.pop_back();
     }
@@ -1011,6 +1091,22 @@ TinyProfileRegion::TinyProfileRegion (const char* a_regname) noexcept
       tprof(std::string("REG::")+std::string(a_regname), false)
 {
     TinyProfiler::StartRegion(a_regname);
+    tprof.start();
+}
+
+TinyProfileRegion::TinyProfileRegion (std::string a_regname, bool gpu_sync) noexcept
+    : regname(std::move(a_regname)),
+      tprof(std::string("REG::")+regname, false, gpu_sync)
+{
+    TinyProfiler::StartRegion(regname, gpu_sync);
+    tprof.start();
+}
+
+TinyProfileRegion::TinyProfileRegion (const char* a_regname, bool gpu_sync) noexcept
+    : regname(a_regname),
+      tprof(std::string("REG::")+std::string(a_regname), false, gpu_sync)
+{
+    TinyProfiler::StartRegion(a_regname, gpu_sync);
     tprof.start();
 }
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -108,6 +108,7 @@ if (AMReX_TEST_TYPE STREQUAL "Small")
    add_subdirectory("Base/Random")
    add_subdirectory("Base/RealBox")
    add_subdirectory("Base/CompensatedSum")
+   add_subdirectory("Profiling")
 
    add_subdirectory("Amr/Advection_AmrCore")
 
@@ -137,7 +138,7 @@ else()
    #
    set( AMREX_TESTS_SUBDIRS Amr ArrayND AsyncOut Base CallNoinline CommType CTOParFor DeviceGlobal
                             Enum GpuParallelReduce HeatEquation MultiBlock MultiPeriod ParmParse Parser Parser2
-                            ParserUserFn Reducer ReduceToPlaneGuards ReduceToPlanePatchy Reinit RoundoffDomain SIMD
+                            ParserUserFn Profiling Reducer ReduceToPlaneGuards ReduceToPlanePatchy Reinit RoundoffDomain SIMD
                             SmallMatrix StochasticHeatEquation SumBoundary TOML)
 
    if (AMReX_PARTICLES)

--- a/Tests/Profiling/CMakeLists.txt
+++ b/Tests/Profiling/CMakeLists.txt
@@ -1,0 +1,9 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources main.cpp)
+    set(_input_files inputs)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Profiling/GNUmakefile
+++ b/Tests/Profiling/GNUmakefile
@@ -1,0 +1,22 @@
+AMREX_HOME ?= ../..
+
+DEBUG = FALSE
+DIM = 3
+COMP = gcc
+
+USE_MPI = TRUE
+USE_OMP = FALSE
+USE_CUDA = FALSE
+USE_HIP = FALSE
+USE_SYCL = FALSE
+
+BL_NO_FORT = TRUE
+
+TINY_PROFILE = TRUE
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+include $(AMREX_HOME)/Src/Base/Make.package
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/Profiling/Make.package
+++ b/Tests/Profiling/Make.package
@@ -1,0 +1,1 @@
+CEXE_sources += main.cpp

--- a/Tests/Profiling/inputs
+++ b/Tests/Profiling/inputs
@@ -1,0 +1,5 @@
+amrex.signal_handling = 0
+amrex.throw_exception = 1
+amrex.verbose = 0
+tiny_profiler.output_file = tiny_profiler_test.out
+tiny_profiler.print_threshold = 0

--- a/Tests/Profiling/main.cpp
+++ b/Tests/Profiling/main.cpp
@@ -1,0 +1,244 @@
+#include <AMReX.H>
+#include <AMReX_BLProfiler.H>
+#include <AMReX_GpuContainers.H>
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr char output_file[] = "tiny_profiler_test.out";
+
+void preactivation_phase ()
+{
+    BL_PROFILE("preactivation_outermost");
+
+    {
+        BL_PROFILE("preactivation_nested");
+    }
+
+    {
+        BL_PROFILE_REGION("preactivation_region");
+        BL_PROFILE("preactivation_region_timer");
+    }
+}
+
+void collective_activation_phase ()
+{
+    BL_PROFILE("ordinary_outermost");
+
+    {
+        BL_PROFILE("ordinary_nested");
+    }
+
+    if (amrex::ParallelDescriptor::NProcs() == 1 ||
+        amrex::ParallelDescriptor::MyProc() == 1) {
+        BL_PROFILE_GPU_SYNC("rank_one_gpu_sync");
+    }
+
+    {
+        BL_PROFILE_REGION("ordinary_region");
+        BL_PROFILE("ordinary_region_timer");
+    }
+}
+
+void macro_coverage_phase ()
+{
+    BL_PROFILE("coverage_outermost");
+
+    {
+        BL_PROFILE_GPU_SYNC("scoped_gpu_sync");
+    }
+
+    BL_PROFILE_VAR_GPU_SYNC("variable_gpu_sync", gpu_sync_var);
+    BL_PROFILE_VAR_STOP(gpu_sync_var);
+
+    BL_PROFILE_VAR_NS_GPU_SYNC("no_start_gpu_sync", no_start_gpu_sync_var);
+    BL_PROFILE_VAR_START(no_start_gpu_sync_var);
+    BL_PROFILE_VAR_STOP(no_start_gpu_sync_var);
+
+    {
+        BL_PROFILE("same_name");
+    }
+    {
+        BL_PROFILE_GPU_SYNC("same_name");
+    }
+
+    {
+        BL_PROFILE_REGION_GPU_SYNC("gpu_sync_region");
+        {
+            BL_PROFILE("ordinary_timer_in_gpu_sync_region");
+        }
+        {
+            BL_PROFILE_GPU_SYNC("gpu_sync_timer_in_gpu_sync_region");
+        }
+    }
+
+#if defined(AMREX_USE_GPU) && defined(AMREX_TINY_PROFILING)
+    amrex::Gpu::DeviceVector<int> device_value(1);
+    amrex::Gpu::PinnedVector<int> host_value(1, 0);
+    int* device_ptr = device_value.data();
+
+    {
+        BL_PROFILE_GPU_SYNC("async_gpu_work");
+        amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE (int) noexcept {
+            device_ptr[0] = 42;
+        });
+        amrex::Gpu::dtoh_memcpy_async(host_value.data(), device_ptr, sizeof(int));
+    }
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(host_value[0] == 42,
+        "BL_PROFILE_GPU_SYNC returned before work on the current GPU stream completed");
+#endif
+}
+
+std::vector<std::string> split_reports (std::string const& output)
+{
+    constexpr char marker[] = "TinyProfiler total time across processes";
+    std::vector<std::string> reports;
+    std::size_t begin = output.find(marker);
+    while (begin != std::string::npos) {
+        std::size_t const next = output.find(marker, begin + 1);
+        reports.emplace_back(output.substr(begin, next - begin));
+        begin = next;
+    }
+    return reports;
+}
+
+bool contains (std::string const& text, std::string const& value)
+{
+    return text.find(value) != std::string::npos;
+}
+
+std::vector<long> calls_in_main_table (std::string const& report, std::string const& name)
+{
+    std::size_t const region_begin = report.find("BEGIN REGION");
+    std::string const main_table = report.substr(0, region_begin);
+    std::istringstream lines(main_table);
+    std::vector<long> result;
+    for (std::string line; std::getline(lines, line); ) {
+        std::istringstream fields(line);
+        std::string row_name;
+        long calls = -1;
+        if ((fields >> row_name >> calls) && row_name == name) {
+            result.push_back(calls);
+        }
+    }
+    return result;
+}
+
+bool expect (bool condition, std::string const& message)
+{
+    if (!condition) {
+        std::cerr << "TinyProfiler test failure: " << message << '\n';
+    }
+    return condition;
+}
+
+bool validate_report ()
+{
+    std::ifstream stream(output_file);
+    std::string const output((std::istreambuf_iterator<char>(stream)),
+                             std::istreambuf_iterator<char>());
+    auto const reports = split_reports(output);
+    bool ok = expect(stream.good() || stream.eof(), "could not read profiler output") &&
+              expect(reports.size() == 3, "expected two flush reports and one final report");
+    if (reports.size() != 3) {
+        return false;
+    }
+
+    auto const& preactivation_report = reports[0];
+    auto const& activated_flush_report = reports[1];
+    auto const& final_report = reports[2];
+
+    ok = expect(contains(preactivation_report, "preactivation_nested") &&
+                contains(preactivation_report, "BEGIN REGION preactivation_region"),
+                "flush before activation did not preserve the complete report") && ok;
+
+#ifdef AMREX_USE_GPU
+    // Only rank 1 uses a synchronized macro before the flush.  Every rank must
+    // nevertheless choose the focused report collectively.
+    ok = expect(contains(activated_flush_report, "ordinary_outermost"),
+                "focused flush omitted the outermost timer") && ok;
+    ok = expect(contains(activated_flush_report, "rank_one_gpu_sync"),
+                "focused flush omitted the rank-local synchronized timer") && ok;
+    ok = expect(!contains(activated_flush_report, "ordinary_nested"),
+                "focused flush retained an ordinary nested timer") && ok;
+    ok = expect(!contains(activated_flush_report, "BEGIN REGION ordinary_region"),
+                "focused flush retained an ordinary region") && ok;
+
+    ok = expect(contains(final_report, "coverage_outermost"),
+                "focused report omitted an outermost timer") && ok;
+    ok = expect(contains(final_report, "scoped_gpu_sync") &&
+                contains(final_report, "variable_gpu_sync") &&
+                contains(final_report, "no_start_gpu_sync"),
+                "focused report omitted a synchronized timer macro") && ok;
+    ok = expect(contains(final_report, "BEGIN REGION gpu_sync_region"),
+                "focused report omitted the synchronized region") && ok;
+    ok = expect(contains(final_report, "gpu_sync_timer_in_gpu_sync_region"),
+                "synchronized region omitted its synchronized timer") && ok;
+    ok = expect(!contains(final_report, "ordinary_timer_in_gpu_sync_region"),
+                "synchronized region retained an ordinary nested timer") && ok;
+
+    auto const same_name_calls = calls_in_main_table(final_report, "same_name");
+    ok = expect(same_name_calls.size() == 2 && same_name_calls[0] == 1 &&
+                same_name_calls[1] == 1,
+                "ordinary samples contaminated the identically named synchronized timer") && ok;
+#else
+    // On CPU, every new macro is an exact alias for its ordinary counterpart.
+    ok = expect(contains(activated_flush_report, "ordinary_nested") &&
+                contains(activated_flush_report, "BEGIN REGION ordinary_region"),
+                "CPU synchronized aliases changed ordinary TinyProfiler output") && ok;
+    ok = expect(contains(final_report, "ordinary_timer_in_gpu_sync_region") &&
+                contains(final_report, "BEGIN REGION gpu_sync_region"),
+                "CPU synchronized region alias changed ordinary region output") && ok;
+
+    auto const same_name_calls = calls_in_main_table(final_report, "same_name");
+    ok = expect(same_name_calls.size() == 2 && same_name_calls[0] == 2 &&
+                same_name_calls[1] == 2,
+                "CPU synchronized timer alias did not aggregate like an ordinary timer") && ok;
+#endif
+
+    return ok;
+}
+
+}
+
+int main (int argc, char* argv[])
+{
+#ifdef AMREX_USE_MPI
+    MPI_Init(&argc, &argv);
+#endif
+
+    amrex::Initialize(argc, argv);
+
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+        std::remove(output_file);
+    }
+    amrex::ParallelDescriptor::Barrier();
+
+    preactivation_phase();
+    BL_PROFILE_TINY_FLUSH();
+    collective_activation_phase();
+    BL_PROFILE_TINY_FLUSH();
+    macro_coverage_phase();
+
+    bool const io_processor = amrex::ParallelDescriptor::IOProcessor();
+    amrex::Finalize();
+
+    int result = 0;
+#ifdef AMREX_TINY_PROFILING
+    if (io_processor && !validate_report()) {
+        result = 1;
+    }
+#endif
+
+#ifdef AMREX_USE_MPI
+    MPI_Finalize();
+#endif
+    return result;
+}


### PR DESCRIPTION
Adds opt-in GPU-synchronized TinyProfiler timer and region macros. On GPU builds, they synchronize the current AMReX stream at timer boundaries and activate a focused report containing synchronized timers, synchronized regions, and the outermost active timer.