### PR TITLE
Fix HIP deprecated-attribute warning on deduction guides

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v7
     - name: Dependencies
       run: |
-        .github/workflows/dependencies/dependencies_hip.sh 7.0
+        .github/workflows/dependencies/dependencies_hip.sh 7.2.4
         .github/workflows/dependencies/dependencies_ccache.sh
     - name: Set Up Cache
       uses: actions/cache@v6
@@ -33,10 +33,6 @@ jobs:
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Install
-      # Have to remove "-fno-operator-names to avoid
-      #    /opt/rocm-6.1.0/include/rocprim/device/detail/device_adjacent_difference.hpp:198:26: error: token is not a valid binary operator in a preprocessor subexpression
-      #      198 | #if defined(__gfx1102__) or defined(__gfx1030__)
-      #          |     ~~~~~~~~~~~~~~~~~~~~~^~
       env: {CXXFLAGS: "-Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
       run: |
         export CCACHE_COMPRESS=1

--- a/Src/Base/AMReX_IndexType.H
+++ b/Src/Base/AMReX_IndexType.H
@@ -242,13 +242,17 @@ using IndexType = IndexTypeND<AMREX_SPACEDIM>;
 
 // Template deduction guide for IndexTypeND
 template<int dim>
+#if defined(__clang__) && __clang_major__ < 22
 AMREX_GPU_HOST_DEVICE // __device__ for HIP
+#endif
 IndexTypeND(const IntVectND<dim>&) -> IndexTypeND<dim>;
 
 // Template deduction guide for IndexTypeND
 template <class...Args>
 requires (IsConvertible_v<IndexType::CellIndex, Args...>)
+#if defined(__clang__) && __clang_major__ < 22
 AMREX_GPU_HOST_DEVICE // __device__ for HIP
+#endif
 IndexTypeND(IndexType::CellIndex, Args...) -> IndexTypeND<sizeof...(Args)+1>;
 
 /// \cond DOXYGEN_IGNORE

--- a/Src/Base/AMReX_IntVect.H
+++ b/Src/Base/AMReX_IntVect.H
@@ -893,13 +893,17 @@ inline constexpr const IntVectND<dim> IntVectND<dim>::Unit{1};
 
 // Template deduction guide for IntVectND
 template<std::size_t dim>
+#if defined(__clang__) && __clang_major__ < 22
 AMREX_GPU_HOST_DEVICE // __device__ for HIP
+#endif
 IntVectND(const Array<int, dim>&) -> IntVectND<dim>;
 
 // Template deduction guide for IntVectND
 template <class...Args>
 requires (IsConvertible_v<int, Args...>)
+#if defined(__clang__) && __clang_major__ < 22
 AMREX_GPU_HOST_DEVICE // __device__ for HIP
+#endif
 IntVectND(int, int, Args...) -> IntVectND<sizeof...(Args)+2>;
 
 //! \brief IntVect is an alias for \ref amrex::IntVectND instantiated with

--- a/Src/Base/AMReX_RealVect.H
+++ b/Src/Base/AMReX_RealVect.H
@@ -594,17 +594,23 @@ protected:
 // Template deduction guide for RealVectND
 template <class... Args>
 requires (IsConvertible_v<Real, Args...>)
+#if defined(__clang__) && __clang_major__ < 22
 AMREX_GPU_HOST_DEVICE // __device__ for HIP
+#endif
 RealVectND(Real, Real, Args...) -> RealVectND<sizeof...(Args)+2>;
 
 // Template deduction guide for RealVectND
 template<int dim>
+#if defined(__clang__) && __clang_major__ < 22
 AMREX_GPU_HOST_DEVICE // __device__ for HIP
+#endif
 RealVectND(const IntVectND<dim>&) -> RealVectND<dim>;
 
 // Template deduction guide for RealVectND
 template<int dim>
+#if defined(__clang__) && __clang_major__ < 22
 AMREX_GPU_HOST_DEVICE // __device__ for HIP
+#endif
 RealVectND(const GpuArray<Real, dim>&) -> RealVectND<dim>;
 
 template <int dim>


### PR DESCRIPTION
Newer Clang deprecates CUDA/HIP target attributes on deduction guides:

  AMReX_IntVect.H:897:1: warning: use of CUDA/HIP target attributes on
  deduction guides is deprecated; they will be rejected in a future
  version of Clang [-Wdeprecated-attributes]

Guard AMREX_GPU_HOST_DEVICE on the IntVectND, IndexTypeND and RealVectND deduction guides with `__clang_major__ < 22`, and bump CI to ROCm 7.2.4.
