### PR TITLE
Reset StateData's preread FabArray header map pointer on restart exit

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -1744,6 +1744,10 @@ Amr::restart (const std::string& filename)
 
         amrex::Print() << "Restart time = " << dRestartTime << " seconds." << '\n';
     }
+
+    // ---- faHeaderMap is local to this function
+    StateData::SetFAHeaderMapPtr(nullptr);
+
     BL_PROFILE_REGION_STOP("Amr::restart()");
 }
 


### PR DESCRIPTION
Amr::restart hands StateData a pointer to a function-local map of preread FabArray headers, but never cleared it, so the static pointer dangled after the function returned.  A second restart in the same run that does not repopulate the map would then read destroyed memory.

Fixes #5781.
