### PR TITLE
Fix GPU safety of BaseFab deep copy and indexFromValue

### DIFF
--- a/Src/Base/AMReX_BaseFab.H
+++ b/Src/Base/AMReX_BaseFab.H
@@ -1658,7 +1658,14 @@ BaseFab<T>::BaseFab (const BaseFab<T>& rhs, MakeType make_type, int scomp, int n
     {
         this->dptr = nullptr;
         define();
-        this->copy<RunOn::Device>(rhs, this->domain, scomp, this->domain, 0, ncomp);
+#ifdef AMREX_USE_GPU
+        if (Gpu::inLaunchRegion() && arena()->isDeviceAccessible()) {
+            this->copy<RunOn::Device>(rhs, this->domain, scomp, this->domain, 0, ncomp);
+        } else
+#endif
+        {
+            this->copy<RunOn::Host>(rhs, this->domain, scomp, this->domain, 0, ncomp);
+        }
     } else if (make_type == amrex::make_alias) {
         ; // nothing to do
     } else {

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1810,7 +1810,9 @@ indexFromValue (FabArray<FAB> const& mf, int comp, IntVect const& nghost,
                 }
             });
         } else {
-            for (MFIter mfi(mf,MFItInfo().SetDeviceSync(false)); mfi.isValid(); ++mfi) {
+            // The result is read on the host below, so the streams used by
+            // MFIter must be synchronized even inside a NoSyncRegion.
+            for (MFIter mfi(mf,MFItInfo().SetDeviceSync(true)); mfi.isValid(); ++mfi) {
                 const Box& bx = amrex::grow(mfi.validbox(), nghost);
                 auto const& arr = mf.const_array(mfi);
                 amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept


### PR DESCRIPTION
The deep-copy constructor always used copy<RunOn::Device>, even for fabs in a host-only arena. Guard it like define() does and copy on the host otherwise.

indexFromValue ran its MFIter with device sync off, so the host read the result buffer while kernels on other streams were still running. Force the sync on, since the result is consumed on the host right away.

Fixes #5726
