### PR TITLE
HYPRE: do not hand out pointers to storage that goes away

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.H
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.H
@@ -147,6 +147,8 @@ private:
     std::string m_solver_name{"BoomerAMG"};
     std::string m_preconditioner_name{"none"};
     std::string m_file_prefix{"IJ"};
+    //! HYPRE keeps a pointer to this, so it must outlive m_precond.
+    std::string m_euclid_file;
 
     //! Verbosity of the HYPRE solvers
     int m_verbose{0};

--- a/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreIJIface.cpp
@@ -338,10 +338,9 @@ void HypreIJIface::boomeramg_precond_configure (const std::string& prefix)
         // Process Euclid smoother parameters
         if (smooth_type == 9) {
             if (hpp.pp.contains("bamg_euclid_file")) {
-                std::string euclid_file;
-                hpp.pp.get("bamg_euclid_file", euclid_file);
+                hpp.pp.get("bamg_euclid_file", m_euclid_file);
                 HYPRE_BoomerAMGSetEuclidFile(
-                    m_precond, const_cast<char*>(euclid_file.c_str()));
+                    m_precond, const_cast<char*>(m_euclid_file.c_str()));
             }
             hpp.set<int>("bamg_smooth_num_levels", HYPRE_BoomerAMGSetSmoothNumLevels);
             hpp.set<int>("bamg_smooth_num_sweeps", HYPRE_BoomerAMGSetSmoothNumSweeps);

--- a/Src/Extern/HYPRE/AMReX_HypreSolver.H
+++ b/Src/Extern/HYPRE/AMReX_HypreSolver.H
@@ -409,6 +409,8 @@ HypreSolver<MSS>::fill_global_id ()
             p_global_id.push_back(&(m_global_id[ivar]));
         }
     } else {
+        // Reserve so that the pointers taken below stay valid.
+        global_id_raii.reserve(m_nvars);
         for (int ivar = 0; ivar < m_nvars; ++ivar) {
             global_id_raii.emplace_back(m_global_id[ivar].boxArray(),
                                         m_global_id[ivar].DistributionMap(),


### PR DESCRIPTION
fill_global_id took pointers into global_id_raii while still growing it, so the first pointer dangled once the vector reallocated. Reserve up front. This only affects HYPRE built with --enable-bigint and more than one index type.

HYPRE_BoomerAMGSetEuclidFile keeps the char* and reads it later in HYPRE_BoomerAMGSetup, so the Euclid file name has to outlive the call. Store it in a HypreIJIface member.

Fixes #5716.
