### PR TITLE
Fix MLMG transfer ops for semicoarsened and hidden-direction MG levels

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -695,6 +695,7 @@ MLABecLaplacianT<MF>::averageDownCoeffsSameAmrLevel (int amrlev, Vector<MF>& a,
     for (int mglev = 1; mglev < nmglevs; ++mglev)
     {
         IntVect ratio = (amrlev > 0) ? IntVect(this->mg_coarsen_ratio) : this->mg_coarsen_ratio_vec[mglev-1];
+        if (this->hasHiddenDimension()) { ratio[this->hiddenDirection()] = 1; }
 
         if (m_a_scalar == 0.0)
         {

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -233,6 +233,10 @@ MLCellABecLapT<MF>::define (const Vector<Geometry>& a_geom,
     LPInfo linfo = a_info;
     linfo.max_coarsening_level = std::min(a_info.max_coarsening_level,
                                           max_overset_mask_coarsening_level);
+    // The overset masks above are coarsened isotropically by 2, so the MG
+    // levels must be too, or the masks and the grids end up in different
+    // index spaces.
+    linfo.do_semicoarsening = false;
 
     MLCellLinOpT<MF>::define(a_geom, a_grids, a_dmap, linfo, a_factory);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -1251,6 +1251,9 @@ MLCellLinOpT<MF>::restriction (int amrlev, int cmglev, MF& crse, MF& fine) const
 {
     const int ncomp = this->getNComp();
     IntVect ratio = (amrlev > 0) ? IntVect(2) : this->mg_coarsen_ratio_vec[cmglev-1];
+    // MG levels inside a fine AMR level are not coarsened in the hidden
+    // direction either.
+    if (this->hasHiddenDimension()) { ratio[this->hiddenDirection()] = 1; }
     amrex::average_down(fine, crse, 0, ncomp, ratio);
 }
 
@@ -1262,6 +1265,7 @@ MLCellLinOpT<MF>::interpolation (int amrlev, int fmglev, MF& fine, const MF& crs
 
     Dim3 ratio3 = {.x = 2, .y = 2, .z = 2};
     IntVect ratio = (amrlev > 0) ? IntVect(2) : this->mg_coarsen_ratio_vec[fmglev];
+    if (this->hasHiddenDimension()) { ratio[this->hiddenDirection()] = 1; }
     AMREX_D_TERM(ratio3.x = ratio[0];,
                  ratio3.y = ratio[1];,
                  ratio3.z = ratio[2];);
@@ -1310,7 +1314,8 @@ MLCellLinOpT<MF>::interpAssign (int amrlev, int fmglev, MF& fine, MF& crse) cons
     const int ncomp = this->getNComp();
 
     const Geometry& crse_geom = this->Geom(amrlev,fmglev+1);
-    const IntVect refratio = (amrlev > 0) ? IntVect(2) : this->mg_coarsen_ratio_vec[fmglev];
+    IntVect refratio = (amrlev > 0) ? IntVect(2) : this->mg_coarsen_ratio_vec[fmglev];
+    if (this->hasHiddenDimension()) { refratio[this->hiddenDirection()] = 1; }
     const IntVect ng = crse.nGrowVect();
 
     MF cfine;

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -175,7 +175,19 @@ MLEBNodeFDLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, MultiF
     applyBC(amrlev, cmglev-1, fine, BCMode::Homogeneous, StateMode::Solution);
 
     IntVect const ratio = (amrlev > 0) ? IntVect(2) : mg_coarsen_ratio_vec[cmglev-1];
-    int semicoarsening_dir = info.semicoarsening_direction;
+#if (AMREX_SPACEDIM == 1)
+    int semicoarsening_dir = 0;
+#else
+    // Direction NOT coarsened by this MG step. Derived from the level's
+    // ratio, because info.semicoarsening_direction is -1 when the direction
+    // is chosen automatically.
+    int semicoarsening_dir = 2;
+    if (ratio[1] == 1) {
+        semicoarsening_dir = 1;
+    } else if (ratio[0] == 1) {
+        semicoarsening_dir = 0;
+    }
+#endif
 
     bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
     MultiFab cfine;
@@ -221,7 +233,19 @@ MLEBNodeFDLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine,
     BL_PROFILE("MLEBNodeFDLaplacian::interpolation()");
 
     IntVect const ratio = (amrlev > 0) ? IntVect(2) : mg_coarsen_ratio_vec[fmglev];
-    int semicoarsening_dir = info.semicoarsening_direction;
+#if (AMREX_SPACEDIM == 1)
+    int semicoarsening_dir = 0;
+#else
+    // Direction NOT coarsened by this MG step. Derived from the level's
+    // ratio, because info.semicoarsening_direction is -1 when the direction
+    // is chosen automatically.
+    int semicoarsening_dir = 2;
+    if (ratio[1] == 1) {
+        semicoarsening_dir = 1;
+    } else if (ratio[0] == 1) {
+        semicoarsening_dir = 0;
+    }
+#endif
 
     bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
     MultiFab cfine;

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -1814,6 +1814,7 @@ MLLinOpT<MF>::makeCoarseMG (int amrlev, int mglev, IntVect const& ng) const
     if constexpr (IsMultiFabLike_v<MF>) {
         BoxArray cba = m_grids[amrlev][mglev];
         IntVect ratio = (amrlev > 0) ? IntVect(2) : mg_coarsen_ratio_vec[mglev];
+        if (hasHiddenDimension()) { ratio[hiddenDirection()] = 1; }
         cba.coarsen(ratio);
         cba.convert(m_ixtype);
         return MF(cba, m_dmap[amrlev][mglev], getNComp(), ng);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeABecLaplacian.cpp
@@ -26,6 +26,9 @@ MLNodeABecLaplacian::define (const Vector<Geometry>& a_geom,
 
     BL_PROFILE("MLNodeABecLaplacian::define()");
 
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!a_info.do_semicoarsening,
+        "MLNodeABecLaplacian does not support semicoarsening");
+
     // This makes sure grids are cell-centered;
     Vector<BoxArray> cc_grids = a_grids;
     for (auto& ba : cc_grids) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -678,7 +678,7 @@ void mlndlap_semi_interpadd_aa (int i, int j, int, Array4<Real> const& fine,
         if (!msk(i,j,0)) {
             int ic = i;
             int jc = amrex::coarsen(j,2);
-            bool j_is_odd = (ic*2 != i);
+            bool j_is_odd = (jc*2 != j);
             if (j_is_odd) {
                 // Node on Y line
                 fine(i,j,0) += aa_interp_line_y(crse,sig,i,j,ic,jc);

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.cpp
@@ -492,10 +492,12 @@ MLNodeLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, MultiFab& 
 
     applyBC(amrlev, cmglev-1, fine, BCMode::Homogeneous, StateMode::Solution);
 
+    IntVect const ratio = (amrlev > 0) ? IntVect(2) : mg_coarsen_ratio_vec[cmglev-1];
+
     bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
     MultiFab cfine;
     if (need_parallel_copy) {
-        const BoxArray& ba = amrex::coarsen(fine.boxArray(), 2);
+        const BoxArray& ba = amrex::coarsen(fine.boxArray(), ratio);
         cfine.define(ba, fine.DistributionMap(), 1, 0);
     }
 
@@ -511,7 +513,6 @@ MLNodeLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, MultiFab& 
     int idir = 2;
     if (amrlev == 0) {
         regular_coarsening = mg_coarsen_ratio_vec[cmglev-1] == mg_coarsen_ratio;
-        IntVect ratio = mg_coarsen_ratio_vec[cmglev-1];
         if (ratio[1] == 1) {
             idir = 1;
         } else if (ratio[0] == 1) {
@@ -607,11 +608,13 @@ MLNodeLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine, const Mu
     const auto& sigma = m_sigma[amrlev][fmglev];
     const auto& stencil = m_stencil[amrlev][fmglev];
 
+    IntVect const ratio = (amrlev > 0) ? IntVect(2) : mg_coarsen_ratio_vec[fmglev];
+
     bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
     MultiFab cfine;
     const MultiFab* cmf = &crse;
     if (need_parallel_copy) {
-        const BoxArray& ba = amrex::coarsen(fine.boxArray(), 2);
+        const BoxArray& ba = amrex::coarsen(fine.boxArray(), ratio);
         cfine.define(ba, fine.DistributionMap(), 1, 0);
         cfine.ParallelCopy(crse);
         cmf = &cfine;
@@ -626,7 +629,6 @@ MLNodeLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine, const Mu
     int idir = 2;
     if (amrlev == 0) {
         regular_coarsening = mg_coarsen_ratio_vec[fmglev] == mg_coarsen_ratio;
-        IntVect ratio = mg_coarsen_ratio_vec[fmglev];
         if (ratio[1] == 1) {
             idir = 1;
         } else if (ratio[0] == 1) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sten.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_sten.cpp
@@ -33,6 +33,10 @@ MLNodeLaplacian::buildStencil ()
                                      "MLNodeLaplacian::buildStencil: 1d not supported");
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!m_geom[0][0].IsRZ(),
                                      "MLNodeLaplacian::buildStencil: cylindrical not supported for RAP");
+    for (auto const& r : mg_coarsen_ratio_vec) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(r == IntVect(mg_coarsen_ratio),
+            "MLNodeLaplacian::buildStencil: semicoarsening not supported for RAP");
+    }
 
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev)
     {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp.cpp
@@ -322,7 +322,9 @@ MLNodeLinOp::buildMasks ()
 
             if (m_overset_dirichlet_mask && mglev > 0) {
                 const auto& dmask_fine = *m_dirichlet_mask[amrlev][mglev-1];
-                amrex::average_down_nodal(dmask_fine, dmask, IntVect(2));
+                IntVect const ratio = (amrlev > 0) ? IntVect(mg_coarsen_ratio)
+                                                   : mg_coarsen_ratio_vec[mglev-1];
+                amrex::average_down_nodal(dmask_fine, dmask, ratio);
             }
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -86,7 +86,19 @@ MLNodeTensorLaplacian::restriction (int amrlev, int cmglev, MultiFab& crse, Mult
     applyBC(amrlev, cmglev-1, fine, BCMode::Homogeneous, StateMode::Solution);
 
     IntVect const ratio = (amrlev > 0) ? IntVect(2) : mg_coarsen_ratio_vec[cmglev-1];
-    int semicoarsening_dir = info.semicoarsening_direction;
+#if (AMREX_SPACEDIM == 1)
+    int semicoarsening_dir = 0;
+#else
+    // Direction NOT coarsened by this MG step. Derived from the level's
+    // ratio, because info.semicoarsening_direction is -1 when the direction
+    // is chosen automatically.
+    int semicoarsening_dir = 2;
+    if (ratio[1] == 1) {
+        semicoarsening_dir = 1;
+    } else if (ratio[0] == 1) {
+        semicoarsening_dir = 0;
+    }
+#endif
 
     bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
     MultiFab cfine;
@@ -132,7 +144,19 @@ MLNodeTensorLaplacian::interpolation (int amrlev, int fmglev, MultiFab& fine,
     BL_PROFILE("MLNodeTensorLaplacian::interpolation()");
 
     IntVect const ratio = (amrlev > 0) ? IntVect(2) : mg_coarsen_ratio_vec[fmglev];
-    int semicoarsening_dir = info.semicoarsening_direction;
+#if (AMREX_SPACEDIM == 1)
+    int semicoarsening_dir = 0;
+#else
+    // Direction NOT coarsened by this MG step. Derived from the level's
+    // ratio, because info.semicoarsening_direction is -1 when the direction
+    // is chosen automatically.
+    int semicoarsening_dir = 2;
+    if (ratio[1] == 1) {
+        semicoarsening_dir = 1;
+    } else if (ratio[0] == 1) {
+        semicoarsening_dir = 0;
+    }
+#endif
 
     bool need_parallel_copy = !amrex::isMFIterSafe(crse, fine);
     MultiFab cfine;


### PR DESCRIPTION
Several restriction/interpolation/mask sites assumed an isotropic ratio of 2 or read info.semicoarsening_direction, which is -1 when the direction is picked automatically. Derive the direction from mg_coarsen_ratio_vec in MLEBNodeFDLaplacian and MLNodeTensorLaplacian, coarsen the parallel-copy temporaries and the nodal overset mask by the level ratio, force ratio 1 in the hidden direction for MG levels inside fine AMR levels, and fix a typo in the 2D semicoarsening prolongation. Overset MLCellABecLap now disables semicoarsening, and MLNodeABecLaplacian rejects it.

Fixes #5684.
