### PR TITLE
Fix CPU/GPU parity of launch(n,f) and three-box HostDeviceParallelFor

### DIFF
--- a/Src/Base/AMReX_GpuLaunchFunctsC.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsC.H
@@ -119,16 +119,22 @@ namespace detail {
 /// \endcond
 
 template<typename T, typename L>
-void launch (T const& n, L&& f) noexcept
+void launch (T const& n, L const& f) noexcept
 {
-    std::forward<L>(f)(n);
+    // Like the GPU backends: f(i) for each i in [0,n) when n is integral,
+    // f(box) once when n is a BoxND.
+    for (auto const i : Gpu::Range(n)) {
+        f(i);
+    }
 }
 
 template<int MT, typename T, typename L>
-void launch (T const& n, L&& f) noexcept
+void launch (T const& n, L const& f) noexcept
 {
     amrex::ignore_unused(MT);
-    std::forward<L>(f)(n);
+    for (auto const i : Gpu::Range(n)) {
+        f(i);
+    }
 }
 
 template <std::integral T, typename L >

--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -1907,6 +1907,28 @@ HostDeviceParallelFor (Gpu::KernelInfo const& info,
     }
 }
 
+template <typename L1, typename L2, typename L3, int dim>
+requires (MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value &&
+          MaybeHostDeviceRunnable<L3>::value)
+void
+HostDeviceParallelFor (Gpu::KernelInfo const& info,
+                       BoxND<dim> const& box1, BoxND<dim> const& box2, BoxND<dim> const& box3,
+                       L1&& f1, L2&& f2, L3&& f3)
+{
+    if (Gpu::inLaunchRegion()) {
+        ParallelFor<AMREX_GPU_MAX_THREADS>(info,box1,box2,box3,
+                    std::forward<L1>(f1),std::forward<L2>(f2),std::forward<L3>(f3));
+    } else {
+#ifdef AMREX_USE_SYCL
+        amrex::Abort("amrex:: HOST_DEVICE disabled for Intel.  It takes too long to compile");
+#else
+        LoopConcurrentOnCpu(box1,std::forward<L1>(f1));
+        LoopConcurrentOnCpu(box2,std::forward<L2>(f2));
+        LoopConcurrentOnCpu(box3,std::forward<L3>(f3));
+#endif
+    }
+}
+
 template <int MT, typename L1, typename L2, typename L3, int dim>
 requires (MaybeHostDeviceRunnable<L1>::value && MaybeHostDeviceRunnable<L2>::value &&
           MaybeHostDeviceRunnable<L3>::value)


### PR DESCRIPTION
The CPU launch(n,f) called f(n) once instead of f(i) for each i in [0,n) like the GPU backends. It now loops over Gpu::Range(n), which also keeps the Box form calling f(box) once.

Add the non-MT three-box HostDeviceParallelFor(KernelInfo, ...) that the CPU header has but the GPU header lacked.

Fixes #5727
