### PR TITLE
Guard STL BVH against unbuilt or too-deep tree

### DIFF
--- a/Src/EB/AMReX_EB_STL_utils.H
+++ b/Src/EB/AMReX_EB_STL_utils.H
@@ -72,8 +72,13 @@ public:
     static constexpr int mixedcells = 0;
     static constexpr int allcovered = 1;
 
-    //! Enable/disable BVH acceleration when sampling.
-    void setBVHOptimization (bool flag) { m_bvh_optimization = flag; }
+    //! Enable/disable BVH acceleration when sampling.  Enabling it must be
+    //! done before the STL file is read.
+    void setBVHOptimization (bool flag) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!flag || m_num_tri == 0 || !m_bvh_nodes.empty(),
+            "STLtools: BVH optimization must be enabled before reading the STL file");
+        m_bvh_optimization = flag;
+    }
 
     /**
      * \brief Read an STL file, apply scaling/translation, and store triangles.

--- a/Src/EB/AMReX_EB_STL_utils.cpp
+++ b/Src/EB/AMReX_EB_STL_utils.cpp
@@ -384,10 +384,6 @@ STLtools::read_binary_stl_file (std::string const& fname, Real scale,
         amrex::readIntData<uint32_t,uint32_t>(&numtris, 1, is, uint32_descr);
         AMREX_ALWAYS_ASSERT(numtris < uint32_t(std::numeric_limits<int>::max()));
         m_num_tri = static_cast<int>(numtris);
-        // maximum number of triangles allowed for traversing the BVH tree
-        // using stack.
-        int max_tri_stack = Math::powi<m_bvh_max_stack_size-1>(m_bvh_max_splits)*m_bvh_max_size;
-        AMREX_ALWAYS_ASSERT(m_num_tri <= max_tri_stack);
         a_tri_pts.resize(m_num_tri);
 
         if (amrex::Verbose()) {
@@ -496,6 +492,11 @@ STLtools::prepare (Gpu::PinnedVector<Triangle> a_tri_pts)
 
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_num_tri > 0,
                                      "STLtools::prepare: STL contains no triangles");
+
+    // maximum number of triangles allowed for traversing the BVH tree
+    // using stack.
+    int max_tri_stack = Math::powi<m_bvh_max_stack_size-1>(m_bvh_max_splits)*m_bvh_max_size;
+    AMREX_ALWAYS_ASSERT(m_num_tri <= max_tri_stack);
 
     Gpu::PinnedVector<Node> bvh_nodes;
     if (m_bvh_optimization) {


### PR DESCRIPTION
Move the max triangle count assert from the binary reader into prepare(), so ASCII STL files are bounded too and cannot build a BVH deeper than the fixed traversal stack.  Also make setBVHOptimization abort when enabling BVH after an STL was read without it, which would leave fill/getBoxType traversing a null root.

Fixes #5811.
