### PR TITLE
Array4: abort on an out-of-bound component and print the right bound

### DIFF
--- a/Src/Base/AMReX_Array4.H
+++ b/Src/Base/AMReX_Array4.H
@@ -111,6 +111,7 @@ namespace amrex {
             if (n < 0 || n >= ncomp) {
                 AMREX_IF_ON_DEVICE((
                     AMREX_DEVICE_PRINTF(" %d is out of bound (0:%d)", n, ncomp-1);
+                    amrex::Abort();
                 ))
                 AMREX_IF_ON_HOST((
                     std::stringstream ss;
@@ -239,7 +240,7 @@ namespace amrex {
 
             AMREX_DEVICE_PRINTF(msg.data(),
                 iv.vect[idx]...,
-                ((idx2x % 2 == 0) ? begin.vect[idx2x / 2] : end.vect[idx2x / 2])...
+                ((idx2x % 2 == 0) ? begin.vect[idx2x / 2] : end.vect[idx2x / 2] - 1)...
             );
         }
 


### PR DESCRIPTION
CellData::operator[] printed the out-of-bound message on device and then went ahead with the access, unlike the host branch and every index_assert.

The generic ArrayND device message printed the exclusive upper bound, so an index one past the end read as being inside the range it was outside of. The host branch and the Array4 device printer both use end-1.

Fixes #5723.
