### PR TITLE
Fix MFInterpolater GPU slope scratch for ghosted coarse data

### DIFF
--- a/Src/AmrCore/AMReX_MFInterpolater.cpp
+++ b/Src/AmrCore/AMReX_MFInterpolater.cpp
@@ -35,8 +35,6 @@ MFPCInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int fco
                     Box const& dest_domain, IntVect const& ratio,
                     Vector<BCRec> const&, int)
 {
-    AMREX_ASSERT(crsemf.nGrowVect() == 0);
-
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
         auto const& crse = crsemf.const_arrays();
@@ -97,7 +95,6 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
                              Box const& dest_domain, IntVect const& ratio,
                              Vector<BCRec> const& bcs, int bcomp)
 {
-    AMREX_ASSERT(crsemf.nGrowVect() == 0);
     amrex::ignore_unused(fgeom);
 
     Box const& cdomain = cgeom.Domain();
@@ -109,8 +106,9 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
 
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
-        MultiFab crse_tmp(crsemf.boxArray(), crsemf.DistributionMap(), AMREX_SPACEDIM*nc, 0,
-                          MFInfo().SetArena(The_Async_Arena()));
+        IntVect const ngtmp = crsemf.nGrowVect() + minus1;
+        MultiFab crse_tmp(crsemf.boxArray(), crsemf.DistributionMap(), AMREX_SPACEDIM*nc,
+                          crsemf.nGrowVect(), MFInfo().SetArena(The_Async_Arena()));
         auto const& crse = crsemf.const_arrays();
         auto const& tmp = crse_tmp.arrays();
         auto const& ctmp = crse_tmp.const_arrays();
@@ -125,14 +123,14 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
             Real drf = fgeom.CellSize(0);
             Real rlo = fgeom.Offset(0);
             if (do_linear_limiting) {
-                ParallelFor(crsemf, minus1,
+                ParallelFor(crsemf, ngtmp,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int, int) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,0,0, tmp[box_no], crse[box_no], ccomp, nc,
                                                     cdomain, ratio, pbc);
                 });
             } else {
-                ParallelFor(crsemf, minus1, nc,
+                ParallelFor(crsemf, ngtmp, nc,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int, int, int n) noexcept
                 {
                     mf_cell_cons_lin_interp_mcslope_sph(i, n, tmp[box_no], crse[box_no], ccomp, nc,
@@ -156,14 +154,14 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
             Real rlo = fgeom.Offset(0);
             Real tlo = fgeom.Offset(1);
             if (do_linear_limiting) {
-                ParallelFor(crsemf, minus1,
+                ParallelFor(crsemf, ngtmp,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,j,0, tmp[box_no], crse[box_no], ccomp, nc,
                                                     cdomain, ratio, pbc);
                 });
             } else {
-                ParallelFor(crsemf, minus1, nc,
+                ParallelFor(crsemf, ngtmp, nc,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int, int n) noexcept
                 {
                     mf_cell_cons_lin_interp_mcslope_sph(i,j,n, tmp[box_no], crse[box_no], ccomp, nc,
@@ -183,14 +181,14 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
             Real drf = fgeom.CellSize(0);
             Real rlo = fgeom.Offset(0);
             if (do_linear_limiting) {
-                ParallelFor(crsemf, minus1,
+                ParallelFor(crsemf, ngtmp,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,j,0, tmp[box_no], crse[box_no], ccomp, nc,
                                                     cdomain, ratio, pbc);
                 });
             } else {
-                ParallelFor(crsemf, minus1, nc,
+                ParallelFor(crsemf, ngtmp, nc,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int, int n) noexcept
                 {
                     mf_cell_cons_lin_interp_mcslope_rz(i,j,n, tmp[box_no], crse[box_no], ccomp, nc,
@@ -210,14 +208,14 @@ MFCellConsLinInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf
 #endif
         {
             if (do_linear_limiting) {
-                ParallelFor(crsemf, minus1,
+                ParallelFor(crsemf, ngtmp,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
                 {
                     mf_cell_cons_lin_interp_llslope(i,j,k, tmp[box_no], crse[box_no], ccomp, nc,
                                                     cdomain, ratio, pbc);
                 });
             } else {
-                ParallelFor(crsemf, minus1, nc,
+                ParallelFor(crsemf, ngtmp, nc,
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
                 {
                     mf_cell_cons_lin_interp_mcslope(i,j,k,n, tmp[box_no], crse[box_no], ccomp, nc,
@@ -399,7 +397,6 @@ MFCellConsLinMinmaxLimitInterp::interp (MultiFab const& crsemf, int ccomp, Multi
                              Box const& dest_domain, IntVect const& ratio,
                              Vector<BCRec> const& bcs, int bcomp)
 {
-    AMREX_ASSERT(crsemf.nGrowVect() == 0);
     amrex::ignore_unused(fgeom);
 
     Box const& cdomain = cgeom.Domain();
@@ -411,8 +408,9 @@ MFCellConsLinMinmaxLimitInterp::interp (MultiFab const& crsemf, int ccomp, Multi
 
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
-        MultiFab crse_tmp(crsemf.boxArray(), crsemf.DistributionMap(), AMREX_SPACEDIM*nc, 0,
-                          MFInfo().SetArena(The_Async_Arena()));
+        IntVect const ngtmp = crsemf.nGrowVect() + minus1;
+        MultiFab crse_tmp(crsemf.boxArray(), crsemf.DistributionMap(), AMREX_SPACEDIM*nc,
+                          crsemf.nGrowVect(), MFInfo().SetArena(The_Async_Arena()));
         auto const& crse = crsemf.const_arrays();
         auto const& tmp = crse_tmp.arrays();
         auto const& ctmp = crse_tmp.const_arrays();
@@ -422,7 +420,7 @@ MFCellConsLinMinmaxLimitInterp::interp (MultiFab const& crsemf, int ccomp, Multi
         BCRec const* pbc = d_bc.data();
         Gpu::copyAsync(Gpu::hostToDevice, bcs.begin()+bcomp, bcs.begin()+bcomp+nc, d_bc.begin());
 
-        ParallelFor(crsemf, minus1,
+        ParallelFor(crsemf, ngtmp,
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
         {
             mf_cell_cons_lin_interp_limit_minmax_llslope(i,j,k, tmp[box_no], crse[box_no], ccomp, nc,


### PR DESCRIPTION
The GPU branch of MFCellConsLinInterp::interp and
MFCellConsLinMinmaxLimitInterp::interp sized the slope scratch with no ghost cells, so slopes were read out of bounds when the coarse MultiFab has ghosts (PhysBCFunctUseCoarseGhost).  Size it like the CPU branch and drop the now-invalid nGrowVect()==0 asserts.

Fixes #5759.
