### PR TITLE
MLNodeLaplacian: use per-direction sigma only when the solve does

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian.H
@@ -12,8 +12,8 @@
 // (harmonic-average) mknewu kernel when setMapped(true) was used.  Prior
 // to this, both functions only used sigma component 0 (sigma_x) for all
 // velocity/flux components, producing the wrong correction for
-// non-identity mesh mappings.  EB is not covered by this feature (see
-// comments in AMReX_MLNodeLaplacian_misc.cpp).
+// non-identity mesh mappings.  EB and RAP coarsening are not covered by
+// this feature (see comments in AMReX_MLNodeLaplacian_misc.cpp).
 #define AMREX_MLNODELAP_HAS_MKNEWU_HA 1
 
 namespace amrex {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -733,8 +733,11 @@ MLNodeLaplacian::updateVelocity (const Vector<MultiFab*>& vel, const Vector<Mult
     // When sigma was set up with AMREX_SPACEDIM components (mesh mapping
     // or harmonic averaging), each velocity component needs its own
     // sigma direction.  Otherwise fall through to the scalar-sigma path.
+    // The RAP stencil is built from sigma component 0 alone, so the
+    // correction must use that component too.
 #if (AMREX_SPACEDIM >= 2)
-    const bool aniso_sigma = m_use_mapped;
+    const bool aniso_sigma = m_use_mapped &&
+        (m_coarsening_strategy != CoarseningStrategy::RAP);
 #endif
 
 #ifdef AMREX_USE_OMP
@@ -930,9 +933,11 @@ MLNodeLaplacian::getFluxes (const Vector<MultiFab*> & a_flux, const Vector<Multi
 #endif
     // When sigma was set up with AMREX_SPACEDIM components (mesh mapping),
     // each flux component needs its own sigma direction.  Otherwise fall
-    // through to the scalar-sigma path.
+    // through to the scalar-sigma path.  The RAP stencil is built from
+    // sigma component 0 alone, so the fluxes must use that component too.
 #if (AMREX_SPACEDIM >= 2)
-    const bool aniso_sigma = m_use_mapped;
+    const bool aniso_sigma = m_use_mapped &&
+        (m_coarsening_strategy != CoarseningStrategy::RAP);
 #endif
 
     AMREX_ASSERT(a_flux[0]->nComp() >= AMREX_SPACEDIM);


### PR DESCRIPTION
Under CoarseningStrategy::RAP the stencil is built from sigma component 0 alone, but updateVelocity and getFluxes selected the anisotropic mknewu_ha path from m_use_mapped alone.  The correction then used sigma_y/sigma_z that the operator never saw, so div(u) was nonzero. Gate aniso_sigma on the strategy, matching Fapply/Fsmooth.

Fixes #5760.
