### PR TITLE
Fix TagBoxArray buffer(), collate() and coarsen()

### DIFF
--- a/Src/AmrCore/AMReX_TagBox.cpp
+++ b/Src/AmrCore/AMReX_TagBox.cpp
@@ -81,8 +81,9 @@ TagBox::buffer (const IntVect& a_nbuff, const IntVect& a_nwid) noexcept
 #ifdef AMREX_USE_GPU
     if (Gpu::inLaunchRegion()) {
         Box const& interiorplusbuf = amrex::grow(interior, a_nbuff);
-        const auto lo = amrex::lbound(interiorplusbuf);
-        const auto hi = amrex::ubound(interiorplusbuf);
+        // Only tags in the interior are used as seeds, just like in the CPU version below.
+        const auto lo = amrex::lbound(interior);
+        const auto hi = amrex::ubound(interior);
         AMREX_HOST_DEVICE_FOR_3D(interiorplusbuf, i, j, k,
         {
             if (a(i,j,k) == TagBox::CLEAR) {
@@ -656,7 +657,8 @@ TagBoxArray::collate (Gpu::PinnedVector<IntVect>& TheGlobalCollateSpace) const
 #else
     const int* psend_int = (count > 0) ? psend->begin() : nullptr;
     int* precv_int = ParallelDescriptor::IOProcessor() ? precv->begin() : nullptr;
-    AMREX_ALWAYS_ASSERT(count <= (std::numeric_limits<int>::max() / AMREX_SPACEDIM));
+    // numtags bounds count as well as every element of countvec and offset.
+    AMREX_ALWAYS_ASSERT(numtags <= (std::numeric_limits<int>::max() / AMREX_SPACEDIM));
     int count_int = static_cast<int>(count) * AMREX_SPACEDIM;
     auto countvec_int = std::vector<int>(countvec.size());
     auto offset_int = std::vector<int>(offset.size());
@@ -737,6 +739,7 @@ TagBoxArray::coarsen (const IntVect & ratio)
 
     boxarray.coarsen(ratio);
     n_grow = new_n_grow;
+    clear_arrays(); // The cached Array4s are for the old boxes.
 }
 
 bool

--- a/Src/Base/AMReX_FabArray.H
+++ b/Src/Base/AMReX_FabArray.H
@@ -1750,6 +1750,9 @@ protected:
     std::unique_ptr<detail::SingleChunkArena> m_single_chunk_arena;
     Long m_single_chunk_size = 0;
 
+    //! Free the cached Array4s so that they are rebuilt by the next arrays() call.
+    void clear_arrays ();
+
     //! has define() been called?
     bool define_function_called = false;
 
@@ -1830,8 +1833,6 @@ private:
     template <class F=FAB>
     requires (BaseFabType<F>)
     void build_arrays () const;
-
-    void clear_arrays ();
 
 #ifdef AMREX_USE_GPU
     std::map<std::uint64_t,


### PR DESCRIPTION
TagBox::buffer: the GPU kernel seeded BUF tags from SET tags in the grow region, unlike the CPU loop.  TagBoxArray::collate: the Fujitsu Gatherv path asserted on the local count, but the displacements are prefix sums of the global count, so they could overflow int. TagBoxArray::coarsen: the cached Array4s were left describing the pre-coarsening boxes.

Fixes #5746.
