### PR TITLE
Fix MLABecLaplacian semi-coarsening line-solve smoother

### DIFF
--- a/Docs/sphinx_documentation/source/LinearSolvers.rst
+++ b/Docs/sphinx_documentation/source/LinearSolvers.rst
@@ -410,6 +410,15 @@ consolidation strategy for multigrid coarsening.
   :cpp:`LPInfo::setConsolidationStrategy(int)`, to give control over how this
   process works.  If agglomeration is used, consolidation is ignored.
 
+- :cpp:`LPInfo::setSemicoarsening(bool)` (by default false) allows multigrid
+  to coarsen in only some of the directions when a direction can no longer be
+  coarsened.  :cpp:`LPInfo::setMaxSemicoarseningLevel(int)` caps how many such
+  levels are built, and :cpp:`LPInfo::setSemicoarseningDirection(int)` pins the
+  direction that is left uncoarsened.  On semi-coarsened levels the
+  cell-centered solvers smooth with a line solve along the uncoarsened
+  direction.  That smoother runs on the CPU only, so cell-centered
+  semi-coarsening is not supported in GPU builds and will abort.
+
 :cpp:`MLMG::setThrowException(bool)` controls whether multigrid failure results
 in aborting (default) or throwing an exception, whereby control will return to the calling
 application. The application code must catch the exception:

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_2D_K.H
@@ -1,6 +1,7 @@
 #ifndef AMREX_MLABECLAP_2D_K_H_
 #define AMREX_MLABECLAP_2D_K_H_
 #include <AMReX_Config.H>
+#include <AMReX_Vector.H>
 
 namespace amrex {
 
@@ -317,33 +318,34 @@ void abec_gsrb_with_line_solve (
                 Box const& vbox, int redblack, int nc)
 {
 
+    // Each tridiagonal line must span the whole valid box, because the
+    // boundary masks below are tested at the valid box faces.
+    AMREX_ASSERT(box == vbox);
+
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
     const auto vlo = amrex::lbound(vbox);
     const auto vhi = amrex::ubound(vbox);
 
-    // idir is the direction in which we will do the tridiagonal solve --
-    // it should be the direction in which the mesh spacing is much larger
-    // than in the other directions
-    // int idir = 1;
+    // The tridiagonal solve is done in the y-direction -- it should be the
+    // direction in which the mesh spacing is much larger than in x.
 
     // This should be moved outside the kernel!
     if (dhy <= dhx) { amrex::Abort("dhy is supposed to be much larger than dhx"); }
 
     int ilen = hi.y - lo.y + 1;
 
-    // This should be moved outside the kernel!
-    if (ilen > 32) { amrex::Abort("abec_gsrb_with_line_solve is hard-wired to be no longer than 32"); }
+    Vector<T> ls_scratch(6*static_cast<std::size_t>(ilen));
+    T* a_ls = ls_scratch.data();
+    T* b_ls = a_ls + ilen;
+    T* c_ls = b_ls + ilen;
+    T* r_ls = c_ls + ilen;
+    T* u_ls = r_ls + ilen;
+    T* gam  = u_ls + ilen;
 
-    Array1D<T,0,31> a_ls;
-    Array1D<T,0,31> b_ls;
-    Array1D<T,0,31> c_ls;
-    Array1D<T,0,31> r_ls;
-    Array1D<T,0,31> u_ls;
-    Array1D<T,0,31> gam;
-
+    // No SIMD pragma on the transverse loop: the scratch arrays above are
+    // reused by every line.
     for (int n = 0; n < nc; ++n) {
-        AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
             if ((i+redblack)%2 == 0) {
                 for (int j = lo.y; j <= hi.y; ++j) {
@@ -371,44 +373,44 @@ void abec_gsrb_with_line_solve (
                     if (i == vlo.x && m0(vlo.x-1,j,0) > 0) {
                         rho -= dhx*bX(i  ,j,0,n)*phi(i-1,j,0,n);
                     }
-                    if (i == vhi.x && m3(vhi.x+1,j,0) > 0) {
+                    if (i == vhi.x && m2(vhi.x+1,j,0) > 0) {
                         rho -= dhx*bX(i+1,j,0,n)*phi(i+1,j,0,n);
                     }
 
-                    a_ls(j-lo.y) = -dhy*bY(i,j,0,n);
-                    b_ls(j-lo.y) =  g_m_d;
-                    c_ls(j-lo.y) = -dhy*bY(i,j+1,0,n);
-                    u_ls(j-lo.y) = T(0.);
-                    r_ls(j-lo.y) = rhs(i,j,0,n) + rho;
+                    a_ls[j-lo.y] = -dhy*bY(i,j,0,n);
+                    b_ls[j-lo.y] =  g_m_d;
+                    c_ls[j-lo.y] = -dhy*bY(i,j+1,0,n);
+                    u_ls[j-lo.y] = T(0.);
+                    r_ls[j-lo.y] = rhs(i,j,0,n) + rho;
 
                     if (j == lo.y) {
-                        a_ls(j-lo.y) = T(0.);
-                        if (!(m1(i,vlo.y-1,0) > 0)) { r_ls(j-lo.y) += dhy*bY(i,j,0,n)*phi(i,j-1,0,n); }
+                        a_ls[j-lo.y] = T(0.);
+                        if (!(m1(i,vlo.y-1,0) > 0)) { r_ls[j-lo.y] += dhy*bY(i,j,0,n)*phi(i,j-1,0,n); }
                     }
                     if (j == hi.y) {
-                        c_ls(j-lo.y) = T(0.);
-                        if (!(m3(i,vhi.y+1,0) > 0)) { r_ls(j-lo.y) += dhy*bY(i,j+1,0,n)*phi(i,j+1,0,n); }
+                        c_ls[j-lo.y] = T(0.);
+                        if (!(m3(i,vhi.y+1,0) > 0)) { r_ls[j-lo.y] += dhy*bY(i,j+1,0,n)*phi(i,j+1,0,n); }
                     }
                 }
 //                      This is the tridiagonal solve
                 {
-                    T bet = b_ls(0);
-                    u_ls(0) = r_ls(0) / bet;
+                    T bet = b_ls[0];
+                    u_ls[0] = r_ls[0] / bet;
 
                     for (int jj = 1; jj <= ilen-1; jj++) {
-                        gam(jj) = c_ls(jj-1) / bet;
-                        bet = b_ls(jj) - a_ls(jj)*gam(jj);
+                        gam[jj] = c_ls[jj-1] / bet;
+                        bet = b_ls[jj] - a_ls[jj]*gam[jj];
                         if (bet == 0) { amrex::Abort(">>>TRIDIAG FAILED"); }
-                        u_ls(jj) = (r_ls(jj)-a_ls(jj)*u_ls(jj-1)) / bet;
+                        u_ls[jj] = (r_ls[jj]-a_ls[jj]*u_ls[jj-1]) / bet;
                     }
 
                     for (int jj = ilen-2; jj >= 0; jj--) {
-                                u_ls(jj) = u_ls(jj) - gam(jj+1)*u_ls(jj+1);
+                                u_ls[jj] = u_ls[jj] - gam[jj+1]*u_ls[jj+1];
                     }
                 }
 
                 for (int j = lo.y; j <= hi.y; ++j) {
-                            phi(i,j,0,n) = u_ls(j-lo.y);
+                            phi(i,j,0,n) = u_ls[j-lo.y];
                 }
             }
         }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLap_3D_K.H
@@ -1,6 +1,7 @@
 #ifndef AMREX_MLABECLAP_3D_K_H_
 #define AMREX_MLABECLAP_3D_K_H_
 #include <AMReX_Config.H>
+#include <AMReX_Vector.H>
 
 namespace amrex {
 
@@ -429,21 +430,19 @@ void abec_jacobi_os (int i, int j, int k, int n,
 
 template <typename T>
 AMREX_FORCE_INLINE
-void tridiagonal_solve (Array1D<T,0,31>& a_ls, Array1D<T,0,31>& b_ls, Array1D<T,0,31>& c_ls,
-                        Array1D<T,0,31>& r_ls, Array1D<T,0,31>& u_ls, Array1D<T,0,31>& gam,
-                        int ilen )
+void tridiagonal_solve (T* a_ls, T* b_ls, T* c_ls, T* r_ls, T* u_ls, T* gam, int ilen)
 {
-    T bet = b_ls(0);
-    u_ls(0) = r_ls(0) / bet;
+    T bet = b_ls[0];
+    u_ls[0] = r_ls[0] / bet;
 
     for (int i = 1; i <= ilen - 1; i++) {
-        gam(i) = c_ls(i-1) / bet;
-        bet = b_ls(i) - a_ls(i)*gam(i);
+        gam[i] = c_ls[i-1] / bet;
+        bet = b_ls[i] - a_ls[i]*gam[i];
         if (bet == 0) { amrex::Abort(">>>TRIDIAG FAILED"); }
-        u_ls(i) = (r_ls(i)-a_ls(i)*u_ls(i-1)) / bet;
+        u_ls[i] = (r_ls[i]-a_ls[i]*u_ls[i-1]) / bet;
     }
     for (int i = ilen-2; i >= 0; i--) {
-        u_ls(i) = u_ls(i) - gam(i+1)*u_ls(i+1);
+        u_ls[i] = u_ls[i] - gam[i+1]*u_ls[i+1];
     }
 }
 
@@ -465,6 +464,10 @@ void abec_gsrb_with_line_solve (
                 Array4<T const> const& f5,
                 Box const& vbox, int redblack, int nc)
 {
+    // Each tridiagonal line must span the whole valid box, because the
+    // boundary masks below are tested at the valid box faces.
+    AMREX_ASSERT(box == vbox);
+
     const auto lo = amrex::lbound(box);
     const auto hi = amrex::ubound(box);
     const auto vlo = amrex::lbound(vbox);
@@ -485,20 +488,19 @@ void abec_gsrb_with_line_solve (
         ilen = hi.x - lo.x + 1;
     }
 
-    // This assertion should be moved outside the kernel for performance!
-    if (ilen > 32) { amrex::Abort("abec_gsrb_with_line_solve is hard-wired to be no longer than 32"); }
+    Vector<T> ls_scratch(6*static_cast<std::size_t>(ilen));
+    T* a_ls = ls_scratch.data();
+    T* b_ls = a_ls + ilen;
+    T* c_ls = b_ls + ilen;
+    T* r_ls = c_ls + ilen;
+    T* u_ls = r_ls + ilen;
+    T* gam  = u_ls + ilen;
 
-    Array1D<T,0,31> a_ls;
-    Array1D<T,0,31> b_ls;
-    Array1D<T,0,31> c_ls;
-    Array1D<T,0,31> r_ls;
-    Array1D<T,0,31> u_ls;
-    Array1D<T,0,31> gam;
-
+    // No SIMD pragma on the transverse loops: the scratch arrays above are
+    // reused by every line.
     if (idir == 2) {
         for (int n = 0; n < nc; ++n) {
             for (int j = lo.y; j <= hi.y; ++j) {
-                AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
                     if ((i+j+redblack)%2 == 0) {
 
@@ -546,22 +548,22 @@ void abec_gsrb_with_line_solve (
                                 rho -= dhy*bY(i,j+1,k,n)*phi(i,j+1,k,n);
                             }
 
-                            a_ls(k-lo.z) = -dhz*bZ(i,j,k,n);
-                            b_ls(k-lo.z) =  g_m_d;
-                            c_ls(k-lo.z) = -dhz*bZ(i,j,k+1,n);
-                            u_ls(k-lo.z) = T(0.);
-                            r_ls(k-lo.z) = rhs(i,j,k,n) + rho;
-                            // r_ls(k-lo.z) = g_m_d*phi(i,j,k,n) -gamma*phi(i,j,k,n) + rhs(i,j,k,n) + rho;
+                            a_ls[k-lo.z] = -dhz*bZ(i,j,k,n);
+                            b_ls[k-lo.z] =  g_m_d;
+                            c_ls[k-lo.z] = -dhz*bZ(i,j,k+1,n);
+                            u_ls[k-lo.z] = T(0.);
+                            r_ls[k-lo.z] = rhs(i,j,k,n) + rho;
+                            // r_ls[k-lo.z] = g_m_d*phi(i,j,k,n) -gamma*phi(i,j,k,n) + rhs(i,j,k,n) + rho;
 
                             if (k == lo.z)
                             {
-                                a_ls(k-lo.z) = T(0.);
-                                if (!(m2(i,j,vlo.z-1) > 0)) { r_ls(k-lo.z) += dhz*bZ(i,j,k,n)*phi(i,j,k-1,n); }
+                                a_ls[k-lo.z] = T(0.);
+                                if (!(m2(i,j,vlo.z-1) > 0)) { r_ls[k-lo.z] += dhz*bZ(i,j,k,n)*phi(i,j,k-1,n); }
                             }
                             if (k == hi.z)
                             {
-                                c_ls(k-lo.z) = T(0.);
-                                if (!(m5(i,j,vhi.z+1) > 0)) { r_ls(k-lo.z) += dhz*bZ(i,j,k+1,n)*phi(i,j,k+1,n); }
+                                c_ls[k-lo.z] = T(0.);
+                                if (!(m5(i,j,vhi.z+1) > 0)) { r_ls[k-lo.z] += dhz*bZ(i,j,k+1,n)*phi(i,j,k+1,n); }
                             }
                         }
 
@@ -569,7 +571,7 @@ void abec_gsrb_with_line_solve (
 
                         for (int k = lo.z; k <= hi.z; ++k)
                         {
-                            phi(i,j,k,n) = u_ls(k-lo.z);
+                            phi(i,j,k,n) = u_ls[k-lo.z];
                         }
                     }
                 }
@@ -578,7 +580,6 @@ void abec_gsrb_with_line_solve (
     } else if (idir == 1) {
         for (int n = 0; n < nc; ++n) {
             for (int i = lo.x; i <= hi.x; ++i) {
-                AMREX_PRAGMA_SIMD
                 for (int k = lo.z; k <= hi.z; ++k) {
                     if ((i+k+redblack)%2 == 0) {
 
@@ -626,21 +627,21 @@ void abec_gsrb_with_line_solve (
                                 rho -= dhz*bZ(i,j,k+1,n)*phi(i,j,k+1,n);
                             }
 
-                            a_ls(j-lo.y) = -dhy*bY(i,j,k,n);
-                            b_ls(j-lo.y) =  g_m_d;
-                            c_ls(j-lo.y) = -dhy*bY(i,j+1,k,n);
-                            u_ls(j-lo.y) = T(0.);
-                            r_ls(j-lo.y) = rhs(i,j,k,n) + rho;
+                            a_ls[j-lo.y] = -dhy*bY(i,j,k,n);
+                            b_ls[j-lo.y] =  g_m_d;
+                            c_ls[j-lo.y] = -dhy*bY(i,j+1,k,n);
+                            u_ls[j-lo.y] = T(0.);
+                            r_ls[j-lo.y] = rhs(i,j,k,n) + rho;
 
                             if (j == lo.y)
                             {
-                                a_ls(j-lo.y) = T(0.);
-                                if (!(m1(i,vlo.y-1,k) > 0)) { r_ls(j-lo.y) += dhy*bY(i,j,k,n)*phi(i,j-1,k,n); }
+                                a_ls[j-lo.y] = T(0.);
+                                if (!(m1(i,vlo.y-1,k) > 0)) { r_ls[j-lo.y] += dhy*bY(i,j,k,n)*phi(i,j-1,k,n); }
                             }
                             if (j == hi.y)
                             {
-                                c_ls(j-lo.y) = T(0.);
-                                if (!(m4(i,vhi.y+1,k) > 0)) { r_ls(j-lo.y) += dhy*bY(i,j+1,k,n)*phi(i,j+1,k,n); }
+                                c_ls[j-lo.y] = T(0.);
+                                if (!(m4(i,vhi.y+1,k) > 0)) { r_ls[j-lo.y] += dhy*bY(i,j+1,k,n)*phi(i,j+1,k,n); }
                             }
                         }
 
@@ -648,7 +649,7 @@ void abec_gsrb_with_line_solve (
 
                         for (int j = lo.y; j <= hi.y; ++j)
                         {
-                            phi(i,j,k,n) = u_ls(j-lo.y);
+                            phi(i,j,k,n) = u_ls[j-lo.y];
                         }
                     }
                 }
@@ -657,7 +658,6 @@ void abec_gsrb_with_line_solve (
     } else if (idir == 0) {
         for (int n = 0; n < nc; ++n) {
             for (int j = lo.y; j <= hi.y; ++j) {
-                AMREX_PRAGMA_SIMD
                 for (int k = lo.z; k <= hi.z; ++k) {
                     if ((j+k+redblack)%2 == 0) {
 
@@ -705,21 +705,21 @@ void abec_gsrb_with_line_solve (
                                 rho -= dhz*bZ(i,j,k+1,n)*phi(i,j,k+1,n);
                             }
 
-                            a_ls(i-lo.x) = -dhx*bX(i,j,k,n);
-                            b_ls(i-lo.x) =  g_m_d;
-                            c_ls(i-lo.x) = -dhx*bX(i+1,j,k,n);
-                            u_ls(i-lo.x) = T(0.);
-                            r_ls(i-lo.x) = rhs(i,j,k,n) + rho;
+                            a_ls[i-lo.x] = -dhx*bX(i,j,k,n);
+                            b_ls[i-lo.x] =  g_m_d;
+                            c_ls[i-lo.x] = -dhx*bX(i+1,j,k,n);
+                            u_ls[i-lo.x] = T(0.);
+                            r_ls[i-lo.x] = rhs(i,j,k,n) + rho;
 
                             if (i == lo.x)
                             {
-                                a_ls(i-lo.x) = T(0.);
-                                if (!(m0(vlo.x-1,j,k) > 0)) { r_ls(i-lo.x) += dhx*bX(i,j,k,n)*phi(i-1,j,k,n); }
+                                a_ls[i-lo.x] = T(0.);
+                                if (!(m0(vlo.x-1,j,k) > 0)) { r_ls[i-lo.x] += dhx*bX(i,j,k,n)*phi(i-1,j,k,n); }
                             }
                             if (i == hi.x)
                             {
-                                c_ls(i-lo.x) = T(0.);
-                                if (!(m3(vhi.x+1,j,k) > 0)) { r_ls(i-lo.x) += dhx*bX(i+1,j,k,n)*phi(i+1,j,k,n); }
+                                c_ls[i-lo.x] = T(0.);
+                                if (!(m3(vhi.x+1,j,k) > 0)) { r_ls[i-lo.x] += dhx*bX(i+1,j,k,n)*phi(i+1,j,k,n); }
                             }
                         }
 
@@ -727,7 +727,7 @@ void abec_gsrb_with_line_solve (
 
                         for (int i = lo.x; i <= hi.x; ++i)
                         {
-                            phi(i,j,k,n) = u_ls(i-lo.x);
+                            phi(i,j,k,n) = u_ls[i-lo.x];
                         }
                     }
                 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLABecLaplacian.H
@@ -995,6 +995,11 @@ MLABecLaplacianT<MF>::Fsmooth (int amrlev, int mglev, MF& sol, const MF& rhs, in
     const RT alpha = m_a_scalar;
 
 #ifdef AMREX_USE_GPU
+    // The line solve taken for semi-coarsened levels is host only.
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(regular_coarsening
+                                     || this->m_overset_mask[amrlev][mglev]
+                                     || Gpu::notInLaunchRegion(),
+                                     "MLABecLaplacian::Fsmooth: line solve is not supported on GPU");
     if (Gpu::inLaunchRegion()
         && (this->m_overset_mask[amrlev][mglev] || regular_coarsening))
     {
@@ -1101,7 +1106,13 @@ MLABecLaplacianT<MF>::Fsmooth (int amrlev, int mglev, MF& sol, const MF& rhs, in
 #endif
     {
         MFItInfo mfi_info;
-        mfi_info.EnableTiling().SetDynamic(true);
+        mfi_info.SetDynamic(true);
+        // The line solve below needs whole valid boxes, not tiles: a tile
+        // would truncate the tridiagonal lines and make neighboring threads
+        // race on the cells at the tile edges.
+        if (regular_coarsening || this->m_overset_mask[amrlev][mglev]) {
+            mfi_info.EnableTiling();
+        }
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -1198,7 +1209,8 @@ MLABecLaplacianT<MF>::Fsmooth (int amrlev, int mglev, MF& sol, const MF& rhs, in
                     });
                 }
             } else {
-                // line solve does not with with GPU
+                // Line solve for semi-coarsening. Host only, and tbx == vbx
+                // because tiling is disabled above for this branch.
                 abec_gsrb_with_line_solve(tbx, solnfab, rhsfab, alpha, afab,
                                           AMREX_D_DECL(dhx, dhy, dhz),
                                           AMREX_D_DECL(bxfab, byfab, bzfab),

--- a/Tests/LinearSolvers/ABecLaplacian_C/CMakeLists.txt
+++ b/Tests/LinearSolvers/ABecLaplacian_C/CMakeLists.txt
@@ -15,6 +15,19 @@ foreach(D IN LISTS AMReX_SPACEDIM)
 
     setup_test(${D} _sources _input_files)
 
+    # Semi-coarsening exercises the line-solve smoother, which is CPU only.
+    set(_input_files  inputs-rt-abeclap-semicoarsening )
+
+    if (AMReX_GPU_BACKEND STREQUAL NONE)
+        set(_no_ctest)
+    else ()
+        set(_no_ctest NO_CTEST)
+    endif ()
+
+    setup_test(${D} _sources _input_files
+       BASE_NAME LinearSolvers_ABecLaplacian_C_semicoarsening ${_no_ctest})
+
+    unset(_no_ctest)
     unset(_sources)
     unset(_input_files)
 endforeach()

--- a/Tests/LinearSolvers/ABecLaplacian_C/CMakeLists.txt
+++ b/Tests/LinearSolvers/ABecLaplacian_C/CMakeLists.txt
@@ -25,7 +25,8 @@ foreach(D IN LISTS AMReX_SPACEDIM)
     endif ()
 
     setup_test(${D} _sources _input_files
-       BASE_NAME LinearSolvers_ABecLaplacian_C_semicoarsening ${_no_ctest})
+       BASE_NAME LinearSolvers_ABecLaplacian_C_semicoarsening
+       RUNTIME_SUBDIR semicoarsening ${_no_ctest})
 
     unset(_no_ctest)
     unset(_sources)

--- a/Tests/LinearSolvers/ABecLaplacian_C/MyTest.H
+++ b/Tests/LinearSolvers/ABecLaplacian_C/MyTest.H
@@ -62,6 +62,7 @@ private:
     bool semicoarsening = false;
     int max_coarsening_level = 30;
     int max_semicoarsening_level = 0;
+    int semicoarsening_direction = -1;
     bool use_gauss_seidel = true; // true: red-black, false: jacobi
     bool use_hypre = false;
     bool use_petsc = false;

--- a/Tests/LinearSolvers/ABecLaplacian_C/MyTest.cpp
+++ b/Tests/LinearSolvers/ABecLaplacian_C/MyTest.cpp
@@ -161,6 +161,7 @@ MyTest::solveABecLaplacian ()
     info.setSemicoarsening(semicoarsening);
     info.setMaxCoarseningLevel(max_coarsening_level);
     info.setMaxSemicoarseningLevel(max_semicoarsening_level);
+    info.setSemicoarseningDirection(semicoarsening_direction);
 
     Real tol_rel;
     if constexpr (std::is_same_v<double,Real>) {
@@ -482,6 +483,7 @@ MyTest::solveABecLaplacianGMRES ()
     info.setSemicoarsening(semicoarsening);
     info.setMaxCoarseningLevel(max_coarsening_level);
     info.setMaxSemicoarseningLevel(max_semicoarsening_level);
+    info.setSemicoarseningDirection(semicoarsening_direction);
 
     const auto tol_rel = Real(1.e-10);
     const auto tol_abs = Real(0.0);
@@ -625,6 +627,7 @@ MyTest::readParameters ()
     pp.query("semicoarsening", semicoarsening);
     pp.query("max_coarsening_level", max_coarsening_level);
     pp.query("max_semicoarsening_level", max_semicoarsening_level);
+    pp.query("semicoarsening_direction", semicoarsening_direction);
 
     pp.query("use_gauss_seidel", use_gauss_seidel);
 

--- a/Tests/LinearSolvers/ABecLaplacian_C/inputs-rt-abeclap-semicoarsening
+++ b/Tests/LinearSolvers/ABecLaplacian_C/inputs-rt-abeclap-semicoarsening
@@ -1,0 +1,22 @@
+
+max_level = 0
+n_cell = 64
+max_grid_size = 32
+
+composite_solve = 0
+
+prob_type = 2       # ABecLaplacian
+
+# For MLMG
+verbose = 2
+bottom_verbose = 0
+max_iter = 100
+max_fmg_iter = 0
+linop_maxorder = 2
+agglomeration = 0
+consolidation = 0
+
+# Exercise the line solve smoother used for semi-coarsened levels.
+semicoarsening = 1
+max_semicoarsening_level = 4
+semicoarsening_direction = 1


### PR DESCRIPTION
The 2D kernel gated the x-hi rho correction with the y-hi mask, reading out of bounds on every box's last column.  Fsmooth also passed tile boxes to a kernel that assumes box == validbox, truncating the tridiagonal lines and racing between OpenMP threads, and fell through to the host-only kernel on GPU.  Tiling is now disabled for this branch, the 32-cell line limit is gone, and GPU builds abort with a clear message.  New ctest covers it.

Fixes #5692.
