### PR TITLE
Simplify AMREX_DEVICE_PRINTF for SYCL

### DIFF
--- a/Src/Base/AMReX_GpuPrint.H
+++ b/Src/Base/AMReX_GpuPrint.H
@@ -9,21 +9,14 @@
 #endif
 
 #if defined(AMREX_USE_SYCL)
-#if defined(__SYCL_DEVICE_ONLY__)
-#  define AMREX_DEVICE_PRINTF(format,...) { \
-      static const __attribute__((opencl_constant)) char amrex_i_format[] = format ; \
-      sycl::ext::oneapi::experimental::printf(amrex_i_format, __VA_ARGS__); }
-#else
-#  define AMREX_DEVICE_PRINTF(format,...) { \
-      std::printf(format, __VA_ARGS__); }
-#endif
+#  define AMREX_DEVICE_PRINTF(...) \
+      sycl::ext::oneapi::experimental::printf(__VA_ARGS__);
 #elif defined(AMREX_USE_CUDA)
 #  define AMREX_DEVICE_PRINTF(...) std::printf(__VA_ARGS__);
 #elif defined(AMREX_USE_HIP)
 #  define AMREX_DEVICE_PRINTF(...) ::printf(__VA_ARGS__);
 #else
-#  define AMREX_DEVICE_PRINTF(format,...) { \
-      std::printf(format, __VA_ARGS__); }
+#  define AMREX_DEVICE_PRINTF(...) std::printf(__VA_ARGS__);
 #endif
 
 #endif  // AMREX_GPU_PRINT_H_


### PR DESCRIPTION
The compiler moves a printf format string to the constant address space itself, so the local opencl_constant copy is no longer needed, and the extension calls std::printf on the host, so the __SYCL_DEVICE_ONLY__ branch is not needed either. Intel's own tests stopped using the attribute by default some time ago.

The macro now takes the same arguments on every backend. The old form needed at least one argument after the format, and could not take a format string that was not a literal, which is what AMReX_Array4.H does for an out-of-bounds message.
