### PR TITLE
Sync all streams in loadVectors before HYPRE/PETSc read the vectors

### DIFF
--- a/Src/Extern/HYPRE/AMReX_HypreABecLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap.cpp
@@ -291,6 +291,7 @@ HypreABecLap::loadVectors (MultiFab& soln, const MultiFab& rhs)
                 rhs_diag_a(i,j,k) = rhs_a(i,j,k) * diaginv_a(i,j,k);
             });
         }
+        if (Gpu::inNoSyncRegion()) { Gpu::synchronize(); }
     }
 
     for (MFIter mfi(soln); mfi.isValid(); ++mfi)

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap2.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap2.cpp
@@ -324,6 +324,7 @@ HypreABecLap2::loadVectors (MultiFab& soln, const MultiFab& rhs)
                 rhs_diag_a(i,j,k) = rhs_a(i,j,k) * diaginv_a(i,j,k);
             });
         }
+        if (Gpu::inNoSyncRegion()) { Gpu::synchronize(); }
     }
 
     const HYPRE_Int part = 0;

--- a/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreABecLap3.cpp
@@ -600,6 +600,7 @@ HypreABecLap3::loadVectors (MultiFab& soln, const MultiFab& rhs)
                     }
                 }
             }
+            if (Gpu::inNoSyncRegion()) { Gpu::synchronize(); }
         }
     } else
 #endif
@@ -653,6 +654,7 @@ HypreABecLap3::loadVectors (MultiFab& soln, const MultiFab& rhs)
                     });
                 }
             }
+            if (Gpu::inNoSyncRegion()) { Gpu::synchronize(); }
         }
     }
 

--- a/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
+++ b/Src/Extern/HYPRE/AMReX_HypreNodeLap.cpp
@@ -296,6 +296,7 @@ HypreNodeLap::loadVectors (MultiFab& soln, const MultiFab& rhs)
     BL_PROFILE("HypreNodeLap::loadVectors()");
 
     soln.setVal(0.0);
+    if (Gpu::inNoSyncRegion()) { Gpu::synchronize(); }
 
     Gpu::DeviceVector<Real> bvec;
     for (MFIter mfi(soln, MFItInfo{}.UseDefaultStream()); mfi.isValid(); ++mfi)

--- a/Src/Extern/PETSc/AMReX_PETSc.cpp
+++ b/Src/Extern/PETSc/AMReX_PETSc.cpp
@@ -669,6 +669,7 @@ PETScABecLap::loadVectors (MultiFab& soln, const MultiFab& rhs)
                     });
                 }
             }
+            if (Gpu::inNoSyncRegion()) { Gpu::synchronize(); }
         }
     } else
 #endif
@@ -702,6 +703,7 @@ PETScABecLap::loadVectors (MultiFab& soln, const MultiFab& rhs)
                     rhs_diag_a(i,j,k) = rhs_a(i,j,k) * diaginv_a(i,j,k);
                 });
             }
+            if (Gpu::inNoSyncRegion()) { Gpu::synchronize(); }
         }
     }
 


### PR DESCRIPTION
The non-fused path relied on MFIter's exit sync, which is disabled inside Gpu::NoSyncRegion, and the fused path's stream-0 sync did not cover soln.setVal or the other MFIter streams. Replace both with a single Gpu::streamSynchronizeActive() right before the load loop.

Fixes #5794.
