### PR TITLE
Use AMR refinement ratio when averaging down eb_phi and kappa

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBABecLap.cpp
@@ -680,7 +680,7 @@ MLEBABecLap::averageDownEBPhi ()
     if (m_eb_phi[0]) {
         for (int amrlev = m_num_amr_levels-1; amrlev > 0; --amrlev) {
             amrex::EB_average_down_boundaries(*m_eb_phi[amrlev], *m_eb_phi[amrlev-1],
-                                              mg_coarsen_ratio, 0);
+                                              AMRRefRatioVect(amrlev-1), 0);
         }
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensorOp.cpp
@@ -156,7 +156,7 @@ MLEBTensorOp::prepareForSolve ()
             if (amrlev > 0) {
                 amrex::EB_average_down_faces(GetArrOfConstPtrs(m_kappa[amrlev  ].back()),
                                              GetArrOfPtrs     (m_kappa[amrlev-1].front()),
-                                             IntVect(mg_coarsen_ratio), m_geom[amrlev-1][0]);
+                                             AMRRefRatioVect(amrlev-1), m_geom[amrlev-1][0]);
             }
         }
     } else {
@@ -179,7 +179,7 @@ MLEBTensorOp::prepareForSolve ()
             if (amrlev > 0) {
                 amrex::EB_average_down_boundaries(m_eb_kappa[amrlev  ].back(),
                                                   m_eb_kappa[amrlev-1].front(),
-                                                  IntVect(mg_coarsen_ratio), 0);
+                                                  AMRRefRatioVect(amrlev-1), 0);
             }
         }
     } else {

--- a/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLTensorOp.cpp
@@ -137,7 +137,7 @@ MLTensorOp::prepareForSolve ()
             if (amrlev > 0) {
                 amrex::average_down_faces(GetArrOfConstPtrs(m_kappa[amrlev  ].back()),
                                           GetArrOfPtrs     (m_kappa[amrlev-1].front()),
-                                          IntVect(mg_coarsen_ratio), m_geom[amrlev-1][0]);
+                                          AMRRefRatioVect(amrlev-1), m_geom[amrlev-1][0]);
             }
         }
     } else {


### PR DESCRIPTION
m_eb_phi in MLEBABecLap and m_kappa/m_eb_kappa in MLTensorOp and MLEBTensorOp have no MG level between two AMR levels, so averaging them down to the next coarser AMR level with mg_coarsen_ratio gave the wrong index space when the AMR refinement ratio is 4.

Fixes #5747.
