### PR TITLE
Check optional solver arguments before using them

### DIFF
--- a/.github/workflows/hypre.yml
+++ b/.github/workflows/hypre.yml
@@ -168,3 +168,45 @@ jobs:
 
         ccache -s
         du -hs ~/.cache/ccache
+
+  test-hypre-nodal-eb-fd-2d:
+    name: GCC Nodal EB FD 2D Hypre@2.32.0
+    runs-on: ubuntu-latest
+    needs: check_changes
+    if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    steps:
+    - uses: actions/checkout@v7
+    - name: Dependencies
+      run: |
+        .github/workflows/dependencies/dependencies.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Build Hypre
+      run: |
+        wget -q https://github.com/hypre-space/hypre/archive/refs/tags/v2.32.0.tar.gz
+        tar xfz v2.32.0.tar.gz
+        cd hypre-2.32.0/src
+        ./configure --with-cxxstandard=20 --enable-bigint
+        make -j 4
+        make install
+        cd ../../
+    - name: Build and Run Test
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        ccache -z
+
+        export AMREX_HYPRE_HOME=${PWD}/hypre-2.32.0/src/hypre
+        cd Tests/LinearSolvers/NodeEBFDLap
+        make -j4 USE_MPI=TRUE USE_HYPRE=TRUE DIM=2 COMP=gnu CCACHE=ccache CXXSTD=c++20
+        mpiexec -n 2 ./main2d.gnu.TEST.MPI.ex inputs_2d
+
+        ccache -s
+        du -hs ~/.cache/ccache

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -359,6 +359,8 @@ MLCellABecLapT<MF>::applyInhomogNeumannTerm (int amrlev, MF& rhs) const
     bool has_inhomog_neumann = this->hasInhomogNeumannBC();
     bool has_robin = this->hasRobinBC();
 
+    // A preconditioner must be linear, so it gets no inhomogeneous terms.
+    if (this->m_precond_mode) { return; }
     if (!has_inhomog_neumann && !has_robin) { return; }
 
     int ncomp = this->getNComp();

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -889,7 +889,9 @@ MLCellLinOpT<MF>::setLevelBC (int amrlev, const MF* a_levelbcdata, const MF* rob
                                                    crse_fine_bc_type);
     }
 
-    if (this->hasRobinBC()) {
+    // In precond mode beginPrecondBC calls this with null Robin data; keep
+    // the user's a, b and f rather than dereferencing the null pointers.
+    if (this->hasRobinBC() && !this->m_precond_mode) {
         AMREX_ASSERT(robinbc_a != nullptr && robinbc_b != nullptr && robinbc_f != nullptr);
         this->m_robin_bcval[amrlev] = std::make_unique<MF>(this->m_grids[amrlev][0],
                                                      this->m_dmap[amrlev][0],

--- a/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCurlCurl.cpp
@@ -377,13 +377,17 @@ MLCurlCurl::apply (int amrlev, int mglev, MF& out, MF& in, BCMode /*bc_mode*/,
     applyBC(amrlev, mglev, in, CurlCurlStateType::x);
 
     auto dxinv = this->m_geom[amrlev][mglev].InvCellSizeArray();
+    bool const has_alpha = (m_acoefs[amrlev][mglev][0] != nullptr);
     auto adxinv = dxinv;
-    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        adxinv[idim] *= std::sqrt(m_alpha);
+    if (!has_alpha) {
+        // m_alpha is a negative sentinel when alpha was given as a
+        // MultiFab, in which case adxinv is never read.
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            adxinv[idim] *= std::sqrt(m_alpha);
+        }
     }
     auto const b = m_beta;
     bool const has_beta = (m_bcoefs[amrlev][mglev][0] != nullptr);
-    bool const has_alpha = (m_acoefs[amrlev][mglev][0] != nullptr);
 
     auto dinfo = getDirichletInfo(amrlev,mglev);
     auto coord = m_coord;
@@ -570,9 +574,14 @@ void MLCurlCurl::smooth1D (int amrlev, int mglev, MF& sol, MF const& rhs,
 
     auto dinfo = getDirichletInfo(amrlev,mglev);
     auto dxinv = this->m_geom[amrlev][mglev].InvCellSizeArray();
+    bool const has_alpha = (m_acoefs[amrlev][mglev][0] != nullptr);
     auto adxinv = dxinv;
-    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        adxinv[idim] *= std::sqrt(m_alpha);
+    if (!has_alpha) {
+        // m_alpha is a negative sentinel when alpha was given as a
+        // MultiFab, in which case adxinv is never read.
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            adxinv[idim] *= std::sqrt(m_alpha);
+        }
     }
 
     int xhi = this->m_geom[amrlev][mglev].Domain().bigEnd(0);
@@ -583,7 +592,6 @@ void MLCurlCurl::smooth1D (int amrlev, int mglev, MF& sol, MF const& rhs,
                  rhs[0].DistributionMap(), 1, 0, MFInfo().SetAlloc(false));
 
     bool const has_beta = (m_bcoefs[amrlev][mglev][0] != nullptr);
-    bool const has_alpha = (m_acoefs[amrlev][mglev][0] != nullptr);
 
     if (has_alpha && has_beta) {
         auto const& acy = m_acoefs[amrlev][mglev][1]->const_arrays();
@@ -651,13 +659,17 @@ void MLCurlCurl::smooth4 (int amrlev, int mglev, MF& sol, MF const& rhs,
     auto const& rhsz = rhs[2].const_arrays();
 
     auto dxinv = this->m_geom[amrlev][mglev].InvCellSizeArray();
+    bool const has_alpha = (m_acoefs[amrlev][mglev][0] != nullptr);
     auto adxinv = dxinv;
-    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        adxinv[idim] *= std::sqrt(m_alpha);
+    if (!has_alpha) {
+        // m_alpha is a negative sentinel when alpha was given as a
+        // MultiFab, in which case adxinv is never read.
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            adxinv[idim] *= std::sqrt(m_alpha);
+        }
     }
 
     bool const has_beta = (m_bcoefs[amrlev][mglev][0] != nullptr);
-    bool const has_alpha = (m_acoefs[amrlev][mglev][0] != nullptr);
     bool const use_pcg = m_use_pcg || has_alpha;
     // We support LU solver with variable beta and scalar alpha.
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -227,6 +227,9 @@ template <typename F>
 requires (IsCallableR<Real,F,AMREX_D_DECL(Real,Real,Real)>::value)
 void MLEBNodeFDLaplacian::setEBDirichlet (F const& f)
 {
+    // Select m_phi_eb again, in case a previous prepareForSolve defaulted
+    // to homogeneous Dirichlet or a scalar value was set earlier.
+    m_s_phi_eb = std::numeric_limits<Real>::lowest();
     m_phi_eb.resize(m_num_amr_levels);
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {
         auto const* factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][0].get());

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -268,6 +268,13 @@ MLEBNodeFDLaplacian::prepareForSolve ()
     buildMasks();
 
 #ifdef AMREX_USE_EB
+    // If neither setEBDirichlet overload was called, m_s_phi_eb still holds
+    // the "use the m_phi_eb array" sentinel while m_phi_eb is empty. Default
+    // to homogeneous Dirichlet on the EB instead.
+    if (m_s_phi_eb == std::numeric_limits<Real>::lowest() && m_phi_eb.empty()) {
+        m_s_phi_eb = Real(0.0);
+    }
+
     // Set covered nodes to Dirichlet, but with a negative value.
     // compGrad relies on the negative value to detect EB.
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev) {

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H
@@ -1756,11 +1756,15 @@ void
 MLLinOpT<MF>::setCoarseFineBC (const AMF* crse, IntVect const& crse_ratio,
                                LinOpBCType bc_type) noexcept
 {
-    m_coarse_data_for_bc_raii = MF(crse->boxArray(), crse->DistributionMap(),
-                                   crse->nComp(), crse->nGrowVect());
-    m_coarse_data_for_bc_raii.LocalCopy(*crse, 0, 0, crse->nComp(),
-                                        crse->nGrowVect());
-    m_coarse_data_for_bc = &m_coarse_data_for_bc_raii;
+    if (crse) {
+        m_coarse_data_for_bc_raii = MF(crse->boxArray(), crse->DistributionMap(),
+                                       crse->nComp(), crse->nGrowVect());
+        m_coarse_data_for_bc_raii.LocalCopy(*crse, 0, 0, crse->nComp(),
+                                            crse->nGrowVect());
+        m_coarse_data_for_bc = &m_coarse_data_for_bc_raii;
+    } else {
+        m_coarse_data_for_bc = nullptr;
+    }
     m_coarse_data_crse_ratio = crse_ratio;
     m_coarse_fine_bc_type = bc_type;
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_eb.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_eb.cpp
@@ -95,7 +95,7 @@ MLNodeLaplacian::buildSurfaceIntegral ()
         MultiFab* sintg = m_surface_integral[amrlev].get();
 
         const auto *factory = dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][0].get());
-        if (factory)
+        if (factory && sintg)
         {
             const int ncomp = sintg->nComp();
             const auto& flags = factory->getMultiEBCellFlagFab();
@@ -141,7 +141,8 @@ MLNodeLaplacian::buildSurfaceIntegral ()
 #else
     for (int amrlev = 0; amrlev < m_num_amr_levels; ++amrlev)
     {
-        if (dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][0].get())) {
+        if (m_surface_integral[amrlev] &&
+            dynamic_cast<EBFArrayBoxFactory const*>(m_factory[amrlev][0].get())) {
             amrex::algoim::compute_surface_integrals(*m_surface_integral[amrlev]);
         }
     }

--- a/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
+++ b/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
@@ -251,7 +251,19 @@ Real OpenBCSolver::solve (const Vector<MultiFab*>& a_sol,
         }
 #endif
     }
-    m_mlmg_1->solve(a_sol, a_rhs, a_tol_rel, a_tol_abs);
+    // get_dpdn_on_domain_faces below reads the domain boundary ghost cells of
+    // the level 0 solution. MLMG only leaves the boundary values there if it
+    // aliased the MultiFab, which it does only for exactly one ghost cell.
+    // Otherwise solve into a temporary that has one.
+    Vector<MultiFab*> sol_1 = a_sol;
+    MultiFab sol_1_tmp;
+    if (a_sol[0]->nGrowVect() != IntVect(1)) {
+        sol_1_tmp.define(m_grids[0], m_dmap[0], 1, 1);
+        sol_1_tmp.setVal(0._rt);
+        MultiFab::Copy(sol_1_tmp, *a_sol[0], 0, 0, 1, 0);
+        sol_1[0] = &sol_1_tmp;
+    }
+    m_mlmg_1->solve(sol_1, a_rhs, a_tol_rel, a_tol_abs);
 
     BL_PROFILE_VAR_STOP(blp_mg1);
 
@@ -261,7 +273,7 @@ Real OpenBCSolver::solve (const Vector<MultiFab*>& a_sol,
                                              IntVect::TheDimensionVector(idim)),
                           m_dmap[0], 1, 0);
     }
-    m_poisson_1->get_dpdn_on_domain_faces(GetArrOfPtrs(dpdn_tmp), *a_sol[0]);
+    m_poisson_1->get_dpdn_on_domain_faces(GetArrOfPtrs(dpdn_tmp), *sol_1[0]);
 
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         m_dpdn[idim].ParallelCopy(dpdn_tmp[idim]);

--- a/Tests/LinearSolvers/NodeEBFDLap/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodeEBFDLap/CMakeLists.txt
@@ -1,4 +1,5 @@
-if ( (NOT AMReX_EB) OR (NOT AMReX_HYPRE) OR (NOT AMReX_LINEAR_SOLVERS_EM) )
+# The hypre comparison is skipped at run time when hypre is not available.
+if ( (NOT AMReX_EB) OR (NOT AMReX_LINEAR_SOLVERS_EM) )
    return()
 endif ()
 

--- a/Tests/LinearSolvers/NodeEBFDLap/inputs_2d
+++ b/Tests/LinearSolvers/NodeEBFDLap/inputs_2d
@@ -1,10 +1,6 @@
 n_cell = 32
 max_grid_size = 16
 
-# Let the hypre bottom solve do all of the work.  That makes this the sharpest
-# possible test of the matrix assembled by MLEBNodeFDLaplacian::fillIJMatrix.
-max_coarsening_level = 0
-
 verbose = 0
 bottom_verbose = 0
 

--- a/Tests/LinearSolvers/NodeEBFDLap/inputs_3d
+++ b/Tests/LinearSolvers/NodeEBFDLap/inputs_3d
@@ -1,10 +1,6 @@
 n_cell = 32
 max_grid_size = 16
 
-# Let the hypre bottom solve do all of the work.  That makes this the sharpest
-# possible test of the matrix assembled by MLEBNodeFDLaplacian::fillIJMatrix.
-max_coarsening_level = 0
-
 verbose = 0
 bottom_verbose = 0
 

--- a/Tests/LinearSolvers/NodeEBFDLap/main.cpp
+++ b/Tests/LinearSolvers/NodeEBFDLap/main.cpp
@@ -4,9 +4,9 @@
 //   * reusing an operator must not lose the EB Dirichlet values supplied by
 //     the callable setEBDirichlet;
 //   * solving del dot (sigma grad phi) = rhs with the hypre bottom solver
-//     must reproduce the native bottom solver.  Set max_coarsening_level = 0
-//     to make the bottom solve do all of the work, which is the sharpest test
-//     of the matrix assembled by MLEBNodeFDLaplacian::fillIJMatrix.  This one
+//     must reproduce the native bottom solver.  That solve does not coarsen,
+//     so the bottom solve does all of the work, which is the sharpest test of
+//     the matrix assembled by MLEBNodeFDLaplacian::fillIJMatrix.  This one
 //     needs hypre, so it is skipped when hypre is not available.
 //
 
@@ -18,6 +18,7 @@
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_PlotFileUtil.H>
+#include <AMReX_Reduce.H>
 
 using namespace amrex;
 
@@ -61,19 +62,23 @@ void test_eb_dirichlet_reuse (Geometry const& geom, BoxArray const& grids,
     do_solve();
 
     auto const& levset = factory.getLevelSet();
-    Real maxdiff = 0.0;
-    Long ncovered = 0;
+    ReduceOps<ReduceOpMax, ReduceOpSum> reduce_op;
+    ReduceData<Real, Long> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
     for (MFIter mfi(sol); mfi.isValid(); ++mfi) {
         Array4<Real const> const& s = sol.const_array(mfi);
         Array4<Real const> const& ls = levset.const_array(mfi);
-        amrex::LoopOnCpu(mfi.validbox(), [&] (int i, int j, int k)
+        reduce_op.eval(mfi.validbox(), reduce_data,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
         {
-            if (ls(i,j,k) >= Real(0.0)) {
-                ++ncovered;
-                maxdiff = std::max(maxdiff, std::abs(s(i,j,k)-phi_eb));
-            }
+            bool const covered = ls(i,j,k) >= Real(0.0);
+            return { covered ? std::abs(s(i,j,k)-phi_eb) : Real(0.0),
+                     covered ? Long(1) : Long(0) };
         });
     }
+    auto const hv = reduce_data.value(reduce_op);
+    Real maxdiff = amrex::get<0>(hv);
+    Long ncovered = amrex::get<1>(hv);
     ParallelDescriptor::ReduceRealMax(maxdiff);
     ParallelDescriptor::ReduceLongSum(ncovered);
 
@@ -93,14 +98,14 @@ void test_native_vs_hypre (Geometry const& geom, BoxArray const& grids,
                            EBFArrayBoxFactory const& factory,
                            Array<LinOpBCType,AMREX_SPACEDIM> const& lobc,
                            Array<LinOpBCType,AMREX_SPACEDIM> const& hibc,
-                           int max_coarsening_level, Real reltol, int verbose)
+                           Real reltol, int verbose)
 {
     int bottom_verbose = 0;
     int use_sigma_mf = 1;
     int plot = 0;
     Real phi_eb = 1.0;
     Real bottom_reltol = 1.e-9;
-    Real max_rel_diff = 1.e-12;
+    Real max_rel_diff = std::is_same_v<Real,float> ? Real(1.e-4) : Real(1.e-12);
     {
         ParmParse pp;
         pp.query("bottom_verbose", bottom_verbose);
@@ -149,8 +154,9 @@ void test_native_vs_hypre (Geometry const& geom, BoxArray const& grids,
 
     auto do_solve = [&] (BottomSolver bottom_solver, MultiFab& sol)
     {
+        // No coarsening, so that the bottom solver does all of the work.
         LPInfo info;
-        info.setMaxCoarseningLevel(max_coarsening_level);
+        info.setMaxCoarseningLevel(0);
 
         MLEBNodeFDLaplacian linop({geom}, {grids}, {dmap}, info,
                                   {&factory});
@@ -217,9 +223,10 @@ int main (int argc, char* argv[])
     {
         int n_cell = 64;
         int max_grid_size = 32;
-        int max_coarsening_level = 0;
+        int max_coarsening_level = 30;
         int verbose = 1;
-        Real reltol = 1.e-11;
+        // Single precision cannot reach the double precision tolerance.
+        Real reltol = std::is_same_v<Real,float> ? Real(1.e-4) : Real(1.e-11);
         Vector<int> periodic{AMREX_D_DECL(0,0,0)};
         {
             ParmParse pp;
@@ -267,7 +274,7 @@ int main (int argc, char* argv[])
 
 #ifdef AMREX_USE_HYPRE
         test_native_vs_hypre(geom, grids, dmap, ebfactory,
-                             lobc, hibc, max_coarsening_level, reltol, verbose);
+                             lobc, hibc, reltol, verbose);
 #endif
     }
     amrex::Finalize();

--- a/Tests/LinearSolvers/NodeEBFDLap/main.cpp
+++ b/Tests/LinearSolvers/NodeEBFDLap/main.cpp
@@ -78,7 +78,7 @@ void test_eb_dirichlet_reuse (Geometry const& geom, BoxArray const& grids,
     ParallelDescriptor::ReduceLongSum(ncovered);
 
     amrex::Print() << "covered nodes      = " << ncovered << "\n"
-                   << "max EB value error = " << maxdiff << std::endl;
+                   << "max EB value error = " << maxdiff << '\n';
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ncovered > 0,
         "No covered nodes: the EB Dirichlet value is not being tested");
@@ -118,7 +118,7 @@ void test_native_vs_hypre (Geometry const& geom, BoxArray const& grids,
     MultiFab sigma(grids, dmap, 1, 1, MFInfo(), factory);
     // Use whole wavenumbers so that sigma and the source stay single valued
     // when a direction is periodic.
-    Real const twopi = Real(2.0)*Real(3.14159265358979323846);
+    Real const twopi = Real(2.0)*Math::pi<Real>();
     auto const dx = geom.CellSizeArray();
     auto const problo = geom.ProbLoArray();
     for (MFIter mfi(sigma); mfi.isValid(); ++mfi) {
@@ -196,7 +196,7 @@ void test_native_vs_hypre (Geometry const& geom, BoxArray const& grids,
                    << ", hypre = " << err_hypre << "\n"
                    << "max |phi|              = " << smax << "\n"
                    << "max |phi_hypre - phi|  = " << dmax << "\n"
-                   << "relative difference    = " << dmax/smax << std::endl;
+                   << "relative difference    = " << dmax/smax << '\n';
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dmax <= max_rel_diff*smax,
         "The hypre bottom solver did not reproduce the native solution");

--- a/Tests/LinearSolvers/NodeEBFDLap/main.cpp
+++ b/Tests/LinearSolvers/NodeEBFDLap/main.cpp
@@ -56,7 +56,7 @@ void test_eb_dirichlet_reuse (Geometry const& geom, BoxArray const& grids,
     do_solve(); // no setEBDirichlet yet
 
     Real const phi_eb = 5.0;
-    linop.setEBDirichlet([=] AMREX_GPU_DEVICE (AMREX_D_DECL(Real,Real,Real)) -> Real
+    linop.setEBDirichlet([=] AMREX_GPU_HOST_DEVICE (AMREX_D_DECL(Real,Real,Real)) -> Real
                          { return phi_eb; });
     do_solve();
 

--- a/Tests/LinearSolvers/NodeEBFDLap/main.cpp
+++ b/Tests/LinearSolvers/NodeEBFDLap/main.cpp
@@ -1,12 +1,13 @@
 //
-// Solves del dot (sigma grad phi) = rhs with MLEBNodeFDLaplacian and compares
-// the solution obtained with the hypre bottom solver against the one obtained
-// with the native bottom solver.  Set max_coarsening_level = 0 to make the
-// bottom solve do all of the work, which is the sharpest test of the matrix
-// assembled by MLEBNodeFDLaplacian::fillIJMatrix.
+// Two checks on MLEBNodeFDLaplacian:
 //
-// It also checks that reusing an operator does not lose the EB Dirichlet
-// values supplied by the callable setEBDirichlet.
+//   * reusing an operator must not lose the EB Dirichlet values supplied by
+//     the callable setEBDirichlet;
+//   * solving del dot (sigma grad phi) = rhs with the hypre bottom solver
+//     must reproduce the native bottom solver.  Set max_coarsening_level = 0
+//     to make the bottom solve do all of the work, which is the sharpest test
+//     of the matrix assembled by MLEBNodeFDLaplacian::fillIJMatrix.  This one
+//     needs hypre, so it is skipped when hypre is not available.
 //
 
 #include <AMReX.H>
@@ -85,6 +86,131 @@ void test_eb_dirichlet_reuse (Geometry const& geom, BoxArray const& grids,
         "setEBDirichlet was ignored after a solve without it");
 }
 
+#ifdef AMREX_USE_HYPRE
+// The hypre bottom solver must reproduce the native one.
+void test_native_vs_hypre (Geometry const& geom, BoxArray const& grids,
+                           DistributionMapping const& dmap,
+                           EBFArrayBoxFactory const& factory,
+                           Array<LinOpBCType,AMREX_SPACEDIM> const& lobc,
+                           Array<LinOpBCType,AMREX_SPACEDIM> const& hibc,
+                           int max_coarsening_level, Real reltol, int verbose)
+{
+    int bottom_verbose = 0;
+    int use_sigma_mf = 1;
+    int plot = 0;
+    Real phi_eb = 1.0;
+    Real bottom_reltol = 1.e-9;
+    Real max_rel_diff = 1.e-12;
+    {
+        ParmParse pp;
+        pp.query("bottom_verbose", bottom_verbose);
+        pp.query("use_sigma_mf", use_sigma_mf);
+        pp.query("phi_eb", phi_eb);
+        pp.query("bottom_reltol", bottom_reltol);
+        pp.query("plot", plot);
+        pp.query("max_rel_diff", max_rel_diff);
+    }
+
+    BoxArray const& nba = amrex::convert(grids, IntVect(1));
+
+    // A smooth, strictly positive sigma so that the variable coefficient
+    // path is exercised.
+    MultiFab sigma(grids, dmap, 1, 1, MFInfo(), factory);
+    // Use whole wavenumbers so that sigma and the source stay single valued
+    // when a direction is periodic.
+    Real const twopi = Real(2.0)*Real(3.14159265358979323846);
+    auto const dx = geom.CellSizeArray();
+    auto const problo = geom.ProbLoArray();
+    for (MFIter mfi(sigma); mfi.isValid(); ++mfi) {
+        Array4<Real> const& s = sigma.array(mfi);
+        amrex::ParallelFor(mfi.growntilebox(), [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            AMREX_D_TERM(Real const x = problo[0] + (i+Real(0.5))*dx[0];,
+                         Real const y = problo[1] + (j+Real(0.5))*dx[1];,
+                         Real const z = problo[2] + (k+Real(0.5))*dx[2];)
+            s(i,j,k) = Real(1.0) + Real(0.5)*std::sin(twopi*x)
+                * AMREX_D_TERM(Real(1.0), *std::cos(Real(2.0)*twopi*y), *std::sin(twopi*z));
+        });
+    }
+    sigma.FillBoundary(geom.periodicity());
+
+    MultiFab rhs(nba, dmap, 1, 0);
+    for (MFIter mfi(rhs); mfi.isValid(); ++mfi) {
+        Array4<Real> const& r = rhs.array(mfi);
+        amrex::ParallelFor(mfi.tilebox(), [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            AMREX_D_TERM(Real const x = problo[0] + i*dx[0];,
+                         Real const y = problo[1] + j*dx[1];,
+                         Real const z = problo[2] + k*dx[2];)
+            r(i,j,k) = std::sin(twopi*x)
+                * AMREX_D_TERM(Real(1.0), *std::cos(Real(3.0)*twopi*y), *std::cos(Real(2.0)*twopi*z));
+        });
+    }
+
+    auto do_solve = [&] (BottomSolver bottom_solver, MultiFab& sol)
+    {
+        LPInfo info;
+        info.setMaxCoarseningLevel(max_coarsening_level);
+
+        MLEBNodeFDLaplacian linop({geom}, {grids}, {dmap}, info,
+                                  {&factory});
+        linop.setDomainBC(lobc, hibc);
+        linop.setEBDirichlet(phi_eb);
+        if (use_sigma_mf) {
+            linop.setSigma(0, sigma);
+        } else {
+            linop.setSigma({AMREX_D_DECL(Real(1.0), Real(1.5), Real(0.7))});
+        }
+
+        MLMG mlmg(linop);
+        mlmg.setVerbose(verbose);
+        mlmg.setBottomVerbose(bottom_verbose);
+        mlmg.setBottomSolver(bottom_solver);
+        mlmg.setBottomTolerance(bottom_reltol);
+        mlmg.setBottomMaxIter(1000);
+
+        MultiFab rhs_copy(nba, dmap, 1, 0);
+        MultiFab::Copy(rhs_copy, rhs, 0, 0, 1, 0);
+
+        sol.define(nba, dmap, 1, 1);
+        sol.setVal(0.0);
+        return mlmg.solve({&sol}, {&rhs_copy}, reltol, Real(0.0));
+    };
+
+    MultiFab sol_native;
+    MultiFab sol_hypre;
+
+    amrex::Print() << "\n==== native bottom solver ====\n";
+    Real const err_native = do_solve(BottomSolver::bicgstab, sol_native);
+
+    amrex::Print() << "\n==== hypre bottom solver ====\n";
+    Real const err_hypre = do_solve(BottomSolver::hypre, sol_hypre);
+
+    MultiFab diff(nba, dmap, 1, 0);
+    MultiFab::Copy(diff, sol_hypre, 0, 0, 1, 0);
+    MultiFab::Subtract(diff, sol_native, 0, 0, 1, 0);
+    Real const dmax = diff.norminf();
+    Real const smax = sol_native.norminf(0, 0);
+
+    amrex::Print() << "\nfinal residual: native = " << err_native
+                   << ", hypre = " << err_hypre << "\n"
+                   << "max |phi|              = " << smax << "\n"
+                   << "max |phi_hypre - phi|  = " << dmax << "\n"
+                   << "relative difference    = " << dmax/smax << std::endl;
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dmax <= max_rel_diff*smax,
+        "The hypre bottom solver did not reproduce the native solution");
+
+    if (plot) {
+        MultiFab plotmf(nba, dmap, 3, 0);
+        MultiFab::Copy(plotmf, sol_native, 0, 0, 1, 0);
+        MultiFab::Copy(plotmf, sol_hypre , 0, 1, 1, 0);
+        MultiFab::Copy(plotmf, diff      , 0, 2, 1, 0);
+        WriteSingleLevelPlotfile("plot", plotmf, {"phi_native","phi_hypre","diff"}, geom, 0.0, 0);
+    }
+}
+#endif
+
 int main (int argc, char* argv[])
 {
     amrex::Initialize(argc, argv);
@@ -93,13 +219,7 @@ int main (int argc, char* argv[])
         int max_grid_size = 32;
         int max_coarsening_level = 0;
         int verbose = 1;
-        int bottom_verbose = 0;
-        int use_sigma_mf = 1;
-        int plot = 0;
-        Real phi_eb = 1.0;
         Real reltol = 1.e-11;
-        Real bottom_reltol = 1.e-9;
-        Real max_rel_diff = 1.e-12;
         Vector<int> periodic{AMREX_D_DECL(0,0,0)};
         {
             ParmParse pp;
@@ -108,13 +228,7 @@ int main (int argc, char* argv[])
             pp.query("max_grid_size", max_grid_size);
             pp.query("max_coarsening_level", max_coarsening_level);
             pp.query("verbose", verbose);
-            pp.query("bottom_verbose", bottom_verbose);
-            pp.query("use_sigma_mf", use_sigma_mf);
-            pp.query("phi_eb", phi_eb);
             pp.query("reltol", reltol);
-            pp.query("bottom_reltol", bottom_reltol);
-            pp.query("plot", plot);
-            pp.query("max_rel_diff", max_rel_diff);
         }
 
         Box const domain(IntVect(0), IntVect(n_cell-1));
@@ -131,42 +245,7 @@ int main (int argc, char* argv[])
 
         EB2::Build(geom, 0, max_coarsening_level);
         auto factory = makeEBFabFactory(geom, grids, dmap, {2,2,2}, EBSupport::full);
-
-        BoxArray const& nba = amrex::convert(grids, IntVect(1));
-
-        // A smooth, strictly positive sigma so that the variable coefficient
-        // path is exercised.
-        MultiFab sigma(grids, dmap, 1, 1, MFInfo(), *factory);
-        // Use whole wavenumbers so that sigma and the source stay single valued
-        // when a direction is periodic.
-        Real const twopi = Real(2.0)*Real(3.14159265358979323846);
-        auto const dx = geom.CellSizeArray();
-        auto const problo = geom.ProbLoArray();
-        for (MFIter mfi(sigma); mfi.isValid(); ++mfi) {
-            Array4<Real> const& s = sigma.array(mfi);
-            amrex::ParallelFor(mfi.growntilebox(), [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                AMREX_D_TERM(Real const x = problo[0] + (i+Real(0.5))*dx[0];,
-                             Real const y = problo[1] + (j+Real(0.5))*dx[1];,
-                             Real const z = problo[2] + (k+Real(0.5))*dx[2];)
-                s(i,j,k) = Real(1.0) + Real(0.5)*std::sin(twopi*x)
-                    * AMREX_D_TERM(Real(1.0), *std::cos(Real(2.0)*twopi*y), *std::sin(twopi*z));
-            });
-        }
-        sigma.FillBoundary(geom.periodicity());
-
-        MultiFab rhs(nba, dmap, 1, 0);
-        for (MFIter mfi(rhs); mfi.isValid(); ++mfi) {
-            Array4<Real> const& r = rhs.array(mfi);
-            amrex::ParallelFor(mfi.tilebox(), [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                AMREX_D_TERM(Real const x = problo[0] + i*dx[0];,
-                             Real const y = problo[1] + j*dx[1];,
-                             Real const z = problo[2] + k*dx[2];)
-                r(i,j,k) = std::sin(twopi*x)
-                    * AMREX_D_TERM(Real(1.0), *std::cos(Real(3.0)*twopi*y), *std::cos(Real(2.0)*twopi*z));
-            });
-        }
+        auto const& ebfactory = *static_cast<EBFArrayBoxFactory const*>(factory.get());
 
         // Mix the boundary conditions so that both the Dirichlet nodes (which
         // are left out of the linear system) and the Neumann nodes (whose ghost
@@ -182,72 +261,14 @@ int main (int argc, char* argv[])
             }
         }
 
-        auto do_solve = [&] (BottomSolver bottom_solver, MultiFab& sol)
-        {
-            LPInfo info;
-            info.setMaxCoarseningLevel(max_coarsening_level);
-
-            MLEBNodeFDLaplacian linop({geom}, {grids}, {dmap}, info,
-                                      {static_cast<EBFArrayBoxFactory const*>(factory.get())});
-            linop.setDomainBC(lobc, hibc);
-            linop.setEBDirichlet(phi_eb);
-            if (use_sigma_mf) {
-                linop.setSigma(0, sigma);
-            } else {
-                linop.setSigma({AMREX_D_DECL(Real(1.0), Real(1.5), Real(0.7))});
-            }
-
-            MLMG mlmg(linop);
-            mlmg.setVerbose(verbose);
-            mlmg.setBottomVerbose(bottom_verbose);
-            mlmg.setBottomSolver(bottom_solver);
-            mlmg.setBottomTolerance(bottom_reltol);
-            mlmg.setBottomMaxIter(1000);
-
-            MultiFab rhs_copy(nba, dmap, 1, 0);
-            MultiFab::Copy(rhs_copy, rhs, 0, 0, 1, 0);
-
-            sol.define(nba, dmap, 1, 1);
-            sol.setVal(0.0);
-            return mlmg.solve({&sol}, {&rhs_copy}, reltol, Real(0.0));
-        };
-
-        MultiFab sol_native;
-        MultiFab sol_hypre;
-
-        amrex::Print() << "\n==== native bottom solver ====\n";
-        Real const err_native = do_solve(BottomSolver::bicgstab, sol_native);
-
-        amrex::Print() << "\n==== hypre bottom solver ====\n";
-        Real const err_hypre = do_solve(BottomSolver::hypre, sol_hypre);
-
-        MultiFab diff(nba, dmap, 1, 0);
-        MultiFab::Copy(diff, sol_hypre, 0, 0, 1, 0);
-        MultiFab::Subtract(diff, sol_native, 0, 0, 1, 0);
-        Real const dmax = diff.norminf();
-        Real const smax = sol_native.norminf(0, 0);
-
-        amrex::Print() << "\nfinal residual: native = " << err_native
-                       << ", hypre = " << err_hypre << "\n"
-                       << "max |phi|              = " << smax << "\n"
-                       << "max |phi_hypre - phi|  = " << dmax << "\n"
-                       << "relative difference    = " << dmax/smax << std::endl;
-
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dmax <= max_rel_diff*smax,
-            "The hypre bottom solver did not reproduce the native solution");
-
         amrex::Print() << "\n==== EB Dirichlet value after operator reuse ====\n";
-        test_eb_dirichlet_reuse(geom, grids, dmap,
-                                *static_cast<EBFArrayBoxFactory const*>(factory.get()),
+        test_eb_dirichlet_reuse(geom, grids, dmap, ebfactory,
                                 lobc, hibc, max_coarsening_level, reltol, verbose);
 
-        if (plot) {
-            MultiFab plotmf(nba, dmap, 3, 0);
-            MultiFab::Copy(plotmf, sol_native, 0, 0, 1, 0);
-            MultiFab::Copy(plotmf, sol_hypre , 0, 1, 1, 0);
-            MultiFab::Copy(plotmf, diff      , 0, 2, 1, 0);
-            WriteSingleLevelPlotfile("plot", plotmf, {"phi_native","phi_hypre","diff"}, geom, 0.0, 0);
-        }
+#ifdef AMREX_USE_HYPRE
+        test_native_vs_hypre(geom, grids, dmap, ebfactory,
+                             lobc, hibc, max_coarsening_level, reltol, verbose);
+#endif
     }
     amrex::Finalize();
 }

--- a/Tests/LinearSolvers/NodeEBFDLap/main.cpp
+++ b/Tests/LinearSolvers/NodeEBFDLap/main.cpp
@@ -5,6 +5,9 @@
 // bottom solve do all of the work, which is the sharpest test of the matrix
 // assembled by MLEBNodeFDLaplacian::fillIJMatrix.
 //
+// It also checks that reusing an operator does not lose the EB Dirichlet
+// values supplied by the callable setEBDirichlet.
+//
 
 #include <AMReX.H>
 #include <AMReX_EB2.H>
@@ -16,6 +19,71 @@
 #include <AMReX_PlotFileUtil.H>
 
 using namespace amrex;
+
+// A solve that never calls setEBDirichlet makes prepareForSolve pick
+// homogeneous Dirichlet on the EB.  A setEBDirichlet call after that must
+// still be honored.  postSolve stores the EB value in the covered nodes, so
+// those nodes tell us which value was used.
+void test_eb_dirichlet_reuse (Geometry const& geom, BoxArray const& grids,
+                              DistributionMapping const& dmap,
+                              EBFArrayBoxFactory const& factory,
+                              Array<LinOpBCType,AMREX_SPACEDIM> const& lobc,
+                              Array<LinOpBCType,AMREX_SPACEDIM> const& hibc,
+                              int max_coarsening_level, Real reltol, int verbose)
+{
+    BoxArray const& nba = amrex::convert(grids, IntVect(1));
+
+    LPInfo info;
+    info.setMaxCoarseningLevel(max_coarsening_level);
+    MLEBNodeFDLaplacian linop({geom}, {grids}, {dmap}, info, {&factory});
+    linop.setDomainBC(lobc, hibc);
+    linop.setSigma({AMREX_D_DECL(Real(1.0), Real(1.0), Real(1.0))});
+
+    MultiFab rhs(nba, dmap, 1, 0);
+    rhs.setVal(Real(1.0));
+    MultiFab sol(nba, dmap, 1, 1);
+
+    auto do_solve = [&] () {
+        MLMG mlmg(linop);
+        mlmg.setVerbose(verbose);
+        MultiFab rhs_copy(nba, dmap, 1, 0);
+        MultiFab::Copy(rhs_copy, rhs, 0, 0, 1, 0);
+        sol.setVal(0.0);
+        mlmg.solve({&sol}, {&rhs_copy}, reltol, Real(0.0));
+    };
+
+    do_solve(); // no setEBDirichlet yet
+
+    Real const phi_eb = 5.0;
+    linop.setEBDirichlet([=] AMREX_GPU_DEVICE (AMREX_D_DECL(Real,Real,Real)) -> Real
+                         { return phi_eb; });
+    do_solve();
+
+    auto const& levset = factory.getLevelSet();
+    Real maxdiff = 0.0;
+    Long ncovered = 0;
+    for (MFIter mfi(sol); mfi.isValid(); ++mfi) {
+        Array4<Real const> const& s = sol.const_array(mfi);
+        Array4<Real const> const& ls = levset.const_array(mfi);
+        amrex::LoopOnCpu(mfi.validbox(), [&] (int i, int j, int k)
+        {
+            if (ls(i,j,k) >= Real(0.0)) {
+                ++ncovered;
+                maxdiff = std::max(maxdiff, std::abs(s(i,j,k)-phi_eb));
+            }
+        });
+    }
+    ParallelDescriptor::ReduceRealMax(maxdiff);
+    ParallelDescriptor::ReduceLongSum(ncovered);
+
+    amrex::Print() << "covered nodes      = " << ncovered << "\n"
+                   << "max EB value error = " << maxdiff << std::endl;
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ncovered > 0,
+        "No covered nodes: the EB Dirichlet value is not being tested");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(maxdiff <= Real(1.e-12),
+        "setEBDirichlet was ignored after a solve without it");
+}
 
 int main (int argc, char* argv[])
 {
@@ -167,6 +235,11 @@ int main (int argc, char* argv[])
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dmax <= max_rel_diff*smax,
             "The hypre bottom solver did not reproduce the native solution");
+
+        amrex::Print() << "\n==== EB Dirichlet value after operator reuse ====\n";
+        test_eb_dirichlet_reuse(geom, grids, dmap,
+                                *static_cast<EBFArrayBoxFactory const*>(factory.get()),
+                                lobc, hibc, max_coarsening_level, reltol, verbose);
 
         if (plot) {
             MultiFab plotmf(nba, dmap, 3, 0);


### PR DESCRIPTION
Six setters or arguments documented as optional were consumed unchecked: setLevelBC dereferenced the null Robin pointers that beginPrecondBC passes, the mixed-type setCoarseFineBC dereferenced a documented-nullable crse, MLCurlCurl took sqrt of the m_alpha sentinel when alpha came from a MultiFab, MLEBNodeFDLaplacian indexed an empty m_phi_eb when setEBDirichlet was never called, buildSurfaceIntegral dereferenced per-level integrals that setEBInflowVelocity had not allocated, and OpenBCSolver read solution ghost cells that MLMG fills only when it aliases the input.

Fixes #5685.
