### PR TITLE
Guard null message and out-of-range argument index

### DIFF
--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -260,7 +260,7 @@ amrex::Error_host (const char* type, const char * msg)
     if (system::error_handler) {
         system::error_handler(msg);
     } else if (system::throw_exception) {
-        throw RuntimeError(msg);
+        throw RuntimeError(msg ? msg : type);
     } else {
         write_lib_id(type);
         write_to_stderr_without_buffering(msg);
@@ -984,13 +984,13 @@ amrex::get_command ()
 int
 amrex::command_argument_count ()
 {
-    return static_cast<int>(command_arguments.size())-1;
+    return std::max(0, static_cast<int>(command_arguments.size())-1);
 }
 
 std::string
 amrex::get_command_argument (int number)
 {
-    if (number < std::ssize(command_arguments)) {
+    if (number >= 0 && number < std::ssize(command_arguments)) {
         return command_arguments[number];
     } else {
         return std::string();


### PR DESCRIPTION
Error_host no longer constructs std::runtime_error from a null message; it falls back to the "Error"/"Abort" label. command_argument_count now returns 0 instead of -1 when no command line was recorded, and get_command_argument returns an empty string for a negative index.

Fixes #5790.
