### PR TITLE
Fix computeGradient in 2D RZ geometry

### DIFF
--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -794,17 +794,6 @@ namespace amrex
     {
         AMREX_ASSERT(grad.nComp() >= AMREX_SPACEDIM);
 
-#if (AMREX_SPACEDIM==2)
-        const auto& ba = grad.boxArray();
-        const auto& dm = grad.DistributionMap();
-        MultiFab volume, areax, areay;
-        if (geom.IsRZ()) {
-            geom.GetVolume(volume, ba, dm, 0);
-            geom.GetFaceArea(areax, ba, dm, 0, 0);
-            geom.GetFaceArea(areay, ba, dm, 1, 0);
-        }
-#endif
-
         const GpuArray<Real,AMREX_SPACEDIM> dxinv = geom.InvCellSizeArray();
 
 #ifdef AMREX_USE_OMP
@@ -817,24 +806,10 @@ namespace amrex
             AMREX_D_TERM(const auto& ufab = umac[0]->const_array(mfi);,
                          const auto& vfab = umac[1]->const_array(mfi);,
                          const auto& wfab = umac[2]->const_array(mfi););
-#if (AMREX_SPACEDIM==2)
-            if (geom.IsRZ()) {
-                Array4<Real const> const&  ax =  areax.array(mfi);
-                Array4<Real const> const&  ay =  areay.array(mfi);
-                Array4<Real const> const& vol = volume.array(mfi);
-
-                AMREX_LAUNCH_HOST_DEVICE_LAMBDA (bx, tbx,
-                {
-                    amrex_compute_gradient_rz(tbx,gradfab,AMREX_D_DECL(ufab,vfab,wfab),ax,ay,vol);
-                });
-            } else
-#endif
+            AMREX_LAUNCH_HOST_DEVICE_LAMBDA (bx, tbx,
             {
-                AMREX_LAUNCH_HOST_DEVICE_LAMBDA (bx, tbx,
-                {
-                    amrex_compute_gradient(tbx,gradfab,AMREX_D_DECL(ufab,vfab,wfab),dxinv);
-                });
-            }
+                amrex_compute_gradient(tbx,gradfab,AMREX_D_DECL(ufab,vfab,wfab),dxinv);
+            });
         }
     }
 

--- a/Src/Base/AMReX_MultiFabUtil_2D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_2D_C.H
@@ -442,27 +442,6 @@ void amrex_compute_divergence_rz (Box const& bx, Array4<Real> const& divu,
     }
 }
 
-AMREX_GPU_HOST_DEVICE
-inline
-void amrex_compute_gradient_rz (Box const& bx, Array4<Real> const& grad,
-                                Array4<Real const> const& u,
-                                Array4<Real const> const& v,
-                                Array4<Real const> const& ax,
-                                Array4<Real const> const& ay,
-                                Array4<Real const> const& vol) noexcept
-{
-    const auto lo = lbound(bx);
-    const auto hi = ubound(bx);
-
-    for     (int j = lo.y; j <= hi.y; ++j) {
-        AMREX_PRAGMA_SIMD
-        for (int i = lo.x; i <= hi.x; ++i) {
-            grad(i,j,0,0) = (ax(i+1,j,0,0)*u(i+1,j,0)-ax(i,j,0,0)*u(i,j,0))/vol(i,j,0,0);
-            grad(i,j,0,1) = (ay(i,j+1,0,0)*v(i,j+1,0)-ay(i,j,0,0)*v(i,j,0))/vol(i,j,0,0);
-        }
-    }
-}
-
 }
 
 #endif


### PR DESCRIPTION
The RZ branch was a copy of the divergence kernel, so the radial component returned (1/r)d(r*u)/dr instead of du/dr.  A cell-centered gradient of face data carries no cylindrical metric, so drop the RZ branch and the now-unused amrex_compute_gradient_rz, letting RZ use the same plain finite differences as Cartesian.

Fixes #5733.
