### PR TITLE
Fix dangling EB IndexSpace pointer in addFineLevels

### DIFF
--- a/Src/EB/AMReX_EB2_IndexSpaceI.H
+++ b/Src/EB/AMReX_EB2_IndexSpaceI.H
@@ -142,6 +142,11 @@ IndexSpaceImp<G>::addFineLevels (int num_new_fine_levels)
     }
     std::swap(fine_isp.m_gslevel, m_gslevel);
 
+    // The new levels were built by fine_isp, which is about to be destroyed.
+    for (auto& lev : m_gslevel) {
+        lev.m_parent = this;
+    }
+
     m_geom.insert(m_geom.begin(), fine_isp.m_geom.begin(), fine_isp.m_geom.end());
     m_domain.insert(m_domain.begin(), fine_isp.m_domain.begin(), fine_isp.m_domain.end());
     m_ngrow.insert(m_ngrow.begin(), fine_isp.m_ngrow.begin(), fine_isp.m_ngrow.end());

--- a/Src/EB/AMReX_EB2_Level.H
+++ b/Src/EB/AMReX_EB2_Level.H
@@ -37,6 +37,7 @@ namespace amrex::EB2 {
 
 class IndexSpace;
 template <typename G> class GShopLevel;
+template <typename G> class IndexSpaceImp;
 
 class Level
 {
@@ -273,6 +274,8 @@ protected:
 
 private:
     template <typename G> friend class GShopLevel;
+    // So that it can update m_parent when a level changes owner.
+    template <typename G> friend class IndexSpaceImp;
 
     // Need this function to work around a gcc bug.
     void setRegularLevel () {


### PR DESCRIPTION
The new fine levels are built by a local IndexSpaceImp, so Level::m_parent points at it. After the levels are swapped into this index space, the local is destroyed and getEBIndexSpace() dangles. Re-point m_parent after the swap.

Fixes #5708.
