### PR TITLE
Fix Message::wait, SYCL warpDim, and fillAsync for odd-sized types

### DIFF
--- a/Src/Base/AMReX_GpuContainers.H
+++ b/Src/Base/AMReX_GpuContainers.H
@@ -431,15 +431,16 @@ namespace amrex::Gpu {
         // No need to use shared memory if the type is small.
         // May not have enough shared memory if the type is too big.
         // Cannot use shared memory, if the type is not trivially copable.
+        // Cannot do the coalesced copy, if the size is not a multiple of 4.
         if constexpr ((sizeof(T) <= 8)
                       || (sizeof(T) > 36*8)
+                      || (sizeof(T) % sizeof(unsigned int) != 0)
                       || ! std::is_trivially_copyable<T>()) {
             amrex::ParallelFor(N, [=] AMREX_GPU_DEVICE (Long i) noexcept
             {
                 f(p[i], i);
             });
         } else {
-            static_assert(sizeof(T) % sizeof(unsigned int) == 0);
             using U = std::conditional_t<sizeof(T) % sizeof(unsigned long long) == 0,
                                          unsigned long long, unsigned int>;
             constexpr Long nU = sizeof(T) / sizeof(U);

--- a/Src/Base/AMReX_GpuTypes.H
+++ b/Src/Base/AMReX_GpuTypes.H
@@ -69,7 +69,7 @@ struct Handler
     // lane index in warp
     std::size_t laneIdx () const { return item->get_sub_group().get_local_id()[0]; }
     // warp size
-    std::size_t warpDim () const { return item->get_sub_group().get_group_range()[0]; }
+    std::size_t warpDim () const { return item->get_sub_group().get_local_range()[0]; }
 
     void* sharedMemory () const { return local; }
 

--- a/Src/Base/AMReX_ParallelDescriptor.cpp
+++ b/Src/Base/AMReX_ParallelDescriptor.cpp
@@ -253,8 +253,9 @@ Message::wait ()
 {
     BL_PROFILE_S("ParallelDescriptor::Message::wait()");
 
-    BL_COMM_PROFILE(BLProfiler::Wait, sizeof(m_type), pid(), tag());
+    BL_COMM_PROFILE(BLProfiler::Wait, sizeof(m_type), BLProfiler::BeforeCall(), BLProfiler::NoTag());
     BL_MPI_REQUIRE( MPI_Wait(&m_req, &m_stat) );
+    m_finished = true;
     BL_COMM_PROFILE(BLProfiler::Wait, sizeof(m_type), BLProfiler::AfterCall(), tag());
 }
 
@@ -263,10 +264,11 @@ Message::test ()
 {
     int flag;
     BL_PROFILE_S("ParallelDescriptor::Message::test()");
-    BL_COMM_PROFILE(BLProfiler::Test, sizeof(m_type), pid(), tag());
+    BL_COMM_PROFILE(BLProfiler::Test, sizeof(m_type), BLProfiler::BeforeCall(), BLProfiler::NoTag());
     BL_MPI_REQUIRE( MPI_Test(&m_req, &flag, &m_stat) );
-    BL_COMM_PROFILE(BLProfiler::Test, flag, BLProfiler::AfterCall(), tag());
     m_finished = flag != 0;
+    BL_COMM_PROFILE(BLProfiler::Test, flag, BLProfiler::AfterCall(),
+                    m_finished ? tag() : BLProfiler::NoTag());
     return m_finished;
 }
 


### PR DESCRIPTION
Message::wait() now marks the message finished so count()/pid()/tag() work afterwards, and the pre-call comm-profile entries use the BeforeCall/NoTag sentinels instead of the not-yet-valid status. SYCL Handler::warpDim() returns the sub-group size, not the number of sub-groups.  Gpu::fillAsync routes types whose size is not a multiple of 4 to the ParallelFor fallback instead of failing a static_assert.

Fixes #5800.
