### PR TITLE
Fix FourthOrderInterpFromFineToCoarse for refinement ratio 4

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -1166,6 +1166,10 @@ namespace amrex
                                   && (ratio[1] == 2 || ratio[1] == 4),
                                   && (ratio[2] == 2 || ratio[2] == 4)));
 
+        AMREX_D_TERM(int const xoff = ratio[0]/2 - 1;,
+                     int const yoff = ratio[1]/2 - 1;,
+                     int const zoff = ratio[2]/2 - 1;)
+
         MultiFab tmp(amrex::coarsen(fmf.boxArray(), ratio), fmf.DistributionMap(),
                      ncomp, 0);
 
@@ -1198,7 +1202,7 @@ namespace amrex
 #endif
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D(xbx, ncomp, i, j, k, n,
                 {
-                    int ii = 2*i;
+                    int ii = ratio[0]*i + xoff;
                     xa(i,j,k,n) = Real(1./16)*(Real(9.)*(fa(ii  ,j,k,n) +
                                                          fa(ii+1,j,k,n))
                                                -         fa(ii-1,j,k,n)
@@ -1219,7 +1223,7 @@ namespace amrex
 #endif
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D(ybx, ncomp, i, j, k, n,
                 {
-                    int jj = 2*j;
+                    int jj = ratio[1]*j + yoff;
                     ya(i,j,k,n) = Real(1./16)*(Real(9.)*(xca(i,jj  ,k,n) +
                                                          xca(i,jj+1,k,n))
                                                -         xca(i,jj-1,k,n)
@@ -1231,7 +1235,7 @@ namespace amrex
                 auto const& ca = tmp.array(mfi);
                 AMREX_HOST_DEVICE_PARALLEL_FOR_4D(bx, ncomp, i, j, k, n,
                 {
-                    int kk = 2*k;
+                    int kk = ratio[2]*k + zoff;
                     ca(i,j,k,n) = Real(1./16)*(Real(9.)*(yca(i,j,kk  ,n) +
                                                          yca(i,j,kk+1,n))
                                                -         yca(i,j,kk-1,n)


### PR DESCRIPTION
The three pass kernels hardcoded the ratio-2 stencil index, so a ratio component of 4 read outside the source fab and produced garbage.  Index at ratio*i + ratio/2 - 1 instead, which keeps the 4-point stencil inside the coarse cell and matches the existing grow-only-if-ratio-2 logic.

Fixes #5681

