### PR TITLE
STL: make EB intersection tolerances scale with the geometry

### DIFF
--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -55,8 +55,11 @@ namespace {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real sign (Real x1, Real y1, Real x2, Real y2, Real x3, Real y3)
     {
-        Real cp = (x2-x1)*(y3-y2) - (x3-x2)*(y2-y1);
-        if (std::abs(cp) < std::numeric_limits<Real>::epsilon()) {
+        Real a = (x2-x1)*(y3-y2);
+        Real b = (x3-x2)*(y2-y1);
+        Real cp = a - b;
+        // the tolerance must follow the magnitude of the two products
+        if (std::abs(cp) <= std::numeric_limits<Real>::epsilon()*amrex::max(std::abs(a),std::abs(b))) {
             return 0._rt;
         } else {
             return std::copysign(1.0_rt, cp);

--- a/Src/EB/AMReX_EB_triGeomOps_K.H
+++ b/Src/EB/AMReX_EB_triGeomOps_K.H
@@ -222,14 +222,18 @@ namespace amrex::tri_geom_ops
             int no_intersections=1;
 
             //the tolerances must follow the size of the objects, because the
-            //side operators scale as length^3 and the areas as length^2
-            Real len=Real(0.0);
+            //side operators scale as length^3 and the areas as length^2.  one
+            //factor is the triangle's own size, so that a long line segment
+            //does not inflate the tolerance past the triangle's scale.
+            Real len_t=Real(0.0), len_v=Real(0.0);
             for(int i=0;i<3;i++)
             {
-                len=amrex::max(len,std::abs(v1[i]),std::abs(v2[i]),
-                               std::abs(t2[i]),std::abs(t3[i]));
+                len_t=amrex::max(len_t,std::abs(t2[i]),std::abs(t3[i]));
+                len_v=amrex::max(len_v,std::abs(v1[i]),std::abs(v2[i]));
             }
-            Real eps_area = std::numeric_limits<Real>::epsilon()*len*len;
+            Real len=amrex::max(len_t,len_v);
+            constexpr Real eps_r = std::numeric_limits<Real>::epsilon();
+            Real eps_area = eps_r*len*len_t;
             Real eps = eps_area*len;
 
             //coplanar (S1,S2,S3 = 0)

--- a/Src/EB/AMReX_EB_triGeomOps_K.H
+++ b/Src/EB/AMReX_EB_triGeomOps_K.H
@@ -1,6 +1,7 @@
 #ifndef AMREX_EB_TRIGEOMOPS_K_H_
 #define AMREX_EB_TRIGEOMOPS_K_H_
 #include <AMReX_Config.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_Math.H>
 #include <AMReX_REAL.H>
 
@@ -197,11 +198,19 @@ namespace amrex::tri_geom_ops
             return(all_ok);
         }
         //================================================================================
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE int lineseg_tri_intersect(const Real v1[3], const Real v2[3],
-                const Real t1[3], const Real t2[3], const Real t3[3])
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE int lineseg_tri_intersect(const Real p1[3], const Real p2[3],
+                const Real q1[3], const Real q2[3], const Real q3[3])
         {
             //see plucker coordinates based method
             //https://members.loria.fr/SLazard/ARC-Visi3D/Pant-project/files/Line_Triangle.html
+
+            //the operators below are translation invariant.  putting q1 at the
+            //origin avoids cancellation for geometries far away from the origin.
+            const Real v1[3]={p1[0]-q1[0],p1[1]-q1[1],p1[2]-q1[2]};
+            const Real v2[3]={p2[0]-q1[0],p2[1]-q1[1],p2[2]-q1[2]};
+            const Real t1[3]={Real(0.0),Real(0.0),Real(0.0)};
+            const Real t2[3]={q2[0]-q1[0],q2[1]-q1[1],q2[2]-q1[2]};
+            const Real t3[3]={q3[0]-q1[0],q3[1]-q1[1],q3[2]-q1[2]};
 
             Real S1,S2,S3;
             Real tri_area,area1,area2;
@@ -212,7 +221,16 @@ namespace amrex::tri_geom_ops
             //we are assuming there are no intersections initially
             int no_intersections=1;
 
-            Real eps = std::numeric_limits<Real>::epsilon();
+            //the tolerances must follow the size of the objects, because the
+            //side operators scale as length^3 and the areas as length^2
+            Real len=Real(0.0);
+            for(int i=0;i<3;i++)
+            {
+                len=amrex::max(len,std::abs(v1[i]),std::abs(v2[i]),
+                               std::abs(t2[i]),std::abs(t3[i]));
+            }
+            Real eps_area = std::numeric_limits<Real>::epsilon()*len*len;
+            Real eps = eps_area*len;
 
             //coplanar (S1,S2,S3 = 0)
             if(std::abs(S1) < eps && std::abs(S2) < eps && std::abs(S3) < eps)
@@ -227,7 +245,7 @@ namespace amrex::tri_geom_ops
                 area1=(triangle_area(t1,t2,v1)+triangle_area(t2,t3,v1)+triangle_area(t3,t1,v1));
                 area2=(triangle_area(t1,t2,v2)+triangle_area(t2,t3,v2)+triangle_area(t3,t1,v2));
 
-                if( std::abs(area1-tri_area)>eps || std::abs(area2-tri_area)>eps )
+                if( std::abs(area1-tri_area)>eps_area || std::abs(area2-tri_area)>eps_area )
                 {
                     no_intersections = 0;
                 }

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -3,7 +3,9 @@
 #
 function (setup_test _dim _srcs  _inputs)
 
-   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES"
+   # NO_CTEST: build the executable and stage its inputs, but do not register
+   # a ctest for it.
+   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES;NO_CTEST"
       "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS;NTASKS;NTHREADS"
       "CMDLINE_PARAMS_AFTER_INPUTS" ${ARGN} )
 
@@ -79,6 +81,10 @@ function (setup_test _dim _srcs  _inputs)
    #
    # Add the test
    #
+   if (_NO_CTEST)
+      return ()
+   endif ()
+
    if (AMReX_OMP)
       add_test(
          NAME               ${_test_name}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -3,9 +3,7 @@
 #
 function (setup_test _dim _srcs  _inputs)
 
-   # NO_CTEST: build the executable and stage its inputs, but do not register
-   # a ctest for it.
-   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES;NO_CTEST"
+   cmake_parse_arguments( "" "HAS_FORTRAN_MODULES"
       "BASE_NAME;RUNTIME_SUBDIR;EXTRA_DEFINITIONS;CMDLINE_PARAMS;NTASKS;NTHREADS"
       "CMDLINE_PARAMS_AFTER_INPUTS" ${ARGN} )
 
@@ -81,10 +79,6 @@ function (setup_test _dim _srcs  _inputs)
    #
    # Add the test
    #
-   if (_NO_CTEST)
-      return ()
-   endif ()
-
    if (AMReX_OMP)
       add_test(
          NAME               ${_test_name}

--- a/Tests/LinearSolvers/NodalPoissonEB/CMakeLists.txt
+++ b/Tests/LinearSolvers/NodalPoissonEB/CMakeLists.txt
@@ -16,17 +16,8 @@ foreach(D IN LISTS AMReX_SPACEDIM)
     if (D EQUAL 3)
         set(_input_files inputs-3d-stl sphere.stl)
 
-        # The STL test does not work in single precision, so only build it there.
-        if (AMReX_PRECISION STREQUAL "SINGLE")
-            set(_no_ctest NO_CTEST)
-        else ()
-            set(_no_ctest)
-        endif ()
-
         setup_test(${D} _sources _input_files
-            BASE_NAME LinearSolvers_NodalPoissonEB_STL ${_no_ctest})
-
-        unset(_no_ctest)
+            BASE_NAME LinearSolvers_NodalPoissonEB_STL)
     endif ()
 
     unset(_sources)


### PR DESCRIPTION
The Plucker side operators scale as length^3 and the areas as length^2,
so an absolute epsilon is meaningless once the geometry is not order
unity. Shift the triangle to the origin and scale the tolerances by the
resulting size, one factor being the triangle's own size so that a long
segment cannot inflate them. Also make sign() relative to its two
products, and re-enable the NodalPoissonEB_STL ctest that this fixes in
single precision.

Fixes #5789.
