### PR TITLE
Fix 2D EB nodal RHS from a cell-centered source

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -2030,10 +2030,18 @@ Real mlndlap_rhcc_eb (int i, int j, int, Array4<Real const> const& rhcc,
 
     if (!msk(i,j,0)) {
         return
-            rhcc(i  ,j  ,0)*(Real(0.25)*vfrac(i  ,j  ,0)-intg(i  ,j  ,0,i_S_x)-intg(i  ,j  ,0,i_S_y)+intg(i  ,j  ,0,i_S_xy)) +
-            rhcc(i-1,j  ,0)*(Real(0.25)*vfrac(i-1,j  ,0)+intg(i-1,j  ,0,i_S_x)-intg(i-1,j  ,0,i_S_y)-intg(i-1,j  ,0,i_S_xy)) +
-            rhcc(i-1,j-1,0)*(Real(0.25)*vfrac(i-1,j-1,0)+intg(i-1,j-1,0,i_S_x)+intg(i-1,j-1,0,i_S_y)+intg(i-1,j-1,0,i_S_xy)) +
-            rhcc(i  ,j-1,0)*(Real(0.25)*vfrac(i  ,j-1,0)-intg(i  ,j-1,0,i_S_x)+intg(i  ,j-1,0,i_S_y)-intg(i  ,j-1,0,i_S_xy));
+            rhcc(i  ,j  ,0)*(Real(0.25)*vfrac(i  ,j  ,0)
+                             + Real(0.5)*(-intg(i  ,j  ,0,i_S_x)-intg(i  ,j  ,0,i_S_y))
+                             +             intg(i  ,j  ,0,i_S_xy)) +
+            rhcc(i-1,j  ,0)*(Real(0.25)*vfrac(i-1,j  ,0)
+                             + Real(0.5)*( intg(i-1,j  ,0,i_S_x)-intg(i-1,j  ,0,i_S_y))
+                             -             intg(i-1,j  ,0,i_S_xy)) +
+            rhcc(i-1,j-1,0)*(Real(0.25)*vfrac(i-1,j-1,0)
+                             + Real(0.5)*( intg(i-1,j-1,0,i_S_x)+intg(i-1,j-1,0,i_S_y))
+                             +             intg(i-1,j-1,0,i_S_xy)) +
+            rhcc(i  ,j-1,0)*(Real(0.25)*vfrac(i  ,j-1,0)
+                             + Real(0.5)*(-intg(i  ,j-1,0,i_S_x)+intg(i  ,j-1,0,i_S_y))
+                             -             intg(i  ,j-1,0,i_S_xy));
     } else {
         return Real(0.);
     }
@@ -2128,7 +2136,7 @@ void mlndlap_set_integral_eb (int i, int j, int, Array4<Real> const& intg,
             Real bb = bcy-kk*bcx;
             Sxy = Real(1./8.)*kk*kk*(xmax4-xmin4) + Real(1./3.)*kk*bb*(xmax3-xmin3)
                 + (Real(0.25)*bb*bb-Real(1./16.))*(xmax*xmax-xmin*xmin);
-            Sxy = std::copysign(Sxy, anrmy);
+            if (anrmy < Real(0.)) { Sxy = -Sxy; }
         }
 
         if (std::abs(anrmy) <= almostzero) {


### PR DESCRIPTION
mlndlap_rhcc_eb weighted the first moments S_x and S_y by 1 instead of 0.5, doubling their contribution to the bilinear nodal basis, and mlndlap_set_integral_eb used copysign on the mixed moment S_xy, which flipped its sign whenever the closed-form value was negative.

Fixes #5752.
