### PR TITLE
Fix routines that ignore the requested component sub-range

### DIFF
--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1354,7 +1354,8 @@ Swap (FabArray<FAB>& dst, FabArray<FAB>& src, int srccomp, int dstcomp, int numc
 
     bool explicit_swap = true;
 
-    if (srccomp == dstcomp && dstcomp == 0 && src.nComp() == dst.nComp() &&
+    if (srccomp == dstcomp && dstcomp == 0 && numcomp == src.nComp() &&
+        src.nComp() == dst.nComp() &&
         src.nGrowVect() == nghost && src.nGrowVect() == dst.nGrowVect() &&
         src.arena() == dst.arena() && src.hasEBFabFactory() == dst.hasEBFabFactory()) {
         explicit_swap = false;

--- a/Src/Base/AMReX_MFCopyDescriptor.cpp
+++ b/Src/Base/AMReX_MFCopyDescriptor.cpp
@@ -81,7 +81,7 @@ InterpFillFab (MultiFabCopyDescriptor& fabCopyDesc,
                int                     num_comp,
                bool                    extrap)
 {
-    amrex::ignore_unused(extrap);
+    amrex::ignore_unused(extrap, src_comp);
 
     const Real teps = (t2-t1)/1000.0_rt;
 
@@ -107,9 +107,9 @@ InterpFillFab (MultiFabCopyDescriptor& fabCopyDesc,
         fabCopyDesc.FillFab(faid2, fillBoxIds[1], dest2);
         dest.linInterp<RunOn::Host>
                       (dest1,
-                       src_comp,
+                       dest_comp,
                        dest2,
-                       src_comp,
+                       dest_comp,
                        t1,
                        t2,
                        t,

--- a/Src/Base/AMReX_NonLocalBCImpl.H
+++ b/Src/Base/AMReX_NonLocalBCImpl.H
@@ -565,7 +565,7 @@ Rotate90 (FabArray<FAB>& mf, int scomp, int ncomp, IntVect const& nghost, Box co
             auto const& fab = mf.array(mfi);
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx,ncomp,i,j,k,n,
             {
-                fab(i,j,k,n) = fab(-i-1,-j-1,k,n);
+                fab(i,j,k,scomp+n) = fab(-i-1,-j-1,k,scomp+n);
             });
         }
     }


### PR DESCRIPTION
- amrex::Swap: the whole-object std::swap shortcut fired for partial swaps.
- InterpFillFab: the time-interpolation branch read the staging FABs at src_comp, but FillFab deposits at dest_comp.
- Rotate90: the corner kernel indexed components from 0 instead of scomp.

Fixes #5678
