### PR TITLE
Fix marching cubes c-vertex indexing

### DIFF
--- a/Src/EB/AMReX_MarchingCubes.cpp
+++ b/Src/EB/AMReX_MarchingCubes.cpp
@@ -292,29 +292,29 @@ void process_cube (std::int8_t ipass, LookUpTable const* lut, int i, int j, int 
 
 
         // Computes the average of the intersection points of the cube
-        vid = ex( i , j , k ,1) ;
+        vid = ex( i , j , k ,0) ? ex( i , j , k ,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ey(i+1, j , k ,1) ;
+        vid = ey(i+1, j , k ,0) ? ey(i+1, j , k ,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ex( i ,j+1, k ,1) ;
+        vid = ex( i ,j+1, k ,0) ? ex( i ,j+1, k ,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ey( i , j , k ,1) ;
+        vid = ey( i , j , k ,0) ? ey( i , j , k ,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ex( i , j ,k+1,1) ;
+        vid = ex( i , j ,k+1,0) ? ex( i , j ,k+1,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ey(i+1, j ,k+1,1) ;
+        vid = ey(i+1, j ,k+1,0) ? ey(i+1, j ,k+1,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ex( i ,j+1,k+1,1) ;
+        vid = ex( i ,j+1,k+1,0) ? ex( i ,j+1,k+1,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ey( i , j ,k+1,1) ;
+        vid = ey( i , j ,k+1,0) ? ey( i , j ,k+1,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ez( i , j , k ,1) ;
+        vid = ez( i , j , k ,0) ? ez( i , j , k ,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ez(i+1, j , k ,1) ;
+        vid = ez(i+1, j , k ,0) ? ez(i+1, j , k ,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ez(i+1,j+1, k ,1) ;
+        vid = ez(i+1,j+1, k ,0) ? ez(i+1,j+1, k ,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
-        vid = ez( i ,j+1, k ,1) ;
+        vid = ez( i ,j+1, k ,0) ? ez( i ,j+1, k ,1) : -1 ;
         if( vid != -1 ) { update_vertex(); }
 
         vert_x  *= Real(1)/u ;
@@ -885,7 +885,8 @@ void marching_cubes (Geometry const& geom, FArrayBox& sdf_fab, MCFab& mc_fab)
                                      },
                                      [=] AMREX_GPU_DEVICE (int m, int ps) {
                                          auto [i,j,k] = c_bi(m);
-                                         ntri(i,j,k,3) = ps;
+                                         // c-vertices live after the edge vertices
+                                         ntri(i,j,k,3) = ps + nvx;
                                      },
                                      Scan::Type::exclusive, Scan::retSum);
 


### PR DESCRIPTION
The c-vertex index was the prefix sum of c-vertex counts alone, so c-vertices overwrote edge vertices instead of being appended after them. Offset it by the edge vertex count.

Also, component 1 of ex/ey/ez holds a prefix sum for cut and uncut edges alike, so the vid == -1 test never fired and uncut edges were pulled into the c-vertex average. Check component 0 first.

Fixes #5704.
