### PR TITLE
Base: check input length and stream state when reading

### DIFF
--- a/Src/Base/AMReX_BoxArray.cpp
+++ b/Src/Base/AMReX_BoxArray.cpp
@@ -111,8 +111,8 @@ BARef::define (std::istream& is, int& ndims)
     AMREX_ASSERT(maxbox >= 0 && maxbox < std::numeric_limits<int>::max());
     resize(maxbox);
     auto pos = is.tellg();
-    {
-        ndims = AMREX_SPACEDIM;
+    ndims = AMREX_SPACEDIM;
+    if (maxbox > 0) { // No box to probe otherwise, and we would hit EOF.
         char c1, c2;
         int itmp;
         is >> std::ws >> c1 >> std::ws >> c2;

--- a/Src/Base/AMReX_FArrayBox.cpp
+++ b/Src/Base/AMReX_FArrayBox.cpp
@@ -824,9 +824,7 @@ FABio_8bit::read (std::istream& is,
     for(int k = 0; k < f.nComp(); ++k) {
         is >> mn >> mx >> nbytes;
         BL_ASSERT(nbytes == siz);
-        while (is.get() != '\n') {
-            ;  // ---- do nothing
-        }
+        is.ignore(BL_IGNORE_MAX, '\n');
         is.read((char*)c,siz);
         Real* dat       = f.dataPtr(k);
         const Real rng  = (mx-mn)/255.0_rt;
@@ -855,9 +853,7 @@ FABio_8bit::skip (std::istream& is,
     for(int k = 0; k < f.nComp(); ++k) {
         is >> mn >> mx >> nbytes;
         BL_ASSERT(nbytes == siz);
-        while(is.get() != '\n') {
-            ;  // ---- do nothing
-        }
+        is.ignore(BL_IGNORE_MAX, '\n');
         is.seekg(siz, std::ios::cur);
     }
 
@@ -878,9 +874,7 @@ FABio_8bit::skip (std::istream& is,
     for(int k = 0; k < nCompToSkip; ++k) {
         is >> mn >> mx >> nbytes;
         BL_ASSERT(nbytes == siz);
-        while(is.get() != '\n') {
-            ;  // ---- do nothing
-        }
+        is.ignore(BL_IGNORE_MAX, '\n');
         is.seekg(siz, std::ios::cur);
     }
 

--- a/Src/Base/AMReX_FabConv.cpp
+++ b/Src/Base/AMReX_FabConv.cpp
@@ -915,6 +915,9 @@ operator>> (std::istream&   is,
     if (c != ')') {
         amrex::Error("operator>>(istream&,RealDescriptor&): expected a \')\'");
     }
+    if (fmt.size() != 8) {
+        amrex::Error("operator>>(istream&,RealDescriptor&): expected 8 format numbers");
+    }
     rd = RealDescriptor(fmt.dataPtr(),ord.dataPtr(),static_cast<int>(ord.size()));
     return is;
 }

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -164,7 +164,8 @@ Geometry::Setup (const RealBox* rb, int coord, int const* isper)
     if (isper == nullptr)
     {
         Vector<int> is_per(AMREX_SPACEDIM,0);
-        pp.queryAdd("is_periodic", is_per);
+        pp.queryAdd("is_periodic", is_per, AMREX_SPACEDIM);
+        AMREX_ASSERT(is_per.size() == AMREX_SPACEDIM);
         for (int n = 0; n < AMREX_SPACEDIM; n++) {
             gg->is_periodic[n] = is_per[n];
         }


### PR DESCRIPTION
geometry.is_periodic was read with the unchecked vector queryAdd, which shrinks the vector to however many values were given, and the loop then indexed all SPACEDIM of them. Use the fixed-count overload, like prob_lo.

operator>> for RealDescriptor passed the format array to a constructor that copies eight Longs, without checking that eight were read.

BARef::define probed two characters for the dimensionality even when the BoxArray held no boxes, so reading back what writeOn wrote for an empty one hit EOF and failed.

FABio_8bit spun in a loop on is.get, which never ends once the stream fails because get keeps returning eof. A truncated 8BIT file hung instead of raising an error. Use is.ignore, as the ASCII path does.

Fixes #5722.
