### PR TITLE
Invalidate cached state in MLMG/MLLinOp mutators

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -274,6 +274,9 @@ private:
 
     int m_ncomp = 1;
 
+    Vector<int> m_a_metric_applied;
+    Vector<int> m_b_metric_applied;
+
     void define_ab_coeffs ();
 
     void update_singular_flags ();
@@ -341,6 +344,8 @@ MLABecLaplacianT<MF>::define_ab_coeffs ()
 {
     m_a_coeffs.resize(this->m_num_amr_levels);
     m_b_coeffs.resize(this->m_num_amr_levels);
+    m_a_metric_applied.assign(this->m_num_amr_levels, 0);
+    m_b_metric_applied.assign(this->m_num_amr_levels, 0);
     for (int amrlev = 0; amrlev < this->m_num_amr_levels; ++amrlev)
     {
         m_a_coeffs[amrlev].resize(this->m_num_mg_levels[amrlev]);
@@ -376,6 +381,7 @@ MLABecLaplacianT<MF>::setScalars (T1 a, T2 b) noexcept
         }
         m_acoef_set = true;
     }
+    m_needs_update = true;
     m_scalars_set = true;
 }
 
@@ -388,6 +394,7 @@ MLABecLaplacianT<MF>::setACoeffs (int amrlev, const AMF& alpha)
     AMREX_ASSERT_WITH_MESSAGE(alpha.nComp() == 1,
                               "MLABecLaplacian::setACoeffs: alpha is supposed to be single component.");
     m_a_coeffs[amrlev][0].LocalCopy(alpha, 0, 0, 1, IntVect(0));
+    m_a_metric_applied[amrlev] = 0;
     m_needs_update = true;
     m_acoef_set = true;
 }
@@ -399,6 +406,7 @@ void
 MLABecLaplacianT<MF>::setACoeffs (int amrlev, T alpha)
 {
     m_a_coeffs[amrlev][0].setVal(RT(alpha));
+    m_a_metric_applied[amrlev] = 0;
     m_needs_update = true;
     m_acoef_set = true;
 }
@@ -426,6 +434,7 @@ MLABecLaplacianT<MF>::setBCoeffs (int amrlev,
             }
         }
     }
+    m_b_metric_applied[amrlev] = 0;
     m_needs_update = true;
 }
 
@@ -438,6 +447,7 @@ MLABecLaplacianT<MF>::setBCoeffs (int amrlev, T beta)
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         m_b_coeffs[amrlev][0][idim].setVal(RT(beta));
     }
+    m_b_metric_applied[amrlev] = 0;
     m_needs_update = true;
 }
 
@@ -453,6 +463,7 @@ MLABecLaplacianT<MF>::setBCoeffs (int amrlev, Vector<T> const& beta)
             m_b_coeffs[amrlev][0][idim].setVal(RT(beta[icomp]), icomp, 1, 0);
         }
     }
+    m_b_metric_applied[amrlev] = 0;
     m_needs_update = true;
 }
 
@@ -506,10 +517,16 @@ MLABecLaplacianT<MF>::applyMetricTermsCoeffs ()
     for (int alev = 0; alev < this->m_num_amr_levels; ++alev)
     {
         const int mglev = 0;
-        this->applyMetricTerm(alev, mglev, m_a_coeffs[alev][mglev]);
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
-        {
-            this->applyMetricTerm(alev, mglev, m_b_coeffs[alev][mglev][idim]);
+        if (!m_a_metric_applied[alev]) {
+            this->applyMetricTerm(alev, mglev, m_a_coeffs[alev][mglev]);
+            m_a_metric_applied[alev] = 1;
+        }
+        if (!m_b_metric_applied[alev]) {
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
+            {
+                this->applyMetricTerm(alev, mglev, m_b_coeffs[alev][mglev][idim]);
+            }
+            m_b_metric_applied[alev] = 1;
         }
     }
 #endif

--- a/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALaplacian.H
@@ -209,6 +209,7 @@ MLALaplacianT<MF>::setScalars (RT a, RT b) noexcept
             m_a_coeffs[amrlev][0].setVal(RT(0.0));
         }
     }
+    m_needs_update = true;
 }
 
 template <typename MF>

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -887,6 +887,7 @@ MLCellLinOpT<MF>::setLevelBC (int amrlev, const MF* a_levelbcdata, const MF* rob
                                                    br_ref_ratio, this->m_coarse_bc_loc,
                                                    this->m_domain_bloc_lo, this->m_domain_bloc_hi,
                                                    crse_fine_bc_type);
+        m_bc_tags[amrlev][mglev].undefine();
     }
 
     if (this->hasRobinBC()) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -143,6 +143,19 @@ void
 MLEBABecLap::setPhiOnCentroid ()
 {
     m_phi_loc = Location::CellCentroid;
+    for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
+        if (m_eb_phi[amrlev] && m_eb_phi[amrlev]->nGrow() == 0) {
+            const int mglev = 0;
+            const int ncomp = getNComp();
+            auto p = std::make_unique<MultiFab>(m_grids[amrlev][mglev],
+                                                m_dmap[amrlev][mglev],
+                                                ncomp, 1, MFInfo(),
+                                                *m_factory[amrlev][mglev]);
+            MultiFab::Copy(*p, *m_eb_phi[amrlev], 0, 0, ncomp, 0);
+            p->FillBoundary(m_geom[amrlev][mglev].periodicity());
+            m_eb_phi[amrlev] = std::move(p);
+        }
+    }
 }
 
 void
@@ -158,6 +171,7 @@ MLEBABecLap::setScalars (Real a, Real b)
         }
         m_acoef_set = true;
     }
+    m_needs_update = true;
     m_scalars_set = true;
 }
 
@@ -802,6 +816,12 @@ MLEBABecLap::prepareForSolve ()
     BL_PROFILE("MLABecLaplacian::prepareForSolve()");
 
     MLCellABecLap::prepareForSolve();
+
+    for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
+        for (int mglev = 0; mglev < m_num_mg_levels[amrlev]; ++mglev) {
+            m_eb_bc_tags[amrlev][mglev].undefine();
+        }
+    }
 
     applyRobinBCTermsCoeffs();
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -1117,6 +1117,13 @@ MLLinOpT<MF>::defineGrids (const Vector<Geometry>& a_geom,
     m_amr_ref_ratio.resize(m_num_amr_levels);
     m_num_mg_levels.resize(m_num_amr_levels);
 
+    m_geom.clear();
+    m_grids.clear();
+    m_dmap.clear();
+    m_factory.clear();
+    m_domain_covered.clear();
+    mg_coarsen_ratio_vec.clear();
+
     m_geom.resize(m_num_amr_levels);
     m_grids.resize(m_num_amr_levels);
     m_dmap.resize(m_num_amr_levels);

--- a/Src/LinearSolvers/MLMG/AMReX_MLMG.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLMG.H
@@ -1286,6 +1286,7 @@ MLMGT<MF>::compResidual (const Vector<MF*>& a_res, const Vector<MF*>& a_sol,
             if (sol_is_alias[alev])
             {
                 sol[alev] = linop.make(alev, 0, ng_sol);
+                sol_is_alias[alev] = false;
             }
             LocalCopy(sol[alev], *a_sol[alev], 0, 0, ncomp, IntVect(0));
         }
@@ -1464,15 +1465,18 @@ MLMGT<MF>::prepareForSolve (Vector<AMF*> const& a_sol, Vector<AMF const*> const&
         }
         else
         {
+            bool alias_made = false;
             if (nGrowVect(*a_sol[alev]) == ng_sol) {
                 if constexpr (std::is_same<AMF,MF>()) {
                     sol[alev] = linop.makeAlias(*a_sol[alev]);
                     sol_is_alias[alev] = true;
+                    alias_made = true;
                 }
             }
-            if (!sol_is_alias[alev]) {
-                if (!solve_called) {
+            if (!alias_made) {
+                if (sol_is_alias[alev] || !solve_called) {
                     sol[alev] = linop.make(alev, 0, ng_sol);
+                    sol_is_alias[alev] = false;
                 }
                 LocalCopy(sol[alev], *a_sol[alev], 0, 0, ncomp, IntVect(0));
                 setBndry(sol[alev], RT(0.0), 0, ncomp);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -1090,10 +1090,13 @@ MLNodeLaplacian::setEBInflowVelocity (int amrlev, const MultiFab& eb_vel)
 #else
     const int ncomp_si = algoim::numSurfIntgs;
 #endif
-    m_surface_integral[amrlev] = std::make_unique<MultiFab>(m_grids[amrlev][0],
-                                                    m_dmap[amrlev][0],
-                                                    ncomp_si, 1, MFInfo(),
-                                                    *m_factory[amrlev][0]);
+    if (m_surface_integral[amrlev] == nullptr) {
+        m_surface_integral[amrlev] = std::make_unique<MultiFab>(m_grids[amrlev][0],
+                                                        m_dmap[amrlev][0],
+                                                        ncomp_si, 1, MFInfo(),
+                                                        *m_factory[amrlev][0]);
+        m_surface_integral_built = false;
+    }
     // Turn on flag for building surface integrals
     m_build_surface_integral = true;
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -496,6 +496,7 @@ MLNodeLinOp::setOversetMask (int amrlev, const iMultiFab& a_dmask)
             dmsk(i,j,k) = 1 - omsk(i,j,k);
         });
     }
+    m_masks_built = false;
     m_overset_dirichlet_mask = true;
 }
 

--- a/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
+++ b/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
@@ -24,6 +24,10 @@ void OpenBCSolver::define (const Vector<Geometry>& a_geom,
     m_grids = a_grids;
     m_dmap = a_dmap;
     m_info = a_info;
+    m_mlmg_1.reset();
+    m_mlmg_2.reset();
+    m_poisson_1.reset();
+    m_poisson_2.reset();
     m_box_offset.clear();
     m_momtags_h.clear();
     m_nblocks_local = 0;


### PR DESCRIPTION
Reusing an operator or MLMG object across solves is documented, but ten mutators left derived state stale:

- MLMG compResidual/prepareForSolve: sol_is_alias could stay true, so a later solve skipped the copy in and back, or reused a stale alias.
- MLLinOp::defineGrids: a second define() appended to the old hierarchy.
- setScalars (ABec, EBABec, ALap): now sets m_needs_update.
- MLABecLaplacian: per-level flags so update() applies the metric term to each coefficient once.
- setLevelBC / MLEBABecLap::prepareForSolve: drop the GPU BC tag caches.
- setEBInflowVelocity: keep the surface integral unless it must be built.
- setPhiOnCentroid: give an already-set m_eb_phi its ghost layer.
- setOversetMask: clear m_masks_built.
- OpenBCSolver::define: reset the MLPoisson and MLMG objects.

Fixes #5682
