### PR TITLE
Honor caller-supplied pmap in Amr::defBaseLevel

### DIFF
--- a/Src/Amr/AMReX_Amr.H
+++ b/Src/Amr/AMReX_Amr.H
@@ -95,7 +95,9 @@ public:
      * \param strt_time Simulation start time.
      * \param stop_time Optional stop time for the initial solve.
      * \param lev0_grids Optional user-supplied level-0 grids.
-     * \param pmap       Optional processor map matching \p lev0_grids.
+     * \param pmap       Optional processor map matching \p lev0_grids.  It is
+     *                   ignored if \c amr.refine_grid_layout further chops
+     *                   \p lev0_grids.
      */
     void InitializeInit (Real strt_time, Real stop_time,
                          const BoxArray* lev0_grids = nullptr, const Vector<int>* pmap = nullptr);
@@ -565,7 +567,9 @@ protected:
      * \param strt_time Simulation start time.
      * \param stop_time Optional time limit for the initialization phase.
      * \param lev0_grids Optional user-defined BoxArray for level 0.
-     * \param pmap       Optional processor map that pairs with \p lev0_grids.
+     * \param pmap       Optional processor map that pairs with \p lev0_grids.  It
+     *                   is ignored if \c amr.refine_grid_layout further chops
+     *                   \p lev0_grids.
      */
     void initialInit (Real strt_time, Real stop_time,
                       const BoxArray* lev0_grids = nullptr, const Vector<int>* pmap = nullptr);
@@ -577,7 +581,9 @@ protected:
     void checkInput ();
     //! Restart from a checkpoint file named \p filename.
     void restart (const std::string& filename);
-    //! Define and initialize the coarsest level using optional level-0 grids \p lev0_grids and map \p pmap.
+    //! Define and initialize the coarsest level using optional level-0 grids \p lev0_grids
+    //! and map \p pmap.  \p pmap is ignored unless its size matches \p lev0_grids after
+    //! any chopping done for \c amr.refine_grid_layout.
     void defBaseLevel (Real strt_time, const BoxArray* lev0_grids = nullptr, const Vector<int>* pmap = nullptr);
     //! Define and initialize refined levels at simulation time \p strt_time.
     void bldFineLevels (Real strt_time);

--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -2566,8 +2566,6 @@ Amr::defBaseLevel (Real              strt_time,
                    const BoxArray*   lev0_grids,
                    const Vector<int>* pmap)
 {
-    amrex::ignore_unused(pmap);
-
     BL_PROFILE("Amr::defBaseLevel()");
     // Just initialize this here for the heck of it
     which_level_being_advanced = -1;
@@ -2585,6 +2583,7 @@ Amr::defBaseLevel (Real              strt_time,
     }
 
     BoxArray lev0;
+    DistributionMapping dm0;
 
     if (lev0_grids != nullptr && !lev0_grids->empty())
     {
@@ -2603,14 +2602,28 @@ Amr::defBaseLevel (Real              strt_time,
         if (refine_grid_layout) {
             ChopGrids(0,lev0,ParallelDescriptor::NProcs());
         }
+
+        // Honor the caller-supplied processor map, unless ChopGrids has
+        // changed the number of boxes.
+        if (pmap != nullptr && !pmap->empty()) {
+            if (std::ssize(*pmap) == lev0.size()) {
+                dm0.define(*pmap);
+            } else {
+                amrex::Warning("defBaseLevel: pmap does not match lev0 grids; ignoring pmap");
+            }
+        }
     }
     else
     {
         lev0 = MakeBaseGrids();
     }
 
+    if (dm0.empty()) {
+        dm0.define(lev0);
+    }
+
     this->SetBoxArray(0, lev0);
-    this->SetDistributionMap(0, DistributionMapping(lev0));
+    this->SetDistributionMap(0, dm0);
 
     //
     // Now build level 0 grids.


### PR DESCRIPTION
defBaseLevel discarded the optional processor map and always built a default DistributionMapping for level 0.  It now defines the level-0 DistributionMapping from pmap when its size matches the level-0 grids, and warns and falls back to the BoxArray-based map when refine_grid_layout has chopped the grids.

Fixes #5780.
