### PR TITLE
Fix RZ inhomogeneous Neumann fluxes and guard MLPoisson overset

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellABecLap.H
@@ -338,16 +338,24 @@ MLCellABecLapT<MF>::getFluxes (const Vector<Array<MF*,AMREX_SPACEDIM> >& a_flux,
     const int ncomp = this->getNComp();
     const RT betainv = RT(1.0) / getBScalar();
     const int nlevs = this->NAMRLevels();
+    // Without b coefficients, the metric factor is in the flux kernels, not in
+    // b, so it must be removed before the boundary faces are set using b = 1.
+    const bool has_bcoef = (getBCoeffs(0,0)[0] != nullptr);
     for (int alev = 0; alev < nlevs; ++alev) {
         this->compFlux(alev, a_flux[alev], *a_sol[alev], a_loc);
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             if (betainv != RT(1.0)) {
                 a_flux[alev][idim]->mult(betainv, 0, ncomp);
             }
+            if (!has_bcoef) {
+                this->unapplyMetricTerm(alev, 0, *a_flux[alev][idim]);
+            }
         }
         this->addInhomogNeumannFlux(alev, a_flux[alev], *a_sol[alev], true);
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            this->unapplyMetricTerm(alev, 0, *a_flux[alev][idim]);
+        if (has_bcoef) {
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                this->unapplyMetricTerm(alev, 0, *a_flux[alev][idim]);
+            }
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson.H
@@ -200,6 +200,8 @@ MLPoissonT<MF>::define (const Vector<Geometry>& a_geom,
 {
     BL_PROFILE("MLPoisson::define(overset)");
     MLCellABecLapT<MF>::define(a_geom, a_grids, a_dmap, a_overset_mask, a_info, a_factory);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!this->m_has_metric_term,
+        "MLPoisson: overset mask does not support metric terms.  Use MLABecLaplacian or LPInfo::setMetricTerm(false).");
 }
 
 template <typename MF>


### PR DESCRIPTION
For operators without b coefficients (MLPoisson, MLALaplacian) the metric factor lives in the flux kernels, so getFluxes now removes it before addInhomogNeumannFlux overwrites the boundary faces with b = 1.  The boundary flux was -g/r instead of -g.  Also promote the debug-only check that MLPoisson's overset kernels are Cartesian to an always assert.

Fixes #5757.
