### PR TITLE
Add asynchronous GPU TinyProfiler markers

### DIFF
--- a/Docs/sphinx_documentation/source/AMReX_Profiling_Tools.rst
+++ b/Docs/sphinx_documentation/source/AMReX_Profiling_Tools.rst
@@ -429,6 +429,41 @@ is isolated in its own group.
 Any timers inside :cpp:`MyFunc_0` and :cpp:`MyFunc_1` are not included in the
 region groupings.
 
+Asynchronous GPU timers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+GPU kernels normally launch asynchronously, so an ordinary TinyProfiler timer
+can stop before the GPU work launched in its scope has completed.  TinyProfiler
+provides opt-in asynchronous variants for scopes whose measurements should be
+reported as potentially inaccurate:
+
+* :cpp:`BL_PROFILE_ASYNC(name)`
+* :cpp:`BL_PROFILE_VAR_ASYNC(name, variable)`
+* :cpp:`BL_PROFILE_VAR_NS_ASYNC(name, variable)`
+* :cpp:`BL_PROFILE_REGION_ASYNC(name)`
+
+Variables created with :cpp:`BL_PROFILE_VAR_NS_ASYNC` are controlled with the
+ordinary :cpp:`BL_PROFILE_VAR_START` and :cpp:`BL_PROFILE_VAR_STOP` macros.
+These macros do not add a GPU synchronization.  On GPU TinyProfiler builds,
+each affected duration and percentage is followed by ``?``; names and call
+counts are unchanged.  A warning below the report explains that the marked
+values may be inaccurate.  Ordinary and asynchronous timers with the same name
+remain separate rows.
+
+Every timing value in a table created by :cpp:`BL_PROFILE_REGION_ASYNC` is
+marked, including values from ordinary timers nested in that region.  Those
+ordinary timers remain unmarked in the main table.  Set
+``tiny_profiler.show_async_gpu_timers=false`` to omit asynchronous timer rows
+from the main and ordinary-region tables and to omit asynchronous-region tables
+entirely.  Ordinary timers and regions with the same displayed names remain
+visible.
+
+The runtime parameter ``tiny_profiler.device_synchronize_around_region`` still
+synchronizes every TinyProfiler timer boundary.  Asynchronous macros remain
+conservatively marked when that global option is enabled.  On CPU TinyProfiler
+builds and with the legacy full profiler, asynchronous macros are aliases for
+their ordinary counterparts and produce no markers.
+
 Instrumenting Fortran90 Code
 ============================
 

--- a/Docs/sphinx_documentation/source/GPU.rst
+++ b/Docs/sphinx_documentation/source/GPU.rst
@@ -2079,12 +2079,11 @@ on the GPU and an efficient way to time and retrieve that information is
 being explored. In the meantime, AMReX's timers can be used to report some
 generic timers that are useful in categorizing an application.
 
-Due to the asynchronous launching of GPU kernels, any AMReX timers inside of
-asynchronous regions or inside GPU kernels will not measure useful
-information.  However, since the :cpp:`MFIter` synchronizes when being
-destroyed, any timer wrapped around an :cpp:`MFIter` loop will yield a
-consistent timing of the entire set of GPU launches contained within. For
-example:
+Due to the asynchronous launching of GPU kernels, an AMReX timer can stop
+before work launched inside it has completed.  However, since the
+:cpp:`MFIter` synchronizes when being destroyed, any timer wrapped around an
+:cpp:`MFIter` loop will yield a consistent timing of the entire set of GPU
+launches contained within. For example:
 
 .. highlight:: cpp
 
@@ -2099,6 +2098,22 @@ example:
 
 For now, this is the best way to profile GPU codes using ``TinyProfiler``.
 If you require further profiling detail, use ``nvprof``.
+
+TinyProfiler also provides :cpp:`BL_PROFILE_ASYNC`,
+:cpp:`BL_PROFILE_VAR_ASYNC`, :cpp:`BL_PROFILE_VAR_NS_ASYNC`, and
+:cpp:`BL_PROFILE_REGION_ASYNC` for scopes that intentionally avoid added
+synchronization.  Their timing and percentage values are followed by ``?`` to
+make the possible inaccuracy visible.  Asynchronous region tables mark all
+their timing results, including ordinary timers nested within them; the nested
+ordinary timers remain unmarked in the main table.  Set
+``tiny_profiler.show_async_gpu_timers=false`` to hide asynchronous timer rows
+and asynchronous region tables.
+
+The asynchronous macros do not synchronize the GPU.  The existing
+``tiny_profiler.device_synchronize_around_region`` option can still synchronize
+all TinyProfiler timer boundaries, but asynchronous timers remain marked even
+when it is enabled.  See :ref:`sec:tiny:profiling` for the complete reporting
+behavior.
 
 
 Performance Tips

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -1608,6 +1608,18 @@ enabled.
   which are unnecessary for correctness, could potentially degrade the
   performance.
 
+.. py:data:: tiny_profiler.show_async_gpu_timers
+  :type: bool
+  :value: true
+
+  This parameter controls output from asynchronous TinyProfiler macros on GPU
+  builds.  When true, asynchronous timing and percentage values are followed
+  by ``?`` and the report includes a warning that they may be inaccurate.
+  When false, asynchronous timer rows are omitted from the main table and from
+  ordinary region tables, and asynchronous region tables are omitted entirely.
+  Ordinary timers and regions with the same displayed names remain visible.
+  This option does not add synchronization or change collected timings.
+
 .. py:data:: tiny_profiler.enabled
    :type: bool
    :value: true

--- a/Src/Base/AMReX_BLProfiler.H
+++ b/Src/Base/AMReX_BLProfiler.H
@@ -414,12 +414,17 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_PROFILE_VAR_START(vname) bl_profiler_##vname.start();
 #define BL_PROFILE_VAR_STOP(vname) bl_profiler_##vname.stop();
 
+#define BL_PROFILE_ASYNC(fname) BL_PROFILE(fname)
+#define BL_PROFILE_VAR_ASYNC(fname, vname) BL_PROFILE_VAR(fname, vname)
+#define BL_PROFILE_VAR_NS_ASYNC(fname, vname) BL_PROFILE_VAR_NS(fname, vname)
+
 #define BL_PROFILE_INIT_PARAMS(ptl,wall,wfabs)  \
     amrex::BLProfiler::InitParams(ptl,wall, wfabs);
 #define BL_PROFILE_ADD_STEP(snum)  amrex::BLProfiler::AddStep(snum);
 #define BL_PROFILE_SET_RUN_TIME(rtime)  amrex::BLProfiler::SetRunTime(rtime);
 
 #define BL_PROFILE_REGION(rname) amrex::BLProfileRegion bl_profile_region_##vname((rname));
+#define BL_PROFILE_REGION_ASYNC(rname) BL_PROFILE_REGION(rname)
 
 #define BL_PROFILE_REGION_START(rname) amrex::BLProfiler::RegionStart(rname);
 #define BL_PROFILE_REGION_STOP(rname)  amrex::BLProfiler::RegionStop(rname);
@@ -501,10 +506,29 @@ inline std::string BLProfiler::CommStats::CFTToString(CommFuncType cft) {
 #define BL_PROFILE_VAR_NS(fname, vname)                   amrex::TinyProfiler tiny_profiler_##vname(fname, false)
 #define BL_PROFILE_VAR_START(vname)                       tiny_profiler_##vname.start()
 #define BL_PROFILE_VAR_STOP(vname)                        tiny_profiler_##vname.stop()
+#ifdef AMREX_USE_GPU
+#define BL_PROFILE_ASYNC(fname)                           \
+    AMREX_WARNING_PUSH_COUNTER                            \
+    BL_PROFILE_ASYNC_IMPL(fname, __COUNTER__)             \
+    AMREX_WARNING_POP
+#define BL_PROFILE_ASYNC_IMPL(funame, counter) amrex::TinyProfiler BL_PROFILE_PASTE(tiny_profiler_, counter)((funame), true, true); \
+    amrex::ignore_unused(BL_PROFILE_PASTE(tiny_profiler_, counter));
+#define BL_PROFILE_VAR_ASYNC(fname, vname)                amrex::TinyProfiler tiny_profiler_##vname((fname), true, true)
+#define BL_PROFILE_VAR_NS_ASYNC(fname, vname)             amrex::TinyProfiler tiny_profiler_##vname((fname), false, true)
+#else
+#define BL_PROFILE_ASYNC(fname)                           BL_PROFILE(fname)
+#define BL_PROFILE_VAR_ASYNC(fname, vname)                BL_PROFILE_VAR(fname, vname)
+#define BL_PROFILE_VAR_NS_ASYNC(fname, vname)             BL_PROFILE_VAR_NS(fname, vname)
+#endif
 #define BL_PROFILE_INIT_PARAMS(ptl,wall,wfabs)
 #define BL_PROFILE_ADD_STEP(snum)
 #define BL_PROFILE_SET_RUN_TIME(rtime)
 #define BL_PROFILE_REGION(rname)          amrex::TinyProfileRegion tiny_profile_region_##vname((rname))
+#ifdef AMREX_USE_GPU
+#define BL_PROFILE_REGION_ASYNC(rname)    amrex::TinyProfileRegion tiny_profile_region_async_##vname((rname), true)
+#else
+#define BL_PROFILE_REGION_ASYNC(rname)    BL_PROFILE_REGION(rname)
+#endif
 #define BL_PROFILE_REGION_START(rname)
 #define BL_PROFILE_REGION_STOP(rname)
 //#define BL_PROFILE_REGION_START(rname)    amrex::TinyProfiler::StartRegion(rname)
@@ -566,10 +590,14 @@ class BLProfiler
 #define BL_PROFILE_VAR_NS(fname, vname)
 #define BL_PROFILE_VAR_START(vname)
 #define BL_PROFILE_VAR_STOP(vname)
+#define BL_PROFILE_ASYNC(fname)
+#define BL_PROFILE_VAR_ASYNC(fname, vname)
+#define BL_PROFILE_VAR_NS_ASYNC(fname, vname)
 #define BL_PROFILE_INIT_PARAMS(ptl,wall,wfabs)
 #define BL_PROFILE_ADD_STEP(snum)
 #define BL_PROFILE_SET_RUN_TIME(rtime)
 #define BL_PROFILE_REGION(rname)
+#define BL_PROFILE_REGION_ASYNC(rname)
 #define BL_PROFILE_REGION_START(rname)
 #define BL_PROFILE_REGION_STOP(rname)
 #define BL_PROFILE_REGION_VAR(fname, rvname)

--- a/Src/Base/AMReX_TinyProfiler.H
+++ b/Src/Base/AMReX_TinyProfiler.H
@@ -32,8 +32,10 @@ class TinyProfiler
 public:
     explicit TinyProfiler (std::string funcname) noexcept;
     TinyProfiler (std::string funcname, bool start_) noexcept;
+    TinyProfiler (std::string funcname, bool start_, bool async_gpu_) noexcept;
     explicit TinyProfiler (const char* funcname) noexcept;
     TinyProfiler (const char* funcname, bool start_) noexcept;
+    TinyProfiler (const char* funcname, bool start_, bool async_gpu_) noexcept;
     ~TinyProfiler ();
 
     TinyProfiler (TinyProfiler const&) = delete;
@@ -63,7 +65,9 @@ public:
     static void DeregisterArena (std::map<std::string, MemStat>& memstats) noexcept;
 
     static void StartRegion (std::string regname) noexcept;
+    static void StartRegion (std::string regname, bool async_gpu) noexcept;
     static void StopRegion (const std::string& regname) noexcept;
+    static void StopRegion (const std::string& regname, bool async_gpu) noexcept;
 
     static void PrintCallStack (std::ostream& os);
     static void PrintMemoryUsage (std::ostream* os, bool only_local) noexcept;
@@ -78,6 +82,36 @@ private:
         double dtex{0.0};    //!< exclusive dt
     };
 
+    struct TimerKey
+    {
+        std::string name;
+        bool async_gpu = false;
+
+        bool operator< (TimerKey const& rhs) const noexcept
+        {
+            return std::tie(name, async_gpu) < std::tie(rhs.name, rhs.async_gpu);
+        }
+    };
+
+    struct RegionKey
+    {
+        std::string name;
+        bool async_gpu = false;
+
+        bool operator< (RegionKey const& rhs) const noexcept
+        {
+            return std::tie(name, async_gpu) < std::tie(rhs.name, rhs.async_gpu);
+        }
+
+        bool operator== (RegionKey const& rhs) const noexcept
+        {
+            return name == rhs.name && async_gpu == rhs.async_gpu;
+        }
+    };
+
+    using RegionStats = std::map<TimerKey, Stats>;
+    using StatsMap = std::map<RegionKey, RegionStats>;
+
     //! stats across processes
     struct ProcStats
     {
@@ -88,6 +122,7 @@ private:
         double dtinavg{0.0}, dtinmax{0.0};
         double dtexmin{std::numeric_limits<double>::max()};
         double dtexavg{0.0}, dtexmax{0.0};
+        bool async_gpu{false};
         bool do_print{true};
         std::string fname;
         static bool compex (const ProcStats& lhs, const ProcStats& rhs) {
@@ -116,6 +151,7 @@ private:
     };
 
     std::string fname;
+    bool async_gpu = false;
     bool in_parallel_region = false;
     int global_depth = -1;
     std::vector<Stats*> stats;
@@ -133,10 +169,10 @@ private:
     static std::vector<std::map<std::string, MemStat>*> all_memstats;
     static std::vector<std::string> all_memnames;
 
-    static std::vector<std::string> regionstack;
-    static std::vector<std::pair<std::string,bool> > regionstartstack;
+    static std::vector<RegionKey> regionstack;
+    static std::vector<std::pair<RegionKey,bool> > regionstartstack;
     static std::deque<std::tuple<double,double,std::string*> > ttstack;
-    static std::map<std::string,std::map<std::string, Stats> > statsmap;
+    static StatsMap statsmap;
     static double t_init;
     static double t_memory_init;
     static bool device_synchronize_around_region;
@@ -145,11 +181,13 @@ private:
     static double print_threshold;
     static bool enabled;
     static bool memprof_enabled;
+    static bool show_async_gpu_timers;
     static std::string output_file;
 
     static std::string const& get_output_file ();
-    static void PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
-                            std::ostream* os);
+    static bool PrintStats (RegionStats& regstats, double dt_max,
+                            std::ostream* os, bool mark_all_async);
+    static void SyncTimerKeys (RegionStats& regstats);
     static void PrintMemStats (std::map<std::string, MemStat>& memstats,
                                std::string const& memname, double dt_max,
                                double t_final, std::ostream* os, bool only_local);
@@ -160,6 +198,8 @@ class TinyProfileRegion
 public:
     explicit TinyProfileRegion (std::string a_regname) noexcept;
     explicit TinyProfileRegion (const char* a_regname) noexcept;
+    TinyProfileRegion (std::string a_regname, bool async_gpu) noexcept;
+    TinyProfileRegion (const char* a_regname, bool async_gpu) noexcept;
     TinyProfileRegion (TinyProfileRegion const&) = delete;
     TinyProfileRegion (TinyProfileRegion &&) = delete;
     TinyProfileRegion& operator= (TinyProfileRegion const&) = delete;
@@ -167,6 +207,7 @@ public:
     ~TinyProfileRegion ();
 private:
     std::string regname;
+    bool async_gpu = false;
     TinyProfiler tprof;
 };
 

--- a/Src/Base/AMReX_TinyProfiler.cpp
+++ b/Src/Base/AMReX_TinyProfiler.cpp
@@ -1,5 +1,4 @@
-// We only support BL_PROFILE, BL_PROFILE_VAR, BL_PROFILE_VAR_STOP, BL_PROFILE_VAR_START,
-// BL_PROFILE_VAR_NS, and BL_PROFILE_REGION.
+// TinyProfiler implementation for the BL_PROFILE family of macros.
 
 #include <AMReX_TinyProfiler.H>
 #include <AMReX_ParallelDescriptor.H>
@@ -46,10 +45,10 @@ std::vector<TinyProfiler::aligned_deque> TinyProfiler::mem_stack_thread_private;
 std::vector<std::map<std::string, MemStat>*> TinyProfiler::all_memstats;
 std::vector<std::string> TinyProfiler::all_memnames;
 
-std::vector<std::string>          TinyProfiler::regionstack;
-std::vector<std::pair<std::string,bool> > TinyProfiler::regionstartstack;
+std::vector<TinyProfiler::RegionKey> TinyProfiler::regionstack;
+std::vector<std::pair<TinyProfiler::RegionKey,bool> > TinyProfiler::regionstartstack;
 std::deque<std::tuple<double,double,std::string*> > TinyProfiler::ttstack;
-std::map<std::string,std::map<std::string, TinyProfiler::Stats> > TinyProfiler::statsmap;
+TinyProfiler::StatsMap TinyProfiler::statsmap;
 double TinyProfiler::t_init = std::numeric_limits<double>::max();
 double TinyProfiler::t_memory_init = std::numeric_limits<double>::max();
 bool TinyProfiler::device_synchronize_around_region = false;
@@ -58,6 +57,7 @@ int TinyProfiler::verbose = 0;
 double TinyProfiler::print_threshold = 1.;
 bool TinyProfiler::enabled = true;
 bool TinyProfiler::memprof_enabled = true;
+bool TinyProfiler::show_async_gpu_timers = true;
 std::string TinyProfiler::output_file{"stdout"};
 
 namespace {
@@ -111,6 +111,12 @@ TinyProfiler::TinyProfiler (std::string funcname, bool start_) noexcept
     if (start_) { start(); }
 }
 
+TinyProfiler::TinyProfiler (std::string funcname, bool start_, bool async_gpu_) noexcept
+    : fname(std::move(funcname)), async_gpu(async_gpu_)
+{
+    if (start_) { start(); }
+}
+
 TinyProfiler::TinyProfiler (const char* funcname) noexcept
     : fname(funcname)
 {
@@ -119,6 +125,12 @@ TinyProfiler::TinyProfiler (const char* funcname) noexcept
 
 TinyProfiler::TinyProfiler (const char* funcname, bool start_) noexcept
     : fname(funcname)
+{
+    if (start_) { start(); }
+}
+
+TinyProfiler::TinyProfiler (const char* funcname, bool start_, bool async_gpu_) noexcept
+    : fname(funcname), async_gpu(async_gpu_)
 {
     if (start_) { start(); }
 }
@@ -169,9 +181,10 @@ TinyProfiler::start ()
         roctxRangePush(fname.c_str());
 #endif
 
+        TimerKey const key{fname, async_gpu};
         for (auto const& region : regionstack)
         {
-            Stats& st = statsmap[region][fname];
+            Stats& st = statsmap[region][key];
             ++st.depth;
             stats.push_back(&st);
         }
@@ -359,6 +372,7 @@ TinyProfiler::Initialize ()
         pp.queryAdd("print_threshold", print_threshold);
 
         pp.queryAdd("enabled", enabled);
+        pp.queryAdd("show_async_gpu_timers", show_async_gpu_timers);
     }
 
     // Re-arm the output-file read for this cycle and reset the cached value, so
@@ -369,7 +383,7 @@ TinyProfiler::Initialize ()
 
     if (!enabled) { return; }
 
-    regionstack.emplace_back(mainregion);
+    regionstack.push_back(RegionKey{mainregion, false});
     t_init = amrex::second();
 
     finalized = false;
@@ -411,7 +425,7 @@ TinyProfiler::Finalize (bool bFlushing)
 
     double t_final = amrex::second();
 
-    // make a local copy so that any functions call after this will not be recorded in the local copy.
+    // Make a local copy so that timers completed during output are not included.
     auto lstatsmap = statsmap;
 
     int nprocs = ParallelDescriptor::NProcs();
@@ -446,32 +460,52 @@ TinyProfiler::Finalize (bool bFlushing)
         Vector<std::string> localRegions, syncedRegions;
         bool alreadySynced;
 
-        for (auto const& kv : lstatsmap) {
-            localRegions.push_back(kv.first);
-        }
+        for (bool const async_key : {false, true}) {
+            localRegions.clear();
+            syncedRegions.clear();
+            for (auto const& kv : lstatsmap) {
+                if (kv.first.async_gpu == async_key) {
+                    localRegions.push_back(kv.first.name);
+                }
+            }
 
-        amrex::SyncStrings(localRegions, syncedRegions, alreadySynced);
+            amrex::SyncStrings(localRegions, syncedRegions, alreadySynced);
 
-        if (!alreadySynced) {
-            for (auto const& s : syncedRegions) {
-                if (!lstatsmap.contains(s)) {
-                    lstatsmap.insert(std::make_pair(s,std::map<std::string,Stats>()));
+            if (!alreadySynced) {
+                for (auto const& s : syncedRegions) {
+                    RegionKey const key{s, async_key};
+                    if (!lstatsmap.contains(key)) {
+                        lstatsmap.insert(std::make_pair(key,RegionStats()));
+                    }
                 }
             }
         }
     }
 
-    PrintStats(lstatsmap[mainregion], dt_max, os);
     for (auto& kv : lstatsmap) {
-        if (kv.first != mainregion) {
+        SyncTimerKeys(kv.second);
+    }
+
+    bool has_marked_results = PrintStats(lstatsmap[RegionKey{mainregion, false}],
+                                         dt_max, os, false);
+    RegionKey const main_key{mainregion, false};
+    for (auto& kv : lstatsmap) {
+        if (!(kv.first == main_key) &&
+            (show_async_gpu_timers || !kv.first.async_gpu)) {
             if (os) {
-                *os << "\n\nBEGIN REGION " << kv.first << "\n";
+                *os << "\n\nBEGIN REGION " << kv.first.name << "\n";
             }
-            PrintStats(kv.second, dt_max, os);
+            has_marked_results = PrintStats(kv.second, dt_max, os,
+                                            kv.first.async_gpu) || has_marked_results;
             if (os) {
-                *os << "END REGION " << kv.first << "\n";
+                *os << "END REGION " << kv.first.name << "\n";
             }
         }
+    }
+
+    if (os && has_marked_results) {
+        *os << "TinyProfiler warning: values marked with ? are asynchronous GPU timings "
+               "and may be inaccurate.\n";
     }
 
     if (!bFlushing) {
@@ -538,30 +572,41 @@ TinyProfiler::DeregisterArena (std::map<std::string, MemStat>& memstats) noexcep
 }
 
 void
-TinyProfiler::PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
-                          std::ostream* os)
+TinyProfiler::SyncTimerKeys (RegionStats& regstats)
 {
-    // make sure the set of profiled functions is the same on all processes
-    {
+    // Make sure ordinary and asynchronous timer keys are the same on all processes.
+    for (bool const async_key : {false, true}) {
         Vector<std::string> localStrings, syncedStrings;
         bool alreadySynced;
 
-        for(auto const& kv : regstats) {
-            localStrings.push_back(kv.first);
+        for (auto const& kv : regstats) {
+            if (kv.first.async_gpu == async_key) {
+                localStrings.push_back(kv.first.name);
+            }
         }
 
         amrex::SyncStrings(localStrings, syncedStrings, alreadySynced);
 
-        if (! alreadySynced) {  // add the new name
+        if (!alreadySynced) {
             for (auto const& s : syncedStrings) {
-                if (!regstats.contains(s)) {
-                    regstats.insert(std::make_pair(s, Stats()));
+                TimerKey const key{s, async_key};
+                if (!regstats.contains(key)) {
+                    regstats.insert(std::make_pair(key, Stats()));
                 }
             }
         }
     }
+}
 
-    if (regstats.empty()) { return; }
+bool
+TinyProfiler::PrintStats (RegionStats& regstats, double dt_max,
+                          std::ostream* os, bool mark_all_async)
+{
+    if (!show_async_gpu_timers) {
+        std::erase_if(regstats, [] (auto const& item) { return item.first.async_gpu; });
+    }
+
+    if (regstats.empty()) { return false; }
 
     int nprocs = ParallelDescriptor::NProcs();
     int ioproc = ParallelDescriptor::IOProcessorNumber();
@@ -606,7 +651,8 @@ TinyProfiler::PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
             pst.navg /= nprocs;
             pst.dtinavg /= nprocs;
             pst.dtexavg /= nprocs;
-            pst.fname = regstat.first;
+            pst.async_gpu = mark_all_async || regstat.first.async_gpu;
+            pst.fname = regstat.first.name;
             allprocstats.push_back(pst);
             maxfnamelen = std::max(maxfnamelen, int(pst.fname.size()));
             maxncalls = std::max(maxncalls, pst.nmax);
@@ -662,6 +708,8 @@ TinyProfiler::PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
                     other_procstat.dtexmin += allprocstats[i].dtexmin;
                     other_procstat.dtexavg += allprocstats[i].dtexavg;
                     other_procstat.dtexmax += allprocstats[i].dtexmax;
+                    other_procstat.async_gpu = other_procstat.async_gpu ||
+                                               allprocstats[i].async_gpu;
                 } else {
                     break;
                 }
@@ -697,15 +745,21 @@ TinyProfiler::PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
             if (!allprocstat.do_print) {
                 continue;
             }
+            int const marker_width = allprocstat.async_gpu ? 1 : 0;
             *os << std::setprecision(4) << std::left
                 << std::setw(maxfnamelen) << allprocstat.fname
                 << std::right
                 << std::setw(wnc+2) << allprocstat.navg
-                << std::setw(wt+2) << allprocstat.dtexmin
-                << std::setw(wt+2) << allprocstat.dtexavg
-                << std::setw(wt+2) << allprocstat.dtexmax
-                << std::setprecision(2) << std::setw(wp+1) << std::fixed
-                << allprocstat.dtexmax*(100.0/dt_max) << "%";
+                << std::setw(wt+2-marker_width) << allprocstat.dtexmin;
+            if (allprocstat.async_gpu) { *os << '?'; }
+            *os << std::setw(wt+2-marker_width) << allprocstat.dtexavg;
+            if (allprocstat.async_gpu) { *os << '?'; }
+            *os << std::setw(wt+2-marker_width) << allprocstat.dtexmax;
+            if (allprocstat.async_gpu) { *os << '?'; }
+            *os << std::setprecision(2) << std::setw(wp+1-marker_width) << std::fixed
+                << allprocstat.dtexmax*(100.0/dt_max);
+            if (allprocstat.async_gpu) { *os << '?'; }
+            *os << "%";
             os->unsetf(std::ios_base::fixed);
             *os << "\n";
         }
@@ -735,20 +789,29 @@ TinyProfiler::PrintStats (std::map<std::string,Stats>& regstats, double dt_max,
             if (!allprocstat.do_print) {
                 continue;
             }
+            int const marker_width = allprocstat.async_gpu ? 1 : 0;
             *os << std::setprecision(4) << std::left
                 << std::setw(maxfnamelen) << allprocstat.fname
                 << std::right
                 << std::setw(wnc+2) << allprocstat.navg
-                << std::setw(wt+2) << allprocstat.dtinmin
-                << std::setw(wt+2) << allprocstat.dtinavg
-                << std::setw(wt+2) << allprocstat.dtinmax
-                << std::setprecision(2) << std::setw(wp+1) << std::fixed
-                << allprocstat.dtinmax*(100.0/dt_max) << "%";
+                << std::setw(wt+2-marker_width) << allprocstat.dtinmin;
+            if (allprocstat.async_gpu) { *os << '?'; }
+            *os << std::setw(wt+2-marker_width) << allprocstat.dtinavg;
+            if (allprocstat.async_gpu) { *os << '?'; }
+            *os << std::setw(wt+2-marker_width) << allprocstat.dtinmax;
+            if (allprocstat.async_gpu) { *os << '?'; }
+            *os << std::setprecision(2) << std::setw(wp+1-marker_width) << std::fixed
+                << allprocstat.dtinmax*(100.0/dt_max);
+            if (allprocstat.async_gpu) { *os << '?'; }
+            *os << "%";
             os->unsetf(std::ios_base::fixed);
             *os << "\n";
         }
         *os << hline << "\n\n";
     }
+
+    return mark_all_async || std::ranges::any_of(regstats,
+        [] (auto const& item) { return item.first.async_gpu; });
 }
 
 void
@@ -973,24 +1036,38 @@ TinyProfiler::PrintMemStats (std::map<std::string, MemStat>& memstats,
 void
 TinyProfiler::StartRegion (std::string regname) noexcept
 {
+    StartRegion(std::move(regname), false);
+}
+
+void
+TinyProfiler::StartRegion (std::string regname, bool async_gpu) noexcept
+{
     if (!enabled) { return; }
 
     bool pushed = false;
-    if (std::ranges::find(regionstack, regname) == regionstack.end()) {
-        regionstack.emplace_back(regname);
+    RegionKey key{std::move(regname), async_gpu};
+    if (std::ranges::find(regionstack, key) == regionstack.end()) {
+        regionstack.push_back(key);
         pushed = true;
     }
-    regionstartstack.emplace_back(std::move(regname), pushed);
+    regionstartstack.emplace_back(std::move(key), pushed);
 }
 
 void
 TinyProfiler::StopRegion (const std::string& regname) noexcept
 {
+    StopRegion(regname, false);
+}
+
+void
+TinyProfiler::StopRegion (const std::string& regname, bool async_gpu) noexcept
+{
     if (!enabled) { return; }
 
-    if (!regionstartstack.empty() && regname == regionstartstack.back().first) {
+    RegionKey const key{regname, async_gpu};
+    if (!regionstartstack.empty() && key == regionstartstack.back().first) {
         if (regionstartstack.back().second) {
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!regionstack.empty() && regname == regionstack.back(),
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!regionstack.empty() && key == regionstack.back(),
                 "TinyProfiler regions must be nested with respect to each other");
             regionstack.pop_back();
         }
@@ -1014,10 +1091,26 @@ TinyProfileRegion::TinyProfileRegion (const char* a_regname) noexcept
     tprof.start();
 }
 
+TinyProfileRegion::TinyProfileRegion (std::string a_regname, bool async_gpu_) noexcept
+    : regname(std::move(a_regname)), async_gpu(async_gpu_),
+      tprof(std::string("REG::")+regname, false, async_gpu_)
+{
+    TinyProfiler::StartRegion(regname, async_gpu);
+    tprof.start();
+}
+
+TinyProfileRegion::TinyProfileRegion (const char* a_regname, bool async_gpu_) noexcept
+    : regname(a_regname), async_gpu(async_gpu_),
+      tprof(std::string("REG::")+std::string(a_regname), false, async_gpu_)
+{
+    TinyProfiler::StartRegion(a_regname, async_gpu);
+    tprof.start();
+}
+
 TinyProfileRegion::~TinyProfileRegion ()
 {
     tprof.stop();
-    TinyProfiler::StopRegion(regname);
+    TinyProfiler::StopRegion(regname, async_gpu);
 }
 
 void

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -108,6 +108,7 @@ if (AMReX_TEST_TYPE STREQUAL "Small")
    add_subdirectory("Base/Random")
    add_subdirectory("Base/RealBox")
    add_subdirectory("Base/CompensatedSum")
+   add_subdirectory("Profiling")
 
    add_subdirectory("Amr/Advection_AmrCore")
 
@@ -137,7 +138,7 @@ else()
    #
    set( AMREX_TESTS_SUBDIRS Amr ArrayND AsyncOut Base CallNoinline CommType CTOParFor DeviceGlobal
                             Enum GpuParallelReduce HeatEquation MultiBlock MultiPeriod ParmParse Parser Parser2
-                            ParserUserFn Reducer ReduceToPlaneGuards ReduceToPlanePatchy Reinit RoundoffDomain SIMD
+                            ParserUserFn Profiling Reducer ReduceToPlaneGuards ReduceToPlanePatchy Reinit RoundoffDomain SIMD
                             SmallMatrix StochasticHeatEquation SumBoundary TOML)
 
    if (AMReX_PARTICLES)

--- a/Tests/Profiling/CMakeLists.txt
+++ b/Tests/Profiling/CMakeLists.txt
@@ -1,0 +1,44 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    set(_sources main.cpp)
+    set(_input_files inputs inputs_hide_async inputs_other)
+
+    setup_test(${D} _sources _input_files BASE_NAME TinyProfilerAsync)
+
+    set(_exe_dir ${CMAKE_CURRENT_BINARY_DIR}/${D}d)
+    set(_exe_name Test_TinyProfilerAsync_${D}d)
+    set(_hidden_test TinyProfilerAsyncHidden_${D}d)
+    set(_other_test TinyProfilerAsyncOther_${D}d)
+
+    if (AMReX_OMP)
+        add_test(NAME ${_hidden_test}
+                 COMMAND ${_exe_dir}/${_exe_name} inputs_hide_async
+                 WORKING_DIRECTORY ${_exe_dir})
+        set_tests_properties(${_hidden_test} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=2)
+    elseif (AMReX_MPI)
+        add_test(NAME ${_hidden_test}
+                 COMMAND mpiexec -n 2 ${_exe_dir}/${_exe_name} inputs_hide_async
+                 WORKING_DIRECTORY ${_exe_dir})
+    else ()
+        add_test(NAME ${_hidden_test}
+                 COMMAND ${_exe_dir}/${_exe_name} inputs_hide_async
+                 WORKING_DIRECTORY ${_exe_dir})
+    endif ()
+
+    if (AMReX_OMP)
+        add_test(NAME ${_other_test}
+                 COMMAND ${_exe_dir}/${_exe_name} inputs_other
+                 WORKING_DIRECTORY ${_exe_dir})
+        set_tests_properties(${_other_test} PROPERTIES ENVIRONMENT OMP_NUM_THREADS=2)
+    elseif (AMReX_MPI)
+        add_test(NAME ${_other_test}
+                 COMMAND mpiexec -n 2 ${_exe_dir}/${_exe_name} inputs_other
+                 WORKING_DIRECTORY ${_exe_dir})
+    else ()
+        add_test(NAME ${_other_test}
+                 COMMAND ${_exe_dir}/${_exe_name} inputs_other
+                 WORKING_DIRECTORY ${_exe_dir})
+    endif ()
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/Profiling/inputs
+++ b/Tests/Profiling/inputs
@@ -1,0 +1,7 @@
+amrex.signal_handling = 0
+amrex.throw_exception = 1
+amrex.verbose = 0
+tiny_profiler.output_file = tiny_profiler_async_default.out
+tiny_profiler.print_threshold = 0
+tiny_profiler.device_synchronize_around_region = true
+test.hide_async = false

--- a/Tests/Profiling/inputs_hide_async
+++ b/Tests/Profiling/inputs_hide_async
@@ -1,0 +1,7 @@
+amrex.signal_handling = 0
+amrex.throw_exception = 1
+amrex.verbose = 0
+tiny_profiler.output_file = tiny_profiler_async_hidden.out
+tiny_profiler.print_threshold = 0
+tiny_profiler.show_async_gpu_timers = false
+test.hide_async = true

--- a/Tests/Profiling/inputs_other
+++ b/Tests/Profiling/inputs_other
@@ -1,0 +1,7 @@
+amrex.signal_handling = 0
+amrex.throw_exception = 1
+amrex.verbose = 0
+tiny_profiler.output_file = tiny_profiler_async_other.out
+tiny_profiler.print_threshold = 1.0e9
+test.hide_async = false
+test.expect_other = true

--- a/Tests/Profiling/main.cpp
+++ b/Tests/Profiling/main.cpp
@@ -1,0 +1,362 @@
+#include <AMReX.H>
+#include <AMReX_BLProfiler.H>
+#include <AMReX_ParmParse.H>
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr char warning[] =
+    "TinyProfiler warning: values marked with ? are asynchronous GPU timings and may be inaccurate.";
+
+void generate_profile ()
+{
+    {
+        BL_PROFILE("ordinary_only");
+    }
+    {
+        BL_PROFILE_ASYNC("async_scoped");
+    }
+
+    BL_PROFILE_VAR_ASYNC("async_variable", async_variable);
+    BL_PROFILE_VAR_STOP(async_variable);
+
+    BL_PROFILE_VAR_NS_ASYNC("async_no_start", async_no_start);
+    BL_PROFILE_VAR_START(async_no_start);
+    BL_PROFILE_VAR_STOP(async_no_start);
+
+    {
+        BL_PROFILE("same_name");
+    }
+    {
+        BL_PROFILE_ASYNC("same_name");
+    }
+
+    if (amrex::ParallelDescriptor::NProcs() == 1 ||
+        amrex::ParallelDescriptor::MyProc() == 1) {
+        BL_PROFILE_ASYNC("rank_local_async");
+    }
+
+    {
+        BL_PROFILE_REGION("ordinary_region");
+        {
+            BL_PROFILE("ordinary_in_ordinary_region");
+        }
+        {
+            BL_PROFILE_ASYNC("async_in_ordinary_region");
+        }
+    }
+
+    {
+        BL_PROFILE_REGION_ASYNC("async_region");
+        {
+            BL_PROFILE("ordinary_in_async_region");
+        }
+        {
+            BL_PROFILE_ASYNC("async_in_async_region");
+        }
+    }
+
+    {
+        BL_PROFILE_REGION("same_region");
+        BL_PROFILE("ordinary_same_region_timer");
+    }
+    {
+        BL_PROFILE_REGION_ASYNC("same_region");
+        BL_PROFILE("async_same_region_timer");
+    }
+
+    if (amrex::ParallelDescriptor::NProcs() == 1 ||
+        amrex::ParallelDescriptor::MyProc() == 1) {
+        BL_PROFILE_REGION_ASYNC("rank_local_async_region");
+        BL_PROFILE("ordinary_rank_local_region_timer");
+    }
+}
+
+bool contains (std::string const& text, std::string const& value)
+{
+    return text.find(value) != std::string::npos;
+}
+
+int count (std::string const& text, std::string const& value)
+{
+    int result = 0;
+    std::size_t pos = 0;
+    while ((pos = text.find(value, pos)) != std::string::npos) {
+        ++result;
+        pos += value.size();
+    }
+    return result;
+}
+
+std::vector<std::string> rows_named (std::string const& table, std::string const& name)
+{
+    std::vector<std::string> result;
+    std::istringstream lines(table);
+    for (std::string line; std::getline(lines, line); ) {
+        std::istringstream fields(line);
+        std::string row_name;
+        if ((fields >> row_name) && row_name == name) {
+            result.push_back(std::move(line));
+        }
+    }
+    return result;
+}
+
+std::vector<std::string> data_rows (std::string const& table)
+{
+    std::vector<std::string> result;
+    std::istringstream lines(table);
+    for (std::string line; std::getline(lines, line); ) {
+        std::istringstream fields(line);
+        std::string name;
+        std::string calls;
+        std::string tmin;
+        std::string tavg;
+        std::string tmax;
+        std::string percent;
+        if ((fields >> name >> calls >> tmin >> tavg >> tmax >> percent) &&
+            name != "Name") {
+            result.push_back(std::move(line));
+        }
+    }
+    return result;
+}
+
+std::vector<std::string> region_tables (std::string const& report, std::string const& name)
+{
+    std::vector<std::string> result;
+    std::string const begin_marker = "BEGIN REGION " + name + "\n";
+    std::string const end_marker = "END REGION " + name + "\n";
+    std::size_t begin = 0;
+    while ((begin = report.find(begin_marker, begin)) != std::string::npos) {
+        std::size_t const end = report.find(end_marker, begin);
+        if (end == std::string::npos) {
+            break;
+        }
+        result.push_back(report.substr(begin, end + end_marker.size() - begin));
+        begin = end + end_marker.size();
+    }
+    return result;
+}
+
+bool marked_row (std::string const& row)
+{
+    std::istringstream fields(row);
+    std::string name;
+    std::string calls;
+    std::string tmin;
+    std::string tavg;
+    std::string tmax;
+    std::string percent;
+    if (!(fields >> name >> calls >> tmin >> tavg >> tmax >> percent)) {
+        return false;
+    }
+    auto ends_with = [] (std::string const& value, std::string const& suffix) {
+        return value.size() >= suffix.size() &&
+               value.compare(value.size()-suffix.size(), suffix.size(), suffix) == 0;
+    };
+    return !contains(name, "?") && !contains(calls, "?") &&
+           ends_with(tmin, "?") && ends_with(tavg, "?") &&
+           ends_with(tmax, "?") && ends_with(percent, "?%");
+}
+
+bool unmarked_row (std::string const& row)
+{
+    return !contains(row, "?");
+}
+
+long calls_in_row (std::string const& row)
+{
+    std::istringstream fields(row);
+    std::string name;
+    long calls = -1;
+    fields >> name >> calls;
+    return calls;
+}
+
+bool expect (bool condition, std::string const& message)
+{
+    if (!condition) {
+        std::cerr << "TinyProfiler async test failure: " << message << '\n';
+    }
+    return condition;
+}
+
+bool validate_tiny_report (std::string const& output, bool hide_async, bool expect_other)
+{
+    bool ok = true;
+    std::size_t const first_region = output.find("BEGIN REGION");
+    std::string const main_table = output.substr(0, first_region);
+
+#ifdef AMREX_USE_GPU
+    if (expect_other) {
+        auto const other = rows_named(main_table, "Other");
+        ok = expect(other.size() == 2 && marked_row(other[0]) && marked_row(other[1]),
+                    "Other did not retain its async classification") && ok;
+        ok = expect(count(output, warning) == 1,
+                    "Other report must contain exactly one async warning") && ok;
+        return ok;
+    }
+
+    if (hide_async) {
+        ok = expect(!contains(output, "?"), "hidden report contains an async marker") && ok;
+        ok = expect(!contains(output, warning), "hidden report contains the async warning") && ok;
+        ok = expect(!contains(main_table, "async_scoped") &&
+                    !contains(main_table, "async_variable") &&
+                    !contains(main_table, "async_no_start") &&
+                    !contains(main_table, "rank_local_async"),
+                    "hidden report retained an async timer") && ok;
+        ok = expect(region_tables(output, "async_region").empty() &&
+                    region_tables(output, "rank_local_async_region").empty(),
+                    "hidden report retained an async region table") && ok;
+
+        auto const same_name = rows_named(main_table, "same_name");
+        ok = expect(same_name.size() == 2 && calls_in_row(same_name[0]) == 1 &&
+                    calls_in_row(same_name[1]) == 1,
+                    "hidden report did not preserve the ordinary same-name timer") && ok;
+        ok = expect(rows_named(main_table, "ordinary_in_async_region").size() == 2,
+                    "hidden report removed an ordinary timer nested in an async region") && ok;
+
+        auto const ordinary_regions = region_tables(output, "ordinary_region");
+        ok = expect(ordinary_regions.size() == 1 &&
+                    rows_named(ordinary_regions[0], "async_in_ordinary_region").empty() &&
+                    rows_named(ordinary_regions[0], "ordinary_in_ordinary_region").size() == 2,
+                    "hidden report filtered an ordinary region incorrectly") && ok;
+        ok = expect(region_tables(output, "same_region").size() == 1,
+                    "hidden report did not preserve only the ordinary same-name region") && ok;
+    } else {
+        ok = expect(count(output, warning) == 1,
+                    "default report must contain exactly one async warning") && ok;
+
+        for (auto const& name : {"async_scoped", "async_variable", "async_no_start",
+                                 "rank_local_async", "async_in_ordinary_region"}) {
+            auto const rows = rows_named(main_table, name);
+            ok = expect(rows.size() == 2 && marked_row(rows[0]) && marked_row(rows[1]),
+                        std::string("default report did not mark ") + name) && ok;
+        }
+
+        auto const same_name = rows_named(main_table, "same_name");
+        int marked = 0;
+        int unmarked = 0;
+        for (auto const& row : same_name) {
+            marked += marked_row(row) ? 1 : 0;
+            unmarked += unmarked_row(row) ? 1 : 0;
+        }
+        ok = expect(same_name.size() == 4 && marked == 2 && unmarked == 2,
+                    "ordinary and async same-name timers were not kept separate") && ok;
+
+        auto const ordinary_in_async = rows_named(main_table, "ordinary_in_async_region");
+        ok = expect(ordinary_in_async.size() == 2 &&
+                    unmarked_row(ordinary_in_async[0]) && unmarked_row(ordinary_in_async[1]),
+                    "async region changed a nested ordinary timer in the main table") && ok;
+
+        auto const async_regions = region_tables(output, "async_region");
+        ok = expect(async_regions.size() == 1,
+                    "default report omitted the async region") && ok;
+        if (async_regions.size() == 1) {
+            auto const rows = data_rows(async_regions[0]);
+            bool all_marked = !rows.empty();
+            for (auto const& row : rows) {
+                all_marked = all_marked && marked_row(row);
+            }
+            ok = expect(all_marked, "async region did not mark every timing row") && ok;
+        }
+
+        auto const same_regions = region_tables(output, "same_region");
+        int marked_tables = 0;
+        int unmarked_tables = 0;
+        for (auto const& table : same_regions) {
+            auto const rows = data_rows(table);
+            bool all_marked = !rows.empty();
+            bool all_unmarked = !rows.empty();
+            for (auto const& row : rows) {
+                all_marked = all_marked && marked_row(row);
+                all_unmarked = all_unmarked && unmarked_row(row);
+            }
+            marked_tables += all_marked ? 1 : 0;
+            unmarked_tables += all_unmarked ? 1 : 0;
+        }
+        ok = expect(same_regions.size() == 2 && marked_tables == 1 && unmarked_tables == 1,
+                    "ordinary and async same-name regions were not kept separate") && ok;
+    }
+#else
+    ok = expect(!contains(output, "?") && !contains(output, warning),
+                "CPU aliases produced async annotations") && ok;
+    if (expect_other) {
+        auto const other = rows_named(main_table, "Other");
+        ok = expect(other.size() == 2 && unmarked_row(other[0]) && unmarked_row(other[1]),
+                    "CPU Other row did not remain ordinary") && ok;
+        return ok;
+    }
+
+    ok = expect(contains(main_table, "async_scoped") &&
+                contains(main_table, "async_variable") &&
+                contains(main_table, "async_no_start") &&
+                contains(main_table, "rank_local_async"),
+                "CPU aliases did not produce ordinary timer output") && ok;
+
+    auto const same_name = rows_named(main_table, "same_name");
+    ok = expect(same_name.size() == 2 && calls_in_row(same_name[0]) == 2 &&
+                calls_in_row(same_name[1]) == 2,
+                "CPU async alias did not aggregate with its ordinary same-name timer") && ok;
+    ok = expect(region_tables(output, "async_region").size() == 1 &&
+                region_tables(output, "same_region").size() == 1,
+                "CPU async region alias did not behave as an ordinary region") && ok;
+#endif
+
+    return ok;
+}
+
+}
+
+int main (int argc, char* argv[])
+{
+#ifdef AMREX_USE_MPI
+    MPI_Init(&argc, &argv);
+#endif
+
+    amrex::Initialize(argc, argv);
+
+    bool hide_async = false;
+    bool expect_other = false;
+    std::string output_file;
+    amrex::ParmParse("test").query("hide_async", hide_async);
+    amrex::ParmParse("test").query("expect_other", expect_other);
+    amrex::ParmParse("tiny_profiler").query("output_file", output_file);
+
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+        std::remove(output_file.c_str());
+    }
+    amrex::ParallelDescriptor::Barrier();
+
+    generate_profile();
+
+    bool const io_processor = amrex::ParallelDescriptor::IOProcessor();
+    amrex::Finalize();
+
+    int result = 0;
+#ifdef AMREX_TINY_PROFILING
+    if (io_processor) {
+        std::ifstream stream(output_file);
+        std::string const output((std::istreambuf_iterator<char>(stream)),
+                                 std::istreambuf_iterator<char>());
+        if (!expect(stream.good() || stream.eof(), "could not read profiler output") ||
+            !validate_tiny_report(output, hide_async, expect_other)) {
+            result = 1;
+        }
+    }
+#else
+    amrex::ignore_unused(io_processor, hide_async, expect_other);
+#endif
+
+#ifdef AMREX_USE_MPI
+    MPI_Finalize();
+#endif
+    return result;
+}


### PR DESCRIPTION
Add opt-in async timer and region macros with marked output and runtime filtering. Include coverage for CPU, MPI, disabled, legacy, and CUDA builds.
