### PR TITLE
Fix SYCL block reduction for large numbers of sub-groups

### DIFF
--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -345,7 +345,8 @@ void ParallelFor (Gpu::KernelInfo const& info, T n, L const& f)
         if (info.hasReduction()) {
             q.submit([&] (sycl::handler& h) {
                 sycl::local_accessor<unsigned long long>
-                    shared_data(sycl::range<1>(Gpu::Device::warp_size), h);
+                    shared_data(sycl::range<1>(std::max(Gpu::Device::warp_size,
+                                                        MT/Gpu::Device::warp_size)), h);
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
                 [=] (sycl::nd_item<1> item)
@@ -410,7 +411,8 @@ void ParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, L const& f
         if (info.hasReduction()) {
             q.submit([&] (sycl::handler& h) {
                 sycl::local_accessor<unsigned long long>
-                    shared_data(sycl::range<1>(Gpu::Device::warp_size), h);
+                    shared_data(sycl::range<1>(std::max(Gpu::Device::warp_size,
+                                                        MT/Gpu::Device::warp_size)), h);
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
                 [=] (sycl::nd_item<1> item)
@@ -479,7 +481,8 @@ void ParallelFor (Gpu::KernelInfo const& info, BoxND<dim> const& box, T ncomp, L
         if (info.hasReduction()) {
             q.submit([&] (sycl::handler& h) {
                 sycl::local_accessor<unsigned long long>
-                    shared_data(sycl::range<1>(Gpu::Device::warp_size), h);
+                    shared_data(sycl::range<1>(std::max(Gpu::Device::warp_size,
+                                                        MT/Gpu::Device::warp_size)), h);
                 h.parallel_for(sycl::nd_range<1>(sycl::range<1>(nthreads_total),
                                                  sycl::range<1>(nthreads_per_block)),
                 [=] (sycl::nd_item<1> item)

--- a/Src/Base/AMReX_GpuReduce.H
+++ b/Src/Base/AMReX_GpuReduce.H
@@ -69,7 +69,6 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 T blockReduce (T x, WARPREDUCE && warp_reduce, T x0, Gpu::Handler const& h)
 {
     T* shared = (T*)h.local;
-    int tid = h.item->get_local_id(0);
     sycl::sub_group const& sg = h.item->get_sub_group();
     int lane = sg.get_local_id()[0];
     int wid = sg.get_group_id()[0];
@@ -82,9 +81,16 @@ T blockReduce (T x, WARPREDUCE && warp_reduce, T x0, Gpu::Handler const& h)
     h.item->barrier(sycl::access::fence_space::local_space);
     if (lane == 0) { shared[wid] = x; }
     h.item->barrier(sycl::access::fence_space::local_space);
-    bool b = (tid == 0) || (tid < numwarps);
-    x =  b ? shared[lane] : x0;
-    if (wid == 0) { x = warp_reduce(x, sg); }
+    x = x0;
+    if (wid == 0) {
+        // numwarps can be greater than warpSize. So warp 0 folds the
+        // partials in rounds of warpSize-1, carrying the result in lane 0.
+        for (int i0 = 0; i0 < numwarps; i0 += warpSize-1) {
+            int i = i0 + lane - 1;
+            T y = (lane == 0) ? x : ((i < numwarps) ? shared[i] : x0);
+            x = warp_reduce(y, sg);
+        }
+    }
     return x;
 }
 

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -894,7 +894,8 @@ namespace amrex
                 int n2dblocks = (n2d+AMREX_GPU_MAX_THREADS-1)/AMREX_GPU_MAX_THREADS;
                 int nblocks = n2dblocks * b.length(direction);
 #ifdef AMREX_USE_SYCL
-                std::size_t shared_mem_byte = sizeof(Real)*Gpu::Device::warp_size;
+                std::size_t shared_mem_byte = sizeof(Real)
+                    * std::max(Gpu::Device::warp_size, AMREX_GPU_MAX_THREADS/Gpu::Device::warp_size);
                 amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks, shared_mem_byte, Gpu::gpuStream(),
                               [=] AMREX_GPU_DEVICE (Gpu::Handler const& h) noexcept
 #else

--- a/Src/Base/AMReX_Reduce.H
+++ b/Src/Base/AMReX_Reduce.H
@@ -623,7 +623,8 @@ public:
 
 #ifdef AMREX_USE_SYCL
             // device reduce needs local(i.e., shared) memory
-            constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
+            constexpr std::size_t shared_mem_bytes = sizeof(ReduceTuple)
+                * std::max(Gpu::Device::warp_size, AMREX_GPU_MAX_THREADS/Gpu::Device::warp_size);
             amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, shared_mem_bytes, stream,
                           [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
             {
@@ -678,7 +679,8 @@ public:
         reduce_data.updateMaxStreamIndex(stream);
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
-        constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
+        constexpr std::size_t shared_mem_bytes = sizeof(ReduceTuple)
+            * std::max(Gpu::Device::warp_size, AMREX_GPU_MAX_THREADS/Gpu::Device::warp_size);
         amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
@@ -805,7 +807,8 @@ public:
         reduce_data.updateMaxStreamIndex(stream);
 #ifdef AMREX_USE_SYCL
         // device reduce needs local(i.e., shared) memory
-        constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
+        constexpr std::size_t shared_mem_bytes = sizeof(ReduceTuple)
+            * std::max(Gpu::Device::warp_size, AMREX_GPU_MAX_THREADS/Gpu::Device::warp_size);
         amrex::launch<AMREX_GPU_MAX_THREADS>(nblocks_ec, shared_mem_bytes, stream,
         [=] AMREX_GPU_DEVICE (Gpu::Handler const& gh) noexcept
         {
@@ -874,7 +877,8 @@ public:
             int maxblocks = reduce_data.maxBlocks();
 #ifdef AMREX_USE_SYCL
             // device reduce needs local(i.e., shared) memory
-            constexpr std::size_t shared_mem_bytes = sizeof(unsigned long long)*Gpu::Device::warp_size;
+            constexpr std::size_t shared_mem_bytes = sizeof(ReduceTuple)
+                * std::max(Gpu::Device::warp_size, AMREX_GPU_MAX_THREADS/Gpu::Device::warp_size);
 #ifndef AMREX_NO_SYCL_REDUCE_WORKAROUND
             // xxxxx SYCL todo: reduce bug workaround
             Gpu::DeviceVector<ReduceTuple> dtmp(1);


### PR DESCRIPTION
The SYCL blockReduce only folded the first warp_size per-sub-group partials, dropping the rest when the block has more sub-groups than warp_size.  Sub-group 0 now folds them all in rounds.  The local memory is also sized by the reduced type and the number of sub-groups instead of a fixed warp_size unsigned long longs.

Fixes #5740.
