### PR TITLE
Fix several minor defects in Amr

### DIFF
--- a/Src/Amr/AMReX_Amr.cpp
+++ b/Src/Amr/AMReX_Amr.cpp
@@ -521,6 +521,9 @@ Amr::InitAmr ()
         is >> in_finest;
         STRIP;
         AMREX_ASSERT(in_finest >= 0  && in_finest < std::numeric_limits<int>::max());
+        if (in_finest > max_level) {
+           amrex::Error("You have fewer levels in your inputs file then in your grids file!");
+        }
         regrid_ba.resize(in_finest);
         for (int lev = 1; lev <= in_finest; lev++)
         {
@@ -1720,6 +1723,7 @@ Amr::restart (const std::string& filename)
     // we know not to unnecessarily overwrite the old file.
     last_checkpoint = level_steps[0];
     last_plotfile = level_steps[0];
+    last_smallplotfile = level_steps[0];
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {
@@ -2323,8 +2327,9 @@ Amr::coarseTimeStep (Real stop_time)
     }
 
     if(to_stop == 1 && to_checkpoint == 0) {  // prevent main from writing files
-        last_checkpoint = level_steps[0];
-        last_plotfile   = level_steps[0];
+        last_checkpoint    = level_steps[0];
+        last_plotfile      = level_steps[0];
+        last_smallplotfile = level_steps[0];
     }
 
     if (to_checkpoint && write_plotfile_with_checkpoint) {
@@ -2470,10 +2475,10 @@ Amr::writePlotNow() noexcept
         int num_per_new = 0;
 
         if (cumtime-dt_level[0] > 0.) {
-            num_per_old = static_cast<int>(std::log10(cumtime-dt_level[0]) / plot_log_per);
+            num_per_old = static_cast<int>(std::floor(std::log10(cumtime-dt_level[0]) / plot_log_per));
         }
         if (cumtime > 0.) {
-            num_per_new = static_cast<int>(std::log10(cumtime) / plot_log_per);
+            num_per_new = static_cast<int>(std::floor(std::log10(cumtime) / plot_log_per));
         }
 
         if (num_per_old != num_per_new)
@@ -2543,10 +2548,10 @@ Amr::writeSmallPlotNow() noexcept
         int num_per_new = 0;
 
         if (cumtime-dt_level[0] > 0.) {
-            num_per_old = static_cast<int>(std::log10(cumtime-dt_level[0]) / small_plot_log_per);
+            num_per_old = static_cast<int>(std::floor(std::log10(cumtime-dt_level[0]) / small_plot_log_per));
         }
         if (cumtime > 0.) {
-            num_per_new = static_cast<int>(std::log10(cumtime) / small_plot_log_per);
+            num_per_new = static_cast<int>(std::floor(std::log10(cumtime) / small_plot_log_per));
         }
 
         if (num_per_old != num_per_new)

--- a/Src/Amr/AMReX_AmrLevel.cpp
+++ b/Src/Amr/AMReX_AmrLevel.cpp
@@ -1761,7 +1761,8 @@ AmrLevel::derive (const std::string& name, Real time, MultiFab& mf, int dcomp)
 
         const BoxArray& srcBA = state[index].boxArray();
 
-        int ngrow_src = ngrow;
+        // growntilebox() below grows by the full mf.nGrowVect().
+        int ngrow_src = mf.nGrowVect().max();
         {
             Box bx0 = srcBA[0];
             Box bx1 = rec->boxMap()(bx0);

--- a/Src/Amr/AMReX_AuxBoundaryData.cpp
+++ b/Src/Amr/AMReX_AuxBoundaryData.cpp
@@ -35,12 +35,16 @@ AuxBoundaryData::copy (const AuxBoundaryData& src,
 
 AuxBoundaryData::AuxBoundaryData (const AuxBoundaryData& rhs)
     :
-    m_fabs(rhs.m_fabs.boxArray(),rhs.m_fabs.DistributionMap(),rhs.m_fabs.nComp(),0,
-           MFInfo(), FArrayBoxFactory()),
     m_ngrow(rhs.m_ngrow),
-    m_initialized(true)
+    m_empty(rhs.m_empty),
+    m_initialized(rhs.m_initialized)
 {
-    m_fabs.ParallelCopy(rhs.m_fabs,0,0,rhs.m_fabs.nComp());
+    if (m_initialized && !m_empty)
+    {
+        m_fabs.define(rhs.m_fabs.boxArray(),rhs.m_fabs.DistributionMap(),
+                      rhs.m_fabs.nComp(),0,MFInfo(),FArrayBoxFactory());
+        m_fabs.ParallelCopy(rhs.m_fabs,0,0,rhs.m_fabs.nComp());
+    }
 }
 
 void


### PR DESCRIPTION
Guard amr.regrid_file against more levels than amr.max_level, reset last_smallplotfile alongside last_plotfile on restart and stop_run, use std::floor so plot_log_per fires at the t=1 decade crossing, size the derive source MultiFab from the full nGrowVect, and propagate m_empty and m_initialized in the AuxBoundaryData copy constructor.

Fixes #5808.

