### PR TITLE
Support disabling FP exception traps on macOS

### DIFF
--- a/Docs/sphinx_documentation/source/Debugging.rst
+++ b/Docs/sphinx_documentation/source/Debugging.rst
@@ -28,8 +28,7 @@ use of uninitialized values, AMReX also initializes ``FArrayBox``\ s in
 with ``TEST=TRUE`` or ``DEBUG=TRUE`` in GNU make, or with ``-DCMAKE_BUILD_TYPE=Debug`` in CMake.
 One can also control this setting for ``FArrayBox`` using the runtime parameter ``fab.init_snan``.
 Note for Macs: Apple silicon chips using the Arm64 architecture are not able to trap
-division by zero.  The trap can still be requested and will be reported as enabled by
-``amrex::getFPExcept()``, but no exception will be raised.
+division by zero.
 
 One can get more information than the backtrace of the call stack by
 instrumenting the code.  Here is an example.

--- a/Docs/sphinx_documentation/source/Debugging.rst
+++ b/Docs/sphinx_documentation/source/Debugging.rst
@@ -27,7 +27,9 @@ use of uninitialized values, AMReX also initializes ``FArrayBox``\ s in
 ``MultiFab``\ s and arrays allocated by ``bl_allocate`` to signaling NaNs when it is compiled
 with ``TEST=TRUE`` or ``DEBUG=TRUE`` in GNU make, or with ``-DCMAKE_BUILD_TYPE=Debug`` in CMake.
 One can also control this setting for ``FArrayBox`` using the runtime parameter ``fab.init_snan``.
-Note for Macs: M1 and M2 chips using the Arm64 architecture are not able to trap division by zero.
+Note for Macs: Apple silicon chips using the Arm64 architecture are not able to trap
+division by zero.  The trap can still be requested and will be reported as enabled by
+``amrex::getFPExcept()``, but no exception will be raised.
 
 One can get more information than the backtrace of the call stack by
 instrumenting the code.  Here is an example.

--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -566,16 +566,19 @@ namespace amrex
         return static_cast<FPExcept>(static_cast<T>(a) & static_cast<T>(b));
     }
 
-    //! Return currently enabled FP exceptions.
+    //! Return currently enabled FP exceptions. Linux and macOS only; a
+    //! no-op elsewhere, including musl-based Linux.
     [[nodiscard]] FPExcept getFPExcept ();
 
-    //! Set FP exception traps. This enables set flags and
-    //! DISABLES unset flags. This can be used to restore previous settings.
+    //! Set FP exception traps. This enables set flags and DISABLES unset
+    //! flags. This can be used to restore previous settings. Linux and
+    //! macOS only; a no-op elsewhere, including musl-based Linux.
     //! \param excepts Bit mask describing which traps should be enabled.
     FPExcept setFPExcept (FPExcept excepts);
 
     /**
-     * \brief Disable FP exceptions.
+     * \brief Disable FP exceptions. Linux and macOS only; a no-op
+     * elsewhere, including musl-based Linux.
      *
      * This function disables given exception traps and keeps the status of
      * the others. The example below disables FPE invalid and
@@ -591,7 +594,8 @@ namespace amrex
     [[nodiscard]] FPExcept disableFPExcept (FPExcept excepts);
 
     /**
-     * \brief Enable FP exceptions.
+     * \brief Enable FP exceptions. Linux and macOS only; a no-op
+     * elsewhere, including musl-based Linux.
      *
      * This function enables given exception traps and keeps the status of
      * the others. The example below enables all FPE traps, and later

--- a/Src/Base/AMReX.H
+++ b/Src/Base/AMReX.H
@@ -566,16 +566,16 @@ namespace amrex
         return static_cast<FPExcept>(static_cast<T>(a) & static_cast<T>(b));
     }
 
-    //! Return currently enabled FP exceptions. Linux only.
+    //! Return currently enabled FP exceptions.
     [[nodiscard]] FPExcept getFPExcept ();
 
-    //! Set FP exception traps. Linux only. This enables set flags and
+    //! Set FP exception traps. This enables set flags and
     //! DISABLES unset flags. This can be used to restore previous settings.
     //! \param excepts Bit mask describing which traps should be enabled.
     FPExcept setFPExcept (FPExcept excepts);
 
     /**
-     * \brief Disable FP exceptions. Linux Only
+     * \brief Disable FP exceptions.
      *
      * This function disables given exception traps and keeps the status of
      * the others. The example below disables FPE invalid and
@@ -591,7 +591,7 @@ namespace amrex
     [[nodiscard]] FPExcept disableFPExcept (FPExcept excepts);
 
     /**
-     * \brief Enable FP exceptions. Linux Only
+     * \brief Enable FP exceptions.
      *
      * This function enables given exception traps and keeps the status of
      * the others. The example below enables all FPE traps, and later

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -1040,6 +1040,62 @@ AMReX::erase (AMReX* pamrex)
     }
 }
 
+#if defined(__APPLE__) && (defined(__x86_64__) || defined(__aarch64__))
+namespace {
+    /* macOS has no fe{get,enable,disable}except, so we read and write the
+     * trap bits of the floating point control register directly. */
+    FPExcept apple_get_fpexcept ()
+    {
+        auto r = FPExcept::none;
+#if defined(__x86_64__)
+        // A set mask bit means the exception is masked, i.e. not trapped.
+        auto const mask = _MM_GET_EXCEPTION_MASK();
+        if (!(mask & _MM_MASK_INVALID )) { r = r | FPExcept::invalid ; }
+        if (!(mask & _MM_MASK_DIV_ZERO)) { r = r | FPExcept::zero    ; }
+        if (!(mask & _MM_MASK_OVERFLOW)) { r = r | FPExcept::overflow; }
+#else
+        fenv_t env;
+        fegetenv(&env);
+        if (env.__fpcr & __fpcr_trap_invalid  ) { r = r | FPExcept::invalid ; }
+        if (env.__fpcr & __fpcr_trap_divbyzero) { r = r | FPExcept::zero    ; }
+        if (env.__fpcr & __fpcr_trap_overflow ) { r = r | FPExcept::overflow; }
+#endif
+        return r;
+    }
+
+    //! Enable trapping of the exceptions in `on`, disable those in `off`.
+    void apple_set_fpexcept (FPExcept on, FPExcept off)
+    {
+        unsigned int on_bits = 0U;
+        unsigned int off_bits = 0U;
+#if defined(__x86_64__)
+        if (any(on  & FPExcept::invalid )) { on_bits  |= _MM_MASK_INVALID ; }
+        if (any(on  & FPExcept::zero    )) { on_bits  |= _MM_MASK_DIV_ZERO; }
+        if (any(on  & FPExcept::overflow)) { on_bits  |= _MM_MASK_OVERFLOW; }
+        if (any(off & FPExcept::invalid )) { off_bits |= _MM_MASK_INVALID ; }
+        if (any(off & FPExcept::zero    )) { off_bits |= _MM_MASK_DIV_ZERO; }
+        if (any(off & FPExcept::overflow)) { off_bits |= _MM_MASK_OVERFLOW; }
+        auto mask = _MM_GET_EXCEPTION_MASK();
+        mask |= off_bits;   // masked, i.e. not trapped
+        mask &= ~on_bits;   // unmasked, i.e. trapped
+        _MM_SET_EXCEPTION_MASK(mask);
+#else
+        if (any(on  & FPExcept::invalid )) { on_bits  |= __fpcr_trap_invalid  ; }
+        if (any(on  & FPExcept::zero    )) { on_bits  |= __fpcr_trap_divbyzero; }
+        if (any(on  & FPExcept::overflow)) { on_bits  |= __fpcr_trap_overflow ; }
+        if (any(off & FPExcept::invalid )) { off_bits |= __fpcr_trap_invalid  ; }
+        if (any(off & FPExcept::zero    )) { off_bits |= __fpcr_trap_divbyzero; }
+        if (any(off & FPExcept::overflow)) { off_bits |= __fpcr_trap_overflow ; }
+        fenv_t env;
+        fegetenv(&env);
+        env.__fpcr &= ~off_bits;
+        env.__fpcr |= on_bits;
+        fesetenv(&env);
+#endif
+    }
+}
+#endif
+
 FPExcept getFPExcept ()
 {
     auto r = FPExcept::none;
@@ -1048,6 +1104,8 @@ FPExcept getFPExcept ()
     if (excepts & FE_INVALID  ) { r = r | FPExcept::invalid ; }
     if (excepts & FE_DIVBYZERO) { r = r | FPExcept::zero    ; }
     if (excepts & FE_OVERFLOW ) { r = r | FPExcept::overflow; }
+#elif defined(__APPLE__) && (defined(__x86_64__) || defined(__aarch64__))
+    r = apple_get_fpexcept();
 #endif
     return r;
 }
@@ -1063,6 +1121,8 @@ FPExcept setFPExcept (FPExcept excepts)
     if (any(excepts & FPExcept::zero    )) { flags |= FE_DIVBYZERO; }
     if (any(excepts & FPExcept::overflow)) { flags |= FE_OVERFLOW ; }
     feenableexcept(flags);
+#elif defined(__APPLE__) && (defined(__x86_64__) || defined(__aarch64__))
+    apple_set_fpexcept(excepts, FPExcept::all);
 #else
     amrex::ignore_unused(excepts);
 #endif
@@ -1078,6 +1138,8 @@ FPExcept disableFPExcept (FPExcept excepts)
     if (any(excepts & FPExcept::zero    )) { flags |= FE_DIVBYZERO; }
     if (any(excepts & FPExcept::overflow)) { flags |= FE_OVERFLOW ; }
     fedisableexcept(flags);
+#elif defined(__APPLE__) && (defined(__x86_64__) || defined(__aarch64__))
+    apple_set_fpexcept(FPExcept::none, excepts);
 #else
     amrex::ignore_unused(excepts);
 #endif
@@ -1093,6 +1155,8 @@ FPExcept enableFPExcept (FPExcept excepts)
     if (any(excepts & FPExcept::zero    )) { flags |= FE_DIVBYZERO; }
     if (any(excepts & FPExcept::overflow)) { flags |= FE_OVERFLOW ; }
     feenableexcept(flags);
+#elif defined(__APPLE__) && (defined(__x86_64__) || defined(__aarch64__))
+    apple_set_fpexcept(excepts, FPExcept::none);
 #else
     amrex::ignore_unused(excepts);
 #endif

--- a/Src/Base/AMReX.cpp
+++ b/Src/Base/AMReX.cpp
@@ -1088,7 +1088,7 @@ namespace {
         if (any(off & FPExcept::overflow)) { off_bits |= __fpcr_trap_overflow ; }
         fenv_t env;
         fegetenv(&env);
-        env.__fpcr &= ~off_bits;
+        env.__fpcr &= ~static_cast<unsigned long long>(off_bits);
         env.__fpcr |= on_bits;
         fesetenv(&env);
 #endif


### PR DESCRIPTION
get/set/enable/disableFPExcept were implemented for Linux/glibc only, and silently did nothing elsewhere. But we do enable trapping on macOS, on both x86_64 and arm64. So a caller that disables trapping to survive a failing computation was still killed by a signal there. Read and write the trap bits of the FP control register directly.
