### PR TITLE
Fix two uninstantiable overloads in Src/Base

### DIFF
--- a/Src/Base/AMReX_FACopyDescriptor.H
+++ b/Src/Base/AMReX_FACopyDescriptor.H
@@ -878,12 +878,13 @@ FabArrayCopyDescriptor<FAB>::FillFab (FabArrayId       faid,
 
     BL_ASSERT(fcdp->subBox.sameSize(destBox));
 
-    destFab.ParallelCopy(*fcdp->localFabSource,
-                         fcdp->subBox,
-                         fcdp->fillType == FillLocally ? fcdp->srcComp : 0,
-                         destBox,
-                         fcdp->destComp,
-                         fcdp->nComp);
+    destFab.template copy<RunOn::Host>
+               (*fcdp->localFabSource,
+                 fcdp->subBox,
+                 fcdp->fillType == FillLocally ? fcdp->srcComp : 0,
+                 destBox,
+                 fcdp->destComp,
+                 fcdp->nComp);
 
     BL_ASSERT(++fmi == fabCopyDescList[faid.Id()].upper_bound(fillboxid.Id()));
 }

--- a/Src/Base/AMReX_FabArrayUtility.H
+++ b/Src/Base/AMReX_FabArrayUtility.H
@@ -1138,11 +1138,11 @@ bool ReduceLogicalOr_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghos
 
 template <BaseFabType FAB, class F>
 requires (amrex::DefinitelyNotHostRunnable<F>::value)
-bool ReduceLogicalOr_host (FabArray<FAB> const& fa, IntVect const& nghost, F&& /*f*/)
+bool ReduceLogicalOr_host_wrapper (FabArray<FAB> const& fa, IntVect const& nghost, F&& f)
 {
-    amrex::ignore_unused(fa,nghost);
+    amrex::ignore_unused(fa,nghost,f);
     amrex::Abort("ReduceLogicalOr: Launch Region is off. Device lambda cannot be called by host.");
-    return 0;
+    return false;
 }
 }
 /// \endcond


### PR DESCRIPTION
The four-argument FabArrayCopyDescriptor::FillFab called a nonexistent BaseFab::ParallelCopy; use BaseFab::copy like the three-argument version.

The device-only ReduceLogicalOr overload was named ReduceLogicalOr_host instead of ReduceLogicalOr_host_wrapper, so nvcc extended device lambdas found no candidate.

Fixes #5728.
