### PR TITLE
Use finite covered-face sentinels in EB face interpolation

### DIFF
--- a/Src/EB/AMReX_EBMultiFabUtil.cpp
+++ b/Src/EB/AMReX_EBMultiFabUtil.cpp
@@ -1066,9 +1066,9 @@ EB_interp_CellCentroid_to_FaceCentroid (const MultiFab& phi_centroid,
     const int nghost(4);
 
    // Initialize edge state
-    AMREX_D_TERM(phi_xface.setVal(1e40,dcomp,ncomp);,
-                 phi_yface.setVal(1e40,dcomp,ncomp);,
-                 phi_zface.setVal(1e40,dcomp,ncomp));
+    AMREX_D_TERM(phi_xface.setVal(1e30_rt,dcomp,ncomp);,
+                 phi_yface.setVal(1e30_rt,dcomp,ncomp);,
+                 phi_zface.setVal(1e30_rt,dcomp,ncomp));
 
     BCRec const* d_bcs;
 #ifdef AMREX_USE_GPU

--- a/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
+++ b/Src/EB/AMReX_EBMultiFabUtil_2D_C.H
@@ -295,7 +295,11 @@ void eb_interp_cc2facecent_x (Box const& ubx,
     {
       if (apx(i,j,k) == 0)
       {
+#ifdef AMREX_USE_FLOAT
+        edg_x(i,j,k,n) = Real(1e20);
+#else
         edg_x(i,j,k,n) = 1e40;
+#endif
       }
       else
       {
@@ -346,7 +350,11 @@ void eb_interp_cc2facecent_y (Box const& vbx,
     {
       if (apy(i,j,k) == 0)
       {
+#ifdef AMREX_USE_FLOAT
+        edg_y(i,j,k,n) = Real(1e20);
+#else
         edg_y(i,j,k,n) = 1e40;
+#endif
       }
       else
       {
@@ -399,7 +407,11 @@ void eb_interp_centroid2facecent_x (Box const& ubx,
   {
       if (apx(i,j,k) == 0)
       {
+#ifdef AMREX_USE_FLOAT
+          edg_x(i,j,k,n) = Real(1e20);
+#else
           edg_x(i,j,k,n) = 1e40;
+#endif
       }
       else if ( (i == domlo.x) && (bc[n].lo(0) == BCType::ext_dir) )
       {
@@ -479,7 +491,11 @@ void eb_interp_centroid2facecent_y (Box const& vbx,
    {
       if (apy(i,j,k) == 0)
       {
+#ifdef AMREX_USE_FLOAT
+          edg_y(i,j,k,n) = Real(1e20);
+#else
           edg_y(i,j,k,n) = 1e40;
+#endif
       }
       else if ( (j == domlo.y) && (bc[n].lo(1) == BCType::ext_dir) )
       {


### PR DESCRIPTION
The 2D face-interpolation kernels and the MultiFab initialization in EB_interp_CellCentroid_to_FaceCentroid stored 1e40 into a Real, which becomes +inf in single precision, so a consumer forming apx*phi_face on a covered face got NaN instead of 0.  Follow the 3D kernels and EB_interp_CC_to_FaceCentroid, which already use finite sentinels.

Fixes #5773.
