### PR TITLE
Stage Mask stream I/O through pinned memory in GPU builds

### DIFF
--- a/Src/Boundary/AMReX_Mask.cpp
+++ b/Src/Boundary/AMReX_Mask.cpp
@@ -31,13 +31,25 @@ operator<< (std::ostream& os,
 
     os << "(Mask: " << m.box() << " " << ncomp << "\n";
 
+    const Mask* mp = &m;
+#ifdef AMREX_USE_GPU
+    Mask hostmask(The_Pinned_Arena());
+    if (m.arena()->isManaged() || m.arena()->isDevice()) {
+        hostmask.resize(m.box(), ncomp);
+        Gpu::dtoh_memcpy_async(hostmask.dataPtr(), m.dataPtr(),
+                               static_cast<std::size_t>(hostmask.size())*sizeof(int));
+        Gpu::streamSynchronize();
+        mp = &hostmask;
+    }
+#endif
+
     IntVect sm = m.box().smallEnd();
     IntVect bg = m.box().bigEnd();
     for (IntVect p = sm; p <= bg; m.box().next(p))
     {
         os << p;
         for (int k = 0; k < ncomp; k++) {
-            os << "  " << m(p,k);
+            os << "  " << (*mp)(p,k);
         }
         os << "\n";
     }
@@ -59,6 +71,16 @@ operator>> (std::istream& is,
     AMREX_ASSERT(ncomp >= 0 && ncomp < std::numeric_limits<int>::max());
     is.ignore(BL_IGNORE_MAX, '\n');
     m.resize(b,ncomp);
+
+    Mask* mp = &m;
+#ifdef AMREX_USE_GPU
+    Mask hostmask(The_Pinned_Arena());
+    if (m.arena()->isManaged() || m.arena()->isDevice()) {
+        hostmask.resize(b,ncomp);
+        mp = &hostmask;
+    }
+#endif
+
     IntVect sm = b.smallEnd();
     IntVect bg = b.bigEnd();
     IntVect q;
@@ -66,10 +88,19 @@ operator>> (std::istream& is,
     {
         is >> q;
         BL_ASSERT( p == q);
-        for( int k=0; k<ncomp; k++ ) { is >> m(p,k); }
+        for( int k=0; k<ncomp; k++ ) { is >> (*mp)(p,k); }
         is.ignore(BL_IGNORE_MAX, '\n');
     }
     is.ignore(BL_IGNORE_MAX,'\n');
+
+#ifdef AMREX_USE_GPU
+    if (mp != &m) {
+        Gpu::htod_memcpy_async(m.dataPtr(), hostmask.dataPtr(),
+                               static_cast<std::size_t>(hostmask.size())*sizeof(int));
+        Gpu::streamSynchronize();
+    }
+#endif
+
     BL_ASSERT(is.good());
     return is;
 }
@@ -80,6 +111,15 @@ Mask::writeOn (std::ostream& os) const
     os << "(Mask: " << domain << " " << nvar << "\n";
     const int* ptr = dataPtr();
     auto len = static_cast<std::size_t>(domain.numPts()) * static_cast<std::size_t>(nvar);
+#ifdef AMREX_USE_GPU
+    Mask hostmask(The_Pinned_Arena());
+    if (this->arena()->isManaged() || this->arena()->isDevice()) {
+        hostmask.resize(domain, nvar);
+        Gpu::dtoh_memcpy_async(hostmask.dataPtr(), ptr, len*sizeof(int));
+        Gpu::streamSynchronize();
+        ptr = hostmask.dataPtr();
+    }
+#endif
     os.write(reinterpret_cast<char const*>(ptr),
              static_cast<std::streamsize>(len*sizeof(int)));
     os << ")\n";
@@ -97,8 +137,21 @@ Mask::readFrom (std::istream& is)
     resize(b,ncomp);
     int *ptr = dataPtr();
     auto len = static_cast<std::size_t>(domain.numPts()) * static_cast<std::size_t>(nvar);
+#ifdef AMREX_USE_GPU
+    Mask hostmask(The_Pinned_Arena());
+    if (this->arena()->isManaged() || this->arena()->isDevice()) {
+        hostmask.resize(domain, nvar);
+        ptr = hostmask.dataPtr();
+    }
+#endif
     is.read(reinterpret_cast<char*>(ptr),
             static_cast<std::streamsize>(len*sizeof(int)));
+#ifdef AMREX_USE_GPU
+    if (ptr != dataPtr()) {
+        Gpu::htod_memcpy_async(dataPtr(), ptr, len*sizeof(int));
+        Gpu::streamSynchronize();
+    }
+#endif
     is.ignore(BL_IGNORE_MAX, '\n');
 }
 


### PR DESCRIPTION
Mask::writeOn/readFrom and the text operator<</operator>> touched the FAB payload on the host, but a Mask allocated from The_Arena is plain device memory in a GPU build. Stage through a pinned-arena Mask with dtoh/htod_memcpy_async, matching FArrayBox::writeOn/readFrom.

Fixes #5749.
