### PR TITLE
Use ParallelContext ranks and communicators consistently

### DIFF
--- a/Src/Base/AMReX_DistributionMapping.cpp
+++ b/Src/Base/AMReX_DistributionMapping.cpp
@@ -1517,7 +1517,7 @@ DistributionMapping::SFCProcessorMap (const BoxArray&          boxes,
 
     if (boxes.size() < Long(sfc_threshold)*nprocs)
     {
-        KnapSackProcessorMap(wgts,nprocs);
+        KnapSackProcessorMap(wgts,nprocs,nullptr,true,std::numeric_limits<int>::max(),sort);
     }
     else
     {
@@ -1540,7 +1540,7 @@ DistributionMapping::SFCProcessorMap (const BoxArray&          boxes,
 
     if (boxes.size() < Long(sfc_threshold)*nprocs)
     {
-        KnapSackProcessorMap(wgts,nprocs,&eff);
+        KnapSackProcessorMap(wgts,nprocs,&eff,true,std::numeric_limits<int>::max(),sort);
     }
     else
     {
@@ -1550,9 +1550,11 @@ DistributionMapping::SFCProcessorMap (const BoxArray&          boxes,
 
 void
 DistributionMapping::RRSFCDoIt (const BoxArray&          boxes,
-                                int                      nprocs)
+                                int                   /* nprocs */)
 {
     BL_PROFILE("DistributionMapping::RRSFCDoIt()");
+
+    int nprocs = ParallelContext::NProcsSub();
 
 #if defined (BL_USE_TEAM)
     amrex::Abort("Team support is not implemented yet in RRSFC");
@@ -1721,7 +1723,8 @@ gather_weights (const MultiFab& weight)
     Vector<Real> rcost(weight.size());
     ParallelDescriptor::GatherLayoutDataToVector(costld, rcost,
                                                  ParallelContext::IOProcessorNumberSub());
-    ParallelDescriptor::Bcast(rcost.data(), rcost.size(), ParallelContext::IOProcessorNumberSub());
+    ParallelDescriptor::Bcast(rcost.data(), rcost.size(), ParallelContext::IOProcessorNumberSub(),
+                              ParallelContext::CommunicatorSub());
     return DistributionMapping::ConvertCostRealToLong(rcost);
 #else
     return Vector<Long>(weight.size(), 1L);
@@ -2037,7 +2040,7 @@ DistributionMapping MakeSimilarDM (const BoxArray& ba, const BoxArray& src_ba,
         if (isects.empty()) {
             // no intersection found, revert to round-robin
             int nprocs = ParallelContext::NProcsSub();
-            pmap[i] = i % nprocs;
+            pmap[i] = ParallelContext::local_to_global_rank(i % nprocs);
         } else {
             Long max_overlap = 0;
             int max_overlap_index = -1;

--- a/Src/Base/AMReX_FACopyDescriptor.H
+++ b/Src/Base/AMReX_FACopyDescriptor.H
@@ -490,7 +490,7 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
 {
     dataAvailable = true;
 
-    if (ParallelDescriptor::NProcs() == 1) { return; }
+    if (ParallelContext::NProcsSub() == 1) { return; }
 
 #ifdef BL_USE_MPI
     using value_type = typename FAB::value_type;
@@ -553,14 +553,15 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
     BL_ASSERT((Total_Rcvs_Size*sizeof(value_type))
               < static_cast<std::size_t>(std::numeric_limits<int>::max()));
 
-    const int NProcs = ParallelDescriptor::NProcs();
+    const int NProcs = ParallelContext::NProcsSub();
+    MPI_Comm comm = ParallelContext::CommunicatorSub();
 
     {
         Vector<int> SndsArray(NProcs,0), RcvsArray(NProcs,0);
 
         for (auto const& Rcv : Rcvs)
         {
-            RcvsArray[Rcv.first] = Rcv.second;
+            RcvsArray[ParallelContext::global_to_local_rank(Rcv.first)] = Rcv.second;
         }
 
         {
@@ -574,14 +575,14 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
                                          SndsArray.dataPtr(),
                                          1,
                                          ParallelDescriptor::Mpi_typemap<int>::type(),
-                                         ParallelDescriptor::Communicator()) );
+                                         comm) );
 
             BL_COMM_PROFILE(BLProfiler::Alltoall, sizeof(int), ParallelDescriptor::MyProc(),
                             BLProfiler::AfterCall());
 
             BL_PROFILE_VAR_STOP(blpvCDATA);
         }
-        BL_ASSERT(SndsArray[MyProc] == 0);
+        BL_ASSERT(SndsArray[ParallelContext::MyProcSub()] == 0);
 
         for (int i = 0; i < NProcs; i++) {
             if (SndsArray[i] > 0) {
@@ -636,7 +637,7 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
         {
             md_recv_reqs.push_back(ParallelDescriptor::Arecv(&md_recv_data[md_offset[i]],
                                                              md_icnts[i], md_sender[i],
-                                                             SeqNum_md).req());
+                                                             SeqNum_md, comm).req());
         }
     }
 
@@ -677,7 +678,8 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
                              md[6+2*AMREX_SPACEDIM] = tp[2]);
             }
 
-            md_send_reqs.push_back(ParallelDescriptor::Asend(p,cnt,rank,SeqNum_md).req());
+            md_send_reqs.push_back(ParallelDescriptor::Asend
+                (p,cnt,ParallelContext::global_to_local_rank(rank),SeqNum_md,comm).req());
         }
     }
 
@@ -694,8 +696,9 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
             BL_ASSERT(Cnt > 0);
             BL_ASSERT(Cnt < std::numeric_limits<int>::max());
             data_sender.push_back(Who);
-            data_recv_reqs.push_back(ParallelDescriptor::Arecv(&recv_data[Idx],
-                                                               Cnt,Who,SeqNum_data).req());
+            data_recv_reqs.push_back(ParallelDescriptor::Arecv
+                (&recv_data[Idx], Cnt, ParallelContext::global_to_local_rank(Who),
+                 SeqNum_data, comm).req());
             data_offset.push_back(Idx);
             Idx += Cnt;
         }
@@ -752,7 +755,7 @@ FabArrayCopyDescriptor<FAB>::CollectData ()
                 dptr += npts[i];
             }
 
-            data_send_reqs.push_back(ParallelDescriptor::Asend(data,N,rank,SeqNum_data).req());
+            data_send_reqs.push_back(ParallelDescriptor::Asend(data,N,rank,SeqNum_data,comm).req());
         }
 
         amrex::The_Arena()->free(md_recv_data);

--- a/Src/Base/AMReX_ParallelContext.H
+++ b/Src/Base/AMReX_ParallelContext.H
@@ -89,6 +89,9 @@ inline void BarrierSub () noexcept { }
 inline void BarrierAll () noexcept { }
 #endif
 
+//! Is a sub-communicator frame pushed?  If not, rank translation is the identity.
+inline bool in_sub_frame () noexcept { return frames.size() > 1; }
+
 //! get and increment mpi tag in current frame
 inline int get_inc_mpi_tag () noexcept { return frames.back().get_inc_mpi_tag(); }
 //! translate between local rank and global rank

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -1061,7 +1061,14 @@ ParallelDescriptor::GatherLayoutDataToVector (const LayoutData<T>& sendbuf,
     int nprocs = ParallelContext::NProcsSub();
     Vector<int> recvcount(nprocs, 0);
     recvbuf.resize(sendbuf.size());
-    const Vector<int>& old_pmap = sendbuf.DistributionMap().ProcessorMap();
+    const Vector<int>& gpmap = sendbuf.DistributionMap().ProcessorMap();
+    Vector<int> lpmap;
+    if (ParallelContext::in_sub_frame()) {
+        lpmap.resize(gpmap.size());
+        ParallelContext::global_to_local_rank(lpmap.data(), gpmap.data(),
+                                              static_cast<int>(gpmap.size()));
+    }
+    const Vector<int>& old_pmap = ParallelContext::in_sub_frame() ? lpmap : gpmap;
     for (int i : old_pmap)
     {
         ++recvcount[i];

--- a/Src/Base/AMReX_ParallelDescriptor.H
+++ b/Src/Base/AMReX_ParallelDescriptor.H
@@ -1064,7 +1064,9 @@ ParallelDescriptor::GatherLayoutDataToVector (const LayoutData<T>& sendbuf,
     const Vector<int>& gpmap = sendbuf.DistributionMap().ProcessorMap();
     Vector<int> lpmap;
     if (ParallelContext::in_sub_frame()) {
-        lpmap.resize(gpmap.size());
+        // assign, not resize: gcc -O3 falsely warns about a null dereference
+        // when resize on an empty vector is inlined here.
+        lpmap.assign(gpmap.size(), 0);
         ParallelContext::global_to_local_rank(lpmap.data(), gpmap.data(),
                                               static_cast<int>(gpmap.size()));
     }


### PR DESCRIPTION
Five sites mixed global ranks/communicators with ParallelContext ones:

- SFCProcessorMap: forward sort into the sfc_threshold knapsack fallback.
- RRSFCDoIt: take nprocs from NProcsSub, like its siblings.
- gather_weights: broadcast on CommunicatorSub, matching its gather.
- GatherLayoutDataToVector: translate pmap ranks to local.
- CollectData: run on CommunicatorSub with translated endpoints.
- MakeSimilarDM: store a global rank in the pmap.

Fixes #5680, Fixes #5734.
