### PR TITLE
Fix tridiagonal system for spline tangents

### DIFF
--- a/Src/EB/AMReX_distFcnElement.H
+++ b/Src/EB/AMReX_distFcnElement.H
@@ -25,6 +25,7 @@ class distFcnElement2d { // NOLINT(cppcoreguidelines-special-member-functions)
 
   [[nodiscard]] virtual amrex::Real cpdist(amrex::RealVect pt, amrex::RealVect& cp) const = 0;
   [[nodiscard]] virtual amrex::Real cpside(amrex::RealVect pt, amrex::RealVect& cp) const = 0;
+  //! Tridiagonal solver. Note that \p b and \p d are eliminated in place.
   static int solve_thomas (const std::vector<amrex::Real> &a,
                            std::vector<amrex::Real> &b,
                            const std::vector<amrex::Real> &c,

--- a/Src/EB/AMReX_distFcnElement.cpp
+++ b/Src/EB/AMReX_distFcnElement.cpp
@@ -249,17 +249,19 @@ void SplineDistFcnElement2d::calc_D(bool clamped_bc)
   }
 
   if (clamped_bc) {
+    // Row i's super-diagonal is diagplus[i] and its sub-diagonal is
+    // diagminus[i-1], so this decouples the first and last rows.
     diag[0] = Real(1.0);
-    diagminus[0] = Real(0.0);
+    diagplus[0] = Real(0.0);
 
     diag[nsplines] = Real(1.0);
-    diagplus[nsplines] = Real(0.0);
+    diagminus[nsplines-1] = Real(0.0);
 
     rhsx[0] = control_points_x[0] - bc_pt_start[0];
-    rhsx[nsplines] = -control_points_x[nsplines-1] + bc_pt_end[0];
+    rhsx[nsplines] = bc_pt_end[0] - control_points_x[nsplines];
 
     rhsy[0] = control_points_y[0] - bc_pt_start[1];
-    rhsy[nsplines] = -control_points_y[nsplines-1] + bc_pt_end[1];
+    rhsy[nsplines] = bc_pt_end[1] - control_points_y[nsplines];
 
   } else {
     // Natural boundary conditions
@@ -275,8 +277,10 @@ void SplineDistFcnElement2d::calc_D(bool clamped_bc)
                             control_points_y[nsplines-1]);
   }
 
+  // solve_thomas eliminates the diagonal in place, so the y solve needs its own.
+  std::vector<amrex::Real> diag_y = diag;
   solve_thomas(diagminus, diag, diagplus, rhsx, Dx);
-  solve_thomas(diagminus, diag, diagplus, rhsy, Dy);
+  solve_thomas(diagminus, diag_y, diagplus, rhsy, Dy);
 }
 
 


### PR DESCRIPTION
solve_thomas eliminates the diagonal in place, so the y solve was using the matrix the x solve had already destroyed, giving wrong y tangents for every SplineIF. Give it its own copy.

The clamped-BC branch also zeroed the wrong off-diagonal entries, leaving the first and last rows coupled, and wrote one past the end of diagplus. Its end row now prescribes Dn = bc_pt_end - control_points[n], mirroring the start row.

Fixes #5707.
