### PR TITLE
Skip NodalPoissonEB_STL ctest in single precision

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -3,7 +3,9 @@
 #
 function (setup_test _dim _srcs  _inputs)
 
-   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES"
+   # NO_CTEST: build the executable and stage its inputs, but do not register
+   # a ctest for it.
+   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES;NO_CTEST"
       "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS;NTASKS;NTHREADS"
       "CMDLINE_PARAMS_AFTER_INPUTS" ${ARGN} )
 
@@ -79,6 +81,10 @@ function (setup_test _dim _srcs  _inputs)
    #
    # Add the test
    #
+   if (_NO_CTEST)
+      return ()
+   endif ()
+
    if (AMReX_OMP)
       add_test(
          NAME               ${_test_name}

--- a/Tests/LinearSolvers/NodalPoissonEB/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodalPoissonEB/CMakeLists.txt
@@ -16,8 +16,17 @@ foreach(D IN LISTS AMReX_SPACEDIM)
     if (D EQUAL 3)
         set(_input_files inputs-3d-stl sphere.stl)
 
+        # The STL test does not work in single precision, so only build it there.
+        if (AMReX_PRECISION STREQUAL "SINGLE")
+            set(_no_ctest NO_CTEST)
+        else ()
+            set(_no_ctest)
+        endif ()
+
         setup_test(${D} _sources _input_files
-            BASE_NAME LinearSolvers_NodalPoissonEB_STL)
+            BASE_NAME LinearSolvers_NodalPoissonEB_STL ${_no_ctest})
+
+        unset(_no_ctest)
     endif ()
 
     unset(_sources)


### PR DESCRIPTION
The STL nodal EB Poisson test does not work in single precision. Add a NO_CTEST option to setup_test that builds the executable and stages its input files without registering a ctest, and use it for the STL test when AMReX_PRECISION is SINGLE.
