### PR TITLE
Assert AmrLevel FillPatcher preconditions

### DIFF
--- a/Src/Amr/AMReX_AmrLevel.H
+++ b/Src/Amr/AMReX_AmrLevel.H
@@ -591,6 +591,8 @@ public:
      * \brief Fill ghost cells using cached FillPatcher (level>0) or FillPatch (level 0).
      *
      * All components in [scomp,scomp+ncomp) must have the same interpolater.
+     * Because the FillPatcher is cached per state, that interpolater must also
+     * be the one used by earlier calls for the same state_index.
      *
      * \param mf          Destination MultiFab.
      * \param dcomp       Destination component offset.

--- a/Src/Amr/AMReX_AmrLevel.H
+++ b/Src/Amr/AMReX_AmrLevel.H
@@ -590,6 +590,8 @@ public:
     /**
      * \brief Fill ghost cells using cached FillPatcher (level>0) or FillPatch (level 0).
      *
+     * All components in [scomp,scomp+ncomp) must have the same interpolater.
+     *
      * \param mf          Destination MultiFab.
      * \param dcomp       Destination component offset.
      * \param ncomp       Number of components to fill.
@@ -648,7 +650,9 @@ public:
      *
      * To use RK, the StateData must have all the ghost cells needed.  See
      * namespace RungeKutta for expected function signatures of the callable
-     * parameters.
+     * parameters.  All components of the StateData must have the same
+     * interpolater.  Note that RK3 and RK4 do not support post-step regrid,
+     * because the coarse level RK data are lost when a level is rebuilt.
      *
      * \param order      order of RK
      * \param state_type index of StateData
@@ -970,6 +974,10 @@ void AmrLevel::storeRKCoarseData (int state_type, Real time, Real dt,
     if (level == parent->finestLevel()) { return; }
 
     const StateDescriptor& desc = AmrLevel::desc_lst[state_type];
+
+    // The FillPatcher holds a single interpolater.
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(desc.identicalInterps(0,desc.nComp()),
+        "AmrLevel::RK: all components must have the same interpolater");
 
     auto& fillpatcher = parent->getLevel(level+1).m_fillpatcher[state_type];
     fillpatcher = std::make_unique<FillPatcher<MultiFab>>

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -2166,6 +2166,10 @@ AmrLevel::FillPatcherFill (MultiFab& mf, int dcomp, int ncomp, int nghost,
 
         const StateDescriptor& desc = AmrLevel::desc_lst[state_index];
 
+        // The cached FillPatcher holds a single interpolater.
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(desc.identicalInterps(scomp,ncomp),
+            "FillPatcherFill: all components must have the same interpolater");
+
         if (level > 1 &&!amrex::ProperlyNested(fine_level.crse_ratio,
                                                parent->blockingFactor(fine_level.level),
                                                nghost, mf.ixType(),
@@ -2280,6 +2284,8 @@ AmrLevel::FillRKPatch (int state_index, MultiFab& S, Real time,
         StateDataPhysBCFunct physbcf_crse(crse_level.state[state_index], 0,
                                           crse_level.geom);
         auto& fillpatcher = m_fillpatcher[state_index];
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(fillpatcher != nullptr,
+            "FillRKPatch: coarse level RK data missing.  Was this level regridded mid-step?");
         fillpatcher->fillRK(stage, iteration, ncycle, S, time, physbcf_crse,
                             physbcf, AmrLevel::desc_lst[state_index].getBCs());
     }

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -2190,6 +2190,11 @@ AmrLevel::FillPatcherFill (MultiFab& mf, int dcomp, int ncomp, int nghost,
                 (parent->boxArray(level), parent->DistributionMap(level), geom_fine,
                  parent->boxArray(level-1), parent->DistributionMap(level-1), geom_crse,
                  IntVect(nghost), desc.nComp(), desc.interp(scomp));
+        } else {
+            // The cache is keyed by state index, so a previous call may have
+            // built it with another component's interpolater.
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(fillpatcher->interp() == desc.interp(scomp),
+                "FillPatcherFill: all components must have the same interpolater");
         }
 
         fillpatcher->fill(mf, IntVect(nghost), time,

--- a/Src/AmrCore/AMReX_FillPatcher.H
+++ b/Src/AmrCore/AMReX_FillPatcher.H
@@ -203,6 +203,9 @@ public:
     void fillRK (int stage, int iteration, int ncycle, MF& mf, Real time,
                  BC& cbc, BC& fbc, Vector<BCRec> const& bcs);
 
+    //! Interpolater this FillPatcher was built with.
+    [[nodiscard]] InterpBase* interp () const noexcept { return m_interp; }
+
 private:
 
     BoxArray m_fba;


### PR DESCRIPTION
The FillPatcher cached in AmrLevel holds a single interpolater and is keyed by state index only, so all components must share one interpolater.  FillRKPatch also assumed the cached FillPatcher exists, but a post-step regrid rebuilds the level with an empty cache.  Assert both instead of interpolating with the wrong mapper or dereferencing a null pointer, and document the restrictions.

Fixes #5770.
