### PR TITLE
Fix shared nodes in nodaltilebox and GpuBndryFuncFab boundary fill

### DIFF
--- a/Src/Base/AMReX_MFIter.H
+++ b/Src/Base/AMReX_MFIter.H
@@ -146,7 +146,11 @@ public:
     //! Return the tilebox with provided nodal flag and grown cells
     [[nodiscard]] Box tilebox (const IntVect& nodal, const IntVect& ngrow) const noexcept;
 
-    //! Return the dir-nodal (or all nodal if dir<0) Box at the current index.
+    /**
+     * \brief Return the dir-nodal (or all nodal if dir<0) tile Box at the
+     * current index.  The Box is cell-centered in the other directions
+     * regardless of the FabArray's index type, like grownnodaltilebox.
+     */
     [[nodiscard]] Box nodaltilebox (int dir=-1) const noexcept;
 
     //! Return the tile box at the current index grown to include ghost cells.

--- a/Src/Base/AMReX_MFIter.cpp
+++ b/Src/Base/AMReX_MFIter.cpp
@@ -448,27 +448,8 @@ Box
 MFIter::nodaltilebox (int dir) const noexcept
 {
     BL_ASSERT(dir < AMREX_SPACEDIM);
-    BL_ASSERT(tile_array != nullptr);
-    Box bx((*tile_array)[currentIndex]);
-    bx.convert(typ);
-    const Box& vbx = validbox();
-    const IntVect& Big = vbx.bigEnd();
-    int d0, d1;
-    if (dir < 0) {
-        d0 = 0;
-        d1 = AMREX_SPACEDIM-1;
-    } else {
-        d0 = d1 = dir;
-    }
-    for (int d=d0; d<=d1; ++d) {
-        if (typ.cellCentered(d)) { // validbox should also be cell-centered in d-direction.
-            bx.surroundingNodes(d);
-            if (bx.bigEnd(d) <= Big[d]) {
-                bx.growHi(d,-1);
-            }
-        }
-    }
-    return bx;
+    if (dir < 0) { return tilebox(IntVect::TheNodeVector()); }
+    return tilebox(IntVect::TheDimensionVector(dir));
 }
 
 // Note that a small negative ng is supported.

--- a/Src/Base/AMReX_PhysBCFunct.H
+++ b/Src/Base/AMReX_PhysBCFunct.H
@@ -439,16 +439,20 @@ GpuBndryFuncFab<F>::ccfcdoit (Box const& bx, FArrayBox& dest,
             if (tmp.ok()) { face_boxes.push_back(tmp); }
         }
         const int n_face_boxes = face_boxes.size();
-        if (n_face_boxes == 1) {
-            amrex::ParallelFor(face_boxes[0],
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
-                AMREX_D_PICK(amrex::ignore_unused(j,k),amrex::ignore_unused(k),(void)0);
-                IntVect const idx(AMREX_D_DECL(i,j,k));
-                fillfunc(idx, fab, dcomp, numcomp, domain, bcr_p, 0);
-                f_user(idx, fab, dcomp, numcomp, geomdata, time,
-                       bcr_p, 0, orig_comp);
-            });
+        // For non-cell-centered data the boxes share nodes, so they must be
+        // launched separately to avoid races, like in the CPU version below.
+        if (n_face_boxes == 1 || ! idxType.cellCentered()) {
+            for (const Box& b : face_boxes) {
+                amrex::ParallelFor(b,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                {
+                    AMREX_D_PICK(amrex::ignore_unused(j,k),amrex::ignore_unused(k),(void)0);
+                    IntVect const idx(AMREX_D_DECL(i,j,k));
+                    fillfunc(idx, fab, dcomp, numcomp, domain, bcr_p, 0);
+                    f_user(idx, fab, dcomp, numcomp, geomdata, time,
+                           bcr_p, 0, orig_comp);
+                });
+            }
         } else if (n_face_boxes > 1) {
             AsyncArray<Box> face_boxes_aa(face_boxes.data(), n_face_boxes);
             Box* boxes_p = face_boxes_aa.data();
@@ -499,16 +503,20 @@ GpuBndryFuncFab<F>::ccfcdoit (Box const& bx, FArrayBox& dest,
             if (tmp.ok()) { edge_boxes.push_back(tmp); }
         }
         const int n_edge_boxes = edge_boxes.size();
-        if (n_edge_boxes == 1) {
-            amrex::ParallelFor(edge_boxes[0],
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
-                AMREX_D_PICK(amrex::ignore_unused(j,k),amrex::ignore_unused(k),(void)0);
-                IntVect const idx(AMREX_D_DECL(i,j,k));
-                fillfunc(idx, fab, dcomp, numcomp, domain, bcr_p, 0);
-                f_user(idx, fab, dcomp, numcomp, geomdata, time,
-                       bcr_p, 0, orig_comp);
-            });
+        // For non-cell-centered data the boxes share nodes, so they must be
+        // launched separately to avoid races, like in the CPU version below.
+        if (n_edge_boxes == 1 || ! idxType.cellCentered()) {
+            for (const Box& b : edge_boxes) {
+                amrex::ParallelFor(b,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                {
+                    AMREX_D_PICK(amrex::ignore_unused(j,k),amrex::ignore_unused(k),(void)0);
+                    IntVect const idx(AMREX_D_DECL(i,j,k));
+                    fillfunc(idx, fab, dcomp, numcomp, domain, bcr_p, 0);
+                    f_user(idx, fab, dcomp, numcomp, geomdata, time,
+                           bcr_p, 0, orig_comp);
+                });
+            }
         } else if (n_edge_boxes > 1) {
             AsyncArray<Box> edge_boxes_aa(edge_boxes.data(), n_edge_boxes);
             Box* boxes_p = edge_boxes_aa.data();


### PR DESCRIPTION
nodaltilebox now delegates to tilebox(IntVect) like grownnodaltilebox, which removes the duplicated node-trimming logic and makes the two agree: the Box is cell-centered in the other directions whatever the FabArray's type.  That also fixes MLTensorOp::prepareForSolve, which iterates the x-face kappa and wrote the y- and z-face arrays out of bounds.  In GpuBndryFuncFab::ccfcdoit, face and edge boxes of non-cell-centered data share nodes on the domain boundary too, so launch them one at a time as the CPU version does instead of fusing them into a single kernel.

Fixes #5730.
