### PR TITLE
SYCL: do not dereference the device functor pointer on the host

### DIFF
--- a/Src/Base/AMReX_GpuLaunchFunctsG.H
+++ b/Src/Base/AMReX_GpuLaunchFunctsG.H
@@ -159,7 +159,7 @@ void single_task (gpuStream_t stream, L const& f)
     try {
         q.submit([&] (sycl::handler& h) {
             if constexpr (detail::is_big_kernel<L>()) {
-                h.single_task(*pf);
+                h.single_task([=] () { (*pf)(); });
             } else {
                 h.single_task(f);
             }


### PR DESCRIPTION
In the big-kernel branch of single_task, the functor lives in device memory allocated from The_Arena, so passing *pf to h.single_task read device USM on the host and also submitted the oversized object as a kernel argument.  Wrap it in a small lambda that calls (*pf)() in device code, matching the launch and ParallelFor branches.

Fixes #5741.
