### PR TITLE
Parser: stop optimizing away the runtime semantics

### DIFF
--- a/Src/Base/Parser/AMReX_IParser_Y.cpp
+++ b/Src/Base/Parser/AMReX_IParser_Y.cpp
@@ -802,10 +802,16 @@ iparser_ast_optimize (struct iparser_node* node)
     case IPARSER_DIV_PP:
         iparser_ast_optimize(node->l);
         iparser_ast_optimize(node->r);
-        // Division by zero is left for the executor, whose if() is lazy.
-        if (node->l->type == IPARSER_NUMBER &&
-            node->r->type == IPARSER_NUMBER &&
-            ((struct iparser_number*)(node->r))->value != 0)
+        if (node->r->type == IPARSER_NUMBER &&
+            ((struct iparser_number*)(node->r))->value == 0)
+        {
+            // Division by zero is left for the executor, whose if() is lazy.
+            // The node must be generic, because its operands are no longer
+            // what IPARSER_DIV_PP and friends claim they are.
+            node->type = IPARSER_DIV;
+        }
+        else if (node->l->type == IPARSER_NUMBER &&
+                 node->r->type == IPARSER_NUMBER)
         {
             auto v= ((struct iparser_number*)(node->l))->value
                 /   ((struct iparser_number*)(node->r))->value;
@@ -820,8 +826,7 @@ iparser_ast_optimize (struct iparser_node* node)
             node->type = IPARSER_DIV_VP;
         }
         else if (node->l->type == IPARSER_SYMBOL &&
-                 node->r->type == IPARSER_NUMBER &&
-                 ((struct iparser_number*)(node->r))->value != 0)
+                 node->r->type == IPARSER_NUMBER)
         {
             node->lvp.v = ((struct iparser_number*)(node->r))->value;
             node->rip   = ((struct iparser_symbol*)(node->l))->ip;

--- a/Src/Base/Parser/AMReX_IParser_Y.cpp
+++ b/Src/Base/Parser/AMReX_IParser_Y.cpp
@@ -802,8 +802,10 @@ iparser_ast_optimize (struct iparser_node* node)
     case IPARSER_DIV_PP:
         iparser_ast_optimize(node->l);
         iparser_ast_optimize(node->r);
+        // Division by zero is left for the executor, whose if() is lazy.
         if (node->l->type == IPARSER_NUMBER &&
-            node->r->type == IPARSER_NUMBER)
+            node->r->type == IPARSER_NUMBER &&
+            ((struct iparser_number*)(node->r))->value != 0)
         {
             auto v= ((struct iparser_number*)(node->l))->value
                 /   ((struct iparser_number*)(node->r))->value;
@@ -818,7 +820,8 @@ iparser_ast_optimize (struct iparser_node* node)
             node->type = IPARSER_DIV_VP;
         }
         else if (node->l->type == IPARSER_SYMBOL &&
-                 node->r->type == IPARSER_NUMBER)
+                 node->r->type == IPARSER_NUMBER &&
+                 ((struct iparser_number*)(node->r))->value != 0)
         {
             node->lvp.v = ((struct iparser_number*)(node->r))->value;
             node->rip   = ((struct iparser_symbol*)(node->l))->ip;
@@ -937,7 +940,9 @@ iparser_ast_optimize (struct iparser_node* node)
             ((struct iparser_f2*)node)->ftype = IPARSER_AND;
         }
         if (node->l->type == IPARSER_NUMBER &&
-            node->r->type == IPARSER_NUMBER)
+            node->r->type == IPARSER_NUMBER &&
+            !(((struct iparser_f2*)node)->ftype == IPARSER_FLRDIV &&
+              ((struct iparser_number*)(node->r))->value == 0))
         {
             auto v= iparser_call_f2
                 (((struct iparser_f2*)node)->ftype,
@@ -995,9 +1000,13 @@ iparser_ast_optimize (struct iparser_node* node)
         iparser_ast_optimize(node->r);
         if (node->r->type == IPARSER_NUMBER)
         {
-            auto v= node->lvp.v / ((struct iparser_number*)(node->r))->value;
-            ((struct iparser_number*)node)->type = IPARSER_NUMBER;
-            ((struct iparser_number*)node)->value = v;
+            if (((struct iparser_number*)(node->r))->value != 0) {
+                auto v= node->lvp.v / ((struct iparser_number*)(node->r))->value;
+                ((struct iparser_number*)node)->type = IPARSER_NUMBER;
+                ((struct iparser_number*)node)->value = v;
+            } else {
+                node->type = IPARSER_DIV; // node->l is still the left number
+            }
         }
         break;
     case IPARSER_DIV_PV:

--- a/Src/Base/Parser/AMReX_IParser_Y.cpp
+++ b/Src/Base/Parser/AMReX_IParser_Y.cpp
@@ -1010,7 +1010,8 @@ iparser_ast_optimize (struct iparser_node* node)
                 ((struct iparser_number*)node)->type = IPARSER_NUMBER;
                 ((struct iparser_number*)node)->value = v;
             } else {
-                node->type = IPARSER_DIV; // node->l is still the left number
+                // The _VP specialization leaves l and r untouched.
+                node->type = IPARSER_DIV;
             }
         }
         break;

--- a/Src/Base/Parser/AMReX_Parser_Y.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Y.cpp
@@ -232,12 +232,12 @@ bool parser_is_comparison (struct parser_node* node)
     }
 }
 
-// Is the node a number with an integer value?
+// Is the node a number with a finite integer value?
 bool parser_is_integer (struct parser_node* node)
 {
     if (node && node->type == PARSER_NUMBER) {
         auto v = parser_get_number(node);
-        return v == std::floor(v);
+        return std::isfinite(v) && v == std::floor(v);
     } else {
         return false;
     }

--- a/Src/Base/Parser/AMReX_Parser_Y.cpp
+++ b/Src/Base/Parser/AMReX_Parser_Y.cpp
@@ -3,6 +3,7 @@
 #include <amrex_parser.tab.h>
 
 #include <algorithm>
+#include <cmath>
 #include <cstdarg>
 #include <vector>
 
@@ -226,6 +227,29 @@ bool parser_is_comparison (struct parser_node* node)
                 ftype == PARSER_LEQ || ftype == PARSER_GEQ ||
                 ftype == PARSER_EQ || ftype == PARSER_NEQ ||
                 (ftype == PARSER_CMP_CHAIN && parser_is_comparison(node->r)));
+    } else {
+        return false;
+    }
+}
+
+// Is the node a number with an integer value?
+bool parser_is_integer (struct parser_node* node)
+{
+    if (node && node->type == PARSER_NUMBER) {
+        auto v = parser_get_number(node);
+        return v == std::floor(v);
+    } else {
+        return false;
+    }
+}
+
+// Does the node already evaluate to 1 or 0?
+bool parser_is_boolean (struct parser_node* node)
+{
+    if (node && node->type == PARSER_F2) {
+        auto ftype = ((struct parser_f2*)node)->ftype;
+        return (ftype == PARSER_AND || ftype == PARSER_OR ||
+                parser_is_comparison(node));
     } else {
         return false;
     }
@@ -1409,8 +1433,13 @@ parser_ast_optimize (struct parser_node*& node, std::map<std::string,double>& lo
         else if (((struct parser_f2*)node)->ftype == PARSER_AND &&
                  ((struct parser_f2*)node)->r->type == PARSER_NUMBER &&
                  parser_get_number(((struct parser_f2*)node)->r) != 0.0)
-        { // ? and true => ?
-            std::memcpy(node, node->l, sizeof(struct parser_node));
+        { // ? and true => (? != 0)
+            if (parser_is_boolean(node->l)) {
+                std::memcpy(node, node->l, sizeof(struct parser_node));
+            } else {
+                ((struct parser_f2*)node)->ftype = PARSER_NEQ;
+                parser_set_number(node->r, 0.0);
+            }
         }
         else if (((struct parser_f2*)node)->ftype == PARSER_AND &&
                  ((struct parser_f2*)node)->l->type == PARSER_NUMBER &&
@@ -1421,8 +1450,14 @@ parser_ast_optimize (struct parser_node*& node, std::map<std::string,double>& lo
         else if (((struct parser_f2*)node)->ftype == PARSER_AND &&
                  ((struct parser_f2*)node)->l->type == PARSER_NUMBER &&
                  parser_get_number(((struct parser_f2*)node)->l) != 0.0)
-        { // true and ? => ?
-            std::memcpy(node, node->r, sizeof(struct parser_node));
+        { // true and ? => (? != 0)
+            if (parser_is_boolean(node->r)) {
+                std::memcpy(node, node->r, sizeof(struct parser_node));
+            } else {
+                std::swap(node->l, node->r);
+                ((struct parser_f2*)node)->ftype = PARSER_NEQ;
+                parser_set_number(node->r, 0.0);
+            }
         }
         else if (((struct parser_f2*)node)->ftype == PARSER_OR &&
                  ((struct parser_f2*)node)->r->type == PARSER_NUMBER &&
@@ -1433,8 +1468,12 @@ parser_ast_optimize (struct parser_node*& node, std::map<std::string,double>& lo
         else if (((struct parser_f2*)node)->ftype == PARSER_OR &&
                  ((struct parser_f2*)node)->r->type == PARSER_NUMBER &&
                  parser_get_number(((struct parser_f2*)node)->r) == 0.0)
-        { // ? or false => ?
-            std::memcpy(node, node->l, sizeof(struct parser_node));
+        { // ? or false => (? != 0)
+            if (parser_is_boolean(node->l)) {
+                std::memcpy(node, node->l, sizeof(struct parser_node));
+            } else {
+                ((struct parser_f2*)node)->ftype = PARSER_NEQ;
+            }
         }
         else if (((struct parser_f2*)node)->ftype == PARSER_OR &&
                  ((struct parser_f2*)node)->l->type == PARSER_NUMBER &&
@@ -1445,8 +1484,13 @@ parser_ast_optimize (struct parser_node*& node, std::map<std::string,double>& lo
         else if (((struct parser_f2*)node)->ftype == PARSER_OR &&
                  ((struct parser_f2*)node)->l->type == PARSER_NUMBER &&
                  parser_get_number(((struct parser_f2*)node)->l) == 0.0)
-        { // false or ? => ?
-            std::memcpy(node, node->r, sizeof(struct parser_node));
+        { // false or ? => (? != 0)
+            if (parser_is_boolean(node->r)) {
+                std::memcpy(node, node->r, sizeof(struct parser_node));
+            } else {
+                std::swap(node->l, node->r);
+                ((struct parser_f2*)node)->ftype = PARSER_NEQ;
+            }
         }
         else if (((struct parser_f2*)node)->ftype == PARSER_POW &&
                  ((struct parser_f2*)node)->r->type == PARSER_NUMBER &&
@@ -1462,12 +1506,6 @@ parser_ast_optimize (struct parser_node*& node, std::map<std::string,double>& lo
                         sizeof(struct parser_node));
         }
         else if (((struct parser_f2*)node)->ftype == PARSER_POW &&
-                 ((struct parser_f2*)node)->l->type == PARSER_NUMBER &&
-                 parser_get_number(((struct parser_f2*)node)->l) == 0.0)
-        {
-            parser_set_number(node, 0.0);
-        }
-        else if (((struct parser_f2*)node)->ftype == PARSER_POW &&
                  ((struct parser_f2*)node)->r->type == PARSER_NUMBER &&
                  parser_get_number(((struct parser_f2*)node)->r) == -1.0)
         {
@@ -1477,8 +1515,10 @@ parser_ast_optimize (struct parser_node*& node, std::map<std::string,double>& lo
         }
         else if (((struct parser_f2*)node)->ftype == PARSER_POW &&
                  ((struct parser_f2*)node)->l->type == PARSER_F2 &&
-                 ((struct parser_f2*)((struct parser_f2*)node)->l)->ftype == PARSER_POW)
-        { // pow(pow(,),)
+                 ((struct parser_f2*)((struct parser_f2*)node)->l)->ftype == PARSER_POW &&
+                 parser_is_integer(((struct parser_f2*)node)->r) &&
+                 parser_is_integer(((struct parser_f2*)((struct parser_f2*)node)->l)->r))
+        { // pow(pow(x,m),n) => pow(x,m*n), for integer m and n only
             std::swap(node->l, node->r);
             std::swap(node->l, node->r->l);
             node->r->type = PARSER_MUL;

--- a/Tests/Parser/main.cpp
+++ b/Tests/Parser/main.cpp
@@ -512,6 +512,55 @@ int main (int argc, char* argv[])
         }
 #endif
 
+        // Edge cases where the optimizer must agree with the runtime evaluator.
+
+        // pow(pow(x,m),n) may only be merged for integer m and n.
+        nerror += test1("(x**2)**0.5", {}, {"x"},
+                        [=] (double x) -> double { return std::pow(std::pow(x,2.0),0.5); },
+                        {-3.0}, {3.0}, 101, 1.e-12, 1.e-15);
+        nerror += test1("(x**2)**1.5", {}, {"x"},
+                        [=] (double x) -> double { return std::pow(std::pow(x,2.0),1.5); },
+                        {-3.0}, {3.0}, 101, 1.e-12, 1.e-15);
+        nerror += test1("((x-1)*(x-1))**0.5", {}, {"x"},
+                        [=] (double x) -> double { return std::pow((x-1.0)*(x-1.0),0.5); },
+                        {-3.0}, {3.0}, 101, 1.e-12, 1.e-15);
+        // Integer exponents still merge.
+        nerror += test1("(x**2)**3", {}, {"x"},
+                        [=] (double x) -> double { return std::pow(std::pow(x,2.0),3.0); },
+                        {-3.0}, {3.0}, 101, 1.e-12, 1.e-15);
+
+        // pow with a constant zero base: std::pow(0,0) is 1 and pow(0,-1) is inf.
+        nerror += test1("c**x", {{"c",0.0}}, {"x"},
+                        [=] (double x) -> double { return std::pow(0.0,x); },
+                        {0.0}, {4.0}, 5, 1.e-12, 1.e-15);
+        nerror += test1("0**x", {}, {"x"},
+                        [=] (double x) -> double { return std::pow(0.0,x); },
+                        {1.0}, {4.0}, 4, 1.e-12, 1.e-15);
+
+        // and/or must return 1 or 0, not the operand.
+        nerror += test1("x and 1", {}, {"x"},
+                        [=] (double x) -> double { return (x != 0.0) ? 1.0 : 0.0; },
+                        {-2.0}, {2.0}, 5, 1.e-12, 1.e-15);
+        nerror += test1("1 and x", {}, {"x"},
+                        [=] (double x) -> double { return (x != 0.0) ? 1.0 : 0.0; },
+                        {-2.0}, {2.0}, 5, 1.e-12, 1.e-15);
+        nerror += test1("(x and 1)+1", {}, {"x"},
+                        [=] (double x) -> double { return ((x != 0.0) ? 1.0 : 0.0) + 1.0; },
+                        {-2.0}, {2.0}, 5, 1.e-12, 1.e-15);
+        nerror += test1("x or 0", {}, {"x"},
+                        [=] (double x) -> double { return (x != 0.0) ? 1.0 : 0.0; },
+                        {-2.0}, {2.0}, 5, 1.e-12, 1.e-15);
+        nerror += test1("0 or x", {}, {"x"},
+                        [=] (double x) -> double { return (x != 0.0) ? 1.0 : 0.0; },
+                        {-2.0}, {2.0}, 5, 1.e-12, 1.e-15);
+        nerror += test1("x and c", {{"c",1.0}}, {"x"},
+                        [=] (double x) -> double { return (x != 0.0) ? 1.0 : 0.0; },
+                        {-2.0}, {2.0}, 5, 1.e-12, 1.e-15);
+        // An operand that is already 0 or 1 needs no extra operation.
+        nerror += test1("(x>0) and 1", {}, {"x"},
+                        [=] (double x) -> double { return (x > 0.0) ? 1.0 : 0.0; },
+                        {-2.0}, {2.0}, 5, 1.e-12, 1.e-15);
+
         amrex::Print() << "\nMax stack size is " << max_stack_size << "\n";
         if (nerror > 0) {
             amrex::Print() << nerror << " tests failed\n";
@@ -588,6 +637,15 @@ int main (int argc, char* argv[])
                     }
                 }
             }
+
+            // A division that the executor never evaluates must not be folded.
+            AMREX_ALWAYS_ASSERT(h("if(0, 1/0, 2)") == 2);
+            AMREX_ALWAYS_ASSERT(h("if(0, 1//0, 2)") == 2);
+            AMREX_ALWAYS_ASSERT(g("if(n > 1, 100/(n-1), 0)", "n", 1) == 0);
+            AMREX_ALWAYS_ASSERT(g("if(n > 1, 100//(n-1), 0)", "n", 1) == 0);
+            AMREX_ALWAYS_ASSERT(g("if(n > 1, x/(n-1), 0)", "n", 1) == 0);
+            AMREX_ALWAYS_ASSERT(g("if(n > 1, 100/(n-1), 0)", "n", 3) == 50);
+            AMREX_ALWAYS_ASSERT(g("if(n > 1, x/(n-1), 0)", "n", 3) == x/2);
 
             AMREX_ALWAYS_ASSERT(h("123456789012345") == 123456789012345LL);
             AMREX_ALWAYS_ASSERT(h("123456789012345.") == 123456789012345LL);

--- a/Tests/Parser/main.cpp
+++ b/Tests/Parser/main.cpp
@@ -535,7 +535,7 @@ int main (int argc, char* argv[])
                         {0.0}, {4.0}, 5, 1.e-12, 1.e-15);
         nerror += test1("0**x", {}, {"x"},
                         [=] (double x) -> double { return std::pow(0.0,x); },
-                        {1.0}, {4.0}, 4, 1.e-12, 1.e-15);
+                        {0.0}, {4.0}, 5, 1.e-12, 1.e-15);
 
         // and/or must return 1 or 0, not the operand.
         nerror += test1("x and 1", {}, {"x"},
@@ -644,7 +644,10 @@ int main (int argc, char* argv[])
             AMREX_ALWAYS_ASSERT(g("if(n > 1, 100/(n-1), 0)", "n", 1) == 0);
             AMREX_ALWAYS_ASSERT(g("if(n > 1, 100//(n-1), 0)", "n", 1) == 0);
             AMREX_ALWAYS_ASSERT(g("if(n > 1, x/(n-1), 0)", "n", 1) == 0);
+            AMREX_ALWAYS_ASSERT(g("if(n > 1, 100/n, 0)", "n", 0) == 0);
+            AMREX_ALWAYS_ASSERT(g("if(n > 1, 100//n, 0)", "n", 0) == 0);
             AMREX_ALWAYS_ASSERT(g("if(n > 1, 100/(n-1), 0)", "n", 3) == 50);
+            AMREX_ALWAYS_ASSERT(g("if(n > 1, 100/n, 0)", "n", 4) == 25);
             AMREX_ALWAYS_ASSERT(g("if(n > 1, x/(n-1), 0)", "n", 3) == x/2);
 
             {   // A local variable makes the compiler resolve symbol offsets, so

--- a/Tests/Parser/main.cpp
+++ b/Tests/Parser/main.cpp
@@ -647,6 +647,16 @@ int main (int argc, char* argv[])
             AMREX_ALWAYS_ASSERT(g("if(n > 1, 100/(n-1), 0)", "n", 3) == 50);
             AMREX_ALWAYS_ASSERT(g("if(n > 1, x/(n-1), 0)", "n", 3) == x/2);
 
+            {   // A local variable makes the compiler resolve symbol offsets, so
+                // a node left claiming the wrong operand types would be fatal.
+                amrex::Print() << count++ << ". Testing \"t=7; if(c, x/n, t)\"\n";
+                IParser iparser("t=7; if(c, x/n, t)");
+                iparser.setConstant("n", 0);
+                iparser.registerVariables({"x","c"});
+                auto exe = iparser.compileHost<2>();
+                AMREX_ALWAYS_ASSERT(exe(10,0) == 7);
+            }
+
             AMREX_ALWAYS_ASSERT(h("123456789012345") == 123456789012345LL);
             AMREX_ALWAYS_ASSERT(h("123456789012345.") == 123456789012345LL);
             AMREX_ALWAYS_ASSERT(h("123'456'789'012'345") == 123456789012345LL);

--- a/Tests/Parser2/fn.cpp
+++ b/Tests/Parser2/fn.cpp
@@ -220,18 +220,6 @@ double f (int icase, double x, double y, double z)
         return x/y/z*x*y*z;
     case 103:
         return ((x+y*z-x*y/z-x*y*z-x/y*z-x/y+z*x/y/z*x*y+z*x-y*z));
-    case 104:
-        return x and 1;
-    case 105:
-        return 1 and x;
-    case 106:
-        return x or 0;
-    case 107:
-        return 0 or x;
-    case 108:
-        return (x and 1) + 1;
-    case 109:
-        return (x > y) and 1;
     default:
         amrex::Abort("Unknown case "+std::to_string(icase));
         return 0.0;

--- a/Tests/Parser2/fn.cpp
+++ b/Tests/Parser2/fn.cpp
@@ -220,6 +220,18 @@ double f (int icase, double x, double y, double z)
         return x/y/z*x*y*z;
     case 103:
         return ((x+y*z-x*y/z-x*y*z-x/y*z-x/y+z*x/y/z*x*y+z*x-y*z));
+    case 104:
+        return x and 1;
+    case 105:
+        return 1 and x;
+    case 106:
+        return x or 0;
+    case 107:
+        return 0 or x;
+    case 108:
+        return (x and 1) + 1;
+    case 109:
+        return (x > y) and 1;
     default:
         amrex::Abort("Unknown case "+std::to_string(icase));
         return 0.0;


### PR DESCRIPTION
Four rewrite rules disagreed with what the executor computes.

`pow(pow(x,m),n)` was merged into `pow(x,m*n)` for any m and n, so `(x^2)^0.5` became `x` and returned -2 at x = -2. Merge only when both exponents are integers.

`0^e` was folded to 0 for any e, but `std::pow(0,0)` is 1. Drop the rule; a literal `0^c` is already folded by the both-constants branch.

`? and true`, `true and ?`, `? or false` and `false or ?` were replaced by the operand, so `x and 1` returned 5 instead of 1. Rewrite them as `? != 0`, unless the operand is already 0 or 1.

IParser folded integer division even when the divisor was 0, so `if(n > 1, 100/(n-1), 0)` with n = 1 raised SIGFPE at setConstant time although the executor's if() is lazy. Leave those nodes to the executor.

Fixes #5720.

