### PR TITLE
Guard the 32-bit item count in CSR::sort

### DIFF
--- a/Src/LinearSolvers/AMReX_CSR.H
+++ b/Src/LinearSolvers/AMReX_CSR.H
@@ -242,6 +242,9 @@ void CSR<T,V>::sort ()
 
     if (*h_needs_fallback)
     {
+        // The item count of the segmented sort below is 32-bit.
+        AMREX_ALWAYS_ASSERT(nnz < Long(std::numeric_limits<int>::max()));
+
         V<Long> col_index_out(col_index.size());
         V<T> mat_out(mat.size());
         auto* d_col_out = col_index_out.data();


### PR DESCRIPTION
The GPU fallback passes nnz to a segmented radix sort whose item count is 32-bit, so assert on it as this function already does for nrows.  The other item in the issue, the cfine lifetime in MLNodeTensorLaplacian, is handled by #4895 with The_Async_Arena.

Fixes #5806.
