### PR TITLE
Update FaceDivFree refinement ratio documentation

### DIFF
--- a/Docs/sphinx_documentation/source/AmrCore.rst
+++ b/Docs/sphinx_documentation/source/AmrCore.rst
@@ -250,7 +250,10 @@ These Interpolaters can be executed on CPU or GPU, with certain limitations:
 
 -  :cpp:`CellConservativeQuartic` only works with a refinement ratio of 2.
 
--  :cpp:`FaceDivFree` only works in 2D and 3D and with a refinement ratio of 2.
+-  :cpp:`FaceDivFree` only works in 2D and 3D, and the refinement ratio in
+   each direction must be 2 or 4. On GPUs, a refinement ratio other than 2
+   must be run on the device. In 2D RZ, only a refinement ratio of 2 is
+   supported.
 
 .. _sec:amrcore:fluxreg:
 

--- a/Src/AmrCore/AMReX_Interpolater.cpp
+++ b/Src/AmrCore/AMReX_Interpolater.cpp
@@ -27,8 +27,9 @@ namespace amrex {
  *
  * FaceConservativeLinear works in 2D and 3D on cpu and gpu.
  *
- * FaceDivFree works in 2D and 3D on cpu and gpu.
- * The algorithm is restricted to ref ratio of 2.
+ * FaceDivFree works in 2D and 3D on cpu and gpu with a ref ratio of 2 or 4
+ * in each direction. On gpu, a ref ratio other than 2 must run on the
+ * device. In 2D RZ, only a ref ratio of 2 is supported.
  */
 
 //


### PR DESCRIPTION
The interpolater has supported a ref ratio of 2 or 4 in each direction since only. Note the two remaining restrictions: on GPUs a ratio other than 2 must run on the device, and 2D RZ is still ratio 2 only.
