### PR TITLE
Fix EBFluxRegister coarse add for a coarse cell between two fine grids

### DIFF
--- a/Src/EB/AMReX_EBFluxRegister.cpp
+++ b/Src/EB/AMReX_EBFluxRegister.cpp
@@ -331,6 +331,8 @@ EBFluxRegister::Reflux (MultiFab& crse_state, const amrex::MultiFab& crse_vfrac,
         }
     }
 
+    // setDeterministic is silently ignored here, because the rereflux kernels
+    // below use atomic adds near cut cells anyway.
     m_crse_data.ParallelCopy(m_cfpatch, srccomp, srccomp, numcomp, m_crse_geom.periodicity(), FabArrayBase::ADD);
 
     {

--- a/Src/EB/AMReX_EBFluxRegister_2D_C.H
+++ b/Src/EB/AMReX_EBFluxRegister_2D_C.H
@@ -21,7 +21,8 @@ void eb_flux_reg_crseadd_va(int i, int j, int k, Array4<Real> const& d,
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) -= tmp*fx(i,j,k,n);
             }
-        } else if (flag(i+1,j,k) == amrex_yafluxreg_fine_cell) {
+        }
+        if (flag(i+1,j,k) == amrex_yafluxreg_fine_cell) {
             Real tmp = dtdx*ax(i+1,j,k)*volinv;
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) += tmp*fx(i+1,j,k,n);
@@ -33,7 +34,8 @@ void eb_flux_reg_crseadd_va(int i, int j, int k, Array4<Real> const& d,
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) -= tmp*fy(i,j,k,n);
             }
-        } else if (flag(i,j+1,k) == amrex_yafluxreg_fine_cell) {
+        }
+        if (flag(i,j+1,k) == amrex_yafluxreg_fine_cell) {
             Real tmp = dtdy*ay(i,j+1,k)*volinv;
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) += tmp*fy(i,j+1,k,n);

--- a/Src/EB/AMReX_EBFluxRegister_3D_C.H
+++ b/Src/EB/AMReX_EBFluxRegister_3D_C.H
@@ -22,7 +22,8 @@ void eb_flux_reg_crseadd_va(int i, int j, int k, Array4<Real> const& d,
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) -= tmp*fx(i,j,k,n);
             }
-        } else if (flag(i+1,j,k) == amrex_yafluxreg_fine_cell) {
+        }
+        if (flag(i+1,j,k) == amrex_yafluxreg_fine_cell) {
             Real tmp = dtdx*ax(i+1,j,k)*volinv;
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) += tmp*fx(i+1,j,k,n);
@@ -34,7 +35,8 @@ void eb_flux_reg_crseadd_va(int i, int j, int k, Array4<Real> const& d,
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) -= tmp*fy(i,j,k,n);
             }
-        } else if (flag(i,j+1,k) == amrex_yafluxreg_fine_cell) {
+        }
+        if (flag(i,j+1,k) == amrex_yafluxreg_fine_cell) {
             Real tmp = dtdy*ay(i,j+1,k)*volinv;
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) += tmp*fy(i,j+1,k,n);
@@ -46,7 +48,8 @@ void eb_flux_reg_crseadd_va(int i, int j, int k, Array4<Real> const& d,
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) -= tmp*fz(i,j,k,n);
             }
-        } else if (flag(i,j,k+1) == amrex_yafluxreg_fine_cell) {
+        }
+        if (flag(i,j,k+1) == amrex_yafluxreg_fine_cell) {
             Real tmp = dtdz*az(i,j,k+1)*volinv;
             for (int n = 0; n < ncomp; ++n) {
                 d(i,j,k,n) += tmp*fz(i,j,k+1,n);


### PR DESCRIPTION
eb_flux_reg_crseadd_va used else-if between the lo- and hi-face fine neighbor checks, so a coarse cell with fine cells on both sides of a direction lost the hi-face correction.  The base class kernel has used independent checks since #2155.

Fixes #5776.
