### PR TITLE
Fix the 1D nodal slope index and guard the limiter divides

### DIFF
--- a/Src/AmrCore/AMReX_Interp_1D_C.H
+++ b/Src/AmrCore/AMReX_Interp_1D_C.H
@@ -62,7 +62,7 @@ nodebilin_interp (Box const& bx, Array4<T> const& fine, const int fcomp, const i
         for (int i = lo.x; i <= hi.x; ++i) {
             const int ic = amrex::min(amrex::coarsen(i,ratio[0]),chi.x);
             const Real fx = i - ic*ratio[0];
-            fine(i,0,0,n+fcomp) = crse(ic,0,0,n+ccomp) + fx*slope(ic,0,0,0);
+            fine(i,0,0,n+fcomp) = crse(ic,0,0,n+ccomp) + fx*slope(ic,0,0,n);
         }
     }
 }

--- a/Src/AmrCore/AMReX_MFInterp_1D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_1D_C.H
@@ -87,6 +87,8 @@ void mf_cell_cons_lin_interp_mcslope (int i, int /*j*/, int /*k*/, int ns,
             umin = amrex::min(umin, u(i+ioff,0,0,nu));
             umax = amrex::max(umax, u(i+ioff,0,0,nu));
         }
+        // Avoid 0/0 if the divides below are if-converted. No-op otherwise.
+        dumax = dumax == Real(0.) ? Real(1.) : dumax;
         if (dumax * alpha > (umax - u(i,0,0,nu))) {
             alpha = (umax - u(i,0,0,nu)) / dumax;
         }
@@ -150,6 +152,9 @@ void mf_cell_cons_lin_interp_mcslope_sph (int i, int ns, Array4<Real> const& slo
             umin = amrex::min(umin, u(i+ioff,0,0,nu));
             umax = amrex::max(umax, u(i+ioff,0,0,nu));
         }
+        // Avoid 0/0 if the divides below are if-converted. No-ops otherwise.
+        dumax = dumax == Real(0.) ? Real(1.) : dumax;
+        dumin = dumin == Real(0.) ? Real(1.) : dumin;
         if (dumax * alpha > (umax - u(i,0,0,nu))) {
             alpha = (umax - u(i,0,0,nu)) / dumax;
         }

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -60,6 +60,8 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int, Array4<Rea
                 umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
                 umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
             }}
+            // Avoid 0/0 if the divides below are if-converted. No-op otherwise.
+            dumax = dumax == Real(0.) ? Real(1.) : dumax;
             if (dumax * alpha > (umax - u(i,j,0,nu))) {
                 alpha = (umax - u(i,j,0,nu)) / dumax;
             }
@@ -176,6 +178,8 @@ void mf_cell_cons_lin_interp_mcslope (int i, int j, int /*k*/, int ns, Array4<Re
             umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
             umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
         }}
+        // Avoid 0/0 if the divides below are if-converted. No-op otherwise.
+        dumax = dumax == Real(0.) ? Real(1.) : dumax;
         if (dumax * alpha > (umax - u(i,j,0,nu))) {
             alpha = (umax - u(i,j,0,nu)) / dumax;
         }
@@ -280,6 +284,9 @@ void mf_cell_cons_lin_interp_mcslope_sph (int i, int j, int ns, Array4<Real> con
             umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
             umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
         }}
+        // Avoid 0/0 if the divides below are if-converted. No-ops otherwise.
+        dumax = dumax == Real(0.) ? Real(1.) : dumax;
+        dumin = dumin == Real(0.) ? Real(1.) : dumin;
         if (dumax * alpha > (umax - u(i,j,0,nu))) {
             alpha = (umax - u(i,j,0,nu)) / dumax;
         }
@@ -388,6 +395,9 @@ void mf_cell_cons_lin_interp_mcslope_rz (int i, int j, int ns, Array4<Real> cons
             umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
             umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
         }}
+        // Avoid 0/0 if the divides below are if-converted. No-ops otherwise.
+        dumax = dumax == Real(0.) ? Real(1.) : dumax;
+        dumin = dumin == Real(0.) ? Real(1.) : dumin;
         if (dumax * alpha > (umax - u(i,j,0,nu))) {
             alpha = (umax - u(i,j,0,nu)) / dumax;
         }

--- a/Src/AmrCore/AMReX_MFInterp_3D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_3D_C.H
@@ -76,6 +76,8 @@ void mf_cell_cons_lin_interp_limit_minmax_llslope (int i, int j, int k, Array4<R
                 umin = amrex::min(umin, u(i+ioff,j+joff,k+koff,nu));
                 umax = amrex::max(umax, u(i+ioff,j+joff,k+koff,nu));
             }}}
+            // Avoid 0/0 if the divides below are if-converted. No-op otherwise.
+            dumax = dumax == Real(0.) ? Real(1.) : dumax;
             if (dumax * alpha > (umax - u(i,j,k,nu))) {
                 alpha = (umax - u(i,j,k,nu)) / dumax;
             }


### PR DESCRIPTION
nodebilin_interp read slope component 0 for every component, so in 1D a multi-component interpolation used the first component's slope throughout.  Also clamp a zero dumax/dumin in the cell-conservative min/max limiters in 1D, 2D and 3D, so an if-converted divide cannot evaluate 0/0.

Fixes #5743.
