### PR TITLE
Flush STL stream before passing the write token in MC::write_stl

### DIFF
--- a/Src/EB/AMReX_MarchingCubes.cpp
+++ b/Src/EB/AMReX_MarchingCubes.cpp
@@ -996,6 +996,9 @@ void write_stl (std::string const& filename, std::map<int,std::unique_ptr<MCFab>
 
 #ifdef AMREX_USE_MPI
     if (myproc < nprocs-1) {
+        // Make sure the data are on disk before the next rank appends.
+        ofs.flush();
+        ofs.close();
         int foo = 0;
         ParallelDescriptor::Send(&foo, 1, myproc+1, 100);
     }


### PR DESCRIPTION
Each rank streamed its facets into the ofstream buffer and handed the ordering token to the next rank without flushing, so the deferred flush could land after the next rank had already appended.  Flush and close before the Send, as NFilesIter does.

Fixes #5786.
