### PR TITLE
Reset Parser/IParser state when compilation fails

### DIFF
--- a/Src/Base/Parser/AMReX_IParser.H
+++ b/Src/Base/Parser/AMReX_IParser.H
@@ -176,6 +176,7 @@ private:
         int m_exe_size = 0;
         Data () = default;
         ~Data ();
+        void clear_host_executor ();
         Data (Data const&) = delete;
         Data (Data &&) = delete;
         Data& operator= (Data const&) = delete;
@@ -218,6 +219,8 @@ IParser::compileHost () const
             try {
                 iparser_compile(m_data->m_iparser, m_data->m_host_executor);
             } catch (const std::runtime_error& e) {
+                // Do not leave a partially compiled executor behind.
+                m_data->clear_host_executor();
                 throw std::runtime_error(std::string(e.what()) + " in IParser expression \""
                                          + m_data->m_expression + "\"");
             }

--- a/Src/Base/Parser/AMReX_IParser.cpp
+++ b/Src/Base/Parser/AMReX_IParser.cpp
@@ -50,16 +50,24 @@ IParser::Data::~Data ()
 {
     m_expression.clear();
     if (m_iparser) { amrex_iparser_delete(m_iparser); }
+    clear_host_executor();
+#ifdef AMREX_USE_GPU
+    if (m_device_executor) { The_Arena()->free(m_device_executor); }
+#endif
+}
+
+void
+IParser::Data::clear_host_executor ()
+{
     if (m_host_executor) {
         if (m_use_arena) {
             The_Pinned_Arena()->free(m_host_executor);
         } else {
             std::free(m_host_executor);
         }
+        m_host_executor = nullptr;
+        m_use_arena = true;
     }
-#ifdef AMREX_USE_GPU
-    if (m_device_executor) { The_Arena()->free(m_device_executor); }
-#endif
 }
 /// \endcond
 

--- a/Src/Base/Parser/AMReX_Parser.H
+++ b/Src/Base/Parser/AMReX_Parser.H
@@ -254,6 +254,7 @@ private:
         Vector<char const*> m_locals;
         Data () = default;
         ~Data ();
+        void clear_host_executor ();
         Data (Data const&) = delete;
         Data (Data &&) = delete;
         Data& operator= (Data const&) = delete;
@@ -309,6 +310,8 @@ Parser::compileHost () const
                 m_data->m_locals = parser_compile(m_data->m_parser, m_uf_ptrs,
                                                   m_data->m_host_executor);
             } catch (const std::runtime_error& e) {
+                // Do not leave a partially compiled executor behind.
+                m_data->clear_host_executor();
                 throw std::runtime_error(std::string(e.what()) + " in Parser expression \""
                                          + m_data->m_expression + "\"");
             }

--- a/Src/Base/Parser/AMReX_Parser.cpp
+++ b/Src/Base/Parser/AMReX_Parser.cpp
@@ -51,16 +51,24 @@ Parser::Data::~Data ()
 {
     m_expression.clear();
     if (m_parser) { amrex_parser_delete(m_parser); }
+    clear_host_executor();
+#ifdef AMREX_USE_GPU
+    if (m_device_executor) { The_Arena()->free(m_device_executor); }
+#endif
+}
+
+void
+Parser::Data::clear_host_executor ()
+{
     if (m_host_executor) {
         if (m_use_arena) {
             The_Pinned_Arena()->free(m_host_executor);
         } else {
             std::free(m_host_executor);
         }
+        m_host_executor = nullptr;
+        m_use_arena = true;
     }
-#ifdef AMREX_USE_GPU
-    if (m_device_executor) { The_Arena()->free(m_device_executor); }
-#endif
 }
 /// \endcond
 


### PR DESCRIPTION
When parser_compile throws, free the partially written bytecode buffer and reset m_host_executor and m_use_arena. Otherwise a later compile() returns an executor over that garbage buffer, and setConstant and registerVariables wrongly refuse with a "after compile()" error.

Fixes #5797.
