### PR TITLE
Fix int overflow for large fabs in FabConv, BaseFab::getVal and transposeCtoF

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1456,8 +1456,8 @@ BaseFab<T>::getVal  (T*             data,
                      int            n,
                      int            numcomp) const noexcept
 {
-    const int loc      = this->domain.index(pos);
-    const Long sz    = this->domain.numPts();
+    const Long loc = this->domain.index(pos);
+    const Long sz  = this->domain.numPts();
 
     AMREX_ASSERT(!(this->dptr == nullptr));
     AMREX_ASSERT(n >= 0 && n + numcomp <= this->nvar);

--- a/Src/Base/AMReX_BaseFabUtility.H
+++ b/Src/Base/AMReX_BaseFabUtility.H
@@ -163,7 +163,7 @@ void transposeCtoF (T const* pi, T* po, int nx, int ny, int nz)
     {
         __shared__ T tile[tile_dim][tile_dim+1]; // +1 to avoid bank conflicts
 
-        for (int j = blockIdx.z; j < ny; j += gridDim.z) { // for y-direction
+        for (unsigned int j = blockIdx.z; j < unsigned(ny); j += gridDim.z) { // for y-direction
 
             int k = blockIdx.y * tile_dim + threadIdx.x; // for loading z-direction
             int i = blockIdx.x * tile_dim + threadIdx.y; // for loading x-direction

--- a/Src/Base/AMReX_BaseFabUtility.H
+++ b/Src/Base/AMReX_BaseFabUtility.H
@@ -152,42 +152,48 @@ void transposeCtoF (T const* pi, T* po, int nx, int ny, int nz)
     // Each block has tile_dim x block_rows threads. They work on a tile_dim
     // x tile_dim tile.
 
+    // gridDim.z is limited to 65535, so blocks loop over y if ny is larger.
     dim3 block{unsigned(tile_dim), unsigned(block_rows), 1};
     dim3 grid{unsigned((nx+tile_dim-1)/tile_dim),
-              unsigned((nz+tile_dim-1)/tile_dim), unsigned(ny)};
+              unsigned((nz+tile_dim-1)/tile_dim),
+              unsigned(std::min(ny, 65535))};
 
     AMREX_LAUNCH_KERNEL(nthreads, grid, block, 0, Gpu::gpuStream(),
     [=] AMREX_GPU_DEVICE ()
     {
         __shared__ T tile[tile_dim][tile_dim+1]; // +1 to avoid bank conflicts
 
-        int k = blockIdx.y * tile_dim + threadIdx.x; // for loading z-direction
-        int i = blockIdx.x * tile_dim + threadIdx.y; // for loading x-direction
+        for (int j = blockIdx.z; j < ny; j += gridDim.z) { // for y-direction
 
-        int j = blockIdx.z; // for y-direction
+            int k = blockIdx.y * tile_dim + threadIdx.x; // for loading z-direction
+            int i = blockIdx.x * tile_dim + threadIdx.y; // for loading x-direction
 
-        if (k < nz) {
-            for (int it = 0; it < tile_dim; it += block_rows, i += block_rows) {
-                if (i < nx) {
-                    //      x               z
-                    tile[threadIdx.y+it][threadIdx.x] = pi[k + (j+i*std::size_t(ny))*nz];
+            if (k < nz) {
+                for (int it = 0; it < tile_dim; it += block_rows, i += block_rows) {
+                    if (i < nx) {
+                        //      x               z
+                        tile[threadIdx.y+it][threadIdx.x] = pi[k + (j+i*std::size_t(ny))*nz];
+                    }
                 }
             }
-        }
 
-        __syncthreads();
+            __syncthreads();
 
-        i = blockIdx.x * tile_dim + threadIdx.x; // for storing x-direction
-        k = blockIdx.y * tile_dim + threadIdx.y; // for storing z-direction
+            i = blockIdx.x * tile_dim + threadIdx.x; // for storing x-direction
+            k = blockIdx.y * tile_dim + threadIdx.y; // for storing z-direction
 
-        if (i < nx) {
-            for (int it = 0; it < tile_dim; it += block_rows, k += block_rows) {
-                if (k < nz) {
-                    po[i + (j+k*std::size_t(ny))*nx] = tile[threadIdx.x][threadIdx.y+it];
+            if (i < nx) {
+                for (int it = 0; it < tile_dim; it += block_rows, k += block_rows) {
+                    if (k < nz) {
+                        po[i + (j+k*std::size_t(ny))*nx] = tile[threadIdx.x][threadIdx.y+it];
+                    }
                 }
             }
+
+            __syncthreads();
         }
     });
+    AMREX_GPU_ERROR_CHECK();
 
 #elif defined(AMREX_USE_SYCL)
 

--- a/Src/Base/AMReX_FabConv.cpp
+++ b/Src/Base/AMReX_FabConv.cpp
@@ -268,14 +268,14 @@ ONES_COMP_NEG (Long& n,
 inline
 int
 _pd_get_bit (char const* base,
-             int         offs,
+             Long        offs,
              int         nby,
              const int*  ord)
 {
-    int n      = offs >> 3;
-    int nbytes = n % nby;
+    Long n     = offs >> 3;
+    int nbytes = int(n % nby);
     n     -= nbytes;
-    offs   = offs % 8;
+    int bit = int(offs % 8);
 
     if (ord == nullptr) {
         base += (n + nbytes);
@@ -283,7 +283,7 @@ _pd_get_bit (char const* base,
         base += (n + (ord[nbytes] - 1));
     }
 
-    int mask = (1 << (7 - offs));
+    int mask = (1 << (7 - bit));
 
     return (*base & mask) != 0;
 }
@@ -298,7 +298,7 @@ _pd_get_bit (char const* base,
 
 Long
 _pd_extract_field (char const* in,
-                   int         offs,
+                   Long        offs,
                    int         nbi,
                    int         nby,
                    const int*  ord)
@@ -313,12 +313,12 @@ _pd_extract_field (char const* in,
     Long n   = offs >> 3;
     int offy = int(n % nby);
     n   -= offy;
-    offs = offs % 8;
+    int bit = int(offs % 8);
     //
     // Advance the pointer past the unneeded items.
     //
     in += n;
-    unsigned char bpb = 8 - offs;
+    unsigned char bpb = 8 - bit;
 
     if (ord == nullptr) {
         ind = offy++;
@@ -403,7 +403,7 @@ void
 _pd_insert_field (Long  in_long,
                   int   nb,
                   char* out,
-                  int   offs,
+                  Long  bit_offs,
                   int   l_order,
                   int   l_bytes)
 {
@@ -415,11 +415,8 @@ _pd_insert_field (Long  in_long,
     // If the output start bit is not in the first byte move past the
     // appropriate number of bytes so that the start bit is in the first byte.
     //
-    if (offs > 7)
-    {
-        out  += (offs >> 3);
-        offs %= 8;
-    }
+    out += (bit_offs >> 3);
+    int offs = int(bit_offs % 8);
     //
     // If mi is less than offs, copy the first dm bits over, reset offs to 0,
     // Advance mi by dm, and handle the rest as if mi >= offs.
@@ -470,14 +467,14 @@ _pd_insert_field (Long  in_long,
 
 inline
 void
-_pd_set_bit (char* base, int offs)
+_pd_set_bit (char* base, Long offs)
 {
-    int nbytes = offs >> 3;
+    Long nbytes = offs >> 3;
 
     base += nbytes;
-    offs -= 8*nbytes;
+    int bit = int(offs - 8*nbytes);
 
-    int mask = (1 << (7 - offs));
+    int mask = (1 << (7 - bit));
 
     *base  |= mask; // NOLINT
 }
@@ -623,8 +620,9 @@ PD_fconvert (void*       out,
 
     Long i, expn, expn_max, hexpn, mant, DeltaBias, hmbo, hmbi;
     int nbits, inbytes, outbytes, sign;
-    int indxin, indxout, inrem, outrem, dindx;
-    int bi_sign, bo_sign, bi_exp, bo_exp, bi_mant, bo_mant;
+    Long indxin, indxout;
+    int inrem, outrem, dindx;
+    Long bi_sign, bo_sign, bi_exp, bo_exp, bi_mant, bo_mant;
     int nbi_exp, nbo_exp, nbi, nbo;
     char *lout, *lin;
     unsigned char *rout;
@@ -633,12 +631,12 @@ PD_fconvert (void*       out,
     nbo     = int(outfor[0]);
     nbi_exp = int(infor[1]);
     nbo_exp = int(outfor[1]);
-    bi_sign = int(infor[3] + boffs);
-    bo_sign = int(outfor[3]);
-    bi_exp  = int(infor[4] + boffs);
-    bo_exp  = int(outfor[4]);
-    bi_mant = int(infor[5] + boffs);
-    bo_mant = int(outfor[5]);
+    bi_sign = infor[3] + boffs;
+    bo_sign = outfor[3];
+    bi_exp  = infor[4] + boffs;
+    bo_exp  = outfor[4];
+    bi_mant = infor[5] + boffs;
+    bo_mant = outfor[5];
 
     hmbo    = (outfor[6] & 1LL);
     hmbi    = (infor[6] & 1LL);
@@ -649,9 +647,7 @@ PD_fconvert (void*       out,
     hexpn     = 1LL << (outfor[1] - 1L);
     expn_max  = (1LL << outfor[1]) - 1LL;
 
-    auto number = size_t(nitems);
-    BL_ASSERT(int(number) == nitems);
-    memset(out, 0, number*outbytes);
+    memset(out, 0, std::size_t(nitems)*outbytes);
 
     lout = (char*)out;
     lin  = (char*)in;
@@ -763,9 +759,9 @@ PD_fconvert (void*       out,
     //
     if (hmbo)
     {
-        int j, mask = (1 << (7 - bo_mant % 8));
+        int j, mask = (1 << (7 - int(bo_mant % 8)));
 
-        indxout = int(outfor[5]/8);
+        indxout = outfor[5]/8;
         rout    = (unsigned char *) out;
         for (i = 0L; i < nitems; i++, rout += outbytes)
         {
@@ -795,7 +791,7 @@ PD_fixdenormals (void*       out,
     const int nbo = int(outfor[0]);
 
     int nbo_exp  = int(outfor[1]);
-    int bo_exp   = int(outfor[4]);
+    Long bo_exp  = outfor[4];
     int outbytes = (nbo + 7) >> 3;
 
     char* lout = (char*) out;


### PR DESCRIPTION
PD_fconvert's running bit offsets were int and overflowed above INT_MAX/64 items; they and the offs parameters of the bit helpers are now Long. BaseFab::getVal kept the Long index from Box::index instead of narrowing to int. transposeCtoF puts ny on gridDim.x instead of gridDim.z, which is capped at 65535, and checks the launch for errors.

Fixes #5725
