### PR TITLE
Fix VisMF reads that silently miss data

### DIFF
--- a/Src/Base/AMReX_VisMF.H
+++ b/Src/Base/AMReX_VisMF.H
@@ -599,7 +599,11 @@ Read (FabArray<FAB>& fa, const std::string& name)
     if (fa.empty()) {
         fa.define(ba, DistributionMapping{ba}, ncomp, ngrow);
     } else {
-        AMREX_ASSERT(amrex::match(ba, fa.boxArray()));
+        // read_fab reads straight into fa[i], which resizes the fab, so unlike
+        // VisMF::Read there is nothing here to absorb a mismatch.
+        AMREX_ALWAYS_ASSERT(amrex::match(ba, fa.boxArray()) &&
+                            ncomp == fa.nComp() &&
+                            ngrow == fa.nGrowVect());
     }
 
 #ifdef AMREX_USE_MPI

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -1673,6 +1673,11 @@ VisMF::Read (FabArray<FArrayBox> &mf,
 
     Vector<int> nRanksPerFile(FileReadChains.size());
     NItemsPerBin(nProcs, nRanksPerFile);
+    // There may be more files than ranks (e.g., restarting on fewer ranks than
+    // the run that wrote the data used).  Every file still needs a reader.
+    for(int & nrpf : nRanksPerFile) {
+      nrpf = std::max(nrpf, 1);
+    }
     int currentFileIndex(0);
 
     for(frcIter = FileReadChains.begin(); frcIter != FileReadChains.end(); ++frcIter) {
@@ -1699,10 +1704,13 @@ VisMF::Read (FabArray<FArrayBox> &mf,
           ++indexFileOrder;
         }
         ++currentRank;
-        currentRank = std::min(currentRank, nProcs - 1);
+        currentRank = currentRank % nProcs;
       }
       ++currentFileIndex;
     }
+
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(indexFileOrder == nBoxes,
+                                     "VisMF::Read: not all boxes are assigned a reader");
 
     DistributionMapping dmFileOrder(std::move(ranksFileOrder));
 


### PR DESCRIPTION
In the synchronous file-order path, NItemsPerBin gives no reader to files beyond the first nProcs, so restarting on fewer ranks than the writer used left those files' boxes untouched and Read returned without error. Give every file a reader and wrap the rank counter, and assert that every box is covered.

The FabArray Read template checked the BoxArray only in debug builds and never checked ncomp or ngrow, but it reads straight into the caller's fabs, which resize. Check all three unconditionally.

Fixes #5711.
