### PR TITLE
Skip empty box in GPU ReduceOps::eval_box

### DIFF
--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -665,6 +665,7 @@ public:
     template <typename I, int dim, typename D, typename F>
     void eval_box (I, BoxND<dim> const& box, int ncomp, D& reduce_data, F const& f)
     {
+        if (box.isEmpty()) { return; }
         using ReduceTuple = typename D::Type;
         auto const& stream = Gpu::gpuStream();
         auto dp = reduce_data.devicePtr(stream);


### PR DESCRIPTION
For an empty box, nblocks_ec is zero and the kernel launch fails with an invalid configuration error on CUDA/HIP.  Return early instead, as the sibling eval(N n) does, matching the CPU behavior of a no-op.

Fixes #5738.
