### PR TITLE
Fix component count and memory leak in SDC, and require double precision

### DIFF
--- a/Src/SDC/AMReX_SDCstruct.H
+++ b/Src/SDC/AMReX_SDCstruct.H
@@ -6,7 +6,13 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_BCRec.H>
 
+#include <type_traits>
+
 using namespace amrex;
+
+// The Fortran quadrature module is written for double precision only.
+static_assert(std::is_same_v<amrex_real,double>,
+              "SDC requires amrex_real to be double");
 
 extern "C"  {
 
@@ -27,8 +33,8 @@ class SDCstruct
  {
 
  public:
-   Real* qnodes;      //!< The quadrature nodes
-   int*  Nflags;      //!< Flags for quadrature rules
+   Vector<Real> qnodes;   //!< The quadrature nodes
+   Vector<int>  Nflags;   //!< Flags for quadrature rules
 
    int Nnodes;         //!< Number of quadrature nodes
    int qtype=1;        //!< Type of quadrature nodes
@@ -37,7 +43,7 @@ class SDCstruct
 
 
    // The quadrature matrices
-   Real* Qall;
+   Vector<Real> Qall;
    Vector<Vector<Real>> Qgauss;     //!< Gauss collocation
    Vector<Vector<Real>> Qexp;       //!< Explicit
    Vector<Vector<Real>> Qimp;       //!< Implicit

--- a/Src/SDC/AMReX_SDCstruct.cpp
+++ b/Src/SDC/AMReX_SDCstruct.cpp
@@ -7,9 +7,9 @@ SDCstruct::SDCstruct(int Nnodes_in,int Npieces_in, MultiFab& sol_in)
   Nnodes=Nnodes_in;
   Npieces=Npieces_in;
 
-  qnodes= new Real[Nnodes];
-  Qall= new Real[4*(Nnodes-1)*Nnodes];
-  Nflags= new int[Nnodes];
+  qnodes.resize(Nnodes);
+  Qall.resize(4*(Nnodes-1)*Nnodes);
+  Nflags.resize(Nnodes);
 
   Qgauss.resize(Nnodes-1, Vector<Real>(Nnodes));
   Qexp.resize(Nnodes-1, Vector<Real>(Nnodes));
@@ -17,7 +17,7 @@ SDCstruct::SDCstruct(int Nnodes_in,int Npieces_in, MultiFab& sol_in)
   QLU.resize(Nnodes-1, Vector<Real>(Nnodes));
 
   //  Make the quadrature tables
-  SDC_quadrature(&qtype, &Nnodes, &Nnodes,qnodes,Nflags, &Qall[0]);
+  SDC_quadrature(&qtype, &Nnodes, &Nnodes,qnodes.data(),Nflags.data(),Qall.data());
 
   //  Load the quadrature nodes into their spots
   for ( int j = 0; j < Nnodes-1; ++j)
@@ -99,7 +99,7 @@ void SDCstruct::SDC_rhs_k_plus_one(MultiFab& sol_new, Real dt,int sdc_m)
   Real qij;
 
   //  Copy first the initial value
-  MultiFab::Copy(sol_new,sol[0], 0, 0, 1, 0);
+  MultiFab::Copy(sol_new,sol[0], 0, 0, sol_new.nComp(), 0);
   for ( MFIter mfi(sol_new); mfi.isValid(); ++mfi )
     {
       sol_new[mfi].saxpy(1.0,res[sdc_m][mfi]);


### PR DESCRIPTION
The Fortran quadrature module writes c_double, so assert that amrex_real is double instead of building SDC in single precision at all. SDC_rhs_k_plus_one now copies all components of sol[0], matching the saxpy calls that follow.  The quadrature arrays are Vector instead of raw new[], which fixes the leak.

Fixes #5792.

