### PR TITLE
Give GPU pack/unpack metadata that matches the comm buffers

### DIFF
--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -146,7 +146,7 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
         if (Gpu::inLaunchRegion())
         {
 #if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
-            if (Gpu::inGraphRegion()) {
+            if (std::is_same_v<BUF,value_type> && Gpu::inGraphRegion()) {
                 FB_pack_send_buffer_cuda_graph(TheFB, scomp, ncomp, send_data, send_size, send_cctc);
             }
             else
@@ -267,7 +267,7 @@ FabArray<FAB>::FillBoundary_finish ()
         if (Gpu::inLaunchRegion())
         {
 #if defined(__CUDACC__) && defined(AMREX_USE_CUDA)
-            if (Gpu::inGraphRegion() && !sumboundary)
+            if (std::is_same_v<BUF,value_type> && Gpu::inGraphRegion() && !sumboundary)
             {
                 FB_unpack_recv_buffer_cuda_graph(*TheFB, fbd->scomp, fbd->ncomp,
                                                  fbd->recv_data, fbd->recv_size,

--- a/Src/Base/AMReX_NonLocalBCImpl.H
+++ b/Src/Base/AMReX_NonLocalBCImpl.H
@@ -460,6 +460,7 @@ Comm_nowait (FabArray<FAB>& mf, int scomp, int ncomp, FabArrayBase::CommMetaData
         handler.send.the_data =
             FabArray<FAB>::PrepareSendBuffers(*cmd.m_SndTags, handler.send.data, handler.send.size,
                                   handler.send.rank, handler.send.request, handler.send.cctc, ncomp);
+        handler.send.id = FabArrayBase::getNextCommMetaDataId();
 
 #ifdef AMREX_USE_GPU
         if (Gpu::inLaunchRegion()) {


### PR DESCRIPTION
NonLocalBC::Comm_nowait keyed pack_send_buffer_gpu's per-FabArray TagVector cache with handler.send.id, which PrepareSendBuffers never assigns, so a second comm pattern on the same FabArray packed the first one's boxes and offsets. Mint an id there as PrepareCommBuffers does.

The cuda-graph FillBoundary helpers pack and unpack value_type, but the buffers were sized with sizeof(BUF), so route BUF != value_type to the generic templated path. The recorded graph is cached per FB without a BUF key, so templating the helpers alone would replay a graph for the wrong type.

Fixes #5687.
