### PR TITLE
Honor subDirPrefix in PreBuildDirectorHierarchy

### DIFF
--- a/Src/Base/AMReX_PlotFileUtil.H
+++ b/Src/Base/AMReX_PlotFileUtil.H
@@ -41,13 +41,13 @@ namespace amrex
     /**
     * \brief  prebuild a hierarchy of directories
     *  dirName is built first. If dirName exists, it is renamed, then build
-    *  dirName/Level_0 .. dirName/Level_{nSubDirs-1}
+    *  dirName/\<subDirPrefix\>0 .. dirName/\<subDirPrefix\>{nSubDirs-1}
     *  if callBarrier is true, call ParallelDescriptor::Barrier()
     *  after all directories are built
     *  ParallelDescriptor::IOProcessor() creates the directories
     *
     * \param dirName Directory name.
-    * \param subDirPrefix This is ignored.
+    * \param subDirPrefix Prefix of the subdirectories, e.g. "Level_".
     * \param nSubDirs Number of subdirectories.
     * \param callBarrier Whether MPI_Barrier is called.
     */

--- a/Src/Base/AMReX_PlotFileUtil.cpp
+++ b/Src/Base/AMReX_PlotFileUtil.cpp
@@ -55,12 +55,12 @@ std::string MultiFabFileFullPrefix (int level,
 
 void
 PreBuildDirectorHierarchy (const std::string &dirName,
-                           const std::string &/*subDirPrefix*/,
+                           const std::string &subDirPrefix,
                            int nSubDirs, bool callBarrier)
 {
   UtilCreateCleanDirectory(dirName, false);  // ---- dont call barrier
   for(int i(0); i < nSubDirs; ++i) {
-    const std::string &fullpath = LevelFullPath(i, dirName);
+    const std::string &fullpath = LevelFullPath(i, dirName, subDirPrefix);
     UtilCreateCleanDirectory(fullpath, false);  // ---- dont call barrier
   }
 


### PR DESCRIPTION
The level subdirectories were always created as `Level_<i>`, so writing a plotfile with a non-default levelPrefix aborted in VisMF::Write because the directory it writes into was never created.

Fixes #5788.
