### PR TITLE
Use atomic add for drho_as_crse and dm_as_fine in state redistribution

### DIFF
--- a/Src/EB/AMReX_EB_Redistribution.H
+++ b/Src/EB/AMReX_EB_Redistribution.H
@@ -131,6 +131,10 @@ namespace amrex {
      * \brief Multi-level redistribution interface that couples coarse and fine levels.
      *
      * Parameters mirror ApplyRedistribution but also include buffers for coarse/fine overlap.
+     *
+     * The caller must zero \p dm_as_fine before the call. Because it receives
+     * contributions from cells outside \p bx, it should be a temporary local to
+     * the MFIter iteration rather than shared between tiles.
      */
     void ApplyMLRedistribution (
         amrex::Box const& bx, int ncomp,

--- a/Src/EB/AMReX_EB_StateRedistribute.cpp
+++ b/Src/EB/AMReX_EB_StateRedistribute.cpp
@@ -106,14 +106,9 @@ MLStateRedistribute ( Box const& bx, int ncomp,
 #endif
     Array4<Real> qt = qtracker_fab.array();
 
-    // Initialize to zero just in case
-    if (as_fine) {
-        amrex::ParallelFor(bx, ncomp,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
-        {
-            dm_as_fine(i,j,k,n) = 0.0;
-        });
-    }
+    // We do not initialize dm_as_fine here because we also add to cells outside
+    // bx, which for a tiled MFIter belong to another tile. Zeroing it is the
+    // caller's responsibility.
 
     for (int n = 0; n < ncomp; n++)
     {
@@ -333,7 +328,8 @@ MLStateRedistribute ( Box const& bx, int ncomp,
                                     flag_as_crse( r, s, t) == amrex_yafluxreg_crse_fine_boundary_cell &&
                                     flag_as_crse(ii,jj,kk) == amrex_yafluxreg_fine_cell )
                                {
-                                   drho_as_crse(r,s,t,n) -= fac*update/nrs(r,s,t) * fac_for_deltaR;
+                                   amrex::HostDevice::Atomic::Add(&drho_as_crse(r,s,t,n),
+                                                                  -fac*update/nrs(r,s,t) * fac_for_deltaR);
                                }
 
                                // Uncovered (by fine) to covered (by fine)
@@ -341,8 +337,9 @@ MLStateRedistribute ( Box const& bx, int ncomp,
                                     flag_as_crse( r, s, t) == amrex_yafluxreg_fine_cell  &&
                                     flag_as_crse(ii,jj,kk) == amrex_yafluxreg_crse_fine_boundary_cell )
                                {
-                                   drho_as_crse(ii,jj,kk,n) += fac * update / nrs(r,s,t) *
-                                                               (vfrac(r,s,t) / vfrac(ii,jj,kk)) * fac_for_deltaR;
+                                   amrex::HostDevice::Atomic::Add(&drho_as_crse(ii,jj,kk,n),
+                                                                  fac * update / nrs(r,s,t) *
+                                                                  (vfrac(r,s,t) / vfrac(ii,jj,kk)) * fac_for_deltaR);
                                }
                             } // as_crse
 
@@ -351,13 +348,15 @@ MLStateRedistribute ( Box const& bx, int ncomp,
                                // Ghost (ii,jj,kk) to valid (r,s,t)
                                if (levmsk(ii,jj,kk) == is_ghost_cell && bx.contains(IntVect(AMREX_D_DECL(r,s,t)))) {
 
-                                   dm_as_fine(ii,jj,kk,n) -= fac*update/nrs(r,s,t) * vfrac(r,s,t) * fac_for_deltaR;
+                                   amrex::HostDevice::Atomic::Add(&dm_as_fine(ii,jj,kk,n),
+                                                                  -fac*update/nrs(r,s,t) * vfrac(r,s,t) * fac_for_deltaR);
                                }
 
                                // Valid (ii,jj,kk) to ghost (r,s,t)
                                if (bx.contains(IntVect(AMREX_D_DECL(ii,jj,kk))) && levmsk(r,s,t) == is_ghost_cell) {
 
-                                   dm_as_fine(r,s,t,n) += fac*update/nrs(r,s,t) * vfrac(r,s,t) * fac_for_deltaR;
+                                   amrex::HostDevice::Atomic::Add(&dm_as_fine(r,s,t,n),
+                                                                  fac*update/nrs(r,s,t) * vfrac(r,s,t) * fac_for_deltaR);
                                }
                             } // as_fine
 


### PR DESCRIPTION
In MLStateRedistribute, the scatters into drho_as_crse and dm_as_fine were plain read-modify-writes. When a cell belongs to more than one merging neighborhood, several threads target the same cell and updates are lost. Use atomic add, as the U_out scatter in the same loop already does.

Fixes #5709.
