### PR TITLE
Fix FFT::OpenBCSolver in 2D and for a shifted twod_mode domain

### DIFF
--- a/Src/FFT/AMReX_FFT_OpenBCSolver.H
+++ b/Src/FFT/AMReX_FFT_OpenBCSolver.H
@@ -182,9 +182,15 @@ void OpenBCSolver<T>::setGreensFunction (F const& greens_function)
 
     auto* infab = m_info.twod_mode ? detail::get_fab(m_r2c_green->m_rx)
         :                             detail::get_fab(m_r2c.m_rx);
-    auto const& lo = m_domain.smallEnd();
+    auto lo = m_domain.smallEnd();
+#if (AMREX_SPACEDIM == 3)
+    // m_r2c_green's domain starts at z = 0.
+    if (m_info.twod_mode) { lo[2] = 0; }
+#endif
     auto const& lo3 = lo.dim3();
-    auto const len3d = m_padded_length.dim3();
+    // Hidden dimensions must have length 1, not 0, so that the mirror plane
+    // checks below cannot fire on them.
+    auto const len3d = m_padded_length.dim3(1);
     GpuArray<int,3> len{len3d.x, len3d.y, len3d.z};
     if (infab) {
         auto const& a = infab->array();
@@ -264,7 +270,7 @@ void OpenBCSolver<T>::solve (MF& phi, MF const& rho)
     inmf.setVal(T(0));
     inmf.ParallelCopy(rho, 0, 0, 1);
 
-    m_r2c.m_openbc_half = !m_info.twod_mode;
+    m_r2c.m_openbc_half = (AMREX_SPACEDIM == 3) && !m_info.twod_mode;
     m_r2c.forward(inmf);
     m_r2c.m_openbc_half = false;
 
@@ -302,7 +308,7 @@ void OpenBCSolver<T>::solve (MF& phi, MF const& rho)
         }
     }
 
-    m_r2c.m_openbc_half = !m_info.twod_mode;
+    m_r2c.m_openbc_half = (AMREX_SPACEDIM == 3) && !m_info.twod_mode;
     m_r2c.backward_doit(phi, phi.nGrowVect());
     m_r2c.m_openbc_half = false;
 }

--- a/Tests/FFT/OpenBC/CMakeLists.txt
+++ b/Tests/FFT/OpenBC/CMakeLists.txt
@@ -1,12 +1,14 @@
-if (NOT (3 IN_LIST AMReX_SPACEDIM))
-    return()
-endif()
+foreach(D IN LISTS AMReX_SPACEDIM)
+    if (D EQUAL 1)
+        continue()
+    endif()
 
-set(_sources  main.cpp)
+    set(_sources  main.cpp)
 
-set(_input_files)
+    set(_input_files)
 
-setup_test(3 _sources _input_files)
+    setup_test(${D} _sources _input_files)
 
-unset(_sources)
-unset(_input_files)
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/FFT/OpenBC/main.cpp
+++ b/Tests/FFT/OpenBC/main.cpp
@@ -6,6 +6,8 @@
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_ParmParse.H>
 
+#include <cmath>
+
 using namespace amrex;
 
 namespace {
@@ -96,13 +98,16 @@ void test_convolution (Box const& domain, int max_grid_size)
     // Gather onto one rank and compare with the direct sum.
     BoxArray const ba1(domain);
     DistributionMapping const dm1(Vector<int>{ParallelDescriptor::IOProcessorNumber()});
-    MultiFab phi_all(ba1, dm1, 1, 0);
+    // Pinned, because the comparison below runs on the host.
+    MultiFab phi_all(ba1, dm1, 1, 0, MFInfo().SetArena(The_Pinned_Arena()));
     phi_all.ParallelCopy(phi, 0, 0, 1);
+    Gpu::streamSynchronize();
 
     if (ParallelDescriptor::IOProcessor()) {
         auto const& a = phi_all[0].const_array();
         auto const hi = amrex::ubound(domain);
         Real errmax = 0, refmax = 0;
+        Long nbad = 0;
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
         for (int i = lo.x; i <= hi.x; ++i) {
@@ -113,11 +118,14 @@ void test_convolution (Box const& domain, int max_grid_size)
                 exact += test_greens_function(std::abs(i-ii), std::abs(j-jj),
                                               std::abs(k-kk)) * test_rhs(ii,jj,kk);
             }}}
+            if (!std::isfinite(a(i,j,k))) { ++nbad; }
             errmax = std::max(errmax, std::abs(a(i,j,k)-exact));
             refmax = std::max(refmax, std::abs(exact));
         }}}
         auto const error = errmax / refmax;
-        amrex::Print() << "  relative error " << error << "\n";
+        amrex::Print() << "  relative error " << error
+                       << ", non-finite values " << nbad << "\n";
+        AMREX_ALWAYS_ASSERT(nbad == 0);
 #ifdef AMREX_USE_FLOAT
         constexpr Real eps = 1.e-4;
 #else
@@ -163,13 +171,16 @@ void test_twod_mode (Box const& domain, int max_grid_size)
 
     BoxArray const ba1(domain);
     DistributionMapping const dm1(Vector<int>{ParallelDescriptor::IOProcessorNumber()});
-    MultiFab phi_all(ba1, dm1, 1, 0);
+    // Pinned, because the comparison below runs on the host.
+    MultiFab phi_all(ba1, dm1, 1, 0, MFInfo().SetArena(The_Pinned_Arena()));
     phi_all.ParallelCopy(phi, 0, 0, 1);
+    Gpu::streamSynchronize();
 
     if (ParallelDescriptor::IOProcessor()) {
         auto const& a = phi_all[0].const_array();
         auto const hi = amrex::ubound(domain);
         Real errmax = 0, refmax = 0;
+        Long nbad = 0;
         for (int k = lo.z; k <= hi.z; ++k) {
         for (int j = lo.y; j <= hi.y; ++j) {
         for (int i = lo.x; i <= hi.x; ++i) {
@@ -179,11 +190,14 @@ void test_twod_mode (Box const& domain, int max_grid_size)
                 exact += test_greens_function(std::abs(i-ii), std::abs(j-jj), 0)
                          * test_rhs(ii,jj,k);
             }}
+            if (!std::isfinite(a(i,j,k))) { ++nbad; }
             errmax = std::max(errmax, std::abs(a(i,j,k)-exact));
             refmax = std::max(refmax, std::abs(exact));
         }}}
         auto const error = errmax / refmax;
-        amrex::Print() << "  relative error " << error << "\n";
+        amrex::Print() << "  relative error " << error
+                       << ", non-finite values " << nbad << "\n";
+        AMREX_ALWAYS_ASSERT(nbad == 0);
 #ifdef AMREX_USE_FLOAT
         constexpr Real eps = 1.e-4;
 #else

--- a/Tests/FFT/OpenBC/main.cpp
+++ b/Tests/FFT/OpenBC/main.cpp
@@ -5,8 +5,7 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_ParmParse.H>
-
-#include <cmath>
+#include <AMReX_Reduce.H>
 
 using namespace amrex;
 
@@ -95,44 +94,50 @@ void test_convolution (Box const& domain, int max_grid_size)
     });
     solver.solve(phi, rho);
 
-    // Gather onto one rank and compare with the direct sum.
-    BoxArray const ba1(domain);
-    DistributionMapping const dm1(Vector<int>{ParallelDescriptor::IOProcessorNumber()});
-    // Pinned, because the comparison below runs on the host.
-    MultiFab phi_all(ba1, dm1, 1, 0, MFInfo().SetArena(The_Pinned_Arena()));
-    phi_all.ParallelCopy(phi, 0, 0, 1);
-    Gpu::streamSynchronize();
+    // The reference is analytic, so each rank can check its own cells in place.
+    auto const hi = amrex::ubound(domain);
+    ReduceOps<ReduceOpMax, ReduceOpMax, ReduceOpSum> reduce_op;
+    ReduceData<Real, Real, Long> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
 
-    if (ParallelDescriptor::IOProcessor()) {
-        auto const& a = phi_all[0].const_array();
-        auto const hi = amrex::ubound(domain);
-        Real errmax = 0, refmax = 0;
-        Long nbad = 0;
-        for (int k = lo.z; k <= hi.z; ++k) {
-        for (int j = lo.y; j <= hi.y; ++j) {
-        for (int i = lo.x; i <= hi.x; ++i) {
+    for (MFIter mfi(phi); mfi.isValid(); ++mfi) {
+        auto const& a = phi.const_array(mfi);
+        reduce_op.eval(mfi.validbox(), reduce_data,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+        {
             Real exact = 0;
             for (int kk = lo.z; kk <= hi.z; ++kk) {
             for (int jj = lo.y; jj <= hi.y; ++jj) {
             for (int ii = lo.x; ii <= hi.x; ++ii) {
-                exact += test_greens_function(std::abs(i-ii), std::abs(j-jj),
-                                              std::abs(k-kk)) * test_rhs(ii,jj,kk);
+                exact += test_greens_function(amrex::Math::abs(i-ii),
+                                              amrex::Math::abs(j-jj),
+                                              amrex::Math::abs(k-kk)) * test_rhs(ii,jj,kk);
             }}}
-            if (!std::isfinite(a(i,j,k))) { ++nbad; }
-            errmax = std::max(errmax, std::abs(a(i,j,k)-exact));
-            refmax = std::max(refmax, std::abs(exact));
-        }}}
-        auto const error = errmax / refmax;
-        amrex::Print() << "  relative error " << error
-                       << ", non-finite values " << nbad << "\n";
-        AMREX_ALWAYS_ASSERT(nbad == 0);
-#ifdef AMREX_USE_FLOAT
-        constexpr Real eps = 1.e-4;
-#else
-        constexpr Real eps = 1.e-12;
-#endif
-        AMREX_ALWAYS_ASSERT(error < eps);
+            // Math::max would keep the other operand if a(i,j,k) were NaN, so
+            // count the non-finite values separately.
+            return {amrex::Math::abs(a(i,j,k)-exact), amrex::Math::abs(exact),
+                    Long(!amrex::Math::isfinite(a(i,j,k)))};
+        });
     }
+
+    auto hv = reduce_data.value(reduce_op);
+    auto errmax = amrex::get<0>(hv);
+    auto refmax = amrex::get<1>(hv);
+    auto nbad   = amrex::get<2>(hv);
+    ParallelDescriptor::ReduceRealMax(errmax);
+    ParallelDescriptor::ReduceRealMax(refmax);
+    ParallelDescriptor::ReduceLongSum(nbad);
+
+    auto const error = errmax / refmax;
+    amrex::Print() << "  relative error " << error
+                   << ", non-finite values " << nbad << "\n";
+    AMREX_ALWAYS_ASSERT(nbad == 0);
+#ifdef AMREX_USE_FLOAT
+    constexpr Real eps = 1.e-4;
+#else
+    constexpr Real eps = 1.e-12;
+#endif
+    AMREX_ALWAYS_ASSERT(error < eps);
 }
 
 
@@ -169,42 +174,45 @@ void test_twod_mode (Box const& domain, int max_grid_size)
     });
     solver.solve(phi, rho);
 
-    BoxArray const ba1(domain);
-    DistributionMapping const dm1(Vector<int>{ParallelDescriptor::IOProcessorNumber()});
-    // Pinned, because the comparison below runs on the host.
-    MultiFab phi_all(ba1, dm1, 1, 0, MFInfo().SetArena(The_Pinned_Arena()));
-    phi_all.ParallelCopy(phi, 0, 0, 1);
-    Gpu::streamSynchronize();
+    auto const hi = amrex::ubound(domain);
+    ReduceOps<ReduceOpMax, ReduceOpMax, ReduceOpSum> reduce_op;
+    ReduceData<Real, Real, Long> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
 
-    if (ParallelDescriptor::IOProcessor()) {
-        auto const& a = phi_all[0].const_array();
-        auto const hi = amrex::ubound(domain);
-        Real errmax = 0, refmax = 0;
-        Long nbad = 0;
-        for (int k = lo.z; k <= hi.z; ++k) {
-        for (int j = lo.y; j <= hi.y; ++j) {
-        for (int i = lo.x; i <= hi.x; ++i) {
+    for (MFIter mfi(phi); mfi.isValid(); ++mfi) {
+        auto const& a = phi.const_array(mfi);
+        reduce_op.eval(mfi.validbox(), reduce_data,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+        {
             Real exact = 0;
             for (int jj = lo.y; jj <= hi.y; ++jj) {
             for (int ii = lo.x; ii <= hi.x; ++ii) {
-                exact += test_greens_function(std::abs(i-ii), std::abs(j-jj), 0)
-                         * test_rhs(ii,jj,k);
+                exact += test_greens_function(amrex::Math::abs(i-ii),
+                                              amrex::Math::abs(j-jj), 0) * test_rhs(ii,jj,k);
             }}
-            if (!std::isfinite(a(i,j,k))) { ++nbad; }
-            errmax = std::max(errmax, std::abs(a(i,j,k)-exact));
-            refmax = std::max(refmax, std::abs(exact));
-        }}}
-        auto const error = errmax / refmax;
-        amrex::Print() << "  relative error " << error
-                       << ", non-finite values " << nbad << "\n";
-        AMREX_ALWAYS_ASSERT(nbad == 0);
-#ifdef AMREX_USE_FLOAT
-        constexpr Real eps = 1.e-4;
-#else
-        constexpr Real eps = 1.e-12;
-#endif
-        AMREX_ALWAYS_ASSERT(error < eps);
+            return {amrex::Math::abs(a(i,j,k)-exact), amrex::Math::abs(exact),
+                    Long(!amrex::Math::isfinite(a(i,j,k)))};
+        });
     }
+
+    auto hv = reduce_data.value(reduce_op);
+    auto errmax = amrex::get<0>(hv);
+    auto refmax = amrex::get<1>(hv);
+    auto nbad   = amrex::get<2>(hv);
+    ParallelDescriptor::ReduceRealMax(errmax);
+    ParallelDescriptor::ReduceRealMax(refmax);
+    ParallelDescriptor::ReduceLongSum(nbad);
+
+    auto const error = errmax / refmax;
+    amrex::Print() << "  relative error " << error
+                   << ", non-finite values " << nbad << "\n";
+    AMREX_ALWAYS_ASSERT(nbad == 0);
+#ifdef AMREX_USE_FLOAT
+    constexpr Real eps = 1.e-4;
+#else
+    constexpr Real eps = 1.e-12;
+#endif
+    AMREX_ALWAYS_ASSERT(error < eps);
 }
 
 #endif

--- a/Tests/FFT/OpenBC/main.cpp
+++ b/Tests/FFT/OpenBC/main.cpp
@@ -1,6 +1,7 @@
 #include <AMReX_FFT_Poisson.H> // Put this at the top for testing
 
 #include <AMReX.H>
+#include <AMReX_FFT_OpenBCSolver.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_MultiFabUtil.H>
 #include <AMReX_ParmParse.H>
@@ -8,6 +9,8 @@
 using namespace amrex;
 
 namespace {
+
+#if (AMREX_SPACEDIM == 3)
 
 void fill_rhs (MultiFab& rho, Geometry const& geom, IndexType ixtype)
 {
@@ -43,16 +46,164 @@ void fill_rhs (MultiFab& rho, Geometry const& geom, IndexType ixtype)
     });
 }
 
+#endif
+
+// OpenBCSolver computes phi(i) = sum_j G(|i-j|) rho(j), so a direct sum with a
+// simple G is an exact reference that does not depend on the FFT machinery.
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+Real test_greens_function (int i, int j, int k)
+{
+    return Real(1) / (Real(1) + Real(i*i+j*j+k*k));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+Real test_rhs (int i, int j, int k)
+{
+    auto h = Real((i*7919 + j*104729 + k*15485863) % 1013);
+    return h / Real(1013) - Real(0.5);
+}
+
+// Solve with OpenBCSolver and compare against the direct convolution. This is
+// the only in-tree coverage of OpenBCSolver in 2D, and of a domain whose
+// smallEnd is not zero.
+void test_convolution (Box const& domain, int max_grid_size)
+{
+    amrex::Print() << "\nTesting OpenBCSolver on " << domain
+                   << " against a direct convolution\n";
+
+    BoxArray ba(domain);
+    ba.maxSize(max_grid_size);
+    DistributionMapping dm(ba);
+
+    MultiFab rho(ba,dm,1,0), phi(ba,dm,1,0);
+    for (MFIter mfi(rho); mfi.isValid(); ++mfi) {
+        auto const& a = rho.array(mfi);
+        amrex::ParallelFor(mfi.validbox(), [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            a(i,j,k) = test_rhs(i,j,k);
+        });
+    }
+
+    auto const lo = amrex::lbound(domain);
+    FFT::OpenBCSolver<Real> solver(domain);
+    // The Green's function is called with absolute indices.
+    solver.setGreensFunction([=] AMREX_GPU_DEVICE (int i, int j, int k) -> Real
+    {
+        return test_greens_function(i-lo.x, j-lo.y, k-lo.z);
+    });
+    solver.solve(phi, rho);
+
+    // Gather onto one rank and compare with the direct sum.
+    BoxArray const ba1(domain);
+    DistributionMapping const dm1(Vector<int>{ParallelDescriptor::IOProcessorNumber()});
+    MultiFab phi_all(ba1, dm1, 1, 0);
+    phi_all.ParallelCopy(phi, 0, 0, 1);
+
+    if (ParallelDescriptor::IOProcessor()) {
+        auto const& a = phi_all[0].const_array();
+        auto const hi = amrex::ubound(domain);
+        Real errmax = 0, refmax = 0;
+        for (int k = lo.z; k <= hi.z; ++k) {
+        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int i = lo.x; i <= hi.x; ++i) {
+            Real exact = 0;
+            for (int kk = lo.z; kk <= hi.z; ++kk) {
+            for (int jj = lo.y; jj <= hi.y; ++jj) {
+            for (int ii = lo.x; ii <= hi.x; ++ii) {
+                exact += test_greens_function(std::abs(i-ii), std::abs(j-jj),
+                                              std::abs(k-kk)) * test_rhs(ii,jj,kk);
+            }}}
+            errmax = std::max(errmax, std::abs(a(i,j,k)-exact));
+            refmax = std::max(refmax, std::abs(exact));
+        }}}
+        auto const error = errmax / refmax;
+        amrex::Print() << "  relative error " << error << "\n";
+#ifdef AMREX_USE_FLOAT
+        constexpr Real eps = 1.e-4;
+#else
+        constexpr Real eps = 1.e-12;
+#endif
+        AMREX_ALWAYS_ASSERT(error < eps);
+    }
+}
+
+
+#if (AMREX_SPACEDIM == 3)
+
+// In twod_mode each z plane is an independent 2D convolution, so the Green's
+// function must not depend on k. A domain whose z range does not start at zero
+// is the interesting case here.
+void test_twod_mode (Box const& domain, int max_grid_size)
+{
+    amrex::Print() << "\nTesting OpenBCSolver twod_mode on " << domain
+                   << " against a direct convolution\n";
+
+    BoxArray ba(domain);
+    ba.maxSize(max_grid_size);
+    DistributionMapping dm(ba);
+
+    MultiFab rho(ba,dm,1,0), phi(ba,dm,1,0);
+    for (MFIter mfi(rho); mfi.isValid(); ++mfi) {
+        auto const& a = rho.array(mfi);
+        amrex::ParallelFor(mfi.validbox(), [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            a(i,j,k) = test_rhs(i,j,k);
+        });
+    }
+
+    auto const lo = amrex::lbound(domain);
+    FFT::Info info{};
+    info.setTwoDMode(true);
+    FFT::OpenBCSolver<Real> solver(domain, info);
+    solver.setGreensFunction([=] AMREX_GPU_DEVICE (int i, int j, int) -> Real
+    {
+        return test_greens_function(i-lo.x, j-lo.y, 0);
+    });
+    solver.solve(phi, rho);
+
+    BoxArray const ba1(domain);
+    DistributionMapping const dm1(Vector<int>{ParallelDescriptor::IOProcessorNumber()});
+    MultiFab phi_all(ba1, dm1, 1, 0);
+    phi_all.ParallelCopy(phi, 0, 0, 1);
+
+    if (ParallelDescriptor::IOProcessor()) {
+        auto const& a = phi_all[0].const_array();
+        auto const hi = amrex::ubound(domain);
+        Real errmax = 0, refmax = 0;
+        for (int k = lo.z; k <= hi.z; ++k) {
+        for (int j = lo.y; j <= hi.y; ++j) {
+        for (int i = lo.x; i <= hi.x; ++i) {
+            Real exact = 0;
+            for (int jj = lo.y; jj <= hi.y; ++jj) {
+            for (int ii = lo.x; ii <= hi.x; ++ii) {
+                exact += test_greens_function(std::abs(i-ii), std::abs(j-jj), 0)
+                         * test_rhs(ii,jj,k);
+            }}
+            errmax = std::max(errmax, std::abs(a(i,j,k)-exact));
+            refmax = std::max(refmax, std::abs(exact));
+        }}}
+        auto const error = errmax / refmax;
+        amrex::Print() << "  relative error " << error << "\n";
+#ifdef AMREX_USE_FLOAT
+        constexpr Real eps = 1.e-4;
+#else
+        constexpr Real eps = 1.e-12;
+#endif
+        AMREX_ALWAYS_ASSERT(error < eps);
+    }
+}
+
+#endif
+
 }
 
 int main (int argc, char* argv[])
 {
-    static_assert(AMREX_SPACEDIM == 3);
-
     amrex::Initialize(argc, argv);
     {
         BL_PROFILE("main");
 
+#if (AMREX_SPACEDIM == 3)
         int n_cell_x = 128;
         int n_cell_y = 128;
         int n_cell_z = 128;
@@ -180,6 +331,26 @@ int main (int argc, char* argv[])
             constexpr Real eps = 1.e-13;
 #endif
             AMREX_ALWAYS_ASSERT(error < eps);
+        }
+#endif
+
+        {
+            int n_cell = 32;
+            int max_grid_size = 16;
+            ParmParse pp;
+            pp.query("conv_n_cell", n_cell);
+            pp.query("conv_max_grid_size", max_grid_size);
+
+            test_convolution(Box(IntVect(0), IntVect(n_cell-1)), max_grid_size);
+            // A domain that does not start at zero.
+            test_convolution(Box(IntVect(-3), IntVect(n_cell-4)), max_grid_size);
+
+#if (AMREX_SPACEDIM == 3)
+            test_twod_mode(Box(IntVect(0), IntVect(n_cell-1)), max_grid_size);
+            // A domain whose z range is entirely negative.
+            test_twod_mode(Box(IntVect(0,0,-n_cell), IntVect(n_cell-1,n_cell-1,-1)),
+                           max_grid_size);
+#endif
         }
     }
     amrex::Finalize();

--- a/Tests/FFT/OpenBC/main.cpp
+++ b/Tests/FFT/OpenBC/main.cpp
@@ -116,7 +116,7 @@ void test_convolution (Box const& domain, int max_grid_size)
             // Math::max would keep the other operand if a(i,j,k) were NaN, so
             // count the non-finite values separately.
             return {amrex::Math::abs(a(i,j,k)-exact), amrex::Math::abs(exact),
-                    Long(!amrex::Math::isfinite(a(i,j,k)))};
+                    Long(amrex::isnan(a(i,j,k)) || amrex::isinf(a(i,j,k)))};
         });
     }
 
@@ -191,7 +191,7 @@ void test_twod_mode (Box const& domain, int max_grid_size)
                                               amrex::Math::abs(j-jj), 0) * test_rhs(ii,jj,k);
             }}
             return {amrex::Math::abs(a(i,j,k)-exact), amrex::Math::abs(exact),
-                    Long(!amrex::Math::isfinite(a(i,j,k)))};
+                    Long(amrex::isnan(a(i,j,k)) || amrex::isinf(a(i,j,k)))};
         });
     }
 

--- a/Tests/FFT/OpenBC/main.cpp
+++ b/Tests/FFT/OpenBC/main.cpp
@@ -212,13 +212,15 @@ int main (int argc, char* argv[])
         int max_grid_size_y = 32;
         int max_grid_size_z = 32;
 
-        ParmParse pp;
-        pp.query("n_cell_x", n_cell_x);
-        pp.query("n_cell_y", n_cell_y);
-        pp.query("n_cell_z", n_cell_z);
-        pp.query("max_grid_size_x", max_grid_size_x);
-        pp.query("max_grid_size_y", max_grid_size_y);
-        pp.query("max_grid_size_z", max_grid_size_z);
+        {
+            ParmParse pp;
+            pp.query("n_cell_x", n_cell_x);
+            pp.query("n_cell_y", n_cell_y);
+            pp.query("n_cell_z", n_cell_z);
+            pp.query("max_grid_size_x", max_grid_size_x);
+            pp.query("max_grid_size_y", max_grid_size_y);
+            pp.query("max_grid_size_z", max_grid_size_z);
+        }
 
         Box domain(IntVect(0), IntVect(n_cell_x-1,n_cell_y-1,n_cell_z-1));
         BoxArray ba(domain);


### PR DESCRIPTION
The Green's function was never written in 2D because the hidden dimension had length 0, so every cell hit the mirror-plane check. Use dim3(1) so hidden dimensions get length 1.

The half-domain shortcut was also enabled in 2D, where R2C::prepare_openbc does not build the _half plans, so the x FFT was silently skipped on more than one rank.

In twod_mode the Green's function domain starts at z = 0, so do not subtract m_domain.smallEnd(2); otherwise a negative z origin zeroed a plane.

Tests/FFT/OpenBC now runs in 2D as well, and checks OpenBCSolver, including twod_mode, against a direct convolution.

Fixes #5717.

