### PR TITLE
Fix asymmetric start/finish counters in FabArray and BaseFab

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1814,7 +1814,7 @@ BaseFab<T>::elixir () noexcept
         o = this->ptr_owner;
         this->ptr_owner = false;
         if (o && this->dptr) {
-            if (this->nvar > 1) {
+            if (this->nvar > 0) {
                 amrex::update_fab_stats(-this->truesize/this->nvar, -this->truesize, sizeof(T));
             } else {
                 amrex::update_fab_stats(0, -this->truesize, sizeof(T));
@@ -1850,7 +1850,7 @@ BaseFab<T>::clear ()
             this->free(this->dptr);
 #endif
 
-            if (this->nvar > 1) {
+            if (this->nvar > 0) {
                 amrex::update_fab_stats(-this->truesize/this->nvar, -this->truesize, sizeof(T));
             } else {
                 amrex::update_fab_stats(0, -this->truesize, sizeof(T));
@@ -1870,7 +1870,7 @@ BaseFab<T>::release () noexcept
     if (this->dptr && this->ptr_owner) {
         r.reset(this->dptr);
         this->ptr_owner = false;
-        if (this->nvar > 1) {
+        if (this->nvar > 0) {
             amrex::update_fab_stats(-this->truesize/this->nvar, -this->truesize, sizeof(T));
         } else {
             amrex::update_fab_stats(0, -this->truesize, sizeof(T));

--- a/Src/Base/AMReX_FabArrayCommI.H
+++ b/Src/Base/AMReX_FabArrayCommI.H
@@ -39,6 +39,16 @@ FabArray<FAB>::FBEP_nowait (int scomp, int ncomp, const IntVect& nghost,
     } else {
         work_to_do = nghost.max() > 0;
     }
+
+    // Only a plain FillBoundary brings the halo up to date.  The other
+    // operations here either touch valid data or only part of the halo, so
+    // they make no claim about it.
+    if (enforce_periodicity_only || override_sync || sumboundary) {
+        n_filled = IntVect::TheZeroVector();
+    } else {
+        n_filled = nghost;
+    }
+
     if (!work_to_do) { return; }
 
     const FB& TheFB = getFB(nghost, period, cross, enforce_periodicity_only, override_sync, sumboundary_src_nghost);
@@ -231,7 +241,7 @@ FabArray<FAB>::FillBoundary_finish ()
     BL_PROFILE("FillBoundary_finish()");
     BL_PROFILE_SYNC_STOP();
 
-    if (!fbd) { n_filled = IntVect::TheZeroVector(); return; }
+    if (!fbd) { return; }
 
     const FB* TheFB = fbd->fb;
     bool sumboundary = TheFB->m_sb_snghost.allGE(0);
@@ -658,6 +668,7 @@ FabArray<FAB>::ParallelCopy_nowait (const FabArray<FAB>& src,
         if (!last_iter)
         {
             ParallelCopy_finish();
+            BL_PROFILE_SYNC_START_TIMED("SyncBeforeComms: PC");
 
             SC += NC;
             DC += NC;


### PR DESCRIPTION
FillBoundary_finish() zeroed n_filled when there was no MPI work and never set it on the MPI path, so nGrowFilled() returned a zeroed or stale halo width.  Record it in FBEP_nowait() instead, claiming only what a plain FillBoundary fills.

BaseFab clear()/elixir()/release() skipped the cell count when nvar == 1, so TotalCellsAllocatedInFabs() drifted upward.  The guard only needs to avoid dividing by zero.

The MaxComp chunk loop in ParallelCopy_nowait() ran one profiler BL_PROFILE_SYNC_STOP() per pass against a single start, driving sync_counter negative and disabling profiler sync barriers.

Fixes #5724.
