### PR TITLE
Clamp the EB bounding box per direction in FillImpFunc

### DIFF
--- a/Docs/sphinx_documentation/source/EB.rst
+++ b/Docs/sphinx_documentation/source/EB.rst
@@ -220,7 +220,9 @@ an STL file using:
                     int num_coarsen_opt = NumCoarsenOpt());
 
 This requires setting :cpp:`ParmParse` parameters ``eb2.geom_type = stl`` and
-``eb2.stl_file`` to specify the STL file path.
+``eb2.stl_file`` to specify the STL file path. Because an STL file is expected
+to describe a water-tight object, the embedded boundary outside the domain is
+always taken from the STL mesh itself, and ``extend_domain_face`` is ignored.
 
 **Managing IndexSpace Objects**
 

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -701,7 +701,10 @@ Embedded Boundary
    extended perpendicularly from the domain face. Otherwise, it's generated
    with the user provided implicit function. Note that this parameter can be
    overridden by the user when calling :cpp:`amrex::EB2::Build` with the
-   optional parameter ``bool extend_domain_face``.
+   optional parameter ``bool extend_domain_face``. Note also that this
+   parameter has no effect for STL geometries, because an STL file is
+   expected to describe a water-tight object that already defines the
+   embedded boundary outside the domain.
 
 .. py:data:: eb2.num_coarsen_opt
    :type: int

--- a/Src/EB/AMReX_EB_utils.H
+++ b/Src/EB/AMReX_EB_utils.H
@@ -37,7 +37,7 @@ namespace amrex {
         bool extend_domain_face = EB2::ExtendDomainFace();
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             if (!extend_domain_face || geom.isPeriodic(idim)) {
-                bounding_box.grow(mf.nGrowVect()[idim]);
+                bounding_box.grow(idim, mf.nGrowVect()[idim]);
             }
         }
 


### PR DESCRIPTION
FillImpFunc grew the bounding box in all directions instead of only idim, so a partially periodic domain was not clamped at its non-periodic faces.

Also document that eb2.extend_domain_face does not apply to STL geometries, which are expected to be water-tight and therefore need no extension.

Fixes #5772.
