### PR TITLE
CI: add a single precision GCC job that runs ctest

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -758,6 +758,69 @@ jobs:
         ccache -s
         du -hs ~/.cache/ccache
 
+  # Single precision build that runs the test suite.  Single precision solvers
+  # used to be exercised only by the GitLab GPU runs.
+  tests_single_precision:
+    name: GNU@13 SP [tests]
+    runs-on: ubuntu-24.04
+    needs: check_changes
+    if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    steps:
+    - uses: actions/checkout@v7
+    - name: Dependencies
+      run: |
+        .github/workflows/dependencies/dependencies_gcc.sh 13
+        .github/workflows/dependencies/dependencies_clang-tidy-apt-llvm.sh 21
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Build & Test
+      # In single precision every double literal in the tests is a narrowing
+      # conversion.  263 such lines remain under Tests/, so -Wfloat-conversion
+      # is not an error here.  Remove the exemption once they are cleaned up.
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wno-error=float-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
+        ccache -z
+
+        cmake -S . -B build                        \
+            -DCMAKE_CXX_STANDARD=20                \
+            -DCMAKE_BUILD_TYPE=Release             \
+            -DCMAKE_VERBOSE_MAKEFILE=ON            \
+            -DAMReX_SPACEDIM="2;3"                 \
+            -DAMReX_PRECISION=SINGLE               \
+            -DAMReX_PARTICLES_PRECISION=SINGLE     \
+            -DAMReX_EB=ON                          \
+            -DAMReX_FFT=ON                         \
+            -DAMReX_LINEAR_SOLVERS=ON              \
+            -DAMReX_AMRLEVEL=ON                    \
+            -DAMReX_PARTICLES=ON                   \
+            -DAMReX_FORTRAN=OFF                    \
+            -DAMReX_ENABLE_TESTS=ON                \
+            -DCMAKE_C_COMPILER=$(which gcc-13)     \
+            -DCMAKE_CXX_COMPILER=$(which g++-13)   \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake --build build -j 4
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j4 -k -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-21 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
+
+        ctest --test-dir build --output-on-failure
+
+        ccache -s
+        du -hs ~/.cache/ccache
+
   test_hdf5:
     name: GNU@13 HDF5 I/O Test [tests]
     runs-on: ubuntu-24.04

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -760,7 +760,10 @@ jobs:
 
   # Single precision 2D build that runs the test suite.  Single precision
   # solvers used to be exercised only by the GitLab GPU runs.  2D and 3D are
-  # separate jobs to keep each one's build time down.
+  # separate jobs to keep each one's build time down.  The two jobs pin
+  # opposite AMReX_MPI and AMReX_OMP settings so that both the threaded and
+  # the MPI paths are covered, and so that the tests that are only built
+  # without MPI are built at least once.
   tests_single_precision_2D:
     name: GNU@13 SP 2D [tests]
     runs-on: ubuntu-24.04
@@ -795,6 +798,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release             \
             -DCMAKE_VERBOSE_MAKEFILE=ON            \
             -DAMReX_SPACEDIM=2                     \
+            -DAMReX_MPI=OFF                        \
+            -DAMReX_OMP=ON                         \
             -DAMReX_PRECISION=SINGLE               \
             -DAMReX_PARTICLES_PRECISION=SINGLE     \
             -DAMReX_EB=ON                          \
@@ -854,6 +859,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release             \
             -DCMAKE_VERBOSE_MAKEFILE=ON            \
             -DAMReX_SPACEDIM=3                     \
+            -DAMReX_MPI=ON                         \
+            -DAMReX_OMP=OFF                        \
             -DAMReX_PRECISION=SINGLE               \
             -DAMReX_PARTICLES_PRECISION=SINGLE     \
             -DAMReX_EB=ON                          \

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -763,7 +763,8 @@ jobs:
   # separate jobs to keep each one's build time down.  The two jobs pin
   # opposite AMReX_MPI and AMReX_OMP settings so that both the threaded and
   # the MPI paths are covered, and so that the tests that are only built
-  # without MPI are built at least once.
+  # without MPI are built at least once.  The 2D job also keeps the particles
+  # in double precision, which is otherwise never built.
   tests_single_precision_2D:
     name: GNU@13 SP 2D [tests]
     runs-on: ubuntu-24.04
@@ -801,7 +802,7 @@ jobs:
             -DAMReX_MPI=OFF                        \
             -DAMReX_OMP=ON                         \
             -DAMReX_PRECISION=SINGLE               \
-            -DAMReX_PARTICLES_PRECISION=SINGLE     \
+            -DAMReX_PARTICLES_PRECISION=DOUBLE     \
             -DAMReX_EB=ON                          \
             -DAMReX_FFT=ON                         \
             -DAMReX_LINEAR_SOLVERS=ON              \

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -758,10 +758,11 @@ jobs:
         ccache -s
         du -hs ~/.cache/ccache
 
-  # Single precision build that runs the test suite.  Single precision solvers
-  # used to be exercised only by the GitLab GPU runs.
-  tests_single_precision:
-    name: GNU@13 SP [tests]
+  # Single precision 2D build that runs the test suite.  Single precision
+  # solvers used to be exercised only by the GitLab GPU runs.  2D and 3D are
+  # separate jobs to keep each one's build time down.
+  tests_single_precision_2D:
+    name: GNU@13 SP 2D [tests]
     runs-on: ubuntu-24.04
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
@@ -780,10 +781,7 @@ jobs:
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: Build & Test
-      # In single precision every double literal in the tests is a narrowing
-      # conversion.  263 such lines remain under Tests/, so -Wfloat-conversion
-      # is not an error here.  Remove the exemption once they are cleaned up.
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wno-error=float-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
@@ -796,7 +794,66 @@ jobs:
             -DCMAKE_CXX_STANDARD=20                \
             -DCMAKE_BUILD_TYPE=Release             \
             -DCMAKE_VERBOSE_MAKEFILE=ON            \
-            -DAMReX_SPACEDIM="2;3"                 \
+            -DAMReX_SPACEDIM=2                     \
+            -DAMReX_PRECISION=SINGLE               \
+            -DAMReX_PARTICLES_PRECISION=SINGLE     \
+            -DAMReX_EB=ON                          \
+            -DAMReX_FFT=ON                         \
+            -DAMReX_LINEAR_SOLVERS=ON              \
+            -DAMReX_AMRLEVEL=ON                    \
+            -DAMReX_PARTICLES=ON                   \
+            -DAMReX_FORTRAN=OFF                    \
+            -DAMReX_ENABLE_TESTS=ON                \
+            -DCMAKE_C_COMPILER=$(which gcc-13)     \
+            -DCMAKE_CXX_COMPILER=$(which g++-13)   \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake --build build -j 4
+
+        ${{github.workspace}}/Tools/C_scripts/mmclt.py --input ${{github.workspace}}/ccache.log.txt
+        make -j4 -k -f clang-tidy-ccache-misses.mak \
+            CLANG_TIDY=clang-tidy-21 \
+            CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
+
+        ctest --test-dir build --output-on-failure
+
+        ccache -s
+        du -hs ~/.cache/ccache
+
+  # Single precision 3D build that runs the test suite.  See the 2D job above.
+  tests_single_precision_3D:
+    name: GNU@13 SP 3D [tests]
+    runs-on: ubuntu-24.04
+    needs: check_changes
+    if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    steps:
+    - uses: actions/checkout@v7
+    - name: Dependencies
+      run: |
+        .github/workflows/dependencies/dependencies_gcc.sh 13
+        .github/workflows/dependencies/dependencies_clang-tidy-apt-llvm.sh 21
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Build & Test
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wnon-virtual-dtor -Wlogical-op -Wmisleading-indentation -Wduplicated-cond -Wduplicated-branches -Wmissing-include-dirs"}
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=100M
+        export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
+        export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
+        ccache -z
+
+        cmake -S . -B build                        \
+            -DCMAKE_CXX_STANDARD=20                \
+            -DCMAKE_BUILD_TYPE=Release             \
+            -DCMAKE_VERBOSE_MAKEFILE=ON            \
+            -DAMReX_SPACEDIM=3                     \
             -DAMReX_PRECISION=SINGLE               \
             -DAMReX_PARTICLES_PRECISION=SINGLE     \
             -DAMReX_EB=ON                          \

--- a/Src/AmrCore/AMReX_Interp_2D_C.H
+++ b/Src/AmrCore/AMReX_Interp_2D_C.H
@@ -173,8 +173,8 @@ facediv_face_interp_RZ (int ci, int cj, int /*ck*/,
         }
         case 1:
         {
-            const Real rm = rcen - drf*ratio[0];
-            const Real rp = rcen + drf*ratio[0];
+            const Real rm = rcen - drf*Real(ratio[0]);
+            const Real rp = rcen + drf*Real(ratio[0]);
 
             fine(fi,   fj, 0, n) = (rcen*crse(ci, cj, 0, n) + (rm*crse(ci-1, cj, 0, n) - rp *crse(ci+1, cj, 0, n))/Real(8.))/(rcen-drf*Real(0.5));
             fine(fi+1, fj, 0, n) = (rcen*crse(ci, cj, 0, n) - (rm*crse(ci-1, cj, 0, n) - rp *crse(ci+1, cj, 0, n))/Real(8.))/(rcen+drf*Real(0.5));
@@ -248,15 +248,15 @@ facediv_int_gen_RZ (int ci, int cj, int /*ck*/, int nf,
     for (int j = 0; j < ratio[1]; ++j) {
     for (int i = 1; i < ratio[0]; ++i) {
         fine[0](fi+i, fj+j, 0, nf) =
-            ((ratio[0]-i)*redge[0]*fine[0](fi,           fj+j, 0, nf)
-           +          i *redge[2]* fine[0](fi+ratio[0], fj+j, 0, nf))/(rcen*ratio[0]);
+            (Real(ratio[0]-i)*redge[0]*fine[0](fi,           fj+j, 0, nf)
+           +         Real(i)*redge[2]* fine[0](fi+ratio[0], fj+j, 0, nf))/(rcen*Real(ratio[0]));
     }}
 
     for (int j = 1; j < ratio[1]; ++j) {
     for (int i = 0; i < ratio[0]; ++i) {
         fine[1](fi+i, fj+j, 0, nf) =
-            ((ratio[1]-j)*fine[1](fi+i, fj,           0, nf)
-           +          j *fine[1](fi+i, fj+ratio[1], 0, nf))/ratio[1];
+            (Real(ratio[1]-j)*fine[1](fi+i, fj,           0, nf)
+           +         Real(j)*fine[1](fi+i, fj+ratio[1], 0, nf))/Real(ratio[1]);
     }}
 
     Real uplus = Real(0.);
@@ -438,15 +438,15 @@ facediv_int_gen (int ci, int cj, int /*ck*/, int nf,
     for (int j = 0; j < ratio[1]; ++j) {
     for (int i = 1; i < ratio[0]; ++i) {
         fine[0](fi+i, fj+j, 0, nf) =
-            ((ratio[0]-i)*fine[0](fi,           fj+j, 0, nf)
-           +          i *fine[0](fi+ratio[0], fj+j, 0, nf))/ratio[0];
+            (Real(ratio[0]-i)*fine[0](fi,           fj+j, 0, nf)
+           +         Real(i)*fine[0](fi+ratio[0], fj+j, 0, nf))/Real(ratio[0]);
     }}
 
     for (int j = 1; j < ratio[1]; ++j) {
     for (int i = 0; i < ratio[0]; ++i) {
         fine[1](fi+i, fj+j, 0, nf) =
-            ((ratio[1]-j)*fine[1](fi+i, fj,           0, nf)
-           +          j *fine[1](fi+i, fj+ratio[1], 0, nf))/ratio[1];
+            (Real(ratio[1]-j)*fine[1](fi+i, fj,           0, nf)
+           +         Real(j)*fine[1](fi+i, fj+ratio[1], 0, nf))/Real(ratio[1]);
     }}
 
     Real uplus = Real(0.);
@@ -577,8 +577,8 @@ void ccprotect_2d (int ic, int jc, int /*kc*/, int nvar,
             } else {
                 // RZ
                 const Real* cs_problo = cs_geomdata.ProbLo();
-                Real rp = cs_problo[0] + (ic+0.5_rt)*cs_dx[0];
-                Real rm = cs_problo[0] + (ic-0.5_rt)*cs_dx[0];
+                Real rp = cs_problo[0] + (Real(ic)+0.5_rt)*cs_dx[0];
+                Real rm = cs_problo[0] + (Real(ic)-0.5_rt)*cs_dx[0];
                 cvol = (rp*rp - rm*rm) * cs_dx[1];
             }
 
@@ -608,8 +608,8 @@ void ccprotect_2d (int ic, int jc, int /*kc*/, int nvar,
                     } else {
                         // RZ
                         const Real* fn_problo = fn_geomdata.ProbLo();
-                        Real rp = fn_problo[0] + (i+0.5_rt)*fn_dx[0];
-                        Real rm = fn_problo[0] + (i-0.5_rt)*fn_dx[0];
+                        Real rp = fn_problo[0] + (Real(i)+0.5_rt)*fn_dx[0];
+                        Real rm = fn_problo[0] + (Real(i)-0.5_rt)*fn_dx[0];
                         fvol = (rp*rp - rm*rm) * fn_dx[1];
                     }
 

--- a/Src/AmrCore/AMReX_Interp_3D_C.H
+++ b/Src/AmrCore/AMReX_Interp_3D_C.H
@@ -456,8 +456,8 @@ facediv_int_gen (int ci, int cj, int ck, int nf,
     for( int j=0; j < ratio[1]; ++j){
     for( int i=1; i < ratio[0]; ++i){
 
-       fine[0](fi + i, fj + j, fk + k, nf) = ((ratio[0]-i)*fine[0](fi,           fj + j, fk + k, nf)
-                                        +     i       *fine[0](fi+ratio[0], fj + j, fk + k, nf) )/ratio[0];
+       fine[0](fi + i, fj + j, fk + k, nf) = (Real(ratio[0]-i)*fine[0](fi,           fj + j, fk + k, nf)
+                                        +     Real(i) *fine[0](fi+ratio[0], fj + j, fk + k, nf) )/Real(ratio[0]);
 
     }
     }
@@ -467,8 +467,8 @@ facediv_int_gen (int ci, int cj, int ck, int nf,
     for( int j=1; j < ratio[1]; ++j){
     for( int i=0; i < ratio[0]; ++i){
 
-       fine[1](fi + i, fj + j, fk + k, nf) = ((ratio[1]-j)*fine[1](fi + i, fj,           fk + k, nf)
-                                        +     j       *fine[1](fi + i, fj+ratio[1], fk + k, nf) )/ratio[1];
+       fine[1](fi + i, fj + j, fk + k, nf) = (Real(ratio[1]-j)*fine[1](fi + i, fj,           fk + k, nf)
+                                        +     Real(j) *fine[1](fi + i, fj+ratio[1], fk + k, nf) )/Real(ratio[1]);
 
     }
     }
@@ -478,8 +478,8 @@ facediv_int_gen (int ci, int cj, int ck, int nf,
     for( int j=0; j < ratio[1]; ++j){
     for( int i=0; i < ratio[0]; ++i){
 
-       fine[2](fi + i, fj + j, fk + k, nf) = ((ratio[2]-k)*fine[2](fi + i, fj + j, fk,           nf)
-                                        +     k       *fine[2](fi + i, fj + j, fk+ratio[2], nf) )/ratio[2];
+       fine[2](fi + i, fj + j, fk + k, nf) = (Real(ratio[2]-k)*fine[2](fi + i, fj + j, fk,           nf)
+                                        +     Real(k) *fine[2](fi + i, fj + j, fk+ratio[2], nf) )/Real(ratio[2]);
 
     }
     }

--- a/Src/AmrCore/AMReX_MFInterp_2D_C.H
+++ b/Src/AmrCore/AMReX_MFInterp_2D_C.H
@@ -236,35 +236,35 @@ void mf_cell_cons_lin_interp_mcslope_sph (int i, int j, int ns, Array4<Real> con
     if (sx != Real(0.0) || sy != Real(0.0)) {
 
         // x-direction
-        const Real drc = drf * ratio[0];
-        const Real rcm =  i    * drc + rlo;
-        const Real rcp = (i+1) * drc + rlo;
+        const Real drc = drf * Real(ratio[0]);
+        const Real rcm = Real(i)   * drc + rlo;
+        const Real rcp = Real(i+1) * drc + rlo;
         Real vcm = rcm*rcm*rcm;
         Real vcp = rcp*rcp*rcp;
-        Real rfm =  i*ratio[0]      * drf + rlo;
-        Real rfp = (i*ratio[0] + 1) * drf + rlo;
+        Real rfm = Real(i*ratio[0])     * drf + rlo;
+        Real rfp = Real(i*ratio[0] + 1) * drf + rlo;
         Real vfm = rfm*rfm*rfm;
         Real vfp = rfp*rfp*rfp;
         Real xlo = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
-        rfm = ((i+1)*ratio[0] - 1) * drf + rlo;
-        rfp =  (i+1)*ratio[0]      * drf + rlo;
+        rfm = Real((i+1)*ratio[0] - 1) * drf + rlo;
+        rfp = Real((i+1)*ratio[0])     * drf + rlo;
         vfm = rfm*rfm*rfm;
         vfp = rfp*rfp*rfp;
         Real xhi = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
 
         // y-direction
-        const Real dtc = dtf * ratio[1];
-        const Real tcm = j     * dtc + tlo;
-        const Real tcp = (j+1) * dtc + tlo;
+        const Real dtc = dtf * Real(ratio[1]);
+        const Real tcm = Real(j)   * dtc + tlo;
+        const Real tcp = Real(j+1) * dtc + tlo;
         vcm = std::cos(tcm);
         vcp = std::cos(tcp);
-        Real tfm =  j*ratio[1]      * dtf + tlo;
-        Real tfp = (j*ratio[1] + 1) * dtf + tlo;
+        Real tfm = Real(j*ratio[1])     * dtf + tlo;
+        Real tfp = Real(j*ratio[1] + 1) * dtf + tlo;
         vfm = std::cos(tfm);
         vfp = std::cos(tfp);
         Real ylo = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
-        tfm = ((j+1)*ratio[1] - 1) * dtf + tlo;
-        tfp =  (j+1)*ratio[1]      * dtf + tlo;
+        tfm = Real((j+1)*ratio[1] - 1) * dtf + tlo;
+        tfp = Real((j+1)*ratio[1])     * dtf + tlo;
         vfm = std::cos(tfm);
         vfp = std::cos(tfp);
         Real yhi = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
@@ -300,11 +300,11 @@ void mf_cell_cons_lin_interp_sph (int i, int j, int ns, Array4<Real> const& fine
 {
     // x-direction
     const int ic = amrex::coarsen(i, ratio[0]);
-    const Real drc =  drf * ratio[0];
-    const Real rcm =  ic    * drc + rlo;
-    const Real rcp = (ic+1) * drc + rlo;
-    const Real rfm =  i     * drf + rlo;
-    const Real rfp = (i +1) * drf + rlo;
+    const Real drc = drf * Real(ratio[0]);
+    const Real rcm = Real(ic)   * drc + rlo;
+    const Real rcp = Real(ic+1) * drc + rlo;
+    const Real rfm = Real(i)    * drf + rlo;
+    const Real rfp = Real(i+1)  * drf + rlo;
     Real vcm = rcm*rcm*rcm;
     Real vcp = rcp*rcp*rcp;
     Real vfm = rfm*rfm*rfm;
@@ -313,11 +313,11 @@ void mf_cell_cons_lin_interp_sph (int i, int j, int ns, Array4<Real> const& fine
 
     // y-direction
     const int jc = amrex::coarsen(j, ratio[1]);
-    const Real dtc =  dtf * ratio[1];
-    const Real tcm =  jc    * dtc + tlo;
-    const Real tcp = (jc+1) * dtc + tlo;
-    const Real tfm =  j     * dtf + tlo;
-    const Real tfp = (j +1) * dtf + tlo;
+    const Real dtc = dtf * Real(ratio[1]);
+    const Real tcm = Real(jc)   * dtc + tlo;
+    const Real tcp = Real(jc+1) * dtc + tlo;
+    const Real tfm = Real(j)    * dtf + tlo;
+    const Real tfp = Real(j+1)  * dtf + tlo;
     vcm = std::cos(tcm);
     vcp = std::cos(tcp);
     vfm = std::cos(tfm);
@@ -360,18 +360,18 @@ void mf_cell_cons_lin_interp_mcslope_rz (int i, int j, int ns, Array4<Real> cons
 
     Real alpha = Real(1.0);
     if (sx != Real(0.0) || sy != Real(0.0)) {
-        const Real drc = drf * ratio[0];
-        const Real rcm =  i    * drc + rlo;
-        const Real rcp = (i+1) * drc + rlo;
+        const Real drc = drf * Real(ratio[0]);
+        const Real rcm = Real(i)   * drc + rlo;
+        const Real rcp = Real(i+1) * drc + rlo;
         const Real vcm = rcm*rcm;
         const Real vcp = rcp*rcp;
-        Real rfm =  i*ratio[0]      * drf + rlo;
-        Real rfp = (i*ratio[0] + 1) * drf + rlo;
+        Real rfm = Real(i*ratio[0])     * drf + rlo;
+        Real rfp = Real(i*ratio[0] + 1) * drf + rlo;
         Real vfm = rfm*rfm;
         Real vfp = rfp*rfp;
         Real xlo = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
-        rfm = ((i+1)*ratio[0] - 1) * drf + rlo;
-        rfp =  (i+1)*ratio[0]      * drf + rlo;
+        rfm = Real((i+1)*ratio[0] - 1) * drf + rlo;
+        rfp = Real((i+1)*ratio[0])     * drf + rlo;
         vfm = rfm*rfm;
         vfp = rfp*rfp;
         Real xhi = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
@@ -407,17 +407,17 @@ void mf_cell_cons_lin_interp_rz (int i, int j, int ns, Array4<Real> const& fine,
 {
     const int ic = amrex::coarsen(i, ratio[0]);
     const int jc = amrex::coarsen(j, ratio[1]);
-    const Real drc =  drf * ratio[0];
-    const Real rcm =  ic    * drc + rlo;
-    const Real rcp = (ic+1) * drc + rlo;
-    const Real rfm =  i     * drf + rlo;
-    const Real rfp = (i +1) * drf + rlo;
+    const Real drc = drf * Real(ratio[0]);
+    const Real rcm = Real(ic)   * drc + rlo;
+    const Real rcp = Real(ic+1) * drc + rlo;
+    const Real rfm = Real(i)    * drf + rlo;
+    const Real rfp = Real(i+1)  * drf + rlo;
     const Real vcm = rcm*rcm;
     const Real vcp = rcp*rcp;
     const Real vfm = rfm*rfm;
     const Real vfp = rfp*rfp;
     const Real xoff = Real(0.5) * ((vfm+vfp) - (vcm+vcp)) / (vcp - vcm);
-    const Real yoff = (j - jc*ratio[1] + Real(0.5)) / Real(ratio[1]) - Real(0.5);
+    const Real yoff = (Real(j - jc*ratio[1]) + Real(0.5)) / Real(ratio[1]) - Real(0.5);
     fine(i,j,0,fcomp+ns) = crse(ic,jc,0,ccomp+ns)
         + xoff * slope(ic,jc,0,ns)
         + yoff * slope(ic,jc,0,ns+ncomp);

--- a/Src/Base/AMReX_Algorithm.H
+++ b/Src/Base/AMReX_Algorithm.H
@@ -141,7 +141,7 @@ namespace amrex
         // Reference: https://en.cppreference.com/w/cpp/types/numeric_limits/epsilon
         // The machine epsilon has to be scaled to the magnitude of the values used
         // and multiplied by the desired precision in ULPs (units in the last place)
-        return std::abs(x-y) <= std::numeric_limits<T>::epsilon() * std::abs(x+y) * ulp
+        return std::abs(x-y) <= std::numeric_limits<T>::epsilon() * std::abs(x+y) * T(ulp)
         // unless the result is subnormal
         || std::abs(x-y) < std::numeric_limits<T>::min();
     }

--- a/Src/Base/AMReX_COORDSYS_2D_C.H
+++ b/Src/Base/AMReX_COORDSYS_2D_C.H
@@ -36,7 +36,7 @@ amrex_setvol (Box const& bx, Array4<Real> const& vol,
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                Real ri = offset[0] + dx[0]*(i);
+                Real ri = offset[0] + dx[0]*Real(i);
                 Real ro = ri + dx[0];
                 Real v = pi*dx[1]*dx[0]*(ro + ri);
                 vol(i,j,0) = std::abs(v);
@@ -47,12 +47,12 @@ amrex_setvol (Box const& bx, Array4<Real> const& vol,
     {
         const Real pi = std::numbers::pi_v<Real>;
         for     (int j = lo.y; j <= hi.y; ++j) {
-            Real ti = offset[1] + dx[1]*(j);
+            Real ti = offset[1] + dx[1]*Real(j);
             Real to = ti + dx[1];
             Real tmp = (Real(2.)*pi)*(std::cos(ti)-std::cos(to))/Real(3.0);
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                Real ri = offset[0] + dx[0]*(i);
+                Real ri = offset[0] + dx[0]*Real(i);
                 Real ro = ri + dx[0];
                 Real v = tmp*(ro-ri)*(ro*ro+ro*ri+ri*ri);
                 vol(i,j,0) = std::abs(v);
@@ -89,7 +89,7 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real ri = offset[0] + dx[0]*(i);
+                    Real ri = offset[0] + dx[0]*Real(i);
                     Real a = std::abs((Real(2.)*pi)*ri*dx[1]);
                     area(i,j,0) = a;
                 }
@@ -100,7 +100,7 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real rc = offset[0] + dx[0]*(i+Real(0.5));
+                    Real rc = offset[0] + dx[0]*(Real(i)+Real(0.5));
                     Real a = std::abs(dx[0]*(Real(2.)*pi)*rc);
                     area(i,j,0) = a;
                 }
@@ -113,12 +113,12 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
         if (dir == 0)
         {
             for     (int j = lo.y; j <= hi.y; ++j) {
-                Real ti = offset[1] + dx[1]*(j);
+                Real ti = offset[1] + dx[1]*Real(j);
                 Real to = ti + dx[1];
                 Real tmp = (Real(2.)*pi)*(std::cos(ti)-std::cos(to));
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real ri = offset[0] + dx[0]*(i);
+                    Real ri = offset[0] + dx[0]*Real(i);
                     Real a = std::abs(tmp*ri*ri);
                     area(i,j,0) = a;
                 }
@@ -127,11 +127,11 @@ amrex_setarea (Box const& bx, Array4<Real> const& area,
         else
         {
             for     (int j = lo.y; j <= hi.y; ++j) {
-                Real ti = offset[1] + dx[1]*(j);
+                Real ti = offset[1] + dx[1]*Real(j);
                 Real tmp = pi*std::sin(ti);
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real ri = offset[0] + dx[0]*(i);
+                    Real ri = offset[0] + dx[0]*Real(i);
                     Real ro = ri + dx[0];
                     Real a = std::abs(tmp*(ro-ri)*(ro+ri));
                     area(i,j,0) = a;
@@ -167,7 +167,7 @@ amrex_setdloga (Box const& bx, Array4<Real> const& dloga,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real rc = offset[0] + dx[0]*(i+Real(0.5));
+                    Real rc = offset[0] + dx[0]*(Real(i)+Real(0.5));
                     dloga(i,j,0) = Real(1.0)/rc;
                 }
             }
@@ -189,7 +189,7 @@ amrex_setdloga (Box const& bx, Array4<Real> const& dloga,
             for     (int j = lo.y; j <= hi.y; ++j) {
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real rc = offset[0] + dx[0]*(i+Real(0.5));
+                    Real rc = offset[0] + dx[0]*(Real(i)+Real(0.5));
                     dloga(i,j,0) = Real(2.0)/rc;
                 }
             }
@@ -197,12 +197,12 @@ amrex_setdloga (Box const& bx, Array4<Real> const& dloga,
         else
         {
             for     (int j = lo.y; j <= hi.y; ++j) {
-                Real ti = offset[1] + dx[1]*(j);
+                Real ti = offset[1] + dx[1]*Real(j);
                 Real to = ti + dx[1];
                 Real tmp = Real(1.0)/std::tan(Real(0.5)*(ti+to));
                 AMREX_PRAGMA_SIMD
                 for (int i = lo.x; i <= hi.x; ++i) {
-                    Real rc = offset[0] + dx[0]*(i+Real(0.5) );
+                    Real rc = offset[0] + dx[0]*(Real(i)+Real(0.5));
                     dloga(i,j,0) = tmp/rc;
                 }
             }

--- a/Src/Base/AMReX_Geometry.cpp
+++ b/Src/Base/AMReX_Geometry.cpp
@@ -553,7 +553,7 @@ Geometry::computeRoundoffDomain ()
         Real dxinv = InvCellSize(idim);
 
         // Check that the grid is well formed and that deltax > roundoff
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE((plo + ihi*CellSize(idim)) < (plo + (ihi + 1)*CellSize(idim)), error_msg_2);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE((plo + Real(ihi)*CellSize(idim)) < (plo + Real(ihi + 1)*CellSize(idim)), error_msg_2);
 
         // roundoff_lo will be the lowest value that will be inside the domain
         // roundoff_hi will be the highest value that will be inside the domain

--- a/Src/Base/AMReX_MultiFabUtil.cpp
+++ b/Src/Base/AMReX_MultiFabUtil.cpp
@@ -1054,7 +1054,7 @@ namespace amrex
                             return Real(0.);
                         } else {
                             constexpr Real pi = std::numbers::pi_v<Real>;
-                            Real ri = rlo + dx[0]*i;
+                            Real ri = rlo + dx[0]*Real(i);
                             Real ro = ri + dx[0];
                             return Real(4./3.)*pi*(ro-ri)*(ro*ro+ro*ri+ri*ri)
                                 * a[box_no](i,j,k,icomp);
@@ -1071,7 +1071,7 @@ namespace amrex
                         if (m[box_no](i,j,k)) {
                             return Real(0.);
                         } else {
-                            Real ri = rlo + dx[0]*i;
+                            Real ri = rlo + dx[0]*Real(i);
                             Real ro = ri + dx[0];
                             constexpr Real pi = std::numbers::pi_v<Real>;
                             return pi*dx[1]*dx[0]*(ro+ri)
@@ -1119,7 +1119,7 @@ namespace amrex
                                noexcept -> Real
                 {
                     constexpr Real pi = std::numbers::pi_v<Real>;
-                    Real ri = rlo + dx[0]*i;
+                    Real ri = rlo + dx[0]*Real(i);
                     Real ro = ri + dx[0];
                     return Real(4./3.)*pi*(ro-ri)*(ro*ro+ro*ri+ri*ri)
                         * a[box_no](i,j,k,icomp);
@@ -1132,7 +1132,7 @@ namespace amrex
                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
                                noexcept -> Real
                 {
-                    Real ri = rlo + dx[0]*i;
+                    Real ri = rlo + dx[0]*Real(i);
                     Real ro = ri + dx[0];
                     constexpr Real pi = std::numbers::pi_v<Real>;
                     return pi*dx[1]*dx[0]*(ro+ri)

--- a/Src/Base/AMReX_MultiFabUtil_3D_C.H
+++ b/Src/Base/AMReX_MultiFabUtil_3D_C.H
@@ -106,7 +106,7 @@ void amrex_avgdown_faces (Box const& bx, Array4<T> const& crse,
     switch (idir) {
     case 0:
     {
-        T facInv = T(1.0) / (facy*facz);
+        T facInv = T(1.0) / T(facy*facz);
         for (int n = 0; n < ncomp; ++n) {
             for (int k = clo.z; k <= chi.z; ++k) {
             for (int j = clo.y; j <= chi.y; ++j) {
@@ -126,7 +126,7 @@ void amrex_avgdown_faces (Box const& bx, Array4<T> const& crse,
     }
     case 1:
     {
-        T facInv = T(1.0) / (facx*facz);
+        T facInv = T(1.0) / T(facx*facz);
         for (int n = 0; n < ncomp; ++n) {
             for (int k = clo.z; k <= chi.z; ++k) {
             for (int j = clo.y; j <= chi.y; ++j) {
@@ -146,7 +146,7 @@ void amrex_avgdown_faces (Box const& bx, Array4<T> const& crse,
     }
     case 2:
     {
-        T facInv = T(1.0) / (facx*facy);
+        T facInv = T(1.0) / T(facx*facy);
         for (int n = 0; n < ncomp; ++n) {
             for (int k = clo.z; k <= chi.z; ++k) {
             for (int j = clo.y; j <= chi.y; ++j) {
@@ -184,7 +184,7 @@ void amrex_avgdown_faces (int i, int j, int k, int n, Array4<T> const& crse,
     switch (idir) {
     case 0:
     {
-        const T facInv = T(1.0) / (facy*facz);
+        const T facInv = T(1.0) / T(facy*facz);
         T c = T(0.);
         for (int kref = 0; kref < facz; ++kref) {
         for (int jref = 0; jref < facy; ++jref) {
@@ -195,7 +195,7 @@ void amrex_avgdown_faces (int i, int j, int k, int n, Array4<T> const& crse,
     }
     case 1:
     {
-        const T facInv = T(1.0) / (facx*facz);
+        const T facInv = T(1.0) / T(facx*facz);
         T c = T(0.);
         for (int kref = 0; kref < facz; ++kref) {
         for (int iref = 0; iref < facx; ++iref) {
@@ -206,7 +206,7 @@ void amrex_avgdown_faces (int i, int j, int k, int n, Array4<T> const& crse,
     }
     case 2:
     {
-        const T facInv = T(1.0) / (facx*facy);
+        const T facInv = T(1.0) / T(facx*facy);
         T c = T(0.);
         for (int jref = 0; jref < facy; ++jref) {
         for (int iref = 0; iref < facx; ++iref) {

--- a/Src/Base/AMReX_REAL.H
+++ b/Src/Base/AMReX_REAL.H
@@ -29,6 +29,7 @@
 #if !defined(BL_LANG_FORT)
 #ifdef __cplusplus
 #include <cfloat>
+#include <type_traits>
 #else
 #include <float.h>
 #endif
@@ -88,6 +89,17 @@ namespace amrex {
      * computations and storage.
      */
     using ParticleReal = amrex_particle_real;
+
+    /**
+     * \ingroup amrex_arithmetic_types
+     * \brief Floating Point Type for Particle-Mesh Operations
+     *
+     * The wider of amrex::Real and amrex::ParticleReal. Use it for the
+     * intermediate results of operations that mix particle and field data,
+     * such as deposition and interpolation, so that they are rounded only
+     * when the final value is stored.
+     */
+    using ParticleMeshReal = std::common_type_t<Real, ParticleReal>;
 
 /** Floating point literals for AMReX precision.
  *

--- a/Src/Boundary/AMReX_InterpBndryData_2D_K.H
+++ b/Src/Boundary/AMReX_InterpBndryData_2D_K.H
@@ -61,7 +61,7 @@ void interpbndrydata_x_o3 (int i, int j, int /*k*/, int n,
         NN = 1;
     }
 
-    T xInt = -T(0.5) + (j-jc*r.y+T(0.5))/r.y;
+    T xInt = -T(0.5) + (T(j-jc*r.y)+T(0.5))/T(r.y);
     poly_interp_coeff(xInt, x, NN, c);
     T b = T(0.0);
     for (int m = 0; m < NN; ++m) {
@@ -113,7 +113,7 @@ void interpbndrydata_y_o3 (int i, int j, int /*k*/, int n,
         NN = 1;
     }
 
-    T xInt = -T(0.5) + (i-ic*r.x+T(0.5))/r.x;
+    T xInt = -T(0.5) + (T(i-ic*r.x)+T(0.5))/T(r.x);
     poly_interp_coeff(xInt, x, NN, c);
     T b = T(0.0);
     for (int m = 0; m < NN; ++m) {

--- a/Src/Boundary/AMReX_InterpBndryData_3D_K.H
+++ b/Src/Boundary/AMReX_InterpBndryData_3D_K.H
@@ -46,8 +46,8 @@ void interpbndrydata_x_o3 (int i, int j, int k, int n,
         ? T(0.25)*(crse(ic,jc+1,kc+1,n+nc)-crse(ic,jc-1,kc+1,n+nc)+crse(ic,jc-1,kc-1,n+nc)-crse(ic,jc+1,kc-1,n+nc))
         : T(0.0);
 
-    T y = -T(0.5) + (j-jc*r.y+T(0.5))/r.y;
-    T z = -T(0.5) + (k-kc*r.z+T(0.5))/r.z;
+    T y = -T(0.5) + (T(j-jc*r.y)+T(0.5))/T(r.y);
+    T z = -T(0.5) + (T(k-kc*r.z)+T(0.5))/T(r.z);
     bdry(i,j,k,n+nb) = crse(ic,jc,kc,n+nc) + y*dy + (y*y)*dy2 + z*dz + (z*z)*dz2 + y*z*dyz;
 }
 
@@ -80,8 +80,8 @@ void interpbndrydata_y_o3 (int i, int j, int k, int n,
         : T(0.0);
 
 
-    T x = -T(0.5) + (i-ic*r.x+T(0.5))/r.x;
-    T z = -T(0.5) + (k-kc*r.z+T(0.5))/r.z;
+    T x = -T(0.5) + (T(i-ic*r.x)+T(0.5))/T(r.x);
+    T z = -T(0.5) + (T(k-kc*r.z)+T(0.5))/T(r.z);
     bdry(i,j,k,n+nb) = crse(ic,jc,kc,n+nc) + x*dx + (x*x)*dx2 + z*dz + (z*z)*dz2 + x*z*dxz;
 }
 
@@ -113,8 +113,8 @@ void interpbndrydata_z_o3 (int i, int j, int k, int n,
         ? T(0.25)*(crse(ic+1,jc+1,kc,n+nc)-crse(ic-1,jc+1,kc,n+nc)+crse(ic-1,jc-1,kc,n+nc)-crse(ic+1,jc-1,kc,n+nc))
         : T(0.0);
 
-    T x = -T(0.5) + (i-ic*r.x+T(0.5))/r.x;
-    T y = -T(0.5) + (j-jc*r.y+T(0.5))/r.y;
+    T x = -T(0.5) + (T(i-ic*r.x)+T(0.5))/T(r.x);
+    T y = -T(0.5) + (T(j-jc*r.y)+T(0.5))/T(r.y);
     bdry(i,j,k,n+nb) = crse(ic,jc,kc,n+nc) + x*dx + (x*x)*dx2 + y*dy + (y*y)*dy2 + x*y*dxy;
 }
 

--- a/Src/EB/AMReX_EB2_2D_C.cpp
+++ b/Src/EB/AMReX_EB2_2D_C.cpp
@@ -229,10 +229,10 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 fcx(i,j,0) = 0.0_rt;
             } else {
                 if (levset(i,j,0) < 0.0_rt) {
-                    apx(i,j,0) = (intery(i,j,0)-(problo[1]+j*dx[1]))*dyinv;
+                    apx(i,j,0) = (intery(i,j,0)-(problo[1]+Real(j)*dx[1]))*dyinv;
                     fcx(i,j,0) = 0.5_rt*apx(i,j,0) - 0.5_rt;
                 } else {
-                    apx(i,j,0) = 1.0_rt - (intery(i,j,0)-(problo[1]+j*dx[1]))*dyinv;
+                    apx(i,j,0) = 1.0_rt - (intery(i,j,0)-(problo[1]+Real(j)*dx[1]))*dyinv;
                     fcx(i,j,0) = 0.5_rt - 0.5_rt*apx(i,j,0);
                 }
 
@@ -262,10 +262,10 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 fcy(i,j,0) = 0.0_rt;
             } else {
                 if (levset(i,j,0) < 0.0_rt) {
-                    apy(i,j,0) = (interx(i,j,0)-(problo[0]+i*dx[0]))*dxinv;
+                    apy(i,j,0) = (interx(i,j,0)-(problo[0]+Real(i)*dx[0]))*dxinv;
                     fcy(i,j,0) = 0.5_rt*apy(i,j,0) - 0.5_rt;
                 } else {
-                    apy(i,j,0) = 1.0_rt - (interx(i,j,0)-(problo[0]+i*dx[0]))*dxinv;
+                    apy(i,j,0) = 1.0_rt - (interx(i,j,0)-(problo[0]+Real(i)*dx[0]))*dxinv;
                     fcy(i,j,0) = 0.5_rt - 0.5_rt*apy(i,j,0);
                 }
 

--- a/Src/EB/AMReX_EB2_3D_C.cpp
+++ b/Src/EB/AMReX_EB2_3D_C.cpp
@@ -426,7 +426,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lym = 0.0_rt;
             } else  {
                 ++ncuts;
-                Real cut = (intery(i,j,k)-(problo[1]+j*dx[1]))*dyinv;
+                Real cut = (intery(i,j,k)-(problo[1]+Real(j)*dx[1]))*dyinv;
                 bcy  += cut;
                 lym = (levset(i,j,k) < 0.0_rt) ? cut : 1.0_rt-cut;
                 lym = amrex::min(amrex::max(Real(0.0),lym),Real(1.0));
@@ -439,7 +439,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lyp = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (intery(i,j,k+1)-(problo[1]+j*dx[1]))*dyinv;
+                Real cut = (intery(i,j,k+1)-(problo[1]+Real(j)*dx[1]))*dyinv;
                 bcy += cut;
                 bcz += 1.0_rt;
                 lyp = (levset(i,j,k+1) < 0.0_rt) ? cut : 1.0_rt-cut;
@@ -453,7 +453,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lzm = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (interz(i,j,k)-(problo[2]+k*dx[2]))*dzinv;
+                Real cut = (interz(i,j,k)-(problo[2]+Real(k)*dx[2]))*dzinv;
                 bcz += cut;
                 lzm = (levset(i,j,k) < 0.0_rt) ? cut : 1.0_rt-cut;
                 lzm = amrex::min(amrex::max(Real(0.0),lzm),Real(1.0));
@@ -466,7 +466,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lzp = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (interz(i,j+1,k)-(problo[2]+k*dx[2]))*dzinv;
+                Real cut = (interz(i,j+1,k)-(problo[2]+Real(k)*dx[2]))*dzinv;
                 bcy += 1.0_rt;
                 bcz += cut;
                 lzp = (levset(i,j+1,k) < 0.0_rt) ? cut : 1.0_rt-cut;
@@ -535,7 +535,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lxm = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (interx(i,j,k)-(problo[0]+i*dx[0]))*dxinv;
+                Real cut = (interx(i,j,k)-(problo[0]+Real(i)*dx[0]))*dxinv;
                 bcx += cut;
                 lxm = (levset(i,j,k) < 0.0_rt) ? cut : 1.0_rt-cut;
                 lxm = amrex::min(amrex::max(Real(0.0),lxm),Real(1.0));
@@ -548,7 +548,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lxp = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (interx(i,j,k+1)-(problo[0]+i*dx[0]))*dxinv;
+                Real cut = (interx(i,j,k+1)-(problo[0]+Real(i)*dx[0]))*dxinv;
                 bcx += cut;
                 bcz += 1.0_rt;
                 lxp = (levset(i,j,k+1) < 0.0_rt) ? cut : 1.0_rt-cut;
@@ -562,7 +562,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lzm = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (interz(i,j,k)-(problo[2]+k*dx[2]))*dzinv;
+                Real cut = (interz(i,j,k)-(problo[2]+Real(k)*dx[2]))*dzinv;
                 bcz += cut;
                 lzm = (levset(i,j,k) < 0.0_rt) ? cut : 1.0_rt-cut;
             }
@@ -574,7 +574,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lzp = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (interz(i+1,j,k)-(problo[2]+k*dx[2]))*dzinv;
+                Real cut = (interz(i+1,j,k)-(problo[2]+Real(k)*dx[2]))*dzinv;
                 bcx += 1.0_rt;
                 bcz += cut;
                 lzp = (levset(i+1,j,k) < 0.0_rt) ? cut : 1.0_rt-cut;
@@ -643,7 +643,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lxm = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (interx(i,j,k)-(problo[0]+i*dx[0]))*dxinv;
+                Real cut = (interx(i,j,k)-(problo[0]+Real(i)*dx[0]))*dxinv;
                 bcx += cut;
                 lxm = (levset(i,j,k) < 0.0_rt) ? cut : 1.0_rt-cut;
                 lxm = amrex::min(amrex::max(Real(0.0),lxm),Real(1.0));
@@ -656,7 +656,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lxp = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (interx(i,j+1,k)-(problo[0]+i*dx[0]))*dxinv;
+                Real cut = (interx(i,j+1,k)-(problo[0]+Real(i)*dx[0]))*dxinv;
                 bcx += cut;
                 bcy += 1.0_rt;
                 lxp = (levset(i,j+1,k) < 0.0_rt) ? cut : 1.0_rt-cut;
@@ -670,7 +670,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lym = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (intery(i,j,k)-(problo[1]+j*dx[1]))*dyinv;
+                Real cut = (intery(i,j,k)-(problo[1]+Real(j)*dx[1]))*dyinv;
                 bcy += cut;
                 lym = (levset(i,j,k) < 0.0_rt) ? cut : 1.0_rt-cut;
             }
@@ -682,7 +682,7 @@ int build_faces (Box const& bx, Array4<EBCellFlag> const& cell,
                 lyp = 0.0_rt;
             } else {
                 ++ncuts;
-                Real cut = (intery(i+1,j,k)-(problo[1]+j*dx[1]))*dyinv;
+                Real cut = (intery(i+1,j,k)-(problo[1]+Real(j)*dx[1]))*dyinv;
                 bcx += 1.0_rt;
                 bcy += cut;
                 lyp = (levset(i+1,j,k) < 0.0_rt) ? cut : 1.0_rt-cut;

--- a/Src/EB/AMReX_EB2_GeometryShop.H
+++ b/Src/EB/AMReX_EB2_GeometryShop.H
@@ -277,9 +277,9 @@ public:
             [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
             {
                 amrex::ignore_unused(j,k);
-                Real v = f(AMREX_D_DECL(problo[0]+i*dx[0],
-                                        problo[1]+j*dx[1],
-                                        problo[2]+k*dx[2]));
+                Real v = f(AMREX_D_DECL(problo[0]+Real(i)*dx[0],
+                                        problo[1]+Real(j)*dx[1],
+                                        problo[2]+Real(k)*dx[2]));
                 int nbody = 0, nzero = 0, nfluid = 0;
                 if (v == 0.0_rt) {
                     ++nzero;
@@ -347,9 +347,9 @@ public:
         const auto& f = m_f;
         AMREX_HOST_DEVICE_FOR_3D_FLAG(run_on, bx, i, j, k,
         {
-            a(i,j,k) = f(AMREX_D_DECL(problo[0]+amrex::Clamp(i,blo.x,bhi.x)*dx[0],
-                                      problo[1]+amrex::Clamp(j,blo.y,bhi.y)*dx[1],
-                                      problo[2]+amrex::Clamp(k,blo.z,bhi.z)*dx[2]));
+            a(i,j,k) = f(AMREX_D_DECL(problo[0]+Real(amrex::Clamp(i,blo.x,bhi.x))*dx[0],
+                                      problo[1]+Real(amrex::Clamp(j,blo.y,bhi.y))*dx[1],
+                                      problo[2]+Real(amrex::Clamp(k,blo.z,bhi.z))*dx[2]));
         });
     }
 
@@ -387,9 +387,9 @@ public:
         const auto& a = levelset.array();
         amrex::LoopOnCpu(bx, [&] (int i, int j, int k) noexcept
         {
-            a(i,j,k) = m_f(RealArray{AMREX_D_DECL(problo[0]+amrex::Clamp(i,blo.x,bhi.x)*dx[0],
-                                                  problo[1]+amrex::Clamp(j,blo.y,bhi.y)*dx[1],
-                                                  problo[2]+amrex::Clamp(k,blo.z,bhi.z)*dx[2])});
+            a(i,j,k) = m_f(RealArray{AMREX_D_DECL(problo[0]+Real(amrex::Clamp(i,blo.x,bhi.x))*dx[0],
+                                                  problo[1]+Real(amrex::Clamp(j,blo.y,bhi.y))*dx[1],
+                                                  problo[2]+Real(amrex::Clamp(k,blo.z,bhi.z))*dx[2])});
         });
     }
 
@@ -426,12 +426,12 @@ public:
                     IntVect ivhi(AMREX_D_DECL(i,j,k));
                     ivhi[idim] += 1;
                     inter(i,j,k) = BrentRootFinder
-                        ({AMREX_D_DECL(problo[0]+amrex::Clamp(ivlo[0],blo.x,bhi.x)*dx[0],
-                                       problo[1]+amrex::Clamp(ivlo[1],blo.y,bhi.y)*dx[1],
-                                       problo[2]+amrex::Clamp(ivlo[2],blo.z,bhi.z)*dx[2])},
-                         {AMREX_D_DECL(problo[0]+amrex::Clamp(ivhi[0],blo.x,bhi.x)*dx[0],
-                                       problo[1]+amrex::Clamp(ivhi[1],blo.y,bhi.y)*dx[1],
-                                       problo[2]+amrex::Clamp(ivhi[2],blo.z,bhi.z)*dx[2])},
+                        ({AMREX_D_DECL(problo[0]+Real(amrex::Clamp(ivlo[0],blo.x,bhi.x))*dx[0],
+                                       problo[1]+Real(amrex::Clamp(ivlo[1],blo.y,bhi.y))*dx[1],
+                                       problo[2]+Real(amrex::Clamp(ivlo[2],blo.z,bhi.z))*dx[2])},
+                         {AMREX_D_DECL(problo[0]+Real(amrex::Clamp(ivhi[0],blo.x,bhi.x))*dx[0],
+                                       problo[1]+Real(amrex::Clamp(ivhi[1],blo.y,bhi.y))*dx[1],
+                                       problo[2]+Real(amrex::Clamp(ivhi[2],blo.z,bhi.z))*dx[2])},
                             idim, f);
                 } else {
                     inter(i,j,k) = std::numeric_limits<Real>::quiet_NaN();
@@ -495,12 +495,12 @@ public:
                 IntVect ivhi(AMREX_D_DECL(i,j,k));
                 ivhi[idim] += 1;
                 inter(i,j,k) = BrentRootFinder
-                    ({AMREX_D_DECL(problo[0]+amrex::Clamp(ivlo[0],blo.x,bhi.x)*dx[0],
-                                   problo[1]+amrex::Clamp(ivlo[1],blo.y,bhi.y)*dx[1],
-                                   problo[2]+amrex::Clamp(ivlo[2],blo.z,bhi.z)*dx[2])},
-                     {AMREX_D_DECL(problo[0]+amrex::Clamp(ivhi[0],blo.x,bhi.x)*dx[0],
-                                   problo[1]+amrex::Clamp(ivhi[1],blo.y,bhi.y)*dx[1],
-                                   problo[2]+amrex::Clamp(ivhi[2],blo.z,bhi.z)*dx[2])},
+                    ({AMREX_D_DECL(problo[0]+Real(amrex::Clamp(ivlo[0],blo.x,bhi.x))*dx[0],
+                                   problo[1]+Real(amrex::Clamp(ivlo[1],blo.y,bhi.y))*dx[1],
+                                   problo[2]+Real(amrex::Clamp(ivlo[2],blo.z,bhi.z))*dx[2])},
+                     {AMREX_D_DECL(problo[0]+Real(amrex::Clamp(ivhi[0],blo.x,bhi.x))*dx[0],
+                                   problo[1]+Real(amrex::Clamp(ivhi[1],blo.y,bhi.y))*dx[1],
+                                   problo[2]+Real(amrex::Clamp(ivhi[2],blo.z,bhi.z))*dx[2])},
                      idim, m_f);
             } else {
                 inter(i,j,k) = std::numeric_limits<Real>::quiet_NaN();
@@ -537,34 +537,34 @@ public:
                             // interp might still be quiet_nan because lst that
                             // was set to zero has been changed by FillBoundary
                             // at periodic boundaries.
-                            inter(i,j,k) = problo[0] + i*dx[0];
+                            inter(i,j,k) = problo[0] + Real(i)*dx[0];
                         }
                         else if (lst(i+1,j,k) == Real(0.0) ||
                                  (lst(i+1,j,k) > Real(0.0) && is_nan))
                         {
-                            inter(i,j,k) = problo[0] + (i+1)*dx[0];
+                            inter(i,j,k) = problo[0] + Real(i+1)*dx[0];
                         }
                     } else if (idim == 1) {
                         if (lst(i,j,k) == Real(0.0) ||
                             (lst(i,j,k) > Real(0.0) && is_nan))
                         {
-                            inter(i,j,k) = problo[1] + j*dx[1];
+                            inter(i,j,k) = problo[1] + Real(j)*dx[1];
                         }
                         else if (lst(i,j+1,k) == Real(0.0) ||
                                  (lst(i,j+1,k) > Real(0.0) && is_nan))
                         {
-                            inter(i,j,k) = problo[1] + (j+1)*dx[1];
+                            inter(i,j,k) = problo[1] + Real(j+1)*dx[1];
                         }
                     } else {
                         if (lst(i,j,k) == Real(0.0) ||
                             (lst(i,j,k) > Real(0.0) && is_nan))
                         {
-                            inter(i,j,k) = problo[2] + k*dx[2];
+                            inter(i,j,k) = problo[2] + Real(k)*dx[2];
                         }
                         else if (lst(i,j,k+1) == Real(0.0) ||
                                  (lst(i,j,k+1) > Real(0.0) && is_nan))
                         {
-                            inter(i,j,k) = problo[2] + (k+1)*dx[2];
+                            inter(i,j,k) = problo[2] + Real(k+1)*dx[2];
                         }
                     }
                 }

--- a/Src/EB/AMReX_EB2_IF_Polynomial.H
+++ b/Src/EB/AMReX_EB2_IF_Polynomial.H
@@ -55,9 +55,9 @@ public:
     {
         Real retval = 0.0_rt;
         for (auto const& term : m_polynomial) {
-            retval += term.coef * AMREX_D_TERM(  std::pow(x, term.powers[0]),
-                                               * std::pow(y, term.powers[1]),
-                                               * std::pow(z, term.powers[2]));
+            retval += Real(term.coef * AMREX_D_TERM(  std::pow(x, term.powers[0]),
+                                                    * std::pow(y, term.powers[1]),
+                                                    * std::pow(z, term.powers[2])));
         }
         return m_sign*retval;
     }
@@ -97,9 +97,9 @@ public:
     {
         Real retval = 0.0_rt;
         for (auto const& term : m_polynomial) {
-            retval += term.coef * AMREX_D_TERM(  std::pow(x, term.powers[0]),
-                                               * std::pow(y, term.powers[1]),
-                                               * std::pow(z, term.powers[2]));
+            retval += Real(term.coef * AMREX_D_TERM(  std::pow(x, term.powers[0]),
+                                                    * std::pow(y, term.powers[1]),
+                                                    * std::pow(z, term.powers[2])));
         }
         return m_sign*retval;
     }

--- a/Src/EB/AMReX_EB2_ND_C.cpp
+++ b/Src/EB/AMReX_EB2_ND_C.cpp
@@ -23,7 +23,7 @@ void intercept_to_edge_centroid (AMREX_D_DECL(Array4<Real> const& excent,
                 } else if (fx(i,j,k) == Type::covered) {
                     excent(i,j,k) = Real(-1.0);
                 } else {
-                    Real xcut = Real(0.5)*(excent(i,j,k) - (problo[0]+i*dx[0]))*dxinv;
+                    Real xcut = Real(0.5)*(excent(i,j,k) - (problo[0]+Real(i)*dx[0]))*dxinv;
                     if (levset(i,j,k) < levset(i+1,j,k)) { // right side covered
                         xcut -= Real(0.5);
                     }
@@ -38,7 +38,7 @@ void intercept_to_edge_centroid (AMREX_D_DECL(Array4<Real> const& excent,
                 } else if (fy(i,j,k) == Type::covered) {
                     eycent(i,j,k) = Real(-1.0);
                 } else {
-                    Real ycut = Real(0.5)*(eycent(i,j,k) - (problo[1]+j*dx[1]))*dyinv;
+                    Real ycut = Real(0.5)*(eycent(i,j,k) - (problo[1]+Real(j)*dx[1]))*dyinv;
                     if (levset(i,j,k) < levset(i,j+1,k)) { // right side covered
                         ycut -= Real(0.5);
                     }
@@ -53,7 +53,7 @@ void intercept_to_edge_centroid (AMREX_D_DECL(Array4<Real> const& excent,
                 } else if (fz(i,j,k) == Type::covered) {
                     ezcent(i,j,k) = Real(-1.0);
                 } else {
-                    Real zcut = Real(0.5)*(ezcent(i,j,k) - (problo[2]+k*dx[2]))*dzinv;
+                    Real zcut = Real(0.5)*(ezcent(i,j,k) - (problo[2]+Real(k)*dx[2]))*dzinv;
                     if (levset(i,j,k) < levset(i,j,k+1)) { // right side covered
                         zcut -= Real(0.5);
                     }

--- a/Src/EB/AMReX_EBFluxRegister.cpp
+++ b/Src/EB/AMReX_EBFluxRegister.cpp
@@ -10,7 +10,7 @@
 
 #ifdef BL_NO_FORT
 namespace {
-    amrex::Real amrex_reredistribution_threshold = 1.e-14;
+    amrex::Real amrex_reredistribution_threshold = amrex::Real(1.e-14);
 }
 extern "C" {
     void amrex_eb_disable_reredistribution () { amrex_reredistribution_threshold = 1.e10; }

--- a/Src/EB/AMReX_EB_StateRedistUtils.cpp
+++ b/Src/EB/AMReX_EB_StateRedistUtils.cpp
@@ -217,9 +217,9 @@ MakeStateRedistUtils ( Box const& bx,
                     int jj = jmap[itracker(i,j,k,i_nbor)]; int s = j+jj;
                     int kk = kmap[itracker(i,j,k,i_nbor)]; int t = k+kk;
 
-                    AMREX_D_TERM(cent_hat(i,j,k,0) += (ccent(r,s,t,0) + ii) * alpha(i,j,k,1) * vfrac(r,s,t) / nrs(r,s,t);,
-                                 cent_hat(i,j,k,1) += (ccent(r,s,t,1) + jj) * alpha(i,j,k,1) * vfrac(r,s,t) / nrs(r,s,t);,
-                                 cent_hat(i,j,k,2) += (ccent(r,s,t,2) + kk) * alpha(i,j,k,1) * vfrac(r,s,t) / nrs(r,s,t););
+                    AMREX_D_TERM(cent_hat(i,j,k,0) += (ccent(r,s,t,0) + Real(ii)) * alpha(i,j,k,1) * vfrac(r,s,t) / nrs(r,s,t);,
+                                 cent_hat(i,j,k,1) += (ccent(r,s,t,1) + Real(jj)) * alpha(i,j,k,1) * vfrac(r,s,t) / nrs(r,s,t);,
+                                 cent_hat(i,j,k,2) += (ccent(r,s,t,2) + Real(kk)) * alpha(i,j,k,1) * vfrac(r,s,t) / nrs(r,s,t););
                 }
 
                 AMREX_D_TERM(cent_hat(i,j,k,0) /= nbhd_vol(i,j,k);,

--- a/Src/EB/AMReX_EB_utils.cpp
+++ b/Src/EB/AMReX_EB_utils.cpp
@@ -309,9 +309,9 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
                     AMREX_D_TERM(Real dxinv = 1._rt/dx_eb[0];,
                                  Real dyinv = 1._rt/dx_eb[1];,
                                  Real dzinv = 1._rt/dx_eb[2]);
-                    AMREX_D_TERM(Real x = i*dx_ls[0];,
-                                 Real y = j*dx_ls[1];,
-                                 Real z = k*dx_ls[2]);
+                    AMREX_D_TERM(Real x = Real(i)*dx_ls[0];,
+                                 Real y = Real(j)*dx_ls[1];,
+                                 Real z = Real(k)*dx_ls[2]);
                     Real min_dist2 = std::numeric_limits<Real>::max();
                     int i_nearest = 0;
                     for (int ifac  = 0; ifac < ncutcells; ++ifac) {
@@ -356,9 +356,9 @@ void FillSignedDistance (MultiFab& mf, EB2::Level const& ls_lev,
 #endif
                         for (int j_shift = -1; j_shift <= 1; ++j_shift) {
                         for (int i_shift = -1; i_shift <= 1; ++i_shift) {
-                            AMREX_D_TERM(vi_x = static_cast<int>(std::floor((eb_min_x+i_shift*1.e-6_rt*dx_eb[0])*dxinv));,
-                                         vi_y = static_cast<int>(std::floor((eb_min_y+j_shift*1.e-6_rt*dx_eb[1])*dyinv));,
-                                         vi_z = static_cast<int>(std::floor((eb_min_z+k_shift*1.e-6_rt*dx_eb[2])*dzinv)));
+                            AMREX_D_TERM(vi_x = static_cast<int>(std::floor((eb_min_x+Real(i_shift)*1.e-6_rt*dx_eb[0])*dxinv));,
+                                         vi_y = static_cast<int>(std::floor((eb_min_y+Real(j_shift)*1.e-6_rt*dx_eb[1])*dyinv));,
+                                         vi_z = static_cast<int>(std::floor((eb_min_z+Real(k_shift)*1.e-6_rt*dx_eb[2])*dzinv)));
                             if (AMREX_D_TERM(vi_cx == vi_x, && vi_cy == vi_y, && vi_cz == vi_z)) {
                                 min_pt_valid = true;
                                 goto after_loops;

--- a/Src/FFT/AMReX_FFT_Poisson.H
+++ b/Src/FFT/AMReX_FFT_Poisson.H
@@ -344,9 +344,9 @@ void Poisson<MF>::solve (MF& a_soln, MF const& a_rhs)
     auto f = [=] AMREX_GPU_DEVICE (int i, int j, int k, auto& spectral_data)
     {
         amrex::ignore_unused(j,k);
-        AMREX_D_TERM(T a = fac[0]*(i+offset[0]);,
-                     T b = fac[1]*(j+offset[1]);,
-                     T c = fac[2]*(k+offset[2]));
+        AMREX_D_TERM(T a = fac[0]*(T(i)+offset[0]);,
+                     T b = fac[1]*(T(j)+offset[1]);,
+                     T c = fac[2]*(T(k)+offset[2]));
         T k2 = AMREX_D_TERM(dxfac[0]*(std::cos(a)-T(1)),
                            +dxfac[1]*(std::cos(b)-T(1)),
                            +dxfac[2]*(std::cos(c)-T(1)));
@@ -412,9 +412,9 @@ void PoissonOpenBC<MF>::define_doit ()
         for (int gx = 0; gx < 2; ++gx) {
         for (int gy = 0; gy < 2; ++gy) {
         for (int gz = 0; gz < 2; ++gz) {
-            auto xg = x + 2*gx*gfac*dx;
-            auto yg = y + 2*gy*gfac*dy;
-            auto zg = z + 2*gz*gfac*dz;
+            auto xg = x + T(2*gx)*gfac*dx;
+            auto yg = y + T(2*gy)*gfac*dy;
+            auto zg = z + T(2*gz)*gfac*dz;
             r += T(1)/std::sqrt(xg*xg+yg*yg+zg*zg);
         }}}
         return fac * r;
@@ -685,8 +685,8 @@ void PoissonHybrid<MF>::solve_z (FA& spmf, TRIA const& tria, TRIC const& tric)
             auto const& box = mfi.validbox();
             amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                T a = facx*(i+offset[0]);
-                T b = facy*(j+offset[1]);
+                T a = facx*(T(i)+offset[0]);
+                T b = facy*(T(j)+offset[1]);
                 T k2 = dxfac * (std::cos(a)-T(1))
                     +  dyfac * (std::cos(b)-T(1));
                 if (k2 != T(0)) {
@@ -725,8 +725,8 @@ void PoissonHybrid<MF>::solve_z (FA& spmf, TRIA const& tria, TRIC const& tric)
 
             amrex::ParallelFor(xybox, [=] AMREX_GPU_DEVICE (int i, int j, int)
             {
-                T a = facx*(i+offset[0]);
-                T b = facy*(j+offset[1]);
+                T a = facx*(T(i)+offset[0]);
+                T b = facy*(T(j)+offset[1]);
                 T k2 = dxfac * (std::cos(a)-T(1))
                     +  dyfac * (std::cos(b)-T(1));
 
@@ -788,8 +788,8 @@ void PoissonHybrid<MF>::solve_z (FA& spmf, TRIA const& tria, TRIC const& tric)
 
             amrex::LoopOnCpu(xybox, [&] (int i, int j, int)
             {
-                T a = facx*(i+offset[0]);
-                T b = facy*(j+offset[1]);
+                T a = facx*(T(i)+offset[0]);
+                T b = facy*(T(j)+offset[1]);
                 T k2 = dxfac * (std::cos(a)-T(1))
                     +  dyfac * (std::cos(b)-T(1));
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLALap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLALap_2D_K.H
@@ -48,9 +48,9 @@ void mlalap_adotx_m (Box const& box, Array4<RT> const& y,
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                RT rel = probxlo + i*dx;
-                RT rer = probxlo +(i+1)*dx;
-                RT rc = probxlo + (i+RT(0.5))*dx;
+                RT rel = probxlo + RT(i)*dx;
+                RT rer = probxlo + RT(i+1)*dx;
+                RT rc = probxlo + (RT(i)+RT(0.5))*dx;
                 y(i,j,0,n) = alpha*a(i,j,0,n)*x(i,j,0,n)*rc
                     - dhx * (rer*(x(i+1,j,0,n) - x(i  ,j,0,n))
                            - rel*(x(i  ,j,0,n) - x(i-1,j,0,n)))
@@ -101,9 +101,9 @@ void mlalap_normalize_m (Box const& box, Array4<RT> const& x,
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                RT rel = probxlo + i*dx;
-                RT rer = probxlo +(i+1)*dx;
-                RT rc = probxlo + (i+RT(0.5))*dx;
+                RT rel = probxlo + RT(i)*dx;
+                RT rer = probxlo + RT(i+1)*dx;
+                RT rc = probxlo + (RT(i)+RT(0.5))*dx;
                 x(i,j,0,n) /= alpha*a(i,j,0,n)*rc
                     + dhx*(rel+rer) + dhy*(rc*RT(2.0));
             }
@@ -142,7 +142,7 @@ void mlalap_flux_x_m (Box const& box, Array4<RT> const& fx,
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                RT re = probxlo + i*dx;
+                RT re = probxlo + RT(i)*dx;
                 fx(i,j,0,n) = -fac*re*(sol(i,j,0,n)-sol(i-1,j,0,n));
             }
         }
@@ -179,10 +179,10 @@ void mlalap_flux_xface_m (Box const& box, Array4<RT> const& fx,
     for (int n = 0; n < ncomp; ++n) {
         for     (int j = lo.y; j <= hi.y; ++j) {
             int i = lo.x;
-            RT re = probxlo + i*dx;
+            RT re = probxlo + RT(i)*dx;
             fx(i,j,0,n) = -fac*re*(sol(i,j,0,n)-sol(i-1,j,0,n));
             i += xlen;
-            re = probxlo + i*dx;
+            re = probxlo + RT(i)*dx;
             fx(i,j,0,n) = -fac*re*(sol(i,j,0,n)-sol(i-1,j,0,n));
         }
     }
@@ -219,7 +219,7 @@ void mlalap_flux_y_m (Box const& box, Array4<RT> const& fy,
         for     (int j = lo.y; j <= hi.y; ++j) {
             AMREX_PRAGMA_SIMD
             for (int i = lo.x; i <= hi.x; ++i) {
-                RT rc = probxlo + (i+RT(0.5))*dx;
+                RT rc = probxlo + (RT(i)+RT(0.5))*dx;
                 fy(i,j,0,n) = -fac*rc*(sol(i,j,0,n)-sol(i,j-1,0,n));
             }
         }
@@ -261,13 +261,13 @@ void mlalap_flux_yface_m (Box const& box, Array4<RT> const& fy,
         int j = lo.y;
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            RT rc = probxlo + (i+RT(0.5))*dx;
+            RT rc = probxlo + (RT(i)+RT(0.5))*dx;
             fy(i,j,0,n) = -fac*rc*(sol(i,j,0,n)-sol(i,j-1,0,n));
         }
         j += ylen;
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            RT rc = probxlo + (i+RT(0.5))*dx;
+            RT rc = probxlo + (RT(i)+RT(0.5))*dx;
             fy(i,j,0,n) = -fac*rc*(sol(i,j,0,n)-sol(i,j-1,0,n));
         }
     }
@@ -349,9 +349,9 @@ void mlalap_gsrb_m (Box const& box, Array4<RT> const& phi,
                     RT cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
                         ? f3(i,vhi.y,0,n) : RT(0.0);
 
-                    RT rel = probxlo + i*dx;
-                    RT rer = probxlo +(i+1)*dx;
-                    RT rc = probxlo + (i+RT(0.5))*dx;
+                    RT rel = probxlo + RT(i)*dx;
+                    RT rer = probxlo + RT(i+1)*dx;
+                    RT rc = probxlo + (RT(i)+RT(0.5))*dx;
 
                     RT delta = dhx*(rel*cf0 + rer*cf2) + dhy*rc*(cf1 + cf3);
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLCellLinOp.H
@@ -1799,13 +1799,13 @@ MLCellLinOpT<MF>::applyMetricTerm (int amrlev, int mglev, MF& rhs) const
         if (cc) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                RT rc = probxlo + (i+RT(0.5))*dx;
+                RT rc = probxlo + (RT(i)+RT(0.5))*dx;
                 rhsarr(i,j,k,n) *= rc*rc;
             });
         } else {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                RT re = probxlo + i*dx;
+                RT re = probxlo + RT(i)*dx;
                 rhsarr(i,j,k,n) *= re*re;
             });
         }
@@ -1813,13 +1813,13 @@ MLCellLinOpT<MF>::applyMetricTerm (int amrlev, int mglev, MF& rhs) const
         if (cc) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                RT rc = probxlo + (i+RT(0.5))*dx;
+                RT rc = probxlo + (RT(i)+RT(0.5))*dx;
                 rhsarr(i,j,k,n) *= rc;
             });
         } else {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                RT re = probxlo + i*dx;
+                RT re = probxlo + RT(i)*dx;
                 rhsarr(i,j,k,n) *= re;
             });
         }
@@ -1855,13 +1855,13 @@ MLCellLinOpT<MF>::unapplyMetricTerm (int amrlev, int mglev, MF& rhs) const
         if (cc) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                RT rcinv = RT(1.0)/(probxlo + (i+RT(0.5))*dx);
+                RT rcinv = RT(1.0)/(probxlo + (RT(i)+RT(0.5))*dx);
                 rhsarr(i,j,k,n) *= rcinv*rcinv;
             });
         } else {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                RT re = probxlo + i*dx;
+                RT re = probxlo + RT(i)*dx;
                 RT reinv = (re==RT(0.0)) ? RT(0.0) : RT(1.)/re;
                 rhsarr(i,j,k,n) *= reinv*reinv;
             });
@@ -1870,13 +1870,13 @@ MLCellLinOpT<MF>::unapplyMetricTerm (int amrlev, int mglev, MF& rhs) const
         if (cc) {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                RT rcinv = RT(1.0)/(probxlo + (i+RT(0.5))*dx);
+                RT rcinv = RT(1.0)/(probxlo + (RT(i)+RT(0.5))*dx);
                 rhsarr(i,j,k,n) *= rcinv;
             });
         } else {
             AMREX_HOST_DEVICE_PARALLEL_FOR_4D ( tbx, ncomp, i, j, k, n,
             {
-                RT re = probxlo + i*dx;
+                RT re = probxlo + RT(i)*dx;
                 RT reinv = (re==RT(0.0)) ? RT(0.0) : RT(1.)/re;
                 rhsarr(i,j,k,n) *= reinv;
             });

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.H
@@ -254,9 +254,9 @@ void MLEBNodeFDLaplacian::setEBDirichlet (F const& f)
                     AMREX_HOST_DEVICE_FOR_3D(ndbx, i, j, k,
                     {
                         if (lstarr(i,j,k) >= Real(0.0)) {
-                            phi(i,j,k) = f(AMREX_D_DECL(problo[0]+i*cellsize[0],
-                                                        problo[1]+j*cellsize[1],
-                                                        problo[2]+k*cellsize[2]));
+                            phi(i,j,k) = f(AMREX_D_DECL(problo[0]+Real(i)*cellsize[0],
+                                                        problo[1]+Real(j)*cellsize[1],
+                                                        problo[2]+Real(k)*cellsize[2]));
                         }
                     });
                 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBTensor_2D_K.H
@@ -307,8 +307,8 @@ void mlebtensor_cross_terms (Box const& box, Array4<Real> const& Ax,
                     int ii = i - isx;
                     int jj = j - isy;
 
-                    gx *= isx;
-                    gy *= isy;
+                    gx *= Real(isx);
+                    gy *= Real(isy);
                     Real gxy = gx*gy;
                     Real oneggg = Real(1.0)+gx+gy+gxy;
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLLinOp_K.H
@@ -985,7 +985,7 @@ void mllinop_apply_innu_ylo_m (int i, int j, int k,
                                T fac, T xlo, T dx, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
-        T b = xlo + (i+T(0.5))*dx;
+        T b = xlo + (T(i)+T(0.5))*dx;
         rhs(i,j+1,k,icomp) -= fac*b*bcval(i,j,k,icomp);
     }
 }
@@ -1016,7 +1016,7 @@ void mllinop_apply_innu_yhi_m (int i, int j, int k,
                                T fac, T xlo, T dx, int icomp) noexcept
 {
     if (bct == AMREX_LO_NEUMANN && mask(i,j,k) == 2) {
-        T b = xlo + (i+T(0.5))*dx;
+        T b = xlo + (T(i)+T(0.5))*dx;
         rhs(i,j-1,k,icomp) += fac*b*bcval(i,j,k,icomp);
     }
 }

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLap_2D_K.H
@@ -1962,7 +1962,7 @@ void add_eb_flow_contribution (int i, int j, int, Array4<Real> const& rhs,
 {
     using namespace nodelap_detail;
 
-    Real fac_eb = 0.25 *dxinv[0];
+    Real fac_eb = Real(0.25) * dxinv[0];
 
     if (!msk(i,j,0)) {
         rhs(i,j,0) += fac_eb*(

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp_2D_K.H
@@ -143,9 +143,9 @@ void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
         const auto ndhi = amrex::ubound(fdom);
         Real tmp = Real(0.0);
         for (int joff = -rr+1; joff <= rr-1; ++joff) {
-            Real wy = rr - std::abs(joff);
+            Real wy = rr - Real(std::abs(joff));
             for (int ioff = -rr+1; ioff <= rr-1; ++ioff) {
-                Real wx = rr - std::abs(ioff);
+                Real wx = rr - Real(std::abs(ioff));
                 int itmp = ii + ioff;
                 int jtmp = jj + joff;
                 if ((itmp < ndlo.x && (bclo[0] == LinOpBCType::Neumann ||

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp_3D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLinOp_3D_K.H
@@ -551,11 +551,11 @@ void mlndlap_restriction (int i, int j, int k, Array4<Real> const& crse,
         const auto ndhi = amrex::ubound(fdom);
         Real tmp = Real(0.0);
         for (int koff = -rr+1; koff <= rr-1; ++koff) {
-            Real wz = rr - std::abs(koff);
+            Real wz = rr - Real(std::abs(koff));
             for (int joff = -rr+1; joff <= rr-1; ++joff) {
-                Real wy = rr - std::abs(joff);
+                Real wy = rr - Real(std::abs(joff));
                 for (int ioff = -rr+1; ioff <= rr-1; ++ioff) {
-                    Real wx = rr - std::abs(ioff);
+                    Real wx = rr - Real(std::abs(ioff));
                     int itmp = ii + ioff;
                     int jtmp = jj + joff;
                     int ktmp = kk + koff;

--- a/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
+++ b/Src/LinearSolvers/MLMG/AMReX_MLPoisson_2D_K.H
@@ -39,9 +39,9 @@ void mlpoisson_adotx_m (int i, int j, Array4<T> const& y,
                         Array4<T const> const& x,
                         T dhx, T dhy, T dx, T probxlo) noexcept
 {
-    T rel = probxlo + i*dx;
-    T rer = probxlo +(i+1)*dx;
-    T rc = probxlo + (i+T(0.5))*dx;
+    T rel = probxlo + T(i)*dx;
+    T rer = probxlo + T(i+1)*dx;
+    T rc = probxlo + (T(i)+T(0.5))*dx;
     y(i,j,0) = dhx * (rel*x(i-1,j,0) - (rel+rer)*x(i,j,0) + rer*x(i+1,j,0))
         +      dhy * rc *(x(i,j-1,0) -  T(2.)*x(i,j,0) +     x(i,j+1,0));
 }
@@ -74,7 +74,7 @@ void mlpoisson_flux_x_m (Box const& box, Array4<T> const& fx,
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            T re = probxlo + i*dx;
+            T re = probxlo + T(i)*dx;
             fx(i,j,0) = dxinv*re*(sol(i,j,0)-sol(i-1,j,0));
         }
     }
@@ -107,10 +107,10 @@ void mlpoisson_flux_xface_m (Box const& box, Array4<T> const& fx,
 
     for     (int j = lo.y; j <= hi.y; ++j) {
         int i = lo.x;
-        T re = probxlo + i*dx;
+        T re = probxlo + T(i)*dx;
         fx(i,j,0) = dxinv*re*(sol(i,j,0)-sol(i-1,j,0));
         i += xlen;
-        re = probxlo + i*dx;
+        re = probxlo + T(i)*dx;
         fx(i,j,0) = dxinv*re*(sol(i,j,0)-sol(i-1,j,0));
     }
 }
@@ -143,7 +143,7 @@ void mlpoisson_flux_y_m (Box const& box, Array4<T> const& fy,
     for     (int j = lo.y; j <= hi.y; ++j) {
         AMREX_PRAGMA_SIMD
         for (int i = lo.x; i <= hi.x; ++i) {
-            T rc = probxlo + (i+T(0.5))*dx;
+            T rc = probxlo + (T(i)+T(0.5))*dx;
             fy(i,j,0) = dyinv*rc*(sol(i,j,0)-sol(i,j-1,0));
         }
     }
@@ -181,13 +181,13 @@ void mlpoisson_flux_yface_m (Box const& box, Array4<T> const& fy,
     int j = lo.y;
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        T rc = probxlo + (i+T(0.5))*dx;
+        T rc = probxlo + (T(i)+T(0.5))*dx;
         fy(i,j,0) = dyinv*rc*(sol(i,j,0)-sol(i,j-1,0));
     }
     j += ylen;
     AMREX_PRAGMA_SIMD
     for (int i = lo.x; i <= hi.x; ++i) {
-        T rc = probxlo + (i+T(0.5))*dx;
+        T rc = probxlo + (T(i)+T(0.5))*dx;
         fy(i,j,0) = dyinv*rc*(sol(i,j,0)-sol(i,j-1,0));
     }
 }
@@ -289,9 +289,9 @@ void mlpoisson_gsrb_m (int i, int j, int, Array4<T> const& phi, Array4<T const> 
         T cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
             ? f3(i,vhi.y,0) : T(0.0);
 
-        T rel = probxlo + i*dx;
-        T rer = probxlo +(i+1)*dx;
-        T rc = probxlo + (i+T(0.5))*dx;
+        T rel = probxlo + T(i)*dx;
+        T rer = probxlo + T(i+1)*dx;
+        T rc = probxlo + (T(i)+T(0.5))*dx;
 
         T gamma = -dhx*(rel+rer) - T(2.0)*dhy*rc;
 
@@ -390,9 +390,9 @@ void mlpoisson_jacobi_m (int i, int j, int, Array4<T> const& phi, Array4<T const
     T cf3 = (j == vhi.y && m3(i,vhi.y+1,0) > 0)
         ? f3(i,vhi.y,0) : T(0.0);
 
-    T rel = probxlo + i*dx;
-    T rer = probxlo +(i+1)*dx;
-    T rc = probxlo + (i+T(0.5))*dx;
+    T rel = probxlo + T(i)*dx;
+    T rer = probxlo + T(i+1)*dx;
+    T rc = probxlo + (T(i)+T(0.5))*dx;
 
     T gamma = -dhx*(rel+rer) - T(2.0)*dhy*rc;
 
@@ -406,9 +406,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mlpoisson_normalize (int i, int j, int, Array4<T> const& x,
                           T dhx, T dhy, T dx, T probxlo) noexcept
 {
-    T rel = probxlo + i*dx;
-    T rer = probxlo +(i+1)*dx;
-    T rc = probxlo + (i+T(0.5))*dx;
+    T rel = probxlo + T(i)*dx;
+    T rer = probxlo + T(i+1)*dx;
+    T rc = probxlo + (T(i)+T(0.5))*dx;
     x(i,j,0) /= (-dhx*(rel+rer) - dhy*rc*T(2.0));
 }
 

--- a/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
+++ b/Src/LinearSolvers/OpenBC/AMReX_OpenBC.cpp
@@ -566,8 +566,8 @@ void OpenBCSolver::compute_moments (Gpu::DeviceVector<openbc::Moments>& moments)
                 for (int jj = 0; jj < m_coarsen_ratio; ++jj) {
                     Real charge = tag.gp(i, jlo+jb*m_coarsen_ratio+jj,
                                          klo+kb*m_coarsen_ratio+kk) * fac;
-                    Real yy = (jj-m_coarsen_ratio/2+0.5_rt)*dx[1]; // NOLINT
-                    Real zz = (kk-m_coarsen_ratio/2+0.5_rt)*dx[2]; // NOLINT
+                    Real yy = (Real(jj-m_coarsen_ratio/2)+0.5_rt)*dx[1]; // NOLINT
+                    Real zz = (Real(kk-m_coarsen_ratio/2)+0.5_rt)*dx[2]; // NOLINT
                     Real zpow = 1._rt;
                     int m = 0;
                     for (int q = 0; q <= openbc::M; ++q) {
@@ -608,8 +608,8 @@ void OpenBCSolver::compute_moments (Gpu::DeviceVector<openbc::Moments>& moments)
                 for (int ii = 0; ii < m_coarsen_ratio; ++ii) {
                     Real charge = tag.gp(ilo+ib*m_coarsen_ratio+ii, j,
                                          klo+kb*m_coarsen_ratio+kk) * fac;
-                    Real xx = (ii-m_coarsen_ratio/2+0.5_rt)*dx[0]; // NOLINT
-                    Real zz = (kk-m_coarsen_ratio/2+0.5_rt)*dx[2]; // NOLINT
+                    Real xx = (Real(ii-m_coarsen_ratio/2)+0.5_rt)*dx[0]; // NOLINT
+                    Real zz = (Real(kk-m_coarsen_ratio/2)+0.5_rt)*dx[2]; // NOLINT
                     Real zpow = 1._rt;
                     int m = 0;
                     for (int q = 0; q <= openbc::M; ++q) {
@@ -649,8 +649,8 @@ void OpenBCSolver::compute_moments (Gpu::DeviceVector<openbc::Moments>& moments)
                 for (int ii = 0; ii < m_coarsen_ratio; ++ii) {
                     Real charge = tag.gp(ilo+ib*m_coarsen_ratio+ii,
                                          jlo+jb*m_coarsen_ratio+jj, k) * fac;
-                    Real xx = (ii-m_coarsen_ratio/2+0.5_rt)*dx[0]; // NOLINT
-                    Real yy = (jj-m_coarsen_ratio/2+0.5_rt)*dx[1]; // NOLINT
+                    Real xx = (Real(ii-m_coarsen_ratio/2)+0.5_rt)*dx[0]; // NOLINT
+                    Real yy = (Real(jj-m_coarsen_ratio/2)+0.5_rt)*dx[1]; // NOLINT
                     Real ypow = 1._rt;
                     int m = 0;
                     for (int q = 0; q <= openbc::M; ++q) {

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -19,9 +19,9 @@ void applyNeighborPeriodicShift (T& value, int dir, const IntVect& periodic_shif
 {
     if (!periodicity.isPeriodic(dir)) { return; }
     if (periodic_shift[dir] < 0) {
-        value += prob_domain.length(dir);
+        value = static_cast<T>(value + prob_domain.length(dir));
     } else if (periodic_shift[dir] > 0) {
-        value -= prob_domain.length(dir);
+        value = static_cast<T>(value - prob_domain.length(dir));
     }
 }
 

--- a/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
+++ b/Src/Particle/AMReX_NeighborParticlesCPUImpl.H
@@ -19,9 +19,9 @@ void applyNeighborPeriodicShift (T& value, int dir, const IntVect& periodic_shif
 {
     if (!periodicity.isPeriodic(dir)) { return; }
     if (periodic_shift[dir] < 0) {
-        value += static_cast<T>(prob_domain.length(dir));
+        value += prob_domain.length(dir);
     } else if (periodic_shift[dir] > 0) {
-        value -= static_cast<T>(prob_domain.length(dir));
+        value -= prob_domain.length(dir);
     }
 }
 

--- a/Src/Particle/AMReX_NeighborParticlesI.H
+++ b/Src/Particle/AMReX_NeighborParticlesI.H
@@ -628,8 +628,8 @@ getNeighborTags (Vector<NeighborCopyTag>& tags, const P& p,
         const auto* plo = this->Geom(src_lev).ProbLo();
         bool is_interior = true;
         for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-            amrex::Real face_lo = plo[d] + tile_box.smallEnd(d) * dx[d];
-            amrex::Real face_hi = plo[d] + (tile_box.bigEnd(d) + 1) * dx[d];
+            amrex::Real face_lo = plo[d] + Real(tile_box.smallEnd(d)) * dx[d];
+            amrex::Real face_hi = plo[d] + Real(tile_box.bigEnd(d) + 1) * dx[d];
             if ((p.pos(d) - face_lo) < search_radius ||
                 (face_hi - p.pos(d)) < search_radius) {
                 is_interior = false;

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -685,9 +685,9 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
                         {
                             if (! is_per[idim]) { continue; }
                             if (pshift[idim] > 0) {
-                                pos[idim] += phi[idim] - plo[idim];
+                                pos[idim] += static_cast<ParticleReal>(phi[idim] - plo[idim]);
                             } else if (pshift[idim] < 0) {
-                                pos[idim] -= phi[idim] - plo[idim];
+                                pos[idim] -= static_cast<ParticleReal>(phi[idim] - plo[idim]);
                             }
                         }
                         amrex::Gpu::memcpy(&p_snd_buffer[pos_offset], &pos[0],
@@ -760,9 +760,9 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
                                 {
                                     if (! is_per[idim]) { continue; }
                                     if (pshift[idim] > 0) {
-                                        pos[idim] += phi[idim] - plo[idim];
+                                        pos[idim] += static_cast<ParticleReal>(phi[idim] - plo[idim]);
                                     } else if (pshift[idim] < 0) {
-                                        pos[idim] -= phi[idim] - plo[idim];
+                                        pos[idim] -= static_cast<ParticleReal>(phi[idim] - plo[idim]);
                                     }
                                 }
                                 amrex::Gpu::memcpy(&p_snd_buffer[pos_offset], &pos[0],

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -685,9 +685,9 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
                         {
                             if (! is_per[idim]) { continue; }
                             if (pshift[idim] > 0) {
-                                pos[idim] += phi[idim] - plo[idim];
+                                pos[idim] = static_cast<ParticleReal>(pos[idim] + (phi[idim] - plo[idim]));
                             } else if (pshift[idim] < 0) {
-                                pos[idim] -= phi[idim] - plo[idim];
+                                pos[idim] = static_cast<ParticleReal>(pos[idim] - (phi[idim] - plo[idim]));
                             }
                         }
                         amrex::Gpu::memcpy(&p_snd_buffer[pos_offset], &pos[0],
@@ -760,9 +760,9 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
                                 {
                                     if (! is_per[idim]) { continue; }
                                     if (pshift[idim] > 0) {
-                                        pos[idim] += phi[idim] - plo[idim];
+                                        pos[idim] = static_cast<ParticleReal>(pos[idim] + (phi[idim] - plo[idim]));
                                     } else if (pshift[idim] < 0) {
-                                        pos[idim] -= phi[idim] - plo[idim];
+                                        pos[idim] = static_cast<ParticleReal>(pos[idim] - (phi[idim] - plo[idim]));
                                     }
                                 }
                                 amrex::Gpu::memcpy(&p_snd_buffer[pos_offset], &pos[0],

--- a/Src/Particle/AMReX_ParticleCommunication.H
+++ b/Src/Particle/AMReX_ParticleCommunication.H
@@ -685,9 +685,9 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
                         {
                             if (! is_per[idim]) { continue; }
                             if (pshift[idim] > 0) {
-                                pos[idim] += static_cast<ParticleReal>(phi[idim] - plo[idim]);
+                                pos[idim] += phi[idim] - plo[idim];
                             } else if (pshift[idim] < 0) {
-                                pos[idim] -= static_cast<ParticleReal>(phi[idim] - plo[idim]);
+                                pos[idim] -= phi[idim] - plo[idim];
                             }
                         }
                         amrex::Gpu::memcpy(&p_snd_buffer[pos_offset], &pos[0],
@@ -760,9 +760,9 @@ void packBuffer (const PC& pc, const ParticleCopyOp& op, const ParticleCopyPlan&
                                 {
                                     if (! is_per[idim]) { continue; }
                                     if (pshift[idim] > 0) {
-                                        pos[idim] += static_cast<ParticleReal>(phi[idim] - plo[idim]);
+                                        pos[idim] += phi[idim] - plo[idim];
                                     } else if (pshift[idim] < 0) {
-                                        pos[idim] -= static_cast<ParticleReal>(phi[idim] - plo[idim]);
+                                        pos[idim] -= phi[idim] - plo[idim];
                                     }
                                 }
                                 amrex::Gpu::memcpy(&p_snd_buffer[pos_offset], &pos[0],

--- a/Src/Particle/AMReX_ParticleInit.H
+++ b/Src/Particle/AMReX_ParticleInit.H
@@ -1496,9 +1496,9 @@ InitOnePerCell (Real x_off, Real y_off, Real z_off, const ParticleInitData& pdat
         for (IntVect beg = grid.smallEnd(), end=grid.bigEnd(), cell = grid.smallEnd(); cell <= end; grid.next(cell))
         {
             // the real struct data
-            AMREX_D_TERM(p.pos(0) = static_cast<ParticleReal>(grid_box.lo(0) + (x_off + cell[0]-beg[0])*dx[0]);,
-                         p.pos(1) = static_cast<ParticleReal>(grid_box.lo(1) + (y_off + cell[1]-beg[1])*dx[1]);,
-                         p.pos(2) = static_cast<ParticleReal>(grid_box.lo(2) + (z_off + cell[2]-beg[2])*dx[2]););
+            AMREX_D_TERM(p.pos(0) = static_cast<ParticleReal>(grid_box.lo(0) + (x_off + Real(cell[0]-beg[0]))*dx[0]);,
+                         p.pos(1) = static_cast<ParticleReal>(grid_box.lo(1) + (y_off + Real(cell[1]-beg[1]))*dx[1]);,
+                         p.pos(2) = static_cast<ParticleReal>(grid_box.lo(2) + (z_off + Real(cell[2]-beg[2]))*dx[2]););
 
             for (int d = 0; d < AMREX_SPACEDIM; ++d) {
                 AMREX_ASSERT(p.pos(d) < grid_box.hi(d));

--- a/Src/Particle/AMReX_ParticleInterpolators.H
+++ b/Src/Particle/AMReX_ParticleInterpolators.H
@@ -194,7 +194,7 @@ struct Nearest : public Base<Nearest, int>
     {
         w = &weights[0];
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-            amrex::Real l = (p.pos(i) - plo[i]) * dxi[i] + 0.5;
+            amrex::Real l = (p.pos(i) - plo[i]) * dxi[i] + amrex::Real(0.5);
             index[i] = static_cast<int>(amrex::Math::floor(l));
             w[i] = 1;
         }
@@ -236,10 +236,10 @@ struct Linear : public Base<Linear, amrex::Real>
     {
         w = &weights[0];
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-            amrex::Real l = (p.pos(i) - plo[i]) * dxi[i] + 0.5;
+            amrex::Real l = (p.pos(i) - plo[i]) * dxi[i] + amrex::Real(0.5);
             index[i] = static_cast<int>(amrex::Math::floor(l)) - 1;
             amrex::Real lint = l - (index[i] + 1);
-            w[stencil_width*i + 0] = 1.-lint;
+            w[stencil_width*i + 0] = amrex::Real(1.)-lint;
             w[stencil_width*i + 1] = lint;
         }
         for (int i = AMREX_SPACEDIM; i < 3; ++i) {

--- a/Src/Particle/AMReX_ParticleInterpolators.H
+++ b/Src/Particle/AMReX_ParticleInterpolators.H
@@ -74,7 +74,8 @@ struct Base // NOLINT(bugprone-crtp-constructor-accessibility)
                         const auto val = w[0*stencil_width+ii] *
                                          w[1*stencil_width+jj] *
                                          w[2*stencil_width+kk] * pval;
-                        Gpu::Atomic::AddNoRet(&arr(index[0]+ii, index[1]+jj, index[2]+kk, ic+dst_comp), val);
+                        Gpu::Atomic::AddNoRet(&arr(index[0]+ii, index[1]+jj, index[2]+kk, ic+dst_comp),
+                                              static_cast<V>(val));
                     }
                 }
             }
@@ -193,8 +194,10 @@ struct Nearest : public Base<Nearest, int>
              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi)
     {
         w = &weights[0];
+        // Index arithmetic uses the wider of ParticleReal and Real.
+        using WT = decltype(p.pos(0) * plo[0]);
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-            amrex::Real l = (p.pos(i) - plo[i]) * dxi[i] + amrex::Real(0.5);
+            WT l = (p.pos(i) - plo[i]) * dxi[i] + WT(0.5);
             index[i] = static_cast<int>(amrex::Math::floor(l));
             w[i] = 1;
         }
@@ -235,12 +238,14 @@ struct Linear : public Base<Linear, amrex::Real>
             amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi)
     {
         w = &weights[0];
+        // Index arithmetic uses the wider of ParticleReal and Real.
+        using WT = decltype(p.pos(0) * plo[0]);
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-            amrex::Real l = (p.pos(i) - plo[i]) * dxi[i] + amrex::Real(0.5);
+            WT l = (p.pos(i) - plo[i]) * dxi[i] + WT(0.5);
             index[i] = static_cast<int>(amrex::Math::floor(l)) - 1;
-            amrex::Real lint = l - Real(index[i] + 1);
-            w[stencil_width*i + 0] = amrex::Real(1.)-lint;
-            w[stencil_width*i + 1] = lint;
+            WT lint = l - static_cast<WT>(index[i] + 1);
+            w[stencil_width*i + 0] = static_cast<amrex::Real>(WT(1.)-lint);
+            w[stencil_width*i + 1] = static_cast<amrex::Real>(lint);
         }
         for (int i = AMREX_SPACEDIM; i < 3; ++i) {
             index[i] = 0;

--- a/Src/Particle/AMReX_ParticleInterpolators.H
+++ b/Src/Particle/AMReX_ParticleInterpolators.H
@@ -194,8 +194,8 @@ struct Nearest : public Base<Nearest, int>
              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi)
     {
         w = &weights[0];
-        // Index arithmetic uses the wider of ParticleReal and Real.
-        using WT = decltype(p.pos(0) * plo[0]);
+        // Compute in the wider of Real and ParticleReal; round when storing.
+        using WT = amrex::ParticleMeshReal;
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
             WT l = (p.pos(i) - plo[i]) * dxi[i] + WT(0.5);
             index[i] = static_cast<int>(amrex::Math::floor(l));
@@ -221,7 +221,7 @@ struct Nearest : public Base<Nearest, int>
  *                    });
  *   \endcode
  */
-struct Linear : public Base<Linear, amrex::Real>
+struct Linear : public Base<Linear, amrex::ParticleMeshReal>
 {
     static constexpr int stencil_width = 2;
 
@@ -229,7 +229,7 @@ struct Linear : public Base<Linear, amrex::Real>
     static constexpr int ny = (AMREX_SPACEDIM >= 2) ? stencil_width - 1 : 0;
     static constexpr int nz = (AMREX_SPACEDIM >= 3) ? stencil_width - 1 : 0;
 
-    amrex::Real weights[3*stencil_width];
+    amrex::ParticleMeshReal weights[3*stencil_width];
 
     template <typename P>
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -238,19 +238,19 @@ struct Linear : public Base<Linear, amrex::Real>
             amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi)
     {
         w = &weights[0];
-        // Index arithmetic uses the wider of ParticleReal and Real.
-        using WT = decltype(p.pos(0) * plo[0]);
+        // Compute in the wider of Real and ParticleReal; round when storing.
+        using WT = amrex::ParticleMeshReal;
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
             WT l = (p.pos(i) - plo[i]) * dxi[i] + WT(0.5);
             index[i] = static_cast<int>(amrex::Math::floor(l)) - 1;
             WT lint = l - static_cast<WT>(index[i] + 1);
-            w[stencil_width*i + 0] = static_cast<amrex::Real>(WT(1.)-lint);
-            w[stencil_width*i + 1] = static_cast<amrex::Real>(lint);
+            w[stencil_width*i + 0] = WT(1.) - lint;
+            w[stencil_width*i + 1] = lint;
         }
         for (int i = AMREX_SPACEDIM; i < 3; ++i) {
             index[i] = 0;
-            w[stencil_width*i + 0] = 1.;
-            w[stencil_width*i + 1] = 0.;
+            w[stencil_width*i + 0] = amrex::ParticleMeshReal(1.);
+            w[stencil_width*i + 1] = amrex::ParticleMeshReal(0.);
         }
     }
 };

--- a/Src/Particle/AMReX_ParticleInterpolators.H
+++ b/Src/Particle/AMReX_ParticleInterpolators.H
@@ -112,7 +112,7 @@ struct Base // NOLINT(bugprone-crtp-constructor-accessibility)
      *                return arr(i, j, k, comp);  // no weighting
      *            },
      *            [=] AMREX_GPU_DEVICE (MyParticleContainer::ParticleType& part,
-     *                                  int comp, amrex::Real val)
+     *                                  int comp, auto val)
      *            {
      *                part.rdata(comp) += val;
      *            });
@@ -249,8 +249,8 @@ struct Linear : public Base<Linear, amrex::ParticleMeshReal>
         }
         for (int i = AMREX_SPACEDIM; i < 3; ++i) {
             index[i] = 0;
-            w[stencil_width*i + 0] = amrex::ParticleMeshReal(1.);
-            w[stencil_width*i + 1] = amrex::ParticleMeshReal(0.);
+            w[stencil_width*i + 0] = WT(1.);
+            w[stencil_width*i + 1] = WT(0.);
         }
     }
 };

--- a/Src/Particle/AMReX_ParticleInterpolators.H
+++ b/Src/Particle/AMReX_ParticleInterpolators.H
@@ -238,7 +238,7 @@ struct Linear : public Base<Linear, amrex::Real>
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
             amrex::Real l = (p.pos(i) - plo[i]) * dxi[i] + amrex::Real(0.5);
             index[i] = static_cast<int>(amrex::Math::floor(l)) - 1;
-            amrex::Real lint = l - (index[i] + 1);
+            amrex::Real lint = l - Real(index[i] + 1);
             w[stencil_width*i + 0] = amrex::Real(1.)-lint;
             w[stencil_width*i + 1] = lint;
         }

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -433,7 +433,7 @@ bool enforcePeriodic (P& p,
         if (! is_per[idim]) { continue; }
         if (p.pos(idim) > rhi[idim]) {
             while (p.pos(idim) > rhi[idim]) {
-                p.pos(idim) -= phi[idim] - plo[idim];
+                p.pos(idim) = static_cast<ParticleReal>(p.pos(idim) - (phi[idim] - plo[idim]));
             }
             // clamp to avoid precision issues;
             if (p.pos(idim) < rlo[idim]) {
@@ -443,7 +443,7 @@ bool enforcePeriodic (P& p,
         }
         else if (p.pos(idim) < rlo[idim]) {
             while (p.pos(idim) < rlo[idim]) {
-                p.pos(idim) += phi[idim] - plo[idim];
+                p.pos(idim) = static_cast<ParticleReal>(p.pos(idim) + (phi[idim] - plo[idim]));
             }
             // clamp to avoid precision issues;
             if (p.pos(idim) > rhi[idim]) {

--- a/Src/Particle/AMReX_ParticleUtil.H
+++ b/Src/Particle/AMReX_ParticleUtil.H
@@ -433,7 +433,7 @@ bool enforcePeriodic (P& p,
         if (! is_per[idim]) { continue; }
         if (p.pos(idim) > rhi[idim]) {
             while (p.pos(idim) > rhi[idim]) {
-                p.pos(idim) -= static_cast<ParticleReal>(phi[idim] - plo[idim]);
+                p.pos(idim) -= phi[idim] - plo[idim];
             }
             // clamp to avoid precision issues;
             if (p.pos(idim) < rlo[idim]) {
@@ -443,7 +443,7 @@ bool enforcePeriodic (P& p,
         }
         else if (p.pos(idim) < rlo[idim]) {
             while (p.pos(idim) < rlo[idim]) {
-                p.pos(idim) += static_cast<ParticleReal>(phi[idim] - plo[idim]);
+                p.pos(idim) += phi[idim] - plo[idim];
             }
             // clamp to avoid precision issues;
             if (p.pos(idim) > rhi[idim]) {

--- a/Src/Particle/AMReX_Particle_mod_K.H
+++ b/Src/Particle/AMReX_Particle_mod_K.H
@@ -20,14 +20,17 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
+    // Index arithmetic uses the wider of ParticleReal and Real.
+    using WT = decltype(p.pos(0) * plo[0]);
+
 #if (AMREX_SPACEDIM == 1)
-    amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] + Real(0.5);
+    WT lx = (p.pos(0) - plo[0]) * dxi[0] + WT(0.5);
 
     int i = static_cast<int>(amrex::Math::floor(lx));
 
-    amrex::Real xint = lx - static_cast<Real>(i);
+    WT xint = lx - static_cast<WT>(i);
 
-    amrex::Real sx[2] = {Real(1.0) - xint, xint};
+    WT sx[2] = {WT(1.0) - xint, xint};
 
     for (int ii = 0; ii <= 1; ++ii) {
         amrex::Gpu::Atomic::AddNoRet(&rho(i+ii-1, 0, 0, 0), static_cast<Real>(sx[ii]*p.rdata(0)));
@@ -40,17 +43,17 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
         }
     }
 #elif (AMREX_SPACEDIM == 2)
-    amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] + Real(0.5);
-    amrex::Real ly = (p.pos(1) - plo[1]) * dxi[1] + Real(0.5);
+    WT lx = (p.pos(0) - plo[0]) * dxi[0] + WT(0.5);
+    WT ly = (p.pos(1) - plo[1]) * dxi[1] + WT(0.5);
 
     int i = static_cast<int>(amrex::Math::floor(lx));
     int j = static_cast<int>(amrex::Math::floor(ly));
 
-    amrex::Real xint = lx - static_cast<Real>(i);
-    amrex::Real yint = ly - static_cast<Real>(j);
+    WT xint = lx - static_cast<WT>(i);
+    WT yint = ly - static_cast<WT>(j);
 
-    amrex::Real sx[2] = {Real(1.0) - xint, xint};
-    amrex::Real sy[2] = {Real(1.0) - yint, yint};
+    WT sx[2] = {WT(1.0) - xint, xint};
+    WT sy[2] = {WT(1.0) - yint, yint};
 
     for (int jj = 0; jj <= 1; ++jj) {
         for (int ii = 0; ii <= 1; ++ii) {
@@ -69,21 +72,21 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
     }
 
 #elif (AMREX_SPACEDIM == 3)
-    amrex::Real lx = (p.pos(0) - plo[0]) * dxi[0] + Real(0.5);
-    amrex::Real ly = (p.pos(1) - plo[1]) * dxi[1] + Real(0.5);
-    amrex::Real lz = (p.pos(2) - plo[2]) * dxi[2] + Real(0.5);
+    WT lx = (p.pos(0) - plo[0]) * dxi[0] + WT(0.5);
+    WT ly = (p.pos(1) - plo[1]) * dxi[1] + WT(0.5);
+    WT lz = (p.pos(2) - plo[2]) * dxi[2] + WT(0.5);
 
     int i = static_cast<int>(amrex::Math::floor(lx));
     int j = static_cast<int>(amrex::Math::floor(ly));
     int k = static_cast<int>(amrex::Math::floor(lz));
 
-    amrex::Real xint = lx - static_cast<Real>(i);
-    amrex::Real yint = ly - static_cast<Real>(j);
-    amrex::Real zint = lz - static_cast<Real>(k);
+    WT xint = lx - static_cast<WT>(i);
+    WT yint = ly - static_cast<WT>(j);
+    WT zint = lz - static_cast<WT>(k);
 
-    amrex::Real sx[] = {Real(1.0) - xint, xint};
-    amrex::Real sy[] = {Real(1.0) - yint, yint};
-    amrex::Real sz[] = {Real(1.0) - zint, zint};
+    WT sx[] = {WT(1.0) - xint, xint};
+    WT sy[] = {WT(1.0) - yint, yint};
+    WT sz[] = {WT(1.0) - zint, zint};
 
     for (int kk = 0; kk <= 1; ++kk) {
         for (int jj = 0; jj <= 1; ++jj) {
@@ -126,12 +129,15 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
+    // Index arithmetic uses the wider of ParticleReal and Real.
+    using WT = decltype(p.pos(0) * plo[0]);
+
 #if (AMREX_SPACEDIM == 1)
     amrex::Real factor = (pdxi[0]/dxi[0]);
 
-    amrex::Real lx = (p.pos(0) - plo[0] - Real(0.5)/pdxi[0]) * dxi[0];
+    WT lx = (p.pos(0) - plo[0] - Real(0.5)/pdxi[0]) * dxi[0];
 
-    amrex::Real hx = (p.pos(0) - plo[0] + Real(0.5)/pdxi[0]) * dxi[0];
+    WT hx = (p.pos(0) - plo[0] + Real(0.5)/pdxi[0]) * dxi[0];
 
     int lo_x = static_cast<int>(amrex::Math::floor(lx));
 
@@ -139,8 +145,8 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 
     for (int i = lo_x; i <= hi_x; ++i) {
         if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
-        amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
-        amrex::Real weight = wx*factor;
+        WT wx = amrex::min(hx - static_cast<WT>(i), WT(1.0)) - amrex::max(lx - static_cast<WT>(i), WT(0.0));
+        WT weight = wx*factor;
         amrex::Gpu::Atomic::AddNoRet(&rho(i, 0, 0, 0), static_cast<Real>(weight*p.rdata(0)));
     }
 
@@ -148,8 +154,8 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     {
         for (int i = lo_x; i <= hi_x; ++i) {
             if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
-            amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
-            amrex::Real weight = wx*factor;
+            WT wx = amrex::min(hx - static_cast<WT>(i), WT(1.0)) - amrex::max(lx - static_cast<WT>(i), WT(0.0));
+            WT weight = wx*factor;
             amrex::Gpu::Atomic::AddNoRet(&rho(i, 0, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
         }
     }
@@ -157,11 +163,11 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 #elif (AMREX_SPACEDIM == 2)
     amrex::Real factor = (pdxi[0]/dxi[0])*(pdxi[1]/dxi[1]);
 
-    amrex::Real lx = (p.pos(0) - plo[0] - Real(0.5)/pdxi[0]) * dxi[0];
-    amrex::Real ly = (p.pos(1) - plo[1] - Real(0.5)/pdxi[1]) * dxi[1];
+    WT lx = (p.pos(0) - plo[0] - Real(0.5)/pdxi[0]) * dxi[0];
+    WT ly = (p.pos(1) - plo[1] - Real(0.5)/pdxi[1]) * dxi[1];
 
-    amrex::Real hx = (p.pos(0) - plo[0] + Real(0.5)/pdxi[0]) * dxi[0];
-    amrex::Real hy = (p.pos(1) - plo[1] + Real(0.5)/pdxi[1]) * dxi[1];
+    WT hx = (p.pos(0) - plo[0] + Real(0.5)/pdxi[0]) * dxi[0];
+    WT hy = (p.pos(1) - plo[1] + Real(0.5)/pdxi[1]) * dxi[1];
 
     int lo_x = static_cast<int>(amrex::Math::floor(lx));
     int lo_y = static_cast<int>(amrex::Math::floor(ly));
@@ -171,11 +177,11 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 
     for (int j = lo_y; j <= hi_y; ++j) {
         if (j < rho.begin[1] || j >= rho.end[1]) { continue; }
-        amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
+        WT wy = amrex::min(hy - static_cast<WT>(j), WT(1.0)) - amrex::max(ly - static_cast<WT>(j), WT(0.0));
         for (int i = lo_x; i <= hi_x; ++i) {
             if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
-            amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
-            amrex::Real weight = wx*wy*factor;
+            WT wx = amrex::min(hx - static_cast<WT>(i), WT(1.0)) - amrex::max(lx - static_cast<WT>(i), WT(0.0));
+            WT weight = wx*wy*factor;
             amrex::Gpu::Atomic::AddNoRet(&rho(i, j, 0, 0), static_cast<Real>(weight*p.rdata(0)));
         }
     }
@@ -183,11 +189,11 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     for (int comp = 1; comp < nc; ++comp) {
         for (int j = lo_y; j <= hi_y; ++j) {
             if (j < rho.begin[1] || j >= rho.end[1]) { continue; }
-            amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
+            WT wy = amrex::min(hy - static_cast<WT>(j), WT(1.0)) - amrex::max(ly - static_cast<WT>(j), WT(0.0));
             for (int i = lo_x; i <= hi_x; ++i) {
                 if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
-                amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
-                amrex::Real weight = wx*wy*factor;
+                WT wx = amrex::min(hx - static_cast<WT>(i), WT(1.0)) - amrex::max(lx - static_cast<WT>(i), WT(0.0));
+                WT weight = wx*wy*factor;
                 amrex::Gpu::Atomic::AddNoRet(&rho(i, j, 0, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
             }
         }
@@ -196,13 +202,13 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 #elif (AMREX_SPACEDIM == 3)
     amrex::Real factor = (pdxi[0]/dxi[0])*(pdxi[1]/dxi[1])*(pdxi[2]/dxi[2]);
 
-    amrex::Real lx = (p.pos(0) - plo[0] - Real(0.5)/pdxi[0]) * dxi[0];
-    amrex::Real ly = (p.pos(1) - plo[1] - Real(0.5)/pdxi[1]) * dxi[1];
-    amrex::Real lz = (p.pos(2) - plo[2] - Real(0.5)/pdxi[2]) * dxi[2];
+    WT lx = (p.pos(0) - plo[0] - Real(0.5)/pdxi[0]) * dxi[0];
+    WT ly = (p.pos(1) - plo[1] - Real(0.5)/pdxi[1]) * dxi[1];
+    WT lz = (p.pos(2) - plo[2] - Real(0.5)/pdxi[2]) * dxi[2];
 
-    amrex::Real hx = (p.pos(0) - plo[0] + Real(0.5)/pdxi[0]) * dxi[0];
-    amrex::Real hy = (p.pos(1) - plo[1] + Real(0.5)/pdxi[1]) * dxi[1];
-    amrex::Real hz = (p.pos(2) - plo[2] + Real(0.5)/pdxi[2]) * dxi[2];
+    WT hx = (p.pos(0) - plo[0] + Real(0.5)/pdxi[0]) * dxi[0];
+    WT hy = (p.pos(1) - plo[1] + Real(0.5)/pdxi[1]) * dxi[1];
+    WT hz = (p.pos(2) - plo[2] + Real(0.5)/pdxi[2]) * dxi[2];
 
     int lo_x = static_cast<int>(amrex::Math::floor(lx));
     int lo_y = static_cast<int>(amrex::Math::floor(ly));
@@ -214,14 +220,14 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 
     for (int k = lo_z; k <= hi_z; ++k) {
         if (k < rho.begin[2] || k >= rho.end[2]) { continue; }
-        amrex::Real wz = amrex::min(hz - static_cast<Real>(k), amrex::Real(1.0)) - amrex::max(lz - static_cast<Real>(k), amrex::Real(0.0));
+        WT wz = amrex::min(hz - static_cast<WT>(k), WT(1.0)) - amrex::max(lz - static_cast<WT>(k), WT(0.0));
         for (int j = lo_y; j <= hi_y; ++j) {
             if (j < rho.begin[1] || j >= rho.end[1]) { continue; }
-            amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
+            WT wy = amrex::min(hy - static_cast<WT>(j), WT(1.0)) - amrex::max(ly - static_cast<WT>(j), WT(0.0));
             for (int i = lo_x; i <= hi_x; ++i) {
                 if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
-                amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
-                amrex::Real weight = wx*wy*wz*factor;
+                WT wx = amrex::min(hx - static_cast<WT>(i), WT(1.0)) - amrex::max(lx - static_cast<WT>(i), WT(0.0));
+                WT weight = wx*wy*wz*factor;
                 amrex::Gpu::Atomic::AddNoRet(&rho(i, j, k, 0), static_cast<Real>(weight*p.rdata(0)));
             }
         }
@@ -230,14 +236,14 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     for (int comp = 1; comp < nc; ++comp) {
         for (int k = lo_z; k <= hi_z; ++k) {
             if (k < rho.begin[2] || k >= rho.end[2]) { continue; }
-            amrex::Real wz = amrex::min(hz - static_cast<Real>(k), amrex::Real(1.0)) - amrex::max(lz - static_cast<Real>(k), amrex::Real(0.0));
+            WT wz = amrex::min(hz - static_cast<WT>(k), WT(1.0)) - amrex::max(lz - static_cast<WT>(k), WT(0.0));
             for (int j = lo_y; j <= hi_y; ++j) {
                 if (j < rho.begin[1] || j >= rho.end[1]) { continue; }
-                amrex::Real wy = amrex::min(hy - static_cast<Real>(j), amrex::Real(1.0)) - amrex::max(ly - static_cast<Real>(j), amrex::Real(0.0));
+                WT wy = amrex::min(hy - static_cast<WT>(j), WT(1.0)) - amrex::max(ly - static_cast<WT>(j), WT(0.0));
                 for (int i = lo_x; i <= hi_x; ++i) {
                     if (i < rho.begin[0] || i >= rho.end[0]) { continue; }
-                    amrex::Real wx = amrex::min(hx - static_cast<Real>(i), amrex::Real(1.0)) - amrex::max(lx - static_cast<Real>(i), amrex::Real(0.0));
-                    amrex::Real weight = wx*wy*wz*factor;
+                    WT wx = amrex::min(hx - static_cast<WT>(i), WT(1.0)) - amrex::max(lx - static_cast<WT>(i), WT(0.0));
+                    WT weight = wx*wy*wz*factor;
                     amrex::Gpu::Atomic::AddNoRet(&rho(i, j, k, comp), static_cast<Real>(weight*p.rdata(0)*p.rdata(comp)));
                 }
             }

--- a/Src/Particle/AMReX_Particle_mod_K.H
+++ b/Src/Particle/AMReX_Particle_mod_K.H
@@ -20,8 +20,8 @@ void amrex_deposit_cic (P const& p, int nc, amrex::Array4<amrex::Real> const& rh
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
-    // Index arithmetic uses the wider of ParticleReal and Real.
-    using WT = decltype(p.pos(0) * plo[0]);
+    // Compute in the wider of Real and ParticleReal; round when adding to the mesh.
+    using WT = amrex::ParticleMeshReal;
 
 #if (AMREX_SPACEDIM == 1)
     WT lx = (p.pos(0) - plo[0]) * dxi[0] + WT(0.5);
@@ -129,15 +129,15 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
 
-    // Index arithmetic uses the wider of ParticleReal and Real.
-    using WT = decltype(p.pos(0) * plo[0]);
+    // Compute in the wider of Real and ParticleReal; round when adding to the mesh.
+    using WT = amrex::ParticleMeshReal;
 
 #if (AMREX_SPACEDIM == 1)
-    amrex::Real factor = (pdxi[0]/dxi[0]);
+    WT factor = WT(pdxi[0])/dxi[0];
 
-    WT lx = (p.pos(0) - plo[0] - Real(0.5)/pdxi[0]) * dxi[0];
+    WT lx = (p.pos(0) - plo[0] - WT(0.5)/pdxi[0]) * dxi[0];
 
-    WT hx = (p.pos(0) - plo[0] + Real(0.5)/pdxi[0]) * dxi[0];
+    WT hx = (p.pos(0) - plo[0] + WT(0.5)/pdxi[0]) * dxi[0];
 
     int lo_x = static_cast<int>(amrex::Math::floor(lx));
 
@@ -161,13 +161,13 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     }
 
 #elif (AMREX_SPACEDIM == 2)
-    amrex::Real factor = (pdxi[0]/dxi[0])*(pdxi[1]/dxi[1]);
+    WT factor = (WT(pdxi[0])/dxi[0])*(WT(pdxi[1])/dxi[1]);
 
-    WT lx = (p.pos(0) - plo[0] - Real(0.5)/pdxi[0]) * dxi[0];
-    WT ly = (p.pos(1) - plo[1] - Real(0.5)/pdxi[1]) * dxi[1];
+    WT lx = (p.pos(0) - plo[0] - WT(0.5)/pdxi[0]) * dxi[0];
+    WT ly = (p.pos(1) - plo[1] - WT(0.5)/pdxi[1]) * dxi[1];
 
-    WT hx = (p.pos(0) - plo[0] + Real(0.5)/pdxi[0]) * dxi[0];
-    WT hy = (p.pos(1) - plo[1] + Real(0.5)/pdxi[1]) * dxi[1];
+    WT hx = (p.pos(0) - plo[0] + WT(0.5)/pdxi[0]) * dxi[0];
+    WT hy = (p.pos(1) - plo[1] + WT(0.5)/pdxi[1]) * dxi[1];
 
     int lo_x = static_cast<int>(amrex::Math::floor(lx));
     int lo_y = static_cast<int>(amrex::Math::floor(ly));
@@ -200,15 +200,15 @@ void amrex_deposit_particle_dx_cic (P const& p, int nc, amrex::Array4<amrex::Rea
     }
 
 #elif (AMREX_SPACEDIM == 3)
-    amrex::Real factor = (pdxi[0]/dxi[0])*(pdxi[1]/dxi[1])*(pdxi[2]/dxi[2]);
+    WT factor = (WT(pdxi[0])/dxi[0])*(WT(pdxi[1])/dxi[1])*(WT(pdxi[2])/dxi[2]);
 
-    WT lx = (p.pos(0) - plo[0] - Real(0.5)/pdxi[0]) * dxi[0];
-    WT ly = (p.pos(1) - plo[1] - Real(0.5)/pdxi[1]) * dxi[1];
-    WT lz = (p.pos(2) - plo[2] - Real(0.5)/pdxi[2]) * dxi[2];
+    WT lx = (p.pos(0) - plo[0] - WT(0.5)/pdxi[0]) * dxi[0];
+    WT ly = (p.pos(1) - plo[1] - WT(0.5)/pdxi[1]) * dxi[1];
+    WT lz = (p.pos(2) - plo[2] - WT(0.5)/pdxi[2]) * dxi[2];
 
-    WT hx = (p.pos(0) - plo[0] + Real(0.5)/pdxi[0]) * dxi[0];
-    WT hy = (p.pos(1) - plo[1] + Real(0.5)/pdxi[1]) * dxi[1];
-    WT hz = (p.pos(2) - plo[2] + Real(0.5)/pdxi[2]) * dxi[2];
+    WT hx = (p.pos(0) - plo[0] + WT(0.5)/pdxi[0]) * dxi[0];
+    WT hy = (p.pos(1) - plo[1] + WT(0.5)/pdxi[1]) * dxi[1];
+    WT hz = (p.pos(2) - plo[2] + WT(0.5)/pdxi[2]) * dxi[2];
 
     int lo_x = static_cast<int>(amrex::Math::floor(lx));
     int lo_y = static_cast<int>(amrex::Math::floor(ly));

--- a/Tests/Algebra/GMRES/main.cpp
+++ b/Tests/Algebra/GMRES/main.cpp
@@ -39,8 +39,8 @@ int main (int argc, char* argv[])
                 auto phixp = Math::powi<5>(std::sin(x+dx));
                 rhs[lrow] = a*phi0 + (Real(2)*phi0-phixm-phixp) / (dx*dx);
 #elif (AMREX_SPACEDIM == 2)
-                auto x = (cell[0]+Real(0.5))*dx;
-                auto y = (cell[1]+Real(0.5))*dx;
+                auto x = (Real(cell[0])+Real(0.5))*dx;
+                auto y = (Real(cell[1])+Real(0.5))*dx;
                 auto phi0 = Math::powi<5>(std::sin(x)*std::sin(y));
                 auto phixm = Math::powi<5>(std::sin(x-dx)*std::sin(y));
                 auto phixp = Math::powi<5>(std::sin(x+dx)*std::sin(y));
@@ -48,9 +48,9 @@ int main (int argc, char* argv[])
                 auto phiyp = Math::powi<5>(std::sin(x)*std::sin(y+dx));
                 rhs[lrow] = a*phi0 + (Real(4)*phi0-phixm-phixp-phiym-phiyp) / (dx*dx);
 #else
-                auto x = (cell[0]+Real(0.5))*dx;
-                auto y = (cell[1]+Real(0.5))*dx;
-                auto z = (cell[2]+Real(0.5))*dx;
+                auto x = (Real(cell[0])+Real(0.5))*dx;
+                auto y = (Real(cell[1])+Real(0.5))*dx;
+                auto z = (Real(cell[2])+Real(0.5))*dx;
                 auto phi0 = Math::powi<5>(std::sin(x)*std::sin(y)*std::sin(z));
                 auto phixm = Math::powi<5>(std::sin(x-dx)*std::sin(y)*std::sin(z));
                 auto phixp = Math::powi<5>(std::sin(x+dx)*std::sin(y)*std::sin(z));

--- a/Tests/Algebra/SpMV/main.cpp
+++ b/Tests/Algebra/SpMV/main.cpp
@@ -54,7 +54,11 @@ int main(int argc, char *argv[]) {
     });
 
 
+    // GMRES relative residual target.
     auto eps = (sizeof(Real) == 4) ? Real(1.e-5) : Real(1.e-12);
+    // The conditioning of the matrix amplifies the residual, so the error in
+    // the solution needs a looser bound than the residual target itself.
+    auto solve_eps = (sizeof(Real) == 4) ? Real(1.e-4) : Real(1.e-12);
     amrex::SpMV(xvec, mat, exact);
 
     // Check the multiplication
@@ -77,7 +81,7 @@ int main(int argc, char *argv[]) {
     amrex::Print() << " Max norm error: multiplication = "
                    << multiplicationError << ", solve = " << solveError << "\n\n";
 
-    AMREX_ALWAYS_ASSERT(multiplicationError < eps && solveError < eps);
+    AMREX_ALWAYS_ASSERT(multiplicationError < eps && solveError < solve_eps);
   }
 
   // restriction

--- a/Tests/Amr/Advection_AmrCore/Exec/Prob.H
+++ b/Tests/Amr/Advection_AmrCore/Exec/Prob.H
@@ -14,10 +14,10 @@ initdata(int i, int j, int k, amrex::Array4<amrex::Real> const& phi,
 {
     using namespace amrex;
 
-    Real y = prob_lo[1] + (0.5+j) * dx[1];
-    Real x = prob_lo[0] + (0.5+i) * dx[0];
-    Real r2 = (std::pow(x-0.5, 2) + std::pow((y-0.75),2)) / 0.01;
-    phi(i,j,k) = 1.0 + std::exp(-r2);
+    Real y = prob_lo[1] + (amrex::Real(0.5)+amrex::Real(j)) * dx[1];
+    Real x = prob_lo[0] + (amrex::Real(0.5)+amrex::Real(i)) * dx[0];
+    Real r2 = (amrex::Real(std::pow(x-amrex::Real(0.5), 2)) + amrex::Real(std::pow((y-amrex::Real(0.75)),2))) / amrex::Real(0.01);
+    phi(i,j,k) = amrex::Real(1.0) + std::exp(-r2);
 }
 
 #endif

--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.H
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.H
@@ -193,7 +193,7 @@ private:
     std::string restart_chkfile;
 
     // advective cfl number - dt = cfl*dx/umax
-    amrex::Real cfl = 0.7;
+    amrex::Real cfl = amrex::Real(0.7);
 
     // how often each level regrids the higher levels of refinement
     // (after a level advances that many time steps)

--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -38,8 +38,8 @@ AmrCoreAdv::AmrCoreAdv ()
     }
 
     t_new.resize(nlevs_max, 0.0);
-    t_old.resize(nlevs_max, -1.e100);
-    dt.resize(nlevs_max, 1.e100);
+    t_old.resize(nlevs_max, Real(-1.e100));
+    dt.resize(nlevs_max, Real(1.e100));
 
     phi_new.resize(nlevs_max);
     phi_old.resize(nlevs_max);
@@ -249,7 +249,7 @@ AmrCoreAdv::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
     phi_old[lev].define(ba, dm, ncomp, ng);
 
     t_new[lev] = time;
-    t_old[lev] = time - 1.e200;
+    t_old[lev] = time - Real(1.e200);
 
     // This clears the old MultiFab and allocates the new one
     for (int idim = 0; idim < AMREX_SPACEDIM; idim++)
@@ -284,7 +284,7 @@ AmrCoreAdv::RemakeLevel (int lev, Real time, const BoxArray& ba,
     std::swap(old_state, phi_old[lev]);
 
     t_new[lev] = time;
-    t_old[lev] = time - 1.e200;
+    t_old[lev] = time - Real(1.e200);
 
     // This clears the old MultiFab and allocates the new one
     for (int idim = 0; idim < AMREX_SPACEDIM; idim++)
@@ -321,7 +321,7 @@ void AmrCoreAdv::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba
     phi_old[lev].define(ba, dm, ncomp, ng);
 
     t_new[lev] = time;
-    t_old[lev] = time - 1.e200;
+    t_old[lev] = time - Real(1.e200);
 
     // This clears the old MultiFab and allocates the new one
     for (int idim = 0; idim < AMREX_SPACEDIM; idim++)
@@ -644,7 +644,7 @@ AmrCoreAdv::timeStepWithSubcycling (int lev, Real time, int iteration)
 
                 // if there are newly created levels, set the time step
                 for (int k = old_finest+1; k <= finest_level; ++k) {
-                    dt[k] = dt[k-1] / MaxRefRatio(k-1);
+                    dt[k] = dt[k-1] / Real(MaxRefRatio(k-1));
                 }
 
 #ifdef AMREX_PARTICLES
@@ -667,7 +667,7 @@ AmrCoreAdv::timeStepWithSubcycling (int lev, Real time, int iteration)
     t_old[lev] = t_new[lev];
     t_new[lev] += dt[lev];
 
-    Real t_nph = t_old[lev] + 0.5*dt[lev];
+    Real t_nph = t_old[lev] + Real(0.5)*dt[lev];
 
     DefineVelocityAtLevel(lev, t_nph);
     AdvancePhiAtLevel(lev, time, dt[lev], iteration, nsubsteps[lev]);
@@ -692,7 +692,7 @@ AmrCoreAdv::timeStepWithSubcycling (int lev, Real time, int iteration)
         // recursive call for next-finer level
         for (int i = 1; i <= nsubsteps[lev+1]; ++i)
         {
-            timeStepWithSubcycling(lev+1, time+(i-1)*dt[lev+1], i);
+            timeStepWithSubcycling(lev+1, time+Real(i-1)*dt[lev+1], i);
         }
 
         if (do_reflux)
@@ -797,18 +797,18 @@ AmrCoreAdv::ComputeDt ()
     }
     ParallelDescriptor::ReduceRealMin(dt_tmp.data(), int(dt_tmp.size()));
 
-    constexpr Real change_max = 1.1;
+    constexpr Real change_max = Real(1.1);
     Real dt_0 = dt_tmp[0];
     int n_factor = 1;
 
     for (int lev = 0; lev <= finest_level; ++lev) {
         dt_tmp[lev] = std::min(dt_tmp[lev], change_max*dt[lev]);
         n_factor *= nsubsteps[lev];
-        dt_0 = std::min(dt_0, n_factor*dt_tmp[lev]);
+        dt_0 = std::min(dt_0, Real(n_factor)*dt_tmp[lev]);
     }
 
     // Limit dt's by the value of stop_time.
-    const Real eps = 1.e-3*dt_0;
+    const Real eps = Real(1.e-3)*dt_0;
 
     if (t_new[0] + dt_0 > stop_time - eps) {
         dt_0 = stop_time - t_new[0];
@@ -817,7 +817,7 @@ AmrCoreAdv::ComputeDt ()
     dt[0] = dt_0;
 
     for (int lev = 1; lev <= finest_level; ++lev) {
-        dt[lev] = dt[lev-1] / nsubsteps[lev];
+        dt[lev] = dt[lev-1] / Real(nsubsteps[lev]);
     }
 }
 
@@ -834,7 +834,7 @@ AmrCoreAdv::EstTimeStep (int lev, Real time)
     if (time == Real(0.0)) {
        DefineVelocityAtLevel(lev,time);
     } else {
-       Real t_nph_predicted = time + 0.5 * dt[lev];
+       Real t_nph_predicted = time + Real(0.5) * dt[lev];
        DefineVelocityAtLevel(lev,t_nph_predicted);
     }
 
@@ -1051,7 +1051,7 @@ AmrCoreAdv::ReadCheckpointFile ()
         std::istringstream lis(line);
         int i = 0;
         while (lis >> word) {
-            dt[i++] = std::stod(word);
+            dt[i++] = Real(std::stod(word));
         }
     }
 
@@ -1061,7 +1061,7 @@ AmrCoreAdv::ReadCheckpointFile ()
         std::istringstream lis(line);
         int i = 0;
         while (lis >> word) {
-            t_new[i++] = std::stod(word);
+            t_new[i++] = Real(std::stod(word));
         }
     }
 

--- a/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
+++ b/Tests/Amr/Advection_AmrCore/Source/AmrCoreAdv.cpp
@@ -38,8 +38,8 @@ AmrCoreAdv::AmrCoreAdv ()
     }
 
     t_new.resize(nlevs_max, 0.0);
-    t_old.resize(nlevs_max, Real(-1.e100));
-    dt.resize(nlevs_max, Real(1.e100));
+    t_old.resize(nlevs_max, Real(-1.e30));
+    dt.resize(nlevs_max, Real(1.e30));
 
     phi_new.resize(nlevs_max);
     phi_old.resize(nlevs_max);
@@ -249,7 +249,7 @@ AmrCoreAdv::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
     phi_old[lev].define(ba, dm, ncomp, ng);
 
     t_new[lev] = time;
-    t_old[lev] = time - Real(1.e200);
+    t_old[lev] = time - Real(1.e30);
 
     // This clears the old MultiFab and allocates the new one
     for (int idim = 0; idim < AMREX_SPACEDIM; idim++)
@@ -284,7 +284,7 @@ AmrCoreAdv::RemakeLevel (int lev, Real time, const BoxArray& ba,
     std::swap(old_state, phi_old[lev]);
 
     t_new[lev] = time;
-    t_old[lev] = time - Real(1.e200);
+    t_old[lev] = time - Real(1.e30);
 
     // This clears the old MultiFab and allocates the new one
     for (int idim = 0; idim < AMREX_SPACEDIM; idim++)
@@ -321,7 +321,7 @@ void AmrCoreAdv::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba
     phi_old[lev].define(ba, dm, ncomp, ng);
 
     t_new[lev] = time;
-    t_old[lev] = time - Real(1.e200);
+    t_old[lev] = time - Real(1.e30);
 
     // This clears the old MultiFab and allocates the new one
     for (int idim = 0; idim < AMREX_SPACEDIM; idim++)

--- a/Tests/Amr/Advection_AmrCore/Source/Src_K/compute_flux_2D_K.H
+++ b/Tests/Amr/Advection_AmrCore/Source/Src_K/compute_flux_2D_K.H
@@ -14,8 +14,8 @@ void flux_x(int i, int j, int k,
             amrex::Real dtdx)
 {
     px(i,j,k) = ( (vx(i,j,k) < 0) ?
-                phi(i  ,j,k) - slope(i  ,j,k)*(0.5 + 0.5*dtdx*vx(i,j,k)) :
-                phi(i-1,j,k) + slope(i-1,j,k)*(0.5 - 0.5*dtdx*vx(i,j,k)) );
+                phi(i  ,j,k) - slope(i  ,j,k)*(amrex::Real(0.5) + amrex::Real(0.5)*dtdx*vx(i,j,k)) :
+                phi(i-1,j,k) + slope(i-1,j,k)*(amrex::Real(0.5) - amrex::Real(0.5)*dtdx*vx(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -28,8 +28,8 @@ void flux_y(int i, int j, int k,
             amrex::Real dtdy)
 {
     py(i,j,k) = ( (vy(i,j,k) < 0) ?
-                phi(i,j  ,k) - slope(i,j  ,k)*(0.5 + 0.5*dtdy*vy(i,j,k)) :
-                phi(i,j-1,k) + slope(i,j-1,k)*(0.5 - 0.5*dtdy*vy(i,j,k)) );
+                phi(i,j  ,k) - slope(i,j  ,k)*(amrex::Real(0.5) + amrex::Real(0.5)*dtdy*vy(i,j,k)) :
+                phi(i,j-1,k) + slope(i,j-1,k)*(amrex::Real(0.5) - amrex::Real(0.5)*dtdy*vy(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -43,8 +43,8 @@ void create_flux_x(int i, int j, int k,
                    amrex::Real dtdy)
 {
     fx(i,j,k) = ( (vx(i,j,k) < 0) ?
-                (px(i,j,k) - 0.5*dtdy * ( 0.5*(vy(i  ,j+1,k  ) + vy(i  ,j,k)) * (py(i  ,j+1,k  )-py(i  ,j,k))))*vx(i,j,k) :
-                (px(i,j,k) - 0.5*dtdy * ( 0.5*(vy(i-1,j+1,k  ) + vy(i-1,j,k)) * (py(i-1,j+1,k  )-py(i-1,j,k))))*vx(i,j,k) );
+                (px(i,j,k) - amrex::Real(0.5)*dtdy * ( amrex::Real(0.5)*(vy(i  ,j+1,k  ) + vy(i  ,j,k)) * (py(i  ,j+1,k  )-py(i  ,j,k))))*vx(i,j,k) :
+                (px(i,j,k) - amrex::Real(0.5)*dtdy * ( amrex::Real(0.5)*(vy(i-1,j+1,k  ) + vy(i-1,j,k)) * (py(i-1,j+1,k  )-py(i-1,j,k))))*vx(i,j,k) );
 }
 
 AMREX_GPU_DEVICE
@@ -58,8 +58,8 @@ void create_flux_y(int i, int j, int k,
                    amrex::Real dtdx)
 {
     fy(i,j,k) = ( (vy(i,j,k) < 0) ?
-                (py(i,j,k) - 0.5*dtdx * ( 0.5*(vx(i+1,j  ,k  ) + vx(i,j  ,k)) * (px(i+1,j  ,k  )-px(i,j  ,k))))*vy(i,j,k) :
-                (py(i,j,k) - 0.5*dtdx * ( 0.5*(vx(i+1,j-1,k  ) + vx(i,j-1,k)) * (px(i+1,j-1,k  )-px(i,j-1,k))))*vy(i,j,k) );
+                (py(i,j,k) - amrex::Real(0.5)*dtdx * ( amrex::Real(0.5)*(vx(i+1,j  ,k  ) + vx(i,j  ,k)) * (px(i+1,j  ,k  )-px(i,j  ,k))))*vy(i,j,k) :
+                (py(i,j,k) - amrex::Real(0.5)*dtdx * ( amrex::Real(0.5)*(vx(i+1,j-1,k  ) + vx(i,j-1,k)) * (px(i+1,j-1,k  )-px(i,j-1,k))))*vy(i,j,k) );
 }
 
 #endif

--- a/Tests/Amr/Advection_AmrCore/Source/Src_K/compute_flux_3D_K.H
+++ b/Tests/Amr/Advection_AmrCore/Source/Src_K/compute_flux_3D_K.H
@@ -14,8 +14,8 @@ void flux_x(int i, int j, int k,
             amrex::Real dtdx)
 {
     px(i,j,k) = ( (vx(i,j,k) < 0) ?
-                phi(i  ,j,k) - slope(i  ,j,k)*(0.5 + 0.5*dtdx*vx(i,j,k)) :
-                phi(i-1,j,k) + slope(i-1,j,k)*(0.5 - 0.5*dtdx*vx(i,j,k)) );
+                phi(i  ,j,k) - slope(i  ,j,k)*(amrex::Real(0.5) + amrex::Real(0.5)*dtdx*vx(i,j,k)) :
+                phi(i-1,j,k) + slope(i-1,j,k)*(amrex::Real(0.5) - amrex::Real(0.5)*dtdx*vx(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -28,8 +28,8 @@ void flux_y(int i, int j, int k,
             amrex::Real dtdy)
 {
     py(i,j,k) = ( (vy(i,j,k) < 0) ?
-                phi(i,j  ,k) - slope(i,j  ,k)*(0.5 + 0.5*dtdy*vy(i,j,k)) :
-                phi(i,j-1,k) + slope(i,j-1,k)*(0.5 - 0.5*dtdy*vy(i,j,k)) );
+                phi(i,j  ,k) - slope(i,j  ,k)*(amrex::Real(0.5) + amrex::Real(0.5)*dtdy*vy(i,j,k)) :
+                phi(i,j-1,k) + slope(i,j-1,k)*(amrex::Real(0.5) - amrex::Real(0.5)*dtdy*vy(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -42,8 +42,8 @@ void flux_z(int i, int j, int k,
             amrex::Real dtdz)
 {
     pz(i,j,k) = ( (vz(i,j,k) < 0) ?
-                phi(i,j,k  ) - slope(i,j,k  )*(0.5 + 0.5*dtdz*vz(i,j,k)) :
-                phi(i,j,k-1) + slope(i,j,k-1)*(0.5 - 0.5*dtdz*vz(i,j,k)) );
+                phi(i,j,k  ) - slope(i,j,k  )*(amrex::Real(0.5) + amrex::Real(0.5)*dtdz*vz(i,j,k)) :
+                phi(i,j,k-1) + slope(i,j,k-1)*(amrex::Real(0.5) - amrex::Real(0.5)*dtdz*vz(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -57,8 +57,8 @@ void flux_xy(int i, int j, int k,
              amrex::Real dtdy)
 {
     pxy(i,j,k) = ( (vx(i,j,k) < 0) ?
-                 px(i,j,k) - dtdy/3.0 * ( 0.5*(vy(i,  j+1,k) + vy(i  ,j,k)) * (py(i  ,j+1,k) - py(i  ,j,k))) :
-                 px(i,j,k) - dtdy/3.0 * ( 0.5*(vy(i-1,j+1,k) + vy(i-1,j,k)) * (py(i-1,j+1,k) - py(i-1,j,k))) );
+                 px(i,j,k) - dtdy/amrex::Real(3.0) * ( amrex::Real(0.5)*(vy(i,  j+1,k) + vy(i  ,j,k)) * (py(i  ,j+1,k) - py(i  ,j,k))) :
+                 px(i,j,k) - dtdy/amrex::Real(3.0) * ( amrex::Real(0.5)*(vy(i-1,j+1,k) + vy(i-1,j,k)) * (py(i-1,j+1,k) - py(i-1,j,k))) );
 }
 
 AMREX_GPU_DEVICE
@@ -72,8 +72,8 @@ void flux_xz(int i, int j, int k,
              amrex::Real dtdz)
 {
     pxz(i,j,k) = ( (vx(i,j,k) < 0) ?
-                 px(i,j,k) - dtdz/3.0 * ( 0.5*(vz(i,  j,k+1) + vz(i  ,j,k)) * (pz(i  ,j,k+1) - pz(i  ,j,k))) :
-                 px(i,j,k) - dtdz/3.0 * ( 0.5*(vz(i-1,j,k+1) + vz(i-1,j,k)) * (pz(i-1,j,k+1) - pz(i-1,j,k))) );
+                 px(i,j,k) - dtdz/amrex::Real(3.0) * ( amrex::Real(0.5)*(vz(i,  j,k+1) + vz(i  ,j,k)) * (pz(i  ,j,k+1) - pz(i  ,j,k))) :
+                 px(i,j,k) - dtdz/amrex::Real(3.0) * ( amrex::Real(0.5)*(vz(i-1,j,k+1) + vz(i-1,j,k)) * (pz(i-1,j,k+1) - pz(i-1,j,k))) );
 }
 
 AMREX_GPU_DEVICE
@@ -87,8 +87,8 @@ void flux_yx(int i, int j, int k,
              amrex::Real dtdx)
 {
     pyx(i,j,k) = ( (vy(i,j,k) < 0) ?
-                 py(i,j,k) - dtdx/3.0 * ( 0.5*(vx(i+1,j  ,k) + vx(i,j  ,k)) * (px(i+1,j  ,k) - px(i,j  ,k))) :
-                 py(i,j,k) - dtdx/3.0 * ( 0.5*(vx(i+1,j-1,k) + vx(i,j-1,k)) * (px(i+1,j-1,k) - px(i,j-1,k))) );
+                 py(i,j,k) - dtdx/amrex::Real(3.0) * ( amrex::Real(0.5)*(vx(i+1,j  ,k) + vx(i,j  ,k)) * (px(i+1,j  ,k) - px(i,j  ,k))) :
+                 py(i,j,k) - dtdx/amrex::Real(3.0) * ( amrex::Real(0.5)*(vx(i+1,j-1,k) + vx(i,j-1,k)) * (px(i+1,j-1,k) - px(i,j-1,k))) );
 }
 
 AMREX_GPU_DEVICE
@@ -102,8 +102,8 @@ void flux_yz(int i, int j, int k,
              amrex::Real dtdz)
 {
     pyz(i,j,k) = ( (vy(i,j,k) < 0) ?
-                 py(i,j,k) - dtdz/3.0 * ( 0.5*(vz(i,  j,k+1) + vz(i,j  ,k)) * (pz(i,j  ,k+1) - pz(i,j  ,k))) :
-                 py(i,j,k) - dtdz/3.0 * ( 0.5*(vz(i,j-1,k+1) + vz(i,j-1,k)) * (pz(i,j-1,k+1) - pz(i,j-1,k))) );
+                 py(i,j,k) - dtdz/amrex::Real(3.0) * ( amrex::Real(0.5)*(vz(i,  j,k+1) + vz(i,j  ,k)) * (pz(i,j  ,k+1) - pz(i,j  ,k))) :
+                 py(i,j,k) - dtdz/amrex::Real(3.0) * ( amrex::Real(0.5)*(vz(i,j-1,k+1) + vz(i,j-1,k)) * (pz(i,j-1,k+1) - pz(i,j-1,k))) );
 }
 
 AMREX_GPU_DEVICE
@@ -117,8 +117,8 @@ void flux_zx(int i, int j, int k,
              amrex::Real dtdx)
 {
     pzx(i,j,k) = ( (vz(i,j,k) < 0) ?
-                 pz(i,j,k) - dtdx/3.0 * ( 0.5*(vx(i+1,j,k  ) + vx(i,j,k  )) * (px(i+1,j,k  ) - px(i,j,k  ))) :
-                 pz(i,j,k) - dtdx/3.0 * ( 0.5*(vx(i+1,j,k-1) + vx(i,j,k-1)) * (px(i+1,j,k-1) - px(i,j,k-1))) );
+                 pz(i,j,k) - dtdx/amrex::Real(3.0) * ( amrex::Real(0.5)*(vx(i+1,j,k  ) + vx(i,j,k  )) * (px(i+1,j,k  ) - px(i,j,k  ))) :
+                 pz(i,j,k) - dtdx/amrex::Real(3.0) * ( amrex::Real(0.5)*(vx(i+1,j,k-1) + vx(i,j,k-1)) * (px(i+1,j,k-1) - px(i,j,k-1))) );
 }
 
 AMREX_GPU_DEVICE
@@ -132,8 +132,8 @@ void flux_zy(int i, int j, int k,
              amrex::Real dtdy)
 {
     pzy(i,j,k) = ( (vz(i,j,k) < 0) ?
-                 pz(i,j,k) - dtdy/3.0 * ( 0.5*(vy(i,j+1,k  ) + vy(i,j,k  )) * (py(i,j+1,k  ) - py(i,j,k  ))) :
-                 pz(i,j,k) - dtdy/3.0 * ( 0.5*(vy(i,j+1,k-1) + vy(i,j,k-1)) * (py(i,j+1,k-1) - py(i,j,k-1))) );
+                 pz(i,j,k) - dtdy/amrex::Real(3.0) * ( amrex::Real(0.5)*(vy(i,j+1,k  ) + vy(i,j,k  )) * (py(i,j+1,k  ) - py(i,j,k  ))) :
+                 pz(i,j,k) - dtdy/amrex::Real(3.0) * ( amrex::Real(0.5)*(vy(i,j+1,k-1) + vy(i,j,k-1)) * (py(i,j+1,k-1) - py(i,j,k-1))) );
 }
 
 AMREX_GPU_DEVICE
@@ -149,10 +149,10 @@ void create_flux_x(int i, int j, int k,
                    amrex::Real dtdy, amrex::Real dtdz)
 {
     amrex::Real f = ( (vx(i,j,k) < 0) ?
-                px(i,j,k) - 0.5*dtdy * ( 0.5*(vy(i  ,j+1,k  ) + vy(i  ,j,k)) * (pyz(i  ,j+1,k  )-pyz(i  ,j,k)))
-                          - 0.5*dtdz * ( 0.5*(vz(i  ,j  ,k+1) + vz(i  ,j,k)) * (pzy(i  ,j  ,k+1)-pzy(i  ,j,k))) :
-                px(i,j,k) - 0.5*dtdy * ( 0.5*(vy(i-1,j+1,k  ) + vy(i-1,j,k)) * (pyz(i-1,j+1,k  )-pyz(i-1,j,k)))
-                          - 0.5*dtdz * ( 0.5*(vz(i-1,j  ,k+1) + vz(i-1,j,k)) * (pzy(i-1,j  ,k+1)-pzy(i-1,j,k))) );
+                px(i,j,k) - amrex::Real(0.5)*dtdy * ( amrex::Real(0.5)*(vy(i  ,j+1,k  ) + vy(i  ,j,k)) * (pyz(i  ,j+1,k  )-pyz(i  ,j,k)))
+                          - amrex::Real(0.5)*dtdz * ( amrex::Real(0.5)*(vz(i  ,j  ,k+1) + vz(i  ,j,k)) * (pzy(i  ,j  ,k+1)-pzy(i  ,j,k))) :
+                px(i,j,k) - amrex::Real(0.5)*dtdy * ( amrex::Real(0.5)*(vy(i-1,j+1,k  ) + vy(i-1,j,k)) * (pyz(i-1,j+1,k  )-pyz(i-1,j,k)))
+                          - amrex::Real(0.5)*dtdz * ( amrex::Real(0.5)*(vz(i-1,j  ,k+1) + vz(i-1,j,k)) * (pzy(i-1,j  ,k+1)-pzy(i-1,j,k))) );
 
     fx(i,j,k) = vx(i,j,k)*f;
 }
@@ -170,10 +170,10 @@ void create_flux_y(int i, int j, int k,
                    amrex::Real dtdx, amrex::Real dtdz)
 {
     amrex::Real f = ( (vy(i,j,k) < 0) ?
-                py(i,j,k) - 0.5*dtdx * ( 0.5*(vx(i+1,j  ,k  ) + vx(i,j  ,k)) * (pxz(i+1,j  ,k  )-pxz(i,j  ,k)))
-                          - 0.5*dtdz * ( 0.5*(vz(i,  j  ,k+1) + vz(i,j  ,k)) * (pzx(i,  j  ,k+1)-pzx(i,j  ,k))) :
-                py(i,j,k) - 0.5*dtdx * ( 0.5*(vx(i+1,j-1,k  ) + vx(i,j-1,k)) * (pxz(i+1,j-1,k  )-pxz(i,j-1,k)))
-                          - 0.5*dtdz * ( 0.5*(vz(i  ,j-1,k+1) + vz(i,j-1,k)) * (pzx(i  ,j-1,k+1)-pzx(i,j-1,k))) );
+                py(i,j,k) - amrex::Real(0.5)*dtdx * ( amrex::Real(0.5)*(vx(i+1,j  ,k  ) + vx(i,j  ,k)) * (pxz(i+1,j  ,k  )-pxz(i,j  ,k)))
+                          - amrex::Real(0.5)*dtdz * ( amrex::Real(0.5)*(vz(i,  j  ,k+1) + vz(i,j  ,k)) * (pzx(i,  j  ,k+1)-pzx(i,j  ,k))) :
+                py(i,j,k) - amrex::Real(0.5)*dtdx * ( amrex::Real(0.5)*(vx(i+1,j-1,k  ) + vx(i,j-1,k)) * (pxz(i+1,j-1,k  )-pxz(i,j-1,k)))
+                          - amrex::Real(0.5)*dtdz * ( amrex::Real(0.5)*(vz(i  ,j-1,k+1) + vz(i,j-1,k)) * (pzx(i  ,j-1,k+1)-pzx(i,j-1,k))) );
 
     fy(i,j,k) = vy(i,j,k)*f;
 }
@@ -191,10 +191,10 @@ void create_flux_z(int i, int j, int k,
                    amrex::Real dtdx, amrex::Real dtdy)
 {
     amrex::Real f = ( (vz(i,j,k) < 0) ?
-                pz(i,j,k) - 0.5*dtdx * ( 0.5*(vx(i+1,j  ,k  ) + vx(i,j,k  )) * (pxy(i+1,j  ,k  )-pxy(i,j,k  )))
-                          - 0.5*dtdy * ( 0.5*(vy(i,  j+1,k  ) + vy(i,j,k  )) * (pyx(i,  j+1,k  )-pyx(i,j,k  ))) :
-                pz(i,j,k) - 0.5*dtdx * ( 0.5*(vx(i+1,j  ,k-1) + vx(i,j,k-1)) * (pxy(i+1,j  ,k-1)-pxy(i,j,k-1)))
-                          - 0.5*dtdy * ( 0.5*(vy(i  ,j+1,k-1) + vy(i,j,k-1)) * (pyx(i  ,j+1,k-1)-pyx(i,j,k-1))) );
+                pz(i,j,k) - amrex::Real(0.5)*dtdx * ( amrex::Real(0.5)*(vx(i+1,j  ,k  ) + vx(i,j,k  )) * (pxy(i+1,j  ,k  )-pxy(i,j,k  )))
+                          - amrex::Real(0.5)*dtdy * ( amrex::Real(0.5)*(vy(i,  j+1,k  ) + vy(i,j,k  )) * (pyx(i,  j+1,k  )-pyx(i,j,k  ))) :
+                pz(i,j,k) - amrex::Real(0.5)*dtdx * ( amrex::Real(0.5)*(vx(i+1,j  ,k-1) + vx(i,j,k-1)) * (pxy(i+1,j  ,k-1)-pxy(i,j,k-1)))
+                          - amrex::Real(0.5)*dtdy * ( amrex::Real(0.5)*(vy(i  ,j+1,k-1) + vy(i,j,k-1)) * (pyx(i  ,j+1,k-1)-pyx(i,j,k-1))) );
 
     fz(i,j,k) = vz(i,j,k)*f;
 }

--- a/Tests/Amr/Advection_AmrCore/Source/face_velocity.H
+++ b/Tests/Amr/Advection_AmrCore/Source/face_velocity.H
@@ -19,10 +19,10 @@ void get_face_velocity_psi(int i, int j,
     const Real* AMREX_RESTRICT prob_lo = geomdata.ProbLo();
     const Real* AMREX_RESTRICT dx      = geomdata.CellSize();
 
-    Real y = dx[1]*(0.5+j) + prob_lo[1];
-    Real x = dx[0]*(0.5+i) + prob_lo[0];
-    psi(i,j,0) = std::pow(std::sin(PI*x), 2) * std::pow(std::sin(PI*y), 2)
-                * std::cos(PI*time/2.0) * 1.0/PI;
+    Real y = dx[1]*(amrex::Real(0.5)+amrex::Real(j)) + prob_lo[1];
+    Real x = dx[0]*(amrex::Real(0.5)+amrex::Real(i)) + prob_lo[0];
+    psi(i,j,0) = amrex::Real(std::pow(std::sin(PI*x), 2)) * amrex::Real(std::pow(std::sin(PI*y), 2))
+                * std::cos(PI*time/amrex::Real(2.0)) * amrex::Real(1.0)/PI;
 }
 
 AMREX_GPU_DEVICE
@@ -32,7 +32,7 @@ void get_face_velocity_x(int i, int j, int k,
                          amrex::Array4<amrex::Real> const& psi,
                          amrex::Real dy)
 {
-    vx(i,j,k) = -( (psi(i,j+1,0)+psi(i-1,j+1,0)) - (psi(i,j-1,0)+psi(i-1,j-1,0)) ) * (0.25/dy);
+    vx(i,j,k) = -( (psi(i,j+1,0)+psi(i-1,j+1,0)) - (psi(i,j-1,0)+psi(i-1,j-1,0)) ) * (amrex::Real(0.25)/dy);
 }
 
 AMREX_GPU_DEVICE
@@ -42,7 +42,7 @@ void get_face_velocity_y(int i, int j, int k,
                          amrex::Array4<amrex::Real> const& psi,
                          amrex::Real dx)
 {
-    vy(i,j,k) =  ( (psi(i+1,j,0)+psi(i+1,j-1,0)) - (psi(i-1,j,0)+psi(i-1,j-1,0)) ) * (0.25/dx);
+    vy(i,j,k) =  ( (psi(i+1,j,0)+psi(i+1,j-1,0)) - (psi(i-1,j,0)+psi(i-1,j-1,0)) ) * (amrex::Real(0.25)/dx);
 }
 
 AMREX_GPU_DEVICE

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/Prob.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/Prob.cpp
@@ -25,8 +25,8 @@ void initdata (MultiFab& S_tmp, const Geometry& geom){
         ParallelFor(box, [=] AMREX_GPU_DEVICE ( int i, int j, int k) noexcept
         {
 
-            Real x = prob_lo[0] + (i + 0.5_rt) * dx[0];
-            Real y = prob_lo[1] + (j + 0.5_rt) * dx[1];
+            Real x = prob_lo[0] + (Real(i) + 0.5_rt) * dx[0];
+            Real y = prob_lo[1] + (Real(j) + 0.5_rt) * dx[1];
 
 #if (AMREX_SPACEDIM == 2)
 
@@ -35,7 +35,7 @@ void initdata (MultiFab& S_tmp, const Geometry& geom){
 
 #elif (AMREX_SPACEDIM == 3)
 
-            Real z = prob_lo[2] + (k + 0.5_rt) * dx[2];
+            Real z = prob_lo[2] + (Real(k) + 0.5_rt) * dx[2];
             Real r2 = ((x-0.5_rt)*(x-0.5_rt) + (y-0.75_rt)*(y-0.75_rt) + (z-0.5_rt)*(z-0.5_rt)) / 0.01_rt;
             phi(i,j,k) = 1.0_rt + std::exp(-r2);
 #endif

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_2d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_2d_K.H
@@ -19,10 +19,10 @@ void get_face_velocity_psi(int i, int j,
     constexpr Real PI = std::numbers::pi_v<Real>;
 
     // Compute streamfunction psi
-    Real y = ( (Real)j + 0.5 )*dy + prob_lo_y;
-    Real x = ( (Real)i + 0.5 )*dx + prob_lo_x;
-    psi(i,j,0) = std::pow(std::sin(PI*x), 2) * std::pow(std::sin(PI*y), 2)
-                * std::cos(PI*time/2.0) * 1.0/PI;
+    Real y = ( amrex::Real(j) + amrex::Real(0.5) )*dy + prob_lo_y;
+    Real x = ( amrex::Real(i) + amrex::Real(0.5) )*dx + prob_lo_x;
+    psi(i,j,0) = amrex::Real(std::pow(std::sin(PI*x), 2)) * amrex::Real(std::pow(std::sin(PI*y), 2))
+                * std::cos(PI*time/amrex::Real(2.0)) * amrex::Real(1.0)/PI;
 }
 
 AMREX_GPU_DEVICE
@@ -32,7 +32,7 @@ void get_face_velocity_x(int i, int j, int k,
                          amrex::Array4<const amrex::Real> const& psi,
                          amrex::Real dy)
 {
-    vx(i,j,k) = -( (psi(i,j+1,0)+psi(i-1,j+1,0)) - (psi(i,j-1,0)+psi(i-1,j-1,0)) ) * (0.25/dy);
+    vx(i,j,k) = -( (psi(i,j+1,0)+psi(i-1,j+1,0)) - (psi(i,j-1,0)+psi(i-1,j-1,0)) ) * (amrex::Real(0.25)/dy);
 }
 
 AMREX_GPU_DEVICE
@@ -42,7 +42,7 @@ void get_face_velocity_y(int i, int j, int k,
                          amrex::Array4<const amrex::Real> const& psi,
                          amrex::Real dx)
 {
-    vy(i,j,k) =  ( (psi(i+1,j,0)+psi(i+1,j-1,0)) - (psi(i-1,j,0)+psi(i-1,j-1,0)) ) * (0.25/dx);
+    vy(i,j,k) =  ( (psi(i+1,j,0)+psi(i+1,j-1,0)) - (psi(i-1,j,0)+psi(i-1,j-1,0)) ) * (amrex::Real(0.25)/dx);
 }
 
 AMREX_GPU_HOST

--- a/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_3d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Exec/SingleVortex/face_velocity_3d_K.H
@@ -21,10 +21,10 @@ void get_face_velocity_psi(int i, int j,
     constexpr Real PI = std::numbers::pi_v<Real>;
 
     // Compute streamfunction psi
-    Real y = ( (Real)j + 0.5 )*dy + prob_lo_y;
-    Real x = ( (Real)i + 0.5 )*dx + prob_lo_x;
-    psi(i,j,0) = std::pow(std::sin(PI*x), 2) * std::pow(std::sin(PI*y), 2)
-                * std::cos(PI*time/2.0) * 1.0/PI;
+    Real y = ( amrex::Real(j) + amrex::Real(0.5) )*dy + prob_lo_y;
+    Real x = ( amrex::Real(i) + amrex::Real(0.5) )*dx + prob_lo_x;
+    psi(i,j,0) = amrex::Real(std::pow(std::sin(PI*x), 2)) * amrex::Real(std::pow(std::sin(PI*y), 2))
+                * std::cos(PI*time/amrex::Real(2.0)) * amrex::Real(1.0)/PI;
 }
 
 AMREX_GPU_DEVICE
@@ -34,7 +34,7 @@ void get_face_velocity_x(int i, int j, int k,
                          amrex::Array4<const amrex::Real> const& psi,
                          amrex::Real dy)
 {
-    vx(i,j,k) = -( (psi(i,j+1,0)+psi(i-1,j+1,0)) - (psi(i,j-1,0)+psi(i-1,j-1,0)) ) * (0.25/dy);
+    vx(i,j,k) = -( (psi(i,j+1,0)+psi(i-1,j+1,0)) - (psi(i,j-1,0)+psi(i-1,j-1,0)) ) * (amrex::Real(0.25)/dy);
 }
 
 AMREX_GPU_DEVICE
@@ -44,7 +44,7 @@ void get_face_velocity_y(int i, int j, int k,
                          amrex::Array4<const amrex::Real> const& psi,
                          amrex::Real dx)
 {
-    vy(i,j,k) =  ( (psi(i+1,j,0)+psi(i+1,j-1,0)) - (psi(i-1,j,0)+psi(i-1,j-1,0)) ) * (0.25/dx);
+    vy(i,j,k) =  ( (psi(i+1,j,0)+psi(i+1,j-1,0)) - (psi(i-1,j,0)+psi(i-1,j-1,0)) ) * (amrex::Real(0.25)/dx);
 }
 
 AMREX_GPU_DEVICE

--- a/Tests/Amr/Advection_AmrLevel/Exec/UniformVelocity/Prob.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Exec/UniformVelocity/Prob.cpp
@@ -25,8 +25,8 @@ void initdata (MultiFab& S_tmp, const Geometry& geom){
         ParallelFor(box, [=] AMREX_GPU_DEVICE ( int i, int j, int k) noexcept
         {
 
-            Real x = prob_lo[0] + (i + Real(0.5)) * dx[0];
-            Real y = prob_lo[1] + (j + Real(0.5)) * dx[1];
+            Real x = prob_lo[0] + (Real(i) + Real(0.5)) * dx[0];
+            Real y = prob_lo[1] + (Real(j) + Real(0.5)) * dx[1];
 
 #if (AMREX_SPACEDIM == 2)
 
@@ -35,7 +35,7 @@ void initdata (MultiFab& S_tmp, const Geometry& geom){
 
 #elif (AMREX_SPACEDIM == 3)
 
-            Real z = prob_lo[2] + (k + Real(0.5)) * dx[2];
+            Real z = prob_lo[2] + (Real(k) + Real(0.5)) * dx[2];
             Real r2 = ((x-Real(0.0))*(x-Real(0.0)) + (y-Real(0.0))*(y-Real(0.0)) + (z-Real(0.0))*(z-Real(0.0))) / Real(0.01);
             phi(i,j,k) = Real(1.0) + std::exp(-r2);
 #endif

--- a/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -484,7 +484,7 @@ AmrLevelAdv::computeInitialDt (int                   finest_level,
         return;
     }
 
-    Real dt_0 = Real(1.0e+100);
+    Real dt_0 = Real(1.0e+30);
     int n_factor = 1;
     for (int i = 0; i <= finest_level; i++)
     {
@@ -564,7 +564,7 @@ AmrLevelAdv::computeNewDt (int                   finest_level,
     //
     // Find the minimum over all levels
     //
-    Real dt_0 = Real(1.0e+100);
+    Real dt_0 = Real(1.0e+30);
     int n_factor = 1;
     for (int i = 0; i <= finest_level; i++)
     {

--- a/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/AmrLevelAdv.cpp
@@ -11,7 +11,7 @@
 using namespace amrex;
 
 int      AmrLevelAdv::verbose         = 0;
-Real     AmrLevelAdv::cfl             = 0.9;
+Real     AmrLevelAdv::cfl             = Real(0.9);
 int      AmrLevelAdv::do_reflux       = 1;
 
 int      AmrLevelAdv::NUM_STATE       = 1;  // One variable in the state
@@ -243,7 +243,7 @@ AmrLevelAdv::advance (Real time,
 
     const Real prev_time = state[Phi_Type].prevTime();
     const Real cur_time = state[Phi_Type].curTime();
-    const Real ctr_time = 0.5*(prev_time + cur_time);
+    const Real ctr_time = Real(0.5)*(prev_time + cur_time);
 
     GpuArray<Real,BL_SPACEDIM> dx = geom.CellSizeArray();
     GpuArray<Real,BL_SPACEDIM> prob_lo = geom.ProbLoArray();
@@ -406,7 +406,7 @@ Real
 AmrLevelAdv::estTimeStep (Real)
 {
     // This is just a dummy value to start with
-    Real dt_est  = 1.0e+20;
+    Real dt_est  = Real(1.0e+20);
 
     GpuArray<Real,BL_SPACEDIM> dx = geom.CellSizeArray();
     GpuArray<Real,BL_SPACEDIM> prob_lo = geom.ProbLoArray();
@@ -484,19 +484,19 @@ AmrLevelAdv::computeInitialDt (int                   finest_level,
         return;
     }
 
-    Real dt_0 = 1.0e+100;
+    Real dt_0 = Real(1.0e+100);
     int n_factor = 1;
     for (int i = 0; i <= finest_level; i++)
     {
         dt_level[i] = getLevel(i).initialTimeStep();
         n_factor   *= n_cycle[i];
-        dt_0 = std::min(dt_0,n_factor*dt_level[i]);
+        dt_0 = std::min(dt_0,Real(n_factor)*dt_level[i]);
     }
 
     //
     // Limit dt's by the value of stop_time.
     //
-    const Real eps = 0.001*dt_0;
+    const Real eps = Real(0.001)*dt_0;
     Real cur_time  = state[Phi_Type].curTime();
     if (stop_time >= 0.0) {
         if ((cur_time + dt_0) > (stop_time - eps)) {
@@ -508,7 +508,7 @@ AmrLevelAdv::computeInitialDt (int                   finest_level,
     for (int i = 0; i <= finest_level; i++)
     {
         n_factor *= n_cycle[i];
-        dt_level[i] = dt_0/n_factor;
+        dt_level[i] = dt_0/Real(n_factor);
     }
 }
 
@@ -554,7 +554,7 @@ AmrLevelAdv::computeNewDt (int                   finest_level,
         //
         // Limit dt's by change_max * old dt
         //
-        static Real change_max = 1.1;
+        static Real change_max = Real(1.1);
         for (int i = 0; i <= finest_level; i++)
         {
             dt_min[i] = std::min(dt_min[i],change_max*dt_level[i]);
@@ -564,18 +564,18 @@ AmrLevelAdv::computeNewDt (int                   finest_level,
     //
     // Find the minimum over all levels
     //
-    Real dt_0 = 1.0e+100;
+    Real dt_0 = Real(1.0e+100);
     int n_factor = 1;
     for (int i = 0; i <= finest_level; i++)
     {
         n_factor *= n_cycle[i];
-        dt_0 = std::min(dt_0,n_factor*dt_min[i]);
+        dt_0 = std::min(dt_0,Real(n_factor)*dt_min[i]);
     }
 
     //
     // Limit dt's by the value of stop_time.
     //
-    const Real eps = 0.001*dt_0;
+    const Real eps = Real(0.001)*dt_0;
     Real cur_time  = state[Phi_Type].curTime();
     if (stop_time >= 0.0) {
         if ((cur_time + dt_0) > (stop_time - eps)) {
@@ -587,7 +587,7 @@ AmrLevelAdv::computeNewDt (int                   finest_level,
     for (int i = 0; i <= finest_level; i++)
     {
         n_factor *= n_cycle[i];
-        dt_level[i] = dt_0/n_factor;
+        dt_level[i] = dt_0/Real(n_factor);
     }
 }
 

--- a/Tests/Amr/Advection_AmrLevel/Source/Src_K/flux_2d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Source/Src_K/flux_2d_K.H
@@ -14,8 +14,8 @@ void flux_x(int i, int j, int k,
             amrex::Real hdtdx)
 {
     px(i,j,k) = ( (vx(i,j,k) < 0) ?
-                phi(i  ,j,k) - slope(i  ,j,k)*(0.5 + hdtdx*vx(i,j,k)) :
-                phi(i-1,j,k) + slope(i-1,j,k)*(0.5 - hdtdx*vx(i,j,k)) );
+                phi(i  ,j,k) - slope(i  ,j,k)*(amrex::Real(0.5) + hdtdx*vx(i,j,k)) :
+                phi(i-1,j,k) + slope(i-1,j,k)*(amrex::Real(0.5) - hdtdx*vx(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -28,8 +28,8 @@ void flux_y(int i, int j, int k,
             amrex::Real hdtdy)
 {
     py(i,j,k) = ( (vy(i,j,k) < 0) ?
-                phi(i,j  ,k) - slope(i,j  ,k)*(0.5 + hdtdy*vy(i,j,k)) :
-                phi(i,j-1,k) + slope(i,j-1,k)*(0.5 - hdtdy*vy(i,j,k)) );
+                phi(i,j  ,k) - slope(i,j  ,k)*(amrex::Real(0.5) + hdtdy*vy(i,j,k)) :
+                phi(i,j-1,k) + slope(i,j-1,k)*(amrex::Real(0.5) - hdtdy*vy(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -43,8 +43,8 @@ void create_flux_x(int i, int j, int k,
                        amrex::Real hdtdy)
 {
     fx(i,j,k) = ( (vx(i,j,k) < 0) ?
-                (px(i,j,k) - hdtdy * ( 0.5*(vy(i  ,j+1,k  ) + vy(i  ,j,k)) * (py(i  ,j+1,k  )-py(i  ,j,k))))*vx(i,j,k) :
-                (px(i,j,k) - hdtdy * ( 0.5*(vy(i-1,j+1,k  ) + vy(i-1,j,k)) * (py(i-1,j+1,k  )-py(i-1,j,k))))*vx(i,j,k) );
+                (px(i,j,k) - hdtdy * ( amrex::Real(0.5)*(vy(i  ,j+1,k  ) + vy(i  ,j,k)) * (py(i  ,j+1,k  )-py(i  ,j,k))))*vx(i,j,k) :
+                (px(i,j,k) - hdtdy * ( amrex::Real(0.5)*(vy(i-1,j+1,k  ) + vy(i-1,j,k)) * (py(i-1,j+1,k  )-py(i-1,j,k))))*vx(i,j,k) );
 }
 
 AMREX_GPU_DEVICE
@@ -58,8 +58,8 @@ void create_flux_y(int i, int j, int k,
                        amrex::Real hdtdx)
 {
     fy(i,j,k) = ( (vy(i,j,k) < 0) ?
-                (py(i,j,k) - hdtdx * ( 0.5*(vx(i+1,j  ,k  ) + vx(i,j  ,k)) * (px(i+1,j  ,k  )-px(i,j  ,k))))*vy(i,j,k) :
-                (py(i,j,k) - hdtdx * ( 0.5*(vx(i+1,j-1,k  ) + vx(i,j-1,k)) * (px(i+1,j-1,k  )-px(i,j-1,k))))*vy(i,j,k) );
+                (py(i,j,k) - hdtdx * ( amrex::Real(0.5)*(vx(i+1,j  ,k  ) + vx(i,j  ,k)) * (px(i+1,j  ,k  )-px(i,j  ,k))))*vy(i,j,k) :
+                (py(i,j,k) - hdtdx * ( amrex::Real(0.5)*(vx(i+1,j-1,k  ) + vx(i,j-1,k)) * (px(i+1,j-1,k  )-px(i,j-1,k))))*vy(i,j,k) );
 }
 
 #endif /* flux_2d_K_H_ */

--- a/Tests/Amr/Advection_AmrLevel/Source/Src_K/flux_3d_K.H
+++ b/Tests/Amr/Advection_AmrLevel/Source/Src_K/flux_3d_K.H
@@ -14,8 +14,8 @@ void flux_x(int i, int j, int k,
             amrex::Real hdtdx)
 {
     px(i,j,k) = ( (vx(i,j,k) < 0) ?
-                phi(i  ,j,k) - slope(i  ,j,k)*(0.5 + hdtdx*vx(i,j,k)) :
-                phi(i-1,j,k) + slope(i-1,j,k)*(0.5 - hdtdx*vx(i,j,k)) );
+                phi(i  ,j,k) - slope(i  ,j,k)*(amrex::Real(0.5) + hdtdx*vx(i,j,k)) :
+                phi(i-1,j,k) + slope(i-1,j,k)*(amrex::Real(0.5) - hdtdx*vx(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -28,8 +28,8 @@ void flux_y(int i, int j, int k,
             amrex::Real hdtdy)
 {
     py(i,j,k) = ( (vy(i,j,k) < 0) ?
-                phi(i,j  ,k) - slope(i,j  ,k)*(0.5 + hdtdy*vy(i,j,k)) :
-                phi(i,j-1,k) + slope(i,j-1,k)*(0.5 - hdtdy*vy(i,j,k)) );
+                phi(i,j  ,k) - slope(i,j  ,k)*(amrex::Real(0.5) + hdtdy*vy(i,j,k)) :
+                phi(i,j-1,k) + slope(i,j-1,k)*(amrex::Real(0.5) - hdtdy*vy(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -42,8 +42,8 @@ void flux_z(int i, int j, int k,
             amrex::Real hdtdz)
 {
     pz(i,j,k) = ( (vz(i,j,k) < 0) ?
-                phi(i,j,k  ) - slope(i,j,k  )*(0.5 + hdtdz*vz(i,j,k)) :
-                phi(i,j,k-1) + slope(i,j,k-1)*(0.5 - hdtdz*vz(i,j,k)) );
+                phi(i,j,k  ) - slope(i,j,k  )*(amrex::Real(0.5) + hdtdz*vz(i,j,k)) :
+                phi(i,j,k-1) + slope(i,j,k-1)*(amrex::Real(0.5) - hdtdz*vz(i,j,k)) );
 }
 
 AMREX_GPU_DEVICE
@@ -57,8 +57,8 @@ void flux_xy(int i, int j, int k,
              amrex::Real tdtdy)
 {
     pxy(i,j,k) = ( (vx(i,j,k) < 0) ?
-                 px(i,j,k) - tdtdy * ( 0.5*(vy(i,  j+1,k) + vy(i  ,j,k)) * (py(i  ,j+1,k) - py(i  ,j,k))) :
-                 px(i,j,k) - tdtdy * ( 0.5*(vy(i-1,j+1,k) + vy(i-1,j,k)) * (py(i-1,j+1,k) - py(i-1,j,k))) );
+                 px(i,j,k) - tdtdy * ( amrex::Real(0.5)*(vy(i,  j+1,k) + vy(i  ,j,k)) * (py(i  ,j+1,k) - py(i  ,j,k))) :
+                 px(i,j,k) - tdtdy * ( amrex::Real(0.5)*(vy(i-1,j+1,k) + vy(i-1,j,k)) * (py(i-1,j+1,k) - py(i-1,j,k))) );
 }
 
 AMREX_GPU_DEVICE
@@ -72,8 +72,8 @@ void flux_xz(int i, int j, int k,
              amrex::Real tdtdz)
 {
     pxz(i,j,k) = ( (vx(i,j,k) < 0) ?
-                 px(i,j,k) - tdtdz * ( 0.5*(vz(i,  j,k+1) + vz(i  ,j,k)) * (pz(i  ,j,k+1) - pz(i  ,j,k))) :
-                 px(i,j,k) - tdtdz * ( 0.5*(vz(i-1,j,k+1) + vz(i-1,j,k)) * (pz(i-1,j,k+1) - pz(i-1,j,k))) );
+                 px(i,j,k) - tdtdz * ( amrex::Real(0.5)*(vz(i,  j,k+1) + vz(i  ,j,k)) * (pz(i  ,j,k+1) - pz(i  ,j,k))) :
+                 px(i,j,k) - tdtdz * ( amrex::Real(0.5)*(vz(i-1,j,k+1) + vz(i-1,j,k)) * (pz(i-1,j,k+1) - pz(i-1,j,k))) );
 }
 
 AMREX_GPU_DEVICE
@@ -87,8 +87,8 @@ void flux_yx(int i, int j, int k,
              amrex::Real tdtdx)
 {
     pyx(i,j,k) = ( (vy(i,j,k) < 0) ?
-                 py(i,j,k) - tdtdx * ( 0.5*(vx(i+1,j  ,k) + vx(i,j  ,k)) * (px(i+1,j  ,k) - px(i,j  ,k))) :
-                 py(i,j,k) - tdtdx * ( 0.5*(vx(i+1,j-1,k) + vx(i,j-1,k)) * (px(i+1,j-1,k) - px(i,j-1,k))) );
+                 py(i,j,k) - tdtdx * ( amrex::Real(0.5)*(vx(i+1,j  ,k) + vx(i,j  ,k)) * (px(i+1,j  ,k) - px(i,j  ,k))) :
+                 py(i,j,k) - tdtdx * ( amrex::Real(0.5)*(vx(i+1,j-1,k) + vx(i,j-1,k)) * (px(i+1,j-1,k) - px(i,j-1,k))) );
 }
 
 AMREX_GPU_DEVICE
@@ -102,8 +102,8 @@ void flux_yz(int i, int j, int k,
              amrex::Real tdtdz)
 {
     pyz(i,j,k) = ( (vy(i,j,k) < 0) ?
-                 py(i,j,k) - tdtdz * ( 0.5*(vz(i,  j,k+1) + vz(i,j  ,k)) * (pz(i,j  ,k+1) - pz(i,j  ,k))) :
-                 py(i,j,k) - tdtdz * ( 0.5*(vz(i,j-1,k+1) + vz(i,j-1,k)) * (pz(i,j-1,k+1) - pz(i,j-1,k))) );
+                 py(i,j,k) - tdtdz * ( amrex::Real(0.5)*(vz(i,  j,k+1) + vz(i,j  ,k)) * (pz(i,j  ,k+1) - pz(i,j  ,k))) :
+                 py(i,j,k) - tdtdz * ( amrex::Real(0.5)*(vz(i,j-1,k+1) + vz(i,j-1,k)) * (pz(i,j-1,k+1) - pz(i,j-1,k))) );
 }
 
 AMREX_GPU_DEVICE
@@ -117,8 +117,8 @@ void flux_zx(int i, int j, int k,
              amrex::Real tdtdx)
 {
     pzx(i,j,k) = ( (vz(i,j,k) < 0) ?
-                 pz(i,j,k) - tdtdx * ( 0.5*(vx(i+1,j,k  ) + vx(i,j,k  )) * (px(i+1,j,k  ) - px(i,j,k  ))) :
-                 pz(i,j,k) - tdtdx * ( 0.5*(vx(i+1,j,k-1) + vx(i,j,k-1)) * (px(i+1,j,k-1) - px(i,j,k-1))) );
+                 pz(i,j,k) - tdtdx * ( amrex::Real(0.5)*(vx(i+1,j,k  ) + vx(i,j,k  )) * (px(i+1,j,k  ) - px(i,j,k  ))) :
+                 pz(i,j,k) - tdtdx * ( amrex::Real(0.5)*(vx(i+1,j,k-1) + vx(i,j,k-1)) * (px(i+1,j,k-1) - px(i,j,k-1))) );
 }
 
 AMREX_GPU_DEVICE
@@ -132,8 +132,8 @@ void flux_zy(int i, int j, int k,
              amrex::Real tdtdy)
 {
     pzy(i,j,k) = ( (vz(i,j,k) < 0) ?
-                 pz(i,j,k) - tdtdy * ( 0.5*(vy(i,j+1,k  ) + vy(i,j,k  )) * (py(i,j+1,k  ) - py(i,j,k  ))) :
-                 pz(i,j,k) - tdtdy * ( 0.5*(vy(i,j+1,k-1) + vy(i,j,k-1)) * (py(i,j+1,k-1) - py(i,j,k-1))) );
+                 pz(i,j,k) - tdtdy * ( amrex::Real(0.5)*(vy(i,j+1,k  ) + vy(i,j,k  )) * (py(i,j+1,k  ) - py(i,j,k  ))) :
+                 pz(i,j,k) - tdtdy * ( amrex::Real(0.5)*(vy(i,j+1,k-1) + vy(i,j,k-1)) * (py(i,j+1,k-1) - py(i,j,k-1))) );
 }
 
 AMREX_GPU_DEVICE
@@ -149,10 +149,10 @@ void create_flux_x(int i, int j, int k,
                    amrex::Real hdtdy, amrex::Real hdtdz)
 {
     amrex::Real f = ( (vx(i,j,k) < 0) ?
-                px(i,j,k) - hdtdy * ( 0.5*(vy(i  ,j+1,k  ) + vy(i  ,j,k)) * (pyz(i  ,j+1,k  )-pyz(i  ,j,k)))
-                          - hdtdz * ( 0.5*(vz(i  ,j  ,k+1) + vz(i  ,j,k)) * (pzy(i  ,j  ,k+1)-pzy(i  ,j,k))) :
-                px(i,j,k) - hdtdy * ( 0.5*(vy(i-1,j+1,k  ) + vy(i-1,j,k)) * (pyz(i-1,j+1,k  )-pyz(i-1,j,k)))
-                          - hdtdz * ( 0.5*(vz(i-1,j  ,k+1) + vz(i-1,j,k)) * (pzy(i-1,j  ,k+1)-pzy(i-1,j,k))) );
+                px(i,j,k) - hdtdy * ( amrex::Real(0.5)*(vy(i  ,j+1,k  ) + vy(i  ,j,k)) * (pyz(i  ,j+1,k  )-pyz(i  ,j,k)))
+                          - hdtdz * ( amrex::Real(0.5)*(vz(i  ,j  ,k+1) + vz(i  ,j,k)) * (pzy(i  ,j  ,k+1)-pzy(i  ,j,k))) :
+                px(i,j,k) - hdtdy * ( amrex::Real(0.5)*(vy(i-1,j+1,k  ) + vy(i-1,j,k)) * (pyz(i-1,j+1,k  )-pyz(i-1,j,k)))
+                          - hdtdz * ( amrex::Real(0.5)*(vz(i-1,j  ,k+1) + vz(i-1,j,k)) * (pzy(i-1,j  ,k+1)-pzy(i-1,j,k))) );
 
     fx(i,j,k) = vx(i,j,k)*f;
 }
@@ -170,10 +170,10 @@ void create_flux_y(int i, int j, int k,
                    amrex::Real hdtdx, amrex::Real hdtdz)
 {
     amrex::Real f = ( (vy(i,j,k) < 0) ?
-                py(i,j,k) - hdtdx * ( 0.5*(vx(i+1,j  ,k  ) + vx(i,j  ,k)) * (pxz(i+1,j  ,k  )-pxz(i,j  ,k)))
-                          - hdtdz * ( 0.5*(vz(i,  j  ,k+1) + vz(i,j  ,k)) * (pzx(i,  j  ,k+1)-pzx(i,j  ,k))) :
-                py(i,j,k) - hdtdx * ( 0.5*(vx(i+1,j-1,k  ) + vx(i,j-1,k)) * (pxz(i+1,j-1,k  )-pxz(i,j-1,k)))
-                          - hdtdz * ( 0.5*(vz(i  ,j-1,k+1) + vz(i,j-1,k)) * (pzx(i  ,j-1,k+1)-pzx(i,j-1,k))) );
+                py(i,j,k) - hdtdx * ( amrex::Real(0.5)*(vx(i+1,j  ,k  ) + vx(i,j  ,k)) * (pxz(i+1,j  ,k  )-pxz(i,j  ,k)))
+                          - hdtdz * ( amrex::Real(0.5)*(vz(i,  j  ,k+1) + vz(i,j  ,k)) * (pzx(i,  j  ,k+1)-pzx(i,j  ,k))) :
+                py(i,j,k) - hdtdx * ( amrex::Real(0.5)*(vx(i+1,j-1,k  ) + vx(i,j-1,k)) * (pxz(i+1,j-1,k  )-pxz(i,j-1,k)))
+                          - hdtdz * ( amrex::Real(0.5)*(vz(i  ,j-1,k+1) + vz(i,j-1,k)) * (pzx(i  ,j-1,k+1)-pzx(i,j-1,k))) );
 
     fy(i,j,k) = vy(i,j,k)*f;
 }
@@ -191,10 +191,10 @@ void create_flux_z(int i, int j, int k,
                    amrex::Real hdtdx, amrex::Real hdtdy)
 {
     amrex::Real f = ( (vz(i,j,k) < 0) ?
-                pz(i,j,k) - hdtdx * ( 0.5*(vx(i+1,j  ,k  ) + vx(i,j,k  )) * (pxy(i+1,j  ,k  )-pxy(i,j,k  )))
-                          - hdtdy * ( 0.5*(vy(i,  j+1,k  ) + vy(i,j,k  )) * (pyx(i,  j+1,k  )-pyx(i,j,k  ))) :
-                pz(i,j,k) - hdtdx * ( 0.5*(vx(i+1,j  ,k-1) + vx(i,j,k-1)) * (pxy(i+1,j  ,k-1)-pxy(i,j,k-1)))
-                          - hdtdy * ( 0.5*(vy(i  ,j+1,k-1) + vy(i,j,k-1)) * (pyx(i  ,j+1,k-1)-pyx(i,j,k-1))) );
+                pz(i,j,k) - hdtdx * ( amrex::Real(0.5)*(vx(i+1,j  ,k  ) + vx(i,j,k  )) * (pxy(i+1,j  ,k  )-pxy(i,j,k  )))
+                          - hdtdy * ( amrex::Real(0.5)*(vy(i,  j+1,k  ) + vy(i,j,k  )) * (pyx(i,  j+1,k  )-pyx(i,j,k  ))) :
+                pz(i,j,k) - hdtdx * ( amrex::Real(0.5)*(vx(i+1,j  ,k-1) + vx(i,j,k-1)) * (pxy(i+1,j  ,k-1)-pxy(i,j,k-1)))
+                          - hdtdy * ( amrex::Real(0.5)*(vy(i  ,j+1,k-1) + vy(i,j,k-1)) * (pyx(i  ,j+1,k-1)-pyx(i,j,k-1))) );
 
     fz(i,j,k) = vz(i,j,k)*f;
 }

--- a/Tests/Amr/Advection_AmrLevel/Source/Tagging_params.cpp
+++ b/Tests/Amr/Advection_AmrLevel/Source/Tagging_params.cpp
@@ -14,11 +14,11 @@ AmrLevelAdv::get_tagging_params()
 
     // Set default values for the error thresholds, then read from input file
     if (max_phierr_lev  != -1) {
-        phierr.resize(max_phierr_lev, 1.0e+20);
+        phierr.resize(max_phierr_lev, amrex::Real(1.0e+20));
         pp.queryarr("phierr",  phierr);
     }
     if (max_phigrad_lev != -1) {
-        phigrad.resize(max_phigrad_lev, 1.0e+20);
+        phigrad.resize(max_phigrad_lev, amrex::Real(1.0e+20));
         pp.queryarr("phigrad", phigrad);
     }
 }

--- a/Tests/CTOParFor/GNUmakefile
+++ b/Tests/CTOParFor/GNUmakefile
@@ -10,8 +10,6 @@ USE_CUDA  = FALSE
 
 TINY_PROFILE = FALSE
 
-CXXSTD = c++17
-
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 include ./Make.package

--- a/Tests/CommType/main.cpp
+++ b/Tests/CommType/main.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[])
             } else if (k >= ncells) {
                 k -= ncells;
             }
-            return n + i*ncomp + j*ncomp*ncells + k*ncomp*ncells*ncells;
+            return Real(n + i*ncomp + j*ncomp*ncells + k*ncomp*ncells*ncells);
         };
 
         // Test GpuArray
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
                     auto v = value(i,j,k,n);
                     r1 = std::max(r1, std::abs(a1(i,j,k)[n] - v));
                     r2 = std::max(r2, std::abs(a2(i,j,k)[n] - v));
-                    r3 = std::max(r3, std::abs(a3(i,j,k)[n] - v*m(i,j,k)));
+                    r3 = std::max(r3, std::abs(a3(i,j,k)[n] - v*Real(m(i,j,k))));
                 }
                 return {r1, r2, r3};
             });

--- a/Tests/EB/FCFactory/main.cpp
+++ b/Tests/EB/FCFactory/main.cpp
@@ -129,7 +129,7 @@ void main_main()
     Real cell_volume = AMREX_D_TERM(geom.CellSize(0),*geom.CellSize(1),*geom.CellSize(2));
     const Real pi = std::numbers::pi_v<Real>;
 #if (AMREX_SPACEDIM == 3)
-    Real vol_analytical = Real(4.0/3.0) * pi * std::pow(sphere_radius, 3);
+    Real vol_analytical = Real(4.0/3.0) * pi * Real(std::pow(sphere_radius, 3));
 #else
     Real vol_analytical = pi * (sphere_radius*sphere_radius);
 #endif

--- a/Tests/EB/MarchingCubes/main.cpp
+++ b/Tests/EB/MarchingCubes/main.cpp
@@ -12,12 +12,12 @@ void main_main ()
     int ny = 64;
     int nz = 64;
     int max_grid_size = 32;
-    Real xmin = -1.2;
-    Real xmax =  1.2;
-    Real ymin = -1.2;
-    Real ymax =  1.2;
-    Real zmin = -1.2;
-    Real zmax =  1.2;
+    Real xmin = Real(-1.2);
+    Real xmax =  Real(1.2);
+    Real ymin = Real(-1.2);
+    Real ymax =  Real(1.2);
+    Real zmin = Real(-1.2);
+    Real zmax =  Real(1.2);
     {
         ParmParse pp;
         pp.query("nx", nx);

--- a/Tests/FFT/Batch/main.cpp
+++ b/Tests/FFT/Batch/main.cpp
@@ -62,9 +62,9 @@ int main (int argc, char* argv[])
         ParallelFor(mf, IntVect(0), batch_size,
                     [=] AMREX_GPU_DEVICE (int b, int i, int j, int k, int n)
         {
-            AMREX_D_TERM(Real x = (i+0.5_rt) * dx[0] - 0.5_rt;,
-                         Real y = (j+0.5_rt) * dx[1] - 0.5_rt;,
-                         Real z = (k+0.5_rt) * dx[2] - 0.5_rt);
+            AMREX_D_TERM(Real x = (Real(i)+0.5_rt) * dx[0] - 0.5_rt;,
+                         Real y = (Real(j)+0.5_rt) * dx[1] - 0.5_rt;,
+                         Real z = (Real(k)+0.5_rt) * dx[2] - 0.5_rt);
             ma[b](i,j,k,n) = std::exp(-10._rt*
                 (AMREX_D_TERM(x*x*1.05_rt, + y*y*0.90_rt, + z*z))) + Real(n);
         });

--- a/Tests/FFT/C2C/main.cpp
+++ b/Tests/FFT/C2C/main.cpp
@@ -58,9 +58,9 @@ int main (int argc, char* argv[])
         auto const& ma = mf.arrays();
         ParallelFor(mf, [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
         {
-            AMREX_D_TERM(Real x = (i+0.5_rt) * dx[0] - 0.5_rt;,
-                         Real y = (j+0.5_rt) * dx[1] - 0.5_rt;,
-                         Real z = (k+0.5_rt) * dx[2] - 0.5_rt);
+            AMREX_D_TERM(Real x = (Real(i)+0.5_rt) * dx[0] - 0.5_rt;,
+                         Real y = (Real(j)+0.5_rt) * dx[1] - 0.5_rt;,
+                         Real z = (Real(k)+0.5_rt) * dx[2] - 0.5_rt);
             auto tmp = std::exp(-10._rt*
                 (AMREX_D_TERM(x*x*1.05_rt, + y*y*0.90_rt, + z*z)));
             ma[b](i,j,k) = GpuComplex<Real>{tmp, 1._rt-tmp};
@@ -92,7 +92,7 @@ int main (int argc, char* argv[])
             auto error = errmf.norminf();
             amrex::Print() << "  Expected to be close to zero: " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 1.e-6f;
+            auto eps = 1.e-6F;
 #else
             auto eps = 1.e-13;
 #endif
@@ -123,7 +123,7 @@ int main (int argc, char* argv[])
             auto error = errmf.norminf();
             amrex::Print() << "  Expected to be close to zero: " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 1.e-6f;
+            auto eps = 1.e-6F;
 #else
             auto eps = 1.e-13;
 #endif
@@ -178,7 +178,7 @@ int main (int argc, char* argv[])
             auto error = errmf.norminf();
             amrex::Print() << "  Expected to be close to zero: " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 1.e-6f;
+            auto eps = 1.e-6F;
 #else
             auto eps = 1.e-13;
 #endif

--- a/Tests/FFT/OpenBC/main.cpp
+++ b/Tests/FFT/OpenBC/main.cpp
@@ -22,9 +22,9 @@ void fill_rhs (MultiFab& rho, Geometry const& geom, IndexType ixtype)
 
     ParallelFor(rho, [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
     {
-        Real x = (i+0.5_rt/nsub)*dx[0] + problo[0];
-        Real y = (j+0.5_rt/nsub)*dx[1] + problo[1];
-        Real z = (k+0.5_rt/nsub)*dx[2] + problo[2];
+        Real x = (Real(i)+0.5_rt/nsub)*dx[0] + problo[0];
+        Real y = (Real(j)+0.5_rt/nsub)*dx[1] + problo[1];
+        Real z = (Real(k)+0.5_rt/nsub)*dx[2] + problo[2];
         if (ixtype.nodeCentered()) {
             x -= 0.5_rt*dx[0];
             y -= 0.5_rt*dx[1];
@@ -34,9 +34,9 @@ void fill_rhs (MultiFab& rho, Geometry const& geom, IndexType ixtype)
         for (int isub = 0; isub < nsub; ++isub) {
         for (int jsub = 0; jsub < nsub; ++jsub) {
         for (int ksub = 0; ksub < nsub; ++ksub) {
-            auto xs = x + isub*dxsub;
-            auto ys = y + jsub*dysub;
-            auto zs = z + ksub*dzsub;
+            auto xs = x + Real(isub)*dxsub;
+            auto ys = y + Real(jsub)*dysub;
+            auto zs = z + Real(ksub)*dzsub;
             if ((xs*xs+ys*ys+zs*zs) < 0.25_rt) { ++n; }
         }}}
         rhoma[b](i,j,k) = Real(n) / Real(nsub*nsub*nsub);
@@ -120,7 +120,7 @@ int main (int argc, char* argv[])
                     auto error = std::abs(expected-v[0])/std::max(std::abs(expected),std::abs(v[0]));
                     amrex::AllPrint() << "  error " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-                    constexpr Real eps = 1.e-5;
+                    constexpr Real eps = Real(1.e-5);
 #else
                     constexpr Real eps = 1.e-6;
 #endif
@@ -175,7 +175,7 @@ int main (int argc, char* argv[])
             Real const error = diff.norm0(0) / refnorm;
             amrex::Print() << "  relative padded/unpadded error " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-            constexpr Real eps = 1.e-5;
+            constexpr Real eps = Real(1.e-5);
 #else
             constexpr Real eps = 1.e-13;
 #endif

--- a/Tests/FFT/Poisson/main.cpp
+++ b/Tests/FFT/Poisson/main.cpp
@@ -32,7 +32,7 @@ void make_rhs (MultiFab& rhs, Geometry const& geom,
         IntVect iv(AMREX_D_DECL(i,j,k));
         Real r = 1.0_rt;
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            Real x = (iv[idim]+0.5_rt) * dx[idim];
+            Real x = (Real(iv[idim])+0.5_rt) * dx[idim];
             if (fft_bc[idim].first == FFT::Boundary::periodic) {
                 r *= (0.11_rt + std::sin((x+0.1_rt)*fac[idim]));
             } else if (fft_bc[idim].first == FFT::Boundary::even &&
@@ -67,7 +67,7 @@ void make_rhs (MultiFab& rhs, Geometry const& geom,
     if (! has_dirichlet) {
         // Shift rhs so that its sum is zero.
         auto rhosum = rhs.sum(0);
-        rhs.plus(-rhosum/geom.Domain().d_numPts(), 0, 1);
+        rhs.plus(Real(-rhosum/geom.Domain().d_numPts()), 0, 1);
     }
 }
 
@@ -118,9 +118,9 @@ void run_test (AMREX_D_DECL(int n_cell_x, int n_cell_y, int n_cell_z))
         AMREX_D_TERM(Real prob_lo_x = 0.;,
                      Real prob_lo_y = 0.;,
                      Real prob_lo_z = 0.);
-        AMREX_D_TERM(Real prob_hi_x = 1.1;,
-                     Real prob_hi_y = 0.8;,
-                     Real prob_hi_z = 1.9);
+        AMREX_D_TERM(Real prob_hi_x = Real(1.1);,
+                     Real prob_hi_y = Real(0.8);,
+                     Real prob_hi_z = Real(1.9));
 
         {
             ParmParse pp;
@@ -199,7 +199,7 @@ void run_test (AMREX_D_DECL(int n_cell_x, int n_cell_y, int n_cell_z))
             amrex::Print() << "       rhs inf norm " << bnorm << "\n"
                            << "       res inf norm " << rnorm << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 2.e-3f;
+            auto eps = 2.e-3F;
 #else
             auto eps = 2.e-10;
 #endif
@@ -240,7 +240,7 @@ void run_test (AMREX_D_DECL(int n_cell_x, int n_cell_y, int n_cell_z))
             amrex::Print() << "       rhs inf norm " << bnorm << "\n"
                            << "       res inf norm " << rnorm << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 2.e-3f;
+            auto eps = 2.e-3F;
 #else
             auto eps = 2.e-10;
 #endif

--- a/Tests/FFT/R2C/main.cpp
+++ b/Tests/FFT/R2C/main.cpp
@@ -59,9 +59,9 @@ int main (int argc, char* argv[])
         auto const& ma = mf.arrays();
         ParallelFor(mf, [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
         {
-            AMREX_D_TERM(Real x = (i+0.5_rt) * dx[0] - 0.5_rt;,
-                         Real y = (j+0.5_rt) * dx[1] - 0.5_rt;,
-                         Real z = (k+0.5_rt) * dx[2] - 0.5_rt);
+            AMREX_D_TERM(Real x = (Real(i)+0.5_rt) * dx[0] - 0.5_rt;,
+                         Real y = (Real(j)+0.5_rt) * dx[1] - 0.5_rt;,
+                         Real z = (Real(k)+0.5_rt) * dx[2] - 0.5_rt);
             ma[b](i,j,k) = std::exp(-10._rt*
                 (AMREX_D_TERM(x*x*1.05_rt, + y*y*0.90_rt, + z*z)));
         });
@@ -98,7 +98,7 @@ int main (int argc, char* argv[])
             auto error = mf2.norminf();
             amrex::Print() << "  Expected to be close to zero: " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 1.e-6f;
+            auto eps = 1.e-6F;
 #else
             auto eps = 1.e-13;
 #endif
@@ -121,7 +121,7 @@ int main (int argc, char* argv[])
             auto error = mf2.norminf();
             amrex::Print() << "  Expected to be close to zero: " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 1.e-6f;
+            auto eps = 1.e-6F;
 #else
             auto eps = 1.e-13;
 #endif
@@ -164,7 +164,7 @@ int main (int argc, char* argv[])
             ParallelDescriptor::ReduceRealMax(error);
             amrex::Print() << "  Expected to be close to zero: " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 1.e-6f;
+            auto eps = 1.e-6F;
 #else
             auto eps = 1.e-13;
 #endif
@@ -230,7 +230,7 @@ int main (int argc, char* argv[])
             auto error = mf2.norminf();
             amrex::Print() << "  Expected to be close to zero: " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 1.e-6f;
+            auto eps = 1.e-6F;
 #else
             auto eps = 1.e-13;
 #endif
@@ -281,7 +281,7 @@ int main (int argc, char* argv[])
                 amrex::Print() << "  Face MultiFab dir " << idim
                                << " expected to be close to zero: " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-                auto eps = 1.e-6f;
+                auto eps = 1.e-6F;
 #else
                 auto eps = 1.e-13;
 #endif

--- a/Tests/FFT/R2X/main.cpp
+++ b/Tests/FFT/R2X/main.cpp
@@ -58,9 +58,9 @@ int main (int argc, char* argv[])
         auto const& ma = mf.arrays();
         ParallelFor(mf, [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
         {
-            AMREX_D_TERM(Real x = (i+0.5_rt) * dx[0] - 0.5_rt;,
-                         Real y = (j+0.5_rt) * dx[1] - 0.5_rt;,
-                         Real z = (k+0.5_rt) * dx[2] - 0.5_rt);
+            AMREX_D_TERM(Real x = (Real(i)+0.5_rt) * dx[0] - 0.5_rt;,
+                         Real y = (Real(j)+0.5_rt) * dx[1] - 0.5_rt;,
+                         Real z = (Real(k)+0.5_rt) * dx[2] - 0.5_rt);
             ma[b](i,j,k) = std::exp(-10._rt*
                 (AMREX_D_TERM(x*x*1.05_rt, + y*y*0.90_rt, + z*z)));
         });
@@ -110,7 +110,7 @@ int main (int argc, char* argv[])
             auto error = mf2.norminf();
             amrex::Print() << "    Expected to be close to zero: " << error << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 1.e-6f;
+            auto eps = 1.e-6F;
 #else
             auto eps = 1.e-13;
 #endif

--- a/Tests/FFT/Stokes/main.cpp
+++ b/Tests/FFT/Stokes/main.cpp
@@ -63,9 +63,9 @@ int main (int argc, char* argv[])
         auto const& p = pres.arrays();
         ParallelFor(pres, [=] AMREX_GPU_DEVICE (int b, int i, int j, int k)
         {
-            AMREX_D_TERM(Real x = (i+0.5_rt) * dx[0] - 0.5_rt;,
-                         Real y = (j+0.5_rt) * dx[1] - 0.5_rt;,
-                         Real z = (k+0.5_rt) * dx[2] - 0.5_rt);
+            AMREX_D_TERM(Real x = (Real(i)+0.5_rt) * dx[0] - 0.5_rt;,
+                         Real y = (Real(j)+0.5_rt) * dx[1] - 0.5_rt;,
+                         Real z = (Real(k)+0.5_rt) * dx[2] - 0.5_rt);
             p[b](i,j,k) = std::cos(Real(2.)*Math::pi<Real>()*x)
                          + std::cos(Real(2.)*Math::pi<Real>()*y);
 #if (BL_SPACEDIM == 3)
@@ -207,7 +207,7 @@ int main (int argc, char* argv[])
             amrex::Print() << "  U error expected to be close to zero: " << u_error << "\n";
             amrex::Print() << "  V error expected to be close to zero: " << v_error << "\n";
 #ifdef AMREX_USE_FLOAT
-            auto eps = 1.e-3f;
+            auto eps = 1.e-3F;
 #else
             auto eps = 1.e-11;
 #endif

--- a/Tests/LinearSolvers/ABecLap_SP/MyTest.H
+++ b/Tests/LinearSolvers/ABecLap_SP/MyTest.H
@@ -68,7 +68,7 @@ private:
     amrex::Vector<amrex::MultiFab> acoef;
     amrex::Vector<amrex::MultiFab> bcoef;
 
-    amrex::Real ascalar = 1.e-3;
+    amrex::Real ascalar = amrex::Real(1.e-3);
     amrex::Real bscalar = 1.0;
 };
 

--- a/Tests/LinearSolvers/ABecLap_SP/initProb_K.H
+++ b/Tests/LinearSolvers/ABecLap_SP/initProb_K.H
@@ -15,23 +15,23 @@ void actual_init_poisson (int i, int j, int k,
     constexpr amrex::Real tpi = 2.*pi;
     constexpr amrex::Real fpi = 4.*pi;
     constexpr amrex::Real fac = tpi*tpi*static_cast<amrex::Real>(AMREX_SPACEDIM);
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 
 #if (AMREX_SPACEDIM == 2)
 
     exact(i,j,k) = (std::sin(tpi*x) * std::sin(tpi*y))
-           + .25 * (std::sin(fpi*x) * std::sin(fpi*y));
+           + amrex::Real(0.25) * (std::sin(fpi*x) * std::sin(fpi*y));
 
     rhs(i,j,k) = -fac * (std::sin(tpi*x) * std::sin(tpi*y))
                  -fac * (std::sin(fpi*x) * std::sin(fpi*y));
 
 #else
 
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 
     exact(i,j,k) = (std::sin(tpi*x) * std::sin(tpi*y) * std::sin(tpi*z))
-           + .25 * (std::sin(fpi*x) * std::sin(fpi*y) * std::sin(fpi*z));
+           + amrex::Real(0.25) * (std::sin(fpi*x) * std::sin(fpi*y) * std::sin(fpi*z));
 
     rhs(i,j,k) = -fac * (std::sin(tpi*x) * std::sin(tpi*y) * std::sin(tpi*z))
                  -fac * (std::sin(fpi*x) * std::sin(fpi*y) * std::sin(fpi*z));
@@ -48,32 +48,32 @@ void actual_init_bcoef (int i, int j, int k,
                         amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
                         amrex::Box const& domain)
 {
-    constexpr amrex::Real w = 0.05;
+    constexpr amrex::Real w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = 0.5*std::log(3.) / (w + 1.e-50);
+    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
 
-    amrex::Real xc = (prob_hi[0] + prob_lo[0])*0.5;
-    amrex::Real yc = (prob_hi[1] + prob_lo[1])*0.5;
+    amrex::Real xc = (prob_hi[0] + prob_lo[0])*amrex::Real(0.5);
+    amrex::Real yc = (prob_hi[1] + prob_lo[1])*amrex::Real(0.5);
 #if (AMREX_SPACEDIM == 2)
     amrex::Real zc = 0.0;
 #else
-    amrex::Real zc = (prob_hi[2] + prob_lo[2])*0.5;
+    amrex::Real zc = (prob_hi[2] + prob_lo[2])*amrex::Real(0.5);
 #endif
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 #endif
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
-    beta(i,j,k) = (sigma-1.)/2.*std::tanh(theta*(r-0.25)) + (sigma+1.)/2.;
+    beta(i,j,k) = static_cast<amrex::Real>((sigma-1.)/2.*std::tanh(theta*(r-amrex::Real(0.25))) + (sigma+1.)/2.);
 
     if (domain.contains(i,j,k)) {
         sol(i,j,k) = 0.0;
@@ -82,7 +82,7 @@ void actual_init_bcoef (int i, int j, int k,
                      y = amrex::Clamp(y, prob_lo[1], prob_hi[1]);,
                      z = amrex::Clamp(z, prob_lo[2], prob_hi[2]););
         sol(i,j,k) = std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-            +  .25 * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z);
+            +  amrex::Real(0.25) * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z);
     }
 }
 
@@ -97,40 +97,40 @@ void actual_init_abeclap (int i, int j, int k,
                           amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_hi,
                           amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx)
 {
-    constexpr amrex::Real w = 0.05;
+    constexpr amrex::Real w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = 0.5*std::log(3.) / (w + 1.e-50);
+    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
     constexpr amrex::Real fac = static_cast<amrex::Real>(AMREX_SPACEDIM*4)*pi*pi;
 
-    amrex::Real xc = (prob_hi[0] + prob_lo[0])*0.5;
-    amrex::Real yc = (prob_hi[1] + prob_lo[1])*0.5;
+    amrex::Real xc = (prob_hi[0] + prob_lo[0])*amrex::Real(0.5);
+    amrex::Real yc = (prob_hi[1] + prob_lo[1])*amrex::Real(0.5);
 #if (AMREX_SPACEDIM == 2)
     amrex::Real zc = 0.0;
 #else
-    amrex::Real zc = (prob_hi[2] + prob_lo[2])*0.5;
+    amrex::Real zc = (prob_hi[2] + prob_lo[2])*amrex::Real(0.5);
 #endif
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 #endif
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
-    amrex::Real tmp = std::cosh(theta*(r-0.25));
-    amrex::Real dbdrfac = (sigma-1.)/2./(tmp*tmp) * theta/r;
+    amrex::Real tmp = std::cosh(theta*(r-amrex::Real(0.25)));
+    amrex::Real dbdrfac = static_cast<amrex::Real>((sigma-1.)/2./(tmp*tmp) * theta/r);
     dbdrfac *= b;
 
     alpha(i,j,k) = 1.;
 
     exact(i,j,k) = std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-           + .25 * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z);
+           + amrex::Real(0.25) * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z);
 
     rhs(i,j,k) = beta(i,j,k)*b*fac*(std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
                                   + std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z))
@@ -141,7 +141,7 @@ void actual_init_abeclap (int i, int j, int k,
                       + (z-zc)*(tpi*std::cos(tpi*x) * std::cos(tpi*y) * std::sin(tpi*z)
                                + pi*std::cos(fpi*x) * std::cos(fpi*y) * std::sin(fpi*z)))
                              + a * (std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-                           + 0.25 * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
+                           + amrex::Real(0.25) * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
 }
 
 #endif

--- a/Tests/LinearSolvers/ABecLap_SP/initProb_K.H
+++ b/Tests/LinearSolvers/ABecLap_SP/initProb_K.H
@@ -48,9 +48,9 @@ void actual_init_bcoef (int i, int j, int k,
                         amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
                         amrex::Box const& domain)
 {
-    constexpr amrex::Real w = amrex::Real(0.05);
+    constexpr auto w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
+    const amrex::Real theta = amrex::Real(0.5)*std::log(amrex::Real(3.)) / (w + amrex::Real(1.e-30));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
@@ -73,7 +73,8 @@ void actual_init_bcoef (int i, int j, int k,
 #endif
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
-    beta(i,j,k) = static_cast<amrex::Real>((sigma-1.)/2.*std::tanh(theta*(r-amrex::Real(0.25))) + (sigma+1.)/2.);
+    beta(i,j,k) = (sigma-amrex::Real(1.))/amrex::Real(2.)*std::tanh(theta*(r-amrex::Real(0.25)))
+                  + (sigma+amrex::Real(1.))/amrex::Real(2.);
 
     if (domain.contains(i,j,k)) {
         sol(i,j,k) = 0.0;
@@ -97,9 +98,9 @@ void actual_init_abeclap (int i, int j, int k,
                           amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_hi,
                           amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx)
 {
-    constexpr amrex::Real w = amrex::Real(0.05);
+    constexpr auto w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
+    const amrex::Real theta = amrex::Real(0.5)*std::log(amrex::Real(3.)) / (w + amrex::Real(1.e-30));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
@@ -124,7 +125,7 @@ void actual_init_abeclap (int i, int j, int k,
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
     amrex::Real tmp = std::cosh(theta*(r-amrex::Real(0.25)));
-    amrex::Real dbdrfac = static_cast<amrex::Real>((sigma-1.)/2./(tmp*tmp) * theta/r);
+    amrex::Real dbdrfac = (sigma-amrex::Real(1.))/amrex::Real(2.)/(tmp*tmp) * theta/r;
     dbdrfac *= b;
 
     alpha(i,j,k) = 1.;

--- a/Tests/LinearSolvers/ABecLaplacian_C/MyTest.H
+++ b/Tests/LinearSolvers/ABecLaplacian_C/MyTest.H
@@ -84,7 +84,7 @@ private:
     amrex::Vector<amrex::MultiFab> acoef;
     amrex::Vector<amrex::MultiFab> bcoef;
 
-    amrex::Real ascalar = 1.e-3;
+    amrex::Real ascalar = amrex::Real(1.e-3);
     amrex::Real bscalar = 1.0;
 };
 

--- a/Tests/LinearSolvers/ABecLaplacian_C/initProb_K.H
+++ b/Tests/LinearSolvers/ABecLaplacian_C/initProb_K.H
@@ -16,23 +16,23 @@ void actual_init_poisson (int i, int j, int k,
     constexpr amrex::Real tpi = 2.*pi;
     constexpr amrex::Real fpi = 4.*pi;
     constexpr amrex::Real fac = tpi*tpi*static_cast<amrex::Real>(AMREX_SPACEDIM);
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 
 #if (AMREX_SPACEDIM == 2)
 
     exact(i,j,k) = (std::sin(tpi*x) * std::sin(tpi*y))
-           + .25 * (std::sin(fpi*x) * std::sin(fpi*y));
+           + amrex::Real(0.25) * (std::sin(fpi*x) * std::sin(fpi*y));
 
     rhs(i,j,k) = -fac * (std::sin(tpi*x) * std::sin(tpi*y))
                  -fac * (std::sin(fpi*x) * std::sin(fpi*y));
 
 #else
 
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 
     exact(i,j,k) = (std::sin(tpi*x) * std::sin(tpi*y) * std::sin(tpi*z))
-           + .25 * (std::sin(fpi*x) * std::sin(fpi*y) * std::sin(fpi*z));
+           + amrex::Real(0.25) * (std::sin(fpi*x) * std::sin(fpi*y) * std::sin(fpi*z));
 
     rhs(i,j,k) = -fac * (std::sin(tpi*x) * std::sin(tpi*y) * std::sin(tpi*z))
                  -fac * (std::sin(fpi*x) * std::sin(fpi*y) * std::sin(fpi*z));
@@ -47,28 +47,28 @@ void actual_init_bcoef (int i, int j, int k,
                         amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_hi,
                         amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx)
 {
-    constexpr amrex::Real w = 0.05;
+    constexpr amrex::Real w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = 0.5*std::log(3.) / (w + 1.e-50);
+    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
 
-    amrex::Real xc = (prob_hi[0] + prob_lo[0])*0.5;
-    amrex::Real yc = (prob_hi[1] + prob_lo[1])*0.5;
+    amrex::Real xc = (prob_hi[0] + prob_lo[0])*amrex::Real(0.5);
+    amrex::Real yc = (prob_hi[1] + prob_lo[1])*amrex::Real(0.5);
 #if (AMREX_SPACEDIM == 2)
     amrex::Real zc = 0.0;
 #else
-    amrex::Real zc = (prob_hi[2] + prob_lo[2])*0.5;
+    amrex::Real zc = (prob_hi[2] + prob_lo[2])*amrex::Real(0.5);
 #endif
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 #endif
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
-    beta(i,j,k) = (sigma-1.)/2.*std::tanh(theta*(r-0.25)) + (sigma+1.)/2.;
+    beta(i,j,k) = static_cast<amrex::Real>((sigma-1.)/2.*std::tanh(theta*(r-amrex::Real(0.25))) + (sigma+1.)/2.);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -84,38 +84,38 @@ void actual_init_abeclap (int i, int j, int k,
                           amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
                           amrex::Box const& vbx)
 {
-    constexpr amrex::Real w = 0.05;
+    constexpr amrex::Real w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = 0.5*std::log(3.) / (w + 1.e-50);
+    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
     constexpr amrex::Real fac = static_cast<amrex::Real>(AMREX_SPACEDIM*4)*pi*pi;
 
-    amrex::Real xc = (prob_hi[0] + prob_lo[0])*0.5;
-    amrex::Real yc = (prob_hi[1] + prob_lo[1])*0.5;
+    amrex::Real xc = (prob_hi[0] + prob_lo[0])*amrex::Real(0.5);
+    amrex::Real yc = (prob_hi[1] + prob_lo[1])*amrex::Real(0.5);
 #if (AMREX_SPACEDIM == 2)
     amrex::Real zc = 0.0;
 #else
-    amrex::Real zc = (prob_hi[2] + prob_lo[2])*0.5;
+    amrex::Real zc = (prob_hi[2] + prob_lo[2])*amrex::Real(0.5);
 #endif
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 #endif
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
 
-    beta(i,j,k) = (sigma-1.)/2.*std::tanh(theta*(r-0.25)) + (sigma+1.)/2.;
+    beta(i,j,k) = static_cast<amrex::Real>((sigma-1.)/2.*std::tanh(theta*(r-amrex::Real(0.25))) + (sigma+1.)/2.);
 
     if (vbx.contains(i,j,k)) {
-        amrex::Real tmp = std::cosh(theta*(r-0.25));
-        amrex::Real dbdrfac = (sigma-1.)/2./(tmp*tmp) * theta/r;
+        amrex::Real tmp = std::cosh(theta*(r-amrex::Real(0.25)));
+        amrex::Real dbdrfac = static_cast<amrex::Real>((sigma-1.)/2./(tmp*tmp) * theta/r);
         dbdrfac *= b;
 
         alpha(i,j,k) = 1.;
@@ -123,7 +123,7 @@ void actual_init_abeclap (int i, int j, int k,
         sol(i,j,k) = 0.; // Use zero as initial guess for the linear solver
 
         exact(i,j,k) = std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-               + .25 * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z);
+               + amrex::Real(0.25) * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z);
 
         rhs(i,j,k) = beta(i,j,k)*b*fac*(std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
                                       + std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z))
@@ -134,7 +134,7 @@ void actual_init_abeclap (int i, int j, int k,
                           + (z-zc)*(tpi*std::cos(tpi*x) * std::cos(tpi*y) * std::sin(tpi*z)
                                    + pi*std::cos(fpi*x) * std::cos(fpi*y) * std::sin(fpi*z)))
                                  + a * (std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-                               + 0.25 * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
+                               + amrex::Real(0.25) * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
     } else {
         amrex::Real xb = amrex::Clamp(x, prob_lo[0], prob_hi[0]);
         amrex::Real yb = amrex::Clamp(y, prob_lo[1], prob_hi[1]);
@@ -145,7 +145,7 @@ void actual_init_abeclap (int i, int j, int k,
 #endif
         // provide Dirichlet BC
         sol(i,j,k) = std::cos(tpi*xb) * std::cos(tpi*yb) * std::cos(tpi*zb)
-             + .25 * std::cos(fpi*xb) * std::cos(fpi*yb) * std::cos(fpi*zb);
+             + amrex::Real(0.25) * std::cos(fpi*xb) * std::cos(fpi*yb) * std::cos(fpi*zb);
     }
 }
 
@@ -160,40 +160,40 @@ void actual_init_abeclap_in (int i, int j, int k,
                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_hi,
                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx)
 {
-    constexpr amrex::Real w = 0.05;
+    constexpr amrex::Real w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = 0.5*std::log(3.) / (w + 1.e-50);
+    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
     constexpr amrex::Real fac = static_cast<amrex::Real>(AMREX_SPACEDIM*4)*pi*pi;
 
-    amrex::Real xc = (prob_hi[0] + prob_lo[0])*0.5;
-    amrex::Real yc = (prob_hi[1] + prob_lo[1])*0.5;
+    amrex::Real xc = (prob_hi[0] + prob_lo[0])*amrex::Real(0.5);
+    amrex::Real yc = (prob_hi[1] + prob_lo[1])*amrex::Real(0.5);
 #if (AMREX_SPACEDIM == 2)
     amrex::Real zc = 0.0;
 #else
-    amrex::Real zc = (prob_hi[2] + prob_lo[2])*0.5;
+    amrex::Real zc = (prob_hi[2] + prob_lo[2])*amrex::Real(0.5);
 #endif
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 #endif
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
-    amrex::Real tmp = std::cosh(theta*(r-0.25));
-    amrex::Real dbdrfac = (sigma-1.)/2./(tmp*tmp) * theta/r;
+    amrex::Real tmp = std::cosh(theta*(r-amrex::Real(0.25)));
+    amrex::Real dbdrfac = static_cast<amrex::Real>((sigma-1.)/2./(tmp*tmp) * theta/r);
     dbdrfac *= b;
 
     alpha(i,j,k) = 1.;
 
     exact(i,j,k) = std::sin(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-           + .25 * std::cos(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z);
+           + amrex::Real(0.25) * std::cos(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z);
 
     rhs(i,j,k) = beta(i,j,k)*b*fac*(std::sin(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
                                   + std::cos(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z))
@@ -204,7 +204,7 @@ void actual_init_abeclap_in (int i, int j, int k,
                      + (z-zc)*( tpi*std::sin(tpi*x) * std::cos(tpi*y) * std::sin(tpi*z)
                                + pi*std::cos(fpi*x) * std::sin(fpi*y) * std::sin(fpi*z)))
                              + a * (std::sin(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-                           + 0.25 * std::cos(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z));
+                           + amrex::Real(0.25) * std::cos(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z));
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -216,16 +216,16 @@ void actual_init_dphi_dx_lo (int i, int j, int k, amrex::Array4<amrex::Real> con
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 1.0);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(1.0));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 #endif
 
     fx(i,j,k) = tpi * std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-        - .25 * fpi * std::sin(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z);
+        - amrex::Real(0.25) * fpi * std::sin(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -237,16 +237,16 @@ void actual_init_dphi_dx_hi (int i, int j, int k, amrex::Array4<amrex::Real> con
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.0);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.0));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 #endif
 
     fx(i,j,k) = tpi * std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-        - .25 * fpi * std::sin(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z);
+        - amrex::Real(0.25) * fpi * std::sin(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -258,16 +258,16 @@ void actual_init_dphi_dy_lo (int i, int j, int k, amrex::Array4<amrex::Real> con
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 1.0 );
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(1.0));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 #endif
 
     fy(i,j,k) = std::sin(tpi*x) * (-tpi) * std::sin(tpi*y) * std::cos(tpi*z)
-        + .25 * std::cos(fpi*x) * ( fpi) * std::cos(fpi*y) * std::cos(fpi*z);
+        + amrex::Real(0.25) * std::cos(fpi*x) * ( fpi) * std::cos(fpi*y) * std::cos(fpi*z);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -279,16 +279,16 @@ void actual_init_dphi_dy_hi (int i, int j, int k, amrex::Array4<amrex::Real> con
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.0);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.0));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.5);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.5));
 #endif
 
     fy(i,j,k) = std::sin(tpi*x) * (-tpi) * std::sin(tpi*y) * std::cos(tpi*z)
-        + .25 * std::cos(fpi*x) * ( fpi) * std::cos(fpi*y) * std::cos(fpi*z);
+        + amrex::Real(0.25) * std::cos(fpi*x) * ( fpi) * std::cos(fpi*y) * std::cos(fpi*z);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -300,16 +300,16 @@ void actual_init_dphi_dz_lo (int i, int j, int k, amrex::Array4<amrex::Real> con
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 1.0);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(1.0));
 #endif
 
     fz(i,j,k) = std::sin(tpi*x) * std::cos(tpi*y) * (-tpi) * std::sin(tpi*z)
-        + .25 * std::cos(fpi*x) * std::sin(fpi*y) * (-fpi) * std::sin(fpi*z);
+        + amrex::Real(0.25) * std::cos(fpi*x) * std::sin(fpi*y) * (-fpi) * std::sin(fpi*z);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -321,16 +321,16 @@ void actual_init_dphi_dz_hi (int i, int j, int k, amrex::Array4<amrex::Real> con
     constexpr amrex::Real tpi =  2.*pi;
     constexpr amrex::Real fpi =  4.*pi;
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i + 0.5);
-    amrex::Real y = prob_lo[1] + dx[1] * (j + 0.5);
+    amrex::Real x = prob_lo[0] + dx[0] * (amrex::Real(i) + amrex::Real(0.5));
+    amrex::Real y = prob_lo[1] + dx[1] * (amrex::Real(j) + amrex::Real(0.5));
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k + 0.0);
+    amrex::Real z = prob_lo[2] + dx[2] * (amrex::Real(k) + amrex::Real(0.0));
 #endif
 
     fz(i,j,k) = std::sin(tpi*x) * std::cos(tpi*y) * (-tpi) * std::sin(tpi*z)
-        + .25 * std::cos(fpi*x) * std::sin(fpi*y) * (-fpi) * std::sin(fpi*z);
+        + amrex::Real(0.25) * std::cos(fpi*x) * std::sin(fpi*y) * (-fpi) * std::sin(fpi*z);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -346,9 +346,9 @@ void actual_init_nodeabeclap(int i, int j, int k,
                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_hi,
                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx)
 {
-    constexpr amrex::Real w = 0.05;
+    constexpr amrex::Real w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = 0.5*std::log(3.) / (w + 1.e-50);
+    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
@@ -360,33 +360,33 @@ void actual_init_nodeabeclap(int i, int j, int k,
         actual_init_bcoef(i,j,k, bcoef, prob_lo, prob_hi, dx);
     }
 
-    amrex::Real xc = (prob_hi[0] + prob_lo[0])*0.5;
-    amrex::Real yc = (prob_hi[1] + prob_lo[1])*0.5;
+    amrex::Real xc = (prob_hi[0] + prob_lo[0])*amrex::Real(0.5);
+    amrex::Real yc = (prob_hi[1] + prob_lo[1])*amrex::Real(0.5);
 #if (AMREX_SPACEDIM == 2)
     amrex::Real zc = 0.0;
 #else
-    amrex::Real zc = (prob_hi[2] + prob_lo[2])*0.5;
+    amrex::Real zc = (prob_hi[2] + prob_lo[2])*amrex::Real(0.5);
 #endif
 
-    amrex::Real x = prob_lo[0] + dx[0] * (i);
-    amrex::Real y = prob_lo[1] + dx[1] * (j);
+    amrex::Real x = prob_lo[0] + dx[0] * amrex::Real(i);
+    amrex::Real y = prob_lo[1] + dx[1] * amrex::Real(j);
 #if (AMREX_SPACEDIM == 2)
     amrex::Real z = 0.0;
 #else
-    amrex::Real z = prob_lo[2] + dx[2] * (k);
+    amrex::Real z = prob_lo[2] + dx[2] * amrex::Real(k);
 #endif
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
-    amrex::Real bcnd = (sigma-1.)/2.*std::tanh(theta*(r-0.25)) + (sigma+1.)/2.;
-    amrex::Real tmp = std::cosh(theta*(r-0.25));
+    amrex::Real bcnd = static_cast<amrex::Real>((sigma-1.)/2.*std::tanh(theta*(r-amrex::Real(0.25))) + (sigma+1.)/2.);
+    amrex::Real tmp = std::cosh(theta*(r-amrex::Real(0.25)));
     amrex::Real dbdrfac = (r == amrex::Real(0.0))
-        ? amrex::Real(0.0) : (sigma-1.)/2./(tmp*tmp) * theta/r;
+        ? amrex::Real(0.0) : static_cast<amrex::Real>((sigma-1.)/2./(tmp*tmp) * theta/r);
     dbdrfac *= b;
 
     acoef(i,j,k) = 1.;
 
     exact(i,j,k) = std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
-           + .25 * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z);
+           + amrex::Real(0.25) * std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z);
 
     rhs(i,j,k) = bcnd*b*fac*(  std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
                              + std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z))

--- a/Tests/LinearSolvers/ABecLaplacian_C/initProb_K.H
+++ b/Tests/LinearSolvers/ABecLaplacian_C/initProb_K.H
@@ -47,9 +47,9 @@ void actual_init_bcoef (int i, int j, int k,
                         amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_hi,
                         amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx)
 {
-    constexpr amrex::Real w = amrex::Real(0.05);
+    constexpr auto w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
+    const amrex::Real theta = amrex::Real(0.5)*std::log(amrex::Real(3.)) / (w + amrex::Real(1.e-30));
 
     amrex::Real xc = (prob_hi[0] + prob_lo[0])*amrex::Real(0.5);
     amrex::Real yc = (prob_hi[1] + prob_lo[1])*amrex::Real(0.5);
@@ -68,7 +68,8 @@ void actual_init_bcoef (int i, int j, int k,
 #endif
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
-    beta(i,j,k) = static_cast<amrex::Real>((sigma-1.)/2.*std::tanh(theta*(r-amrex::Real(0.25))) + (sigma+1.)/2.);
+    beta(i,j,k) = (sigma-amrex::Real(1.))/amrex::Real(2.)*std::tanh(theta*(r-amrex::Real(0.25)))
+                  + (sigma+amrex::Real(1.))/amrex::Real(2.);
 }
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -84,9 +85,9 @@ void actual_init_abeclap (int i, int j, int k,
                           amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx,
                           amrex::Box const& vbx)
 {
-    constexpr amrex::Real w = amrex::Real(0.05);
+    constexpr auto w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
+    const amrex::Real theta = amrex::Real(0.5)*std::log(amrex::Real(3.)) / (w + amrex::Real(1.e-30));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
@@ -111,11 +112,12 @@ void actual_init_abeclap (int i, int j, int k,
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
 
-    beta(i,j,k) = static_cast<amrex::Real>((sigma-1.)/2.*std::tanh(theta*(r-amrex::Real(0.25))) + (sigma+1.)/2.);
+    beta(i,j,k) = (sigma-amrex::Real(1.))/amrex::Real(2.)*std::tanh(theta*(r-amrex::Real(0.25)))
+                  + (sigma+amrex::Real(1.))/amrex::Real(2.);
 
     if (vbx.contains(i,j,k)) {
         amrex::Real tmp = std::cosh(theta*(r-amrex::Real(0.25)));
-        amrex::Real dbdrfac = static_cast<amrex::Real>((sigma-1.)/2./(tmp*tmp) * theta/r);
+        amrex::Real dbdrfac = (sigma-amrex::Real(1.))/amrex::Real(2.)/(tmp*tmp) * theta/r;
         dbdrfac *= b;
 
         alpha(i,j,k) = 1.;
@@ -160,9 +162,9 @@ void actual_init_abeclap_in (int i, int j, int k,
                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_hi,
                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx)
 {
-    constexpr amrex::Real w = amrex::Real(0.05);
+    constexpr auto w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
+    const amrex::Real theta = amrex::Real(0.5)*std::log(amrex::Real(3.)) / (w + amrex::Real(1.e-30));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
@@ -187,7 +189,7 @@ void actual_init_abeclap_in (int i, int j, int k,
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
     amrex::Real tmp = std::cosh(theta*(r-amrex::Real(0.25)));
-    amrex::Real dbdrfac = static_cast<amrex::Real>((sigma-1.)/2./(tmp*tmp) * theta/r);
+    amrex::Real dbdrfac = (sigma-amrex::Real(1.))/amrex::Real(2.)/(tmp*tmp) * theta/r;
     dbdrfac *= b;
 
     alpha(i,j,k) = 1.;
@@ -346,9 +348,9 @@ void actual_init_nodeabeclap(int i, int j, int k,
                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& prob_hi,
                              amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dx)
 {
-    constexpr amrex::Real w = amrex::Real(0.05);
+    constexpr auto w = amrex::Real(0.05);
     constexpr amrex::Real sigma = 10.;
-    const amrex::Real theta = static_cast<amrex::Real>(0.5*std::log(3.) / (w + 1.e-50));
+    const amrex::Real theta = amrex::Real(0.5)*std::log(amrex::Real(3.)) / (w + amrex::Real(1.e-30));
 
     constexpr amrex::Real pi = std::numbers::pi_v<amrex::Real>;
     constexpr amrex::Real tpi =  2.*pi;
@@ -377,10 +379,11 @@ void actual_init_nodeabeclap(int i, int j, int k,
 #endif
 
     amrex::Real r = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
-    amrex::Real bcnd = static_cast<amrex::Real>((sigma-1.)/2.*std::tanh(theta*(r-amrex::Real(0.25))) + (sigma+1.)/2.);
+    amrex::Real bcnd = (sigma-amrex::Real(1.))/amrex::Real(2.)*std::tanh(theta*(r-amrex::Real(0.25)))
+                     + (sigma+amrex::Real(1.))/amrex::Real(2.);
     amrex::Real tmp = std::cosh(theta*(r-amrex::Real(0.25)));
     amrex::Real dbdrfac = (r == amrex::Real(0.0))
-        ? amrex::Real(0.0) : static_cast<amrex::Real>((sigma-1.)/2./(tmp*tmp) * theta/r);
+        ? amrex::Real(0.0) : (sigma-amrex::Real(1.))/amrex::Real(2.)/(tmp*tmp) * theta/r;
     dbdrfac *= b;
 
     acoef(i,j,k) = 1.;

--- a/Tests/LinearSolvers/CurlCurl/MyTest.H
+++ b/Tests/LinearSolvers/CurlCurl/MyTest.H
@@ -45,7 +45,7 @@ private:
     amrex::Array<amrex::MultiFab,3> rhs;
     amrex::MultiFab alpha_node;
 
-    amrex::Real beta_factor = 1.e-2;
+    amrex::Real beta_factor = amrex::Real(1.e-2);
     amrex::Real alpha = 1.0;
     amrex::Real beta = 1.0;
     bool variable_beta = false;

--- a/Tests/LinearSolvers/NodalPoisson/MyTest.H
+++ b/Tests/LinearSolvers/NodalPoisson/MyTest.H
@@ -42,7 +42,7 @@ private:
     int bottom_verbose = 0;
     int max_iter = 100;
     int max_fmg_iter = 0;
-    amrex::Real reltol = 1.e-11;
+    amrex::Real reltol = amrex::Real(1.e-11);
     int gpu_regtest = 0;
 
 

--- a/Tests/LinearSolvers/NodalPoisson/MyTest.cpp
+++ b/Tests/LinearSolvers/NodalPoisson/MyTest.cpp
@@ -270,20 +270,20 @@ MyTest::initData ()
                 constexpr Real fpi = 4.*pi;
                 constexpr Real fac = tpi*tpi*AMREX_SPACEDIM;
 
-                Real x = i*dx[0];
+                Real x = Real(i)*dx[0];
 #if (AMREX_SPACEDIM > 1)
-                Real y = j*dx[1];
+                Real y = Real(j)*dx[1];
 #else
                 Real y = Real(0.0);
 #endif
 #if (AMREX_SPACEDIM > 2)
-                Real z = k*dx[2];
+                Real z = Real(k)*dx[2];
 #else
                 Real z = Real(0.0);
 #endif
 
                 phi(i,j,k) = (std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z))
-                    + 0.25 * (std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
+                    + Real(0.25) * (std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
 
                 rh(i,j,k) = -fac * (std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z))
                     -        fac * (std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));

--- a/Tests/LinearSolvers/NodalPoissonEB/MyTest.H
+++ b/Tests/LinearSolvers/NodalPoissonEB/MyTest.H
@@ -35,7 +35,7 @@ private:
     int bottom_verbose = 0;
     int max_iter = 200;
     int max_fmg_iter = 0;
-    amrex::Real reltol = 1.e-10;
+    amrex::Real reltol = amrex::Real(1.e-10);
 
     int gpu_regtest = 0;
     bool do_plots = true;

--- a/Tests/LinearSolvers/NodalPoissonEB/MyTest.cpp
+++ b/Tests/LinearSolvers/NodalPoissonEB/MyTest.cpp
@@ -173,9 +173,9 @@ MyTest::initData ()
         Array4<Real> const rh = rhs[0].array(mfi);
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            AMREX_D_TERM(const Real x = problo[0] + i * dx[0];,
-                         const Real y = problo[1] + j * dx[1];,
-                         const Real z = problo[2] + k * dx[2];)
+            AMREX_D_TERM(const Real x = problo[0] + Real(i) * dx[0];,
+                         const Real y = problo[1] + Real(j) * dx[1];,
+                         const Real z = problo[2] + Real(k) * dx[2];)
             phi(i,j,k) = exact_phi(AMREX_D_DECL(x, y, z));
             rh(i,j,k) = exact_rhs(AMREX_D_DECL(x, y, z));
         });

--- a/Tests/LinearSolvers/Nodal_Projection_EB/main.cpp
+++ b/Tests/LinearSolvers/Nodal_Projection_EB/main.cpp
@@ -44,7 +44,7 @@ int main (int argc, char* argv[])
         int max_grid_size = 32;
         int use_hypre  = 0;
 
-        Real obstacle_radius = 0.10;
+        Real obstacle_radius = Real(0.10);
 
         // read parameters
         {
@@ -71,8 +71,8 @@ int main (int argc, char* argv[])
         int n_cell_z =   n_cell/8;
 
         Real ylen = 1.0;
-        Real xlen = 2.0 * ylen;
-        Real zlen = ylen / 8.0;
+        Real xlen = Real(2.0) * ylen;
+        Real zlen = ylen / Real(8.0);
 
         Geometry geom;
         BoxArray grids;
@@ -94,15 +94,15 @@ int main (int argc, char* argv[])
         int max_coarsening_level = 100;    // typically a huge number so MG coarsens as much as possible
 
         amrex::Vector<amrex::RealArray> obstacle_center = {
-            {AMREX_D_DECL(0.3,0.2,0.5)},
-            {AMREX_D_DECL(0.3,0.5,0.5)},
-            {AMREX_D_DECL(0.3,0.8,0.5)},
-            {AMREX_D_DECL(0.7,0.25,0.5)},
-            {AMREX_D_DECL(0.7,0.60,0.5)},
-            {AMREX_D_DECL(0.7,0.85,0.5)},
-            {AMREX_D_DECL(1.1,0.2,0.5)},
-            {AMREX_D_DECL(1.1,0.5,0.5)},
-            {AMREX_D_DECL(1.1,0.8,0.5)}};
+            {AMREX_D_DECL(Real(0.3),Real(0.2),0.5)},
+            {AMREX_D_DECL(Real(0.3),0.5,0.5)},
+            {AMREX_D_DECL(Real(0.3),Real(0.8),0.5)},
+            {AMREX_D_DECL(Real(0.7),0.25,0.5)},
+            {AMREX_D_DECL(Real(0.7),Real(0.60),0.5)},
+            {AMREX_D_DECL(Real(0.7),Real(0.85),0.5)},
+            {AMREX_D_DECL(Real(1.1),Real(0.2),0.5)},
+            {AMREX_D_DECL(Real(1.1),0.5,0.5)},
+            {AMREX_D_DECL(Real(1.1),Real(0.8),0.5)}};
 
         int direction =  2;
         Real height   = -1.0;  // Putting a negative number for height means it extends beyond the domain
@@ -114,9 +114,9 @@ int main (int argc, char* argv[])
             EB2::CylinderIF(    obstacle_radius, height, direction, obstacle_center[ 0], false),
             EB2::CylinderIF(    obstacle_radius, height, direction, obstacle_center[ 1], false),
             EB2::CylinderIF(    obstacle_radius, height, direction, obstacle_center[ 2], false),
-            EB2::CylinderIF(0.9*obstacle_radius, height, direction, obstacle_center[ 3], false),
-            EB2::CylinderIF(0.9*obstacle_radius, height, direction, obstacle_center[ 4], false),
-            EB2::CylinderIF(0.9*obstacle_radius, height, direction, obstacle_center[ 5], false),
+            EB2::CylinderIF(Real(0.9)*obstacle_radius, height, direction, obstacle_center[ 3], false),
+            EB2::CylinderIF(Real(0.9)*obstacle_radius, height, direction, obstacle_center[ 4], false),
+            EB2::CylinderIF(Real(0.9)*obstacle_radius, height, direction, obstacle_center[ 5], false),
             EB2::CylinderIF(    obstacle_radius, height, direction, obstacle_center[ 6], false),
             EB2::CylinderIF(    obstacle_radius, height, direction, obstacle_center[ 7], false),
             EB2::CylinderIF(    obstacle_radius, height, direction, obstacle_center[ 8], false)};
@@ -250,13 +250,13 @@ int main (int argc, char* argv[])
 
         // Define the relative tolerance
 #ifdef AMREX_USE_FLOAT
-        Real reltol = 2.e-4;
+        Real reltol = Real(2.e-4);
 #else
         Real reltol = 1.e-8;
 #endif
 
         // Define the absolute tolerance; note that this argument is optional
-        Real abstol = 1.e-15;
+        Real abstol = Real(1.e-15);
 
         amrex::Print() << " \n********************************************************************" << '\n';
         amrex::Print() << " Let's project the initial velocity to find " << '\n';
@@ -295,8 +295,8 @@ int main (int argc, char* argv[])
         MultiFab plotfile_mf(grids, dmap, AMREX_SPACEDIM+1, 0, MFInfo(), factory);
 
         // copy processor id into plotfile_mf
-        plotfile_mf.setVal(ParallelDescriptor::MyProc(), 0, 1);
-        plotfile_mf.setVal(ParallelDescriptor::MyProc(), 0, 1);
+        plotfile_mf.setVal(Real(ParallelDescriptor::MyProc()), 0, 1);
+        plotfile_mf.setVal(Real(ParallelDescriptor::MyProc()), 0, 1);
 
         // copy velocity into plotfile
         MultiFab::Copy(plotfile_mf, vel, 0, 1, AMREX_SPACEDIM, 0);

--- a/Tests/LinearSolvers/NodeTensorLap/MyTest.H
+++ b/Tests/LinearSolvers/NodeTensorLap/MyTest.H
@@ -33,7 +33,7 @@ private:
     int max_fmg_iter = 0;
     int max_coarsening_level = 30;
     int use_hypre = 0;
-    amrex::Real reltol = 1.e-11;
+    amrex::Real reltol = amrex::Real(1.e-11);
 
     amrex::Vector<amrex::Geometry> geom;
     amrex::Vector<amrex::BoxArray> grids;
@@ -42,7 +42,7 @@ private:
     amrex::Vector<amrex::MultiFab> solution;
     amrex::Vector<amrex::MultiFab> rhs;
     amrex::Vector<amrex::MultiFab> exact_solution;
-    amrex::Array<amrex::Real,AMREX_SPACEDIM> beta = {{AMREX_D_DECL(0.9,0.0,0.0)}};
+    amrex::Array<amrex::Real,AMREX_SPACEDIM> beta = {{AMREX_D_DECL(amrex::Real(0.9),0.0,0.0)}};
 };
 
 #endif

--- a/Tests/LinearSolvers/NodeTensorLap/MyTest.cpp
+++ b/Tests/LinearSolvers/NodeTensorLap/MyTest.cpp
@@ -169,18 +169,18 @@ MyTest::initData ()
                 constexpr Real pi = std::numbers::pi_v<Real>;
                 constexpr Real tpi = 2.*pi;
                 constexpr Real fpi = 4.*pi;
-                constexpr Real fac = 4.*pi*pi;
+                constexpr Real fac = Real(4.)*pi*pi;
 
-                Real x = i*dx[0];
-                Real y = j*dx[1];
+                Real x = Real(i)*dx[0];
+                Real y = Real(j)*dx[1];
 #if (AMREX_SPACEDIM == 2)
                 Real z = 0;
 #else
-                Real z = k*dx[2];
+                Real z = Real(k)*dx[2];
 #endif
 
                 phi(i,j,k) = (std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z))
-                    + 0.25 * (std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
+                    + Real(0.25) * (std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
 
                 Real d2phidx2 = -fac * (std::cos(tpi*x) * std::cos(tpi*y) * std::cos(tpi*z)
                                       + std::cos(fpi*x) * std::cos(fpi*y) * std::cos(fpi*z));
@@ -189,21 +189,21 @@ MyTest::initData ()
                                       + std::sin(fpi*x) * std::sin(fpi*y) * std::cos(fpi*z));
 
 #if (AMREX_SPACEDIM == 2)
-                rh(i,j,k) = (1.0-lbeta[0]*lbeta[0]) * d2phidx2
-                    +       (1.0-lbeta[1]*lbeta[1]) * d2phidy2
-                    -         2.*lbeta[0]*lbeta[1]  * d2phidxdy;
+                rh(i,j,k) = (Real(1.0)-lbeta[0]*lbeta[0]) * d2phidx2
+                    +       (Real(1.0)-lbeta[1]*lbeta[1]) * d2phidy2
+                    -         Real(2.)*lbeta[0]*lbeta[1]  * d2phidxdy;
 #else
                 Real d2phidz2 = d2phidx2;
                 Real d2phidxdz = fac * (std::sin(tpi*x) * std::sin(tpi*z) * std::cos(tpi*y)
                                       + std::sin(fpi*x) * std::sin(fpi*z) * std::cos(fpi*y));
                 Real d2phidydz = fac * (std::sin(tpi*y) * std::sin(tpi*z) * std::cos(tpi*x)
                                       + std::sin(fpi*y) * std::sin(fpi*z) * std::cos(fpi*x));
-                rh(i,j,k) = (1.0-lbeta[0]*lbeta[0]) * d2phidx2
-                    +       (1.0-lbeta[1]*lbeta[1]) * d2phidy2
-                    +       (1.0-lbeta[2]*lbeta[2]) * d2phidz2
-                    -         2.*lbeta[0]*lbeta[1]  * d2phidxdy
-                    -         2.*lbeta[0]*lbeta[2]  * d2phidxdz
-                    -         2.*lbeta[1]*lbeta[2]  * d2phidydz;
+                rh(i,j,k) = (Real(1.0)-lbeta[0]*lbeta[0]) * d2phidx2
+                    +       (Real(1.0)-lbeta[1]*lbeta[1]) * d2phidy2
+                    +       (Real(1.0)-lbeta[2]*lbeta[2]) * d2phidz2
+                    -         Real(2.)*lbeta[0]*lbeta[1]  * d2phidxdy
+                    -         Real(2.)*lbeta[0]*lbeta[2]  * d2phidxdz
+                    -         Real(2.)*lbeta[1]*lbeta[2]  * d2phidydz;
 #endif
             });
         }

--- a/Tests/LinearSolvers/NodeTensorLap/MyTest.cpp
+++ b/Tests/LinearSolvers/NodeTensorLap/MyTest.cpp
@@ -100,6 +100,9 @@ MyTest::readParameters ()
     pp.query("max_fmg_iter", max_fmg_iter);
     pp.query("max_coarsening_level", max_coarsening_level);
     pp.query("reltol", reltol);
+#ifdef AMREX_USE_FLOAT
+    reltol = std::max(reltol, 1.e-5F);
+#endif
 
     Vector<Real> vbeta;
     pp.queryarr("beta", vbeta);

--- a/Tests/MultiBlock/Advection/main.cpp
+++ b/Tests/MultiBlock/Advection/main.cpp
@@ -53,8 +53,8 @@ class AdvectionAmrCore : public AmrCore {
             Array4<Real> vx = mass.array(mfi, 1);
             Array4<Real> vy = mass.array(mfi, 2);
             amrex::ParallelFor(mfi.tilebox(), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                Real x[] = {problo[0] + (0.5_rt+i)*dx[0],
-                            problo[1] + (0.5_rt+j)*dx[1]};
+                Real x[] = {problo[0] + (0.5_rt+Real(i))*dx[0],
+                            problo[1] + (0.5_rt+Real(j))*dx[1]};
                 const Real r2 = x[0] * x[0] + x[1] * x[1];
                 constexpr Real R = 0.1_rt * 0.1_rt;
                 m(i, j, k) = r2 < R ? 1_rt : 0_rt;

--- a/Tests/MultiBlock/Advection/main.cpp
+++ b/Tests/MultiBlock/Advection/main.cpp
@@ -74,7 +74,7 @@ class AdvectionAmrCore : public AmrCore {
     void DoOperatorSplitStep(double dt, Direction dir) {
         // Perform first order accurate upwinding with velocity 1 in the stored direction.
         const double dx = Geom(0).CellSize(0);
-        const double a_dt_over_dx = dt / dx * (velocity == dir);
+        const Real a_dt_over_dx = Real(dt / dx * (velocity == dir));
         if (dir == Direction::x) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Tests/OpenMP/atomicAdd/main.cpp
+++ b/Tests/OpenMP/atomicAdd/main.cpp
@@ -16,7 +16,7 @@ void test_atomicAdd (MultiFab& mf)
         for (MFIter mfi(mf,true); mfi.isValid(); ++mfi) {
             Box const& tbx = mfi.growntilebox();
             tmp.resize(tbx);
-            tmp.template setVal<RunOn::Host>(0.2);
+            tmp.template setVal<RunOn::Host>(Real(0.2));
             mf[mfi].template atomicAdd<RunOn::Host>(tmp, tbx, tbx, 0, 0, 1);
         }
     }
@@ -33,7 +33,7 @@ void test_lockAdd (MultiFab& mf)
         for (MFIter mfi(mf,true); mfi.isValid(); ++mfi) {
             Box const& tbx = mfi.growntilebox();
             tmp.resize(tbx);
-            tmp.template setVal<RunOn::Host>(0.2);
+            tmp.template setVal<RunOn::Host>(Real(0.2));
             mf[mfi].template lockAdd<RunOn::Host>(tmp, tbx, tbx, 0, 0, 1);
         }
     }

--- a/Tests/Particles/Ascent_Insitu_SOA/main.cpp
+++ b/Tests/Particles/Ascent_Insitu_SOA/main.cpp
@@ -213,8 +213,8 @@ void testAscent ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setLo(n, Real(0.0));
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/AsyncIO/main.cpp
+++ b/Tests/Particles/AsyncIO/main.cpp
@@ -43,9 +43,9 @@ void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
     int iy_part = (i_part % (ny * nz)) % ny;
     int iz_part = (i_part % (ny * nz)) / ny;
 
-    r[0] = (0.5+ix_part)/nx;
-    r[1] = (0.5+iy_part)/ny;
-    r[2] = (0.5+iz_part)/nz;
+    r[0] = (Real(0.5)+Real(ix_part))/Real(nx);
+    r[1] = (Real(0.5)+Real(iy_part))/Real(ny);
+    r[2] = (Real(0.5)+Real(iz_part))/Real(nz);
 }
 
 class MyParticleContainer
@@ -93,12 +93,12 @@ public:
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
                     p.cpu() = ParallelDescriptor::MyProc();
-                    p.pos(0) = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);
+                    p.pos(0) = static_cast<ParticleReal> (plo[0] + (Real(iv[0]) + r[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                    p.pos(1) = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);
+                    p.pos(1) = static_cast<ParticleReal> (plo[1] + (Real(iv[1]) + r[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                    p.pos(2) = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
+                    p.pos(2) = static_cast<ParticleReal> (plo[2] + (Real(iv[2]) + r[2])*dx[2]);
 #endif
 
                     if constexpr (NSR > 0) {

--- a/Tests/Particles/CheckpointRestart/main.cpp
+++ b/Tests/Particles/CheckpointRestart/main.cpp
@@ -70,7 +70,7 @@ void test ()
     for (int lev = 0; lev < nlevs; lev++) {
         dmap[lev] = DistributionMapping{ba[lev]};
         mf[lev] = std::make_unique<MultiFab>(ba[lev], dmap[lev], ncomp, nghost);
-        mf[lev]->setVal(lev);
+        mf[lev]->setVal(Real(lev));
     }
 
     // these don't really matter, make something up

--- a/Tests/Particles/CheckpointRestart/main.cpp
+++ b/Tests/Particles/CheckpointRestart/main.cpp
@@ -158,13 +158,13 @@ void test ()
             auto sm_new = amrex::ReduceSum(newPC,
                 [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
                 {
-                    return p.rdata(1);
+                    return static_cast<Real>(p.rdata(1));
                 });
 
             auto sm_old = amrex::ReduceSum(myPC,
                 [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
                 {
-                    return p.rdata(1);
+                    return static_cast<Real>(p.rdata(1));
                 });
 
             ParallelDescriptor::ReduceRealSum(sm_new);

--- a/Tests/Particles/CheckpointRestartDualGrid/main.cpp
+++ b/Tests/Particles/CheckpointRestartDualGrid/main.cpp
@@ -174,11 +174,11 @@ void verify_same (MyPC& pc_orig, MyPC& pc_new)
     for (int icomp = 0; icomp < NStructReal + NArrayReal; ++icomp) {
         auto sm_orig = amrex::ReduceSum(pc_orig,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real {
-                return p.rdata(icomp);
+                return static_cast<Real>(p.rdata(icomp));
             });
         auto sm_new = amrex::ReduceSum(pc_new,
             [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real {
-                return p.rdata(icomp);
+                return static_cast<Real>(p.rdata(icomp));
             });
         ParallelDescriptor::ReduceRealSum(sm_orig);
         ParallelDescriptor::ReduceRealSum(sm_new);

--- a/Tests/Particles/CheckpointRestartDualGrid/main.cpp
+++ b/Tests/Particles/CheckpointRestartDualGrid/main.cpp
@@ -134,7 +134,7 @@ void add_finest_level_particles (MyPC& pc, MeshData const& mesh,
 
             PType p;
             for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-                p.pos(d) = static_cast<ParticleReal>(problo[d] + (iv[d] + 0.5_rt) * dx[d]);
+                p.pos(d) = static_cast<ParticleReal>(problo[d] + (Real(iv[d]) + 0.5_rt) * dx[d]);
             }
             for (int i = 0; i < NStructReal; ++i) {
                 p.rdata(i) = static_cast<ParticleReal>(pdata.real_struct_data[i]);

--- a/Tests/Particles/CheckpointRestartDualGridHDF5SOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartDualGridHDF5SOA/main.cpp
@@ -107,11 +107,11 @@ void verify_same (MyPC& pc_orig, MyPC& pc_new)
     for (int icomp = AMREX_SPACEDIM; icomp < NReal; ++icomp) {
         auto sm_orig = amrex::ReduceSum(pc_orig,
             [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
-                return ptd.rdata(icomp)[i];
+                return static_cast<Real>(ptd.rdata(icomp)[i]);
             });
         auto sm_new = amrex::ReduceSum(pc_new,
             [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
-                return ptd.rdata(icomp)[i];
+                return static_cast<Real>(ptd.rdata(icomp)[i]);
             });
         ParallelDescriptor::ReduceRealSum(sm_orig);
         ParallelDescriptor::ReduceRealSum(sm_new);

--- a/Tests/Particles/CheckpointRestartDualGridSOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartDualGridSOA/main.cpp
@@ -106,11 +106,11 @@ void verify_same (MyPC& pc_orig, MyPC& pc_new)
     for (int icomp = AMREX_SPACEDIM; icomp < NReal; ++icomp) {
         auto sm_orig = amrex::ReduceSum(pc_orig,
             [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
-                return ptd.rdata(icomp)[i];
+                return static_cast<Real>(ptd.rdata(icomp)[i]);
             });
         auto sm_new = amrex::ReduceSum(pc_new,
             [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real {
-                return ptd.rdata(icomp)[i];
+                return static_cast<Real>(ptd.rdata(icomp)[i]);
             });
         ParallelDescriptor::ReduceRealSum(sm_orig);
         ParallelDescriptor::ReduceRealSum(sm_new);

--- a/Tests/Particles/CheckpointRestartSOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartSOA/main.cpp
@@ -158,13 +158,13 @@ void test ()
             auto sm_new = amrex::ReduceSum(newPC,
                 [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real
                 {
-                    return ptd.rdata(icomp)[i];
+                    return static_cast<Real>(ptd.rdata(icomp)[i]);
                 });
 
             auto sm_old = amrex::ReduceSum(myPC,
                 [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real
                 {
-                    return ptd.rdata(icomp)[i];
+                    return static_cast<Real>(ptd.rdata(icomp)[i]);
                 });
 
             ParallelDescriptor::ReduceRealSum(sm_new);

--- a/Tests/Particles/CheckpointRestartSOA/main.cpp
+++ b/Tests/Particles/CheckpointRestartSOA/main.cpp
@@ -71,7 +71,7 @@ void test ()
     for (int lev = 0; lev < nlevs; lev++) {
         dmap[lev] = DistributionMapping{ba[lev]};
         mf[lev] = std::make_unique<MultiFab>(ba[lev], dmap[lev], ncomp, nghost);
-        mf[lev]->setVal(lev);
+        mf[lev]->setVal(Real(lev));
     }
 
     // these don't really matter, make something up
@@ -180,13 +180,13 @@ void test ()
             auto sm_new = amrex::ReduceSum(newPC,
                 [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real
                 {
-                    return ptd.idata(icomp)[i];
+                    return Real(ptd.idata(icomp)[i]);
                 });
 
             auto sm_old = amrex::ReduceSum(myPC,
                 [=] AMREX_GPU_HOST_DEVICE (const ConstPTDType& ptd, const int i) -> Real
                 {
-                    return ptd.idata(icomp)[i];
+                    return Real(ptd.idata(icomp)[i]);
                 });
 
             ParallelDescriptor::ReduceRealSum(sm_new);

--- a/Tests/Particles/InitFromBinary/main.cpp
+++ b/Tests/Particles/InitFromBinary/main.cpp
@@ -46,7 +46,7 @@ void test_init_binary ()
     Real total_mass = amrex::ReduceSum(pc,
                                        [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real
                                        {
-                                           return p.rdata(0);
+                                           return static_cast<Real>(p.rdata(0));
                                        });
 
     ParallelDescriptor::ReduceRealSum(total_mass);

--- a/Tests/Particles/NamedSoAComponents/main.cpp
+++ b/Tests/Particles/NamedSoAComponents/main.cpp
@@ -95,7 +95,7 @@ void addParticles ()
         for (int d = 0; d < AMREX_SPACEDIM; d++) {
             ptile1.pos(i, d) = 12.0;
         }
-        ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = Real(1.2);  // w
+        ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = ParticleReal(1.2);  // w
 
         ptile1.push_back_int(0, int(ParticleType::NextID()));
         ptile1.push_back_int(1, amrex::ParallelDescriptor::MyProc());

--- a/Tests/Particles/NamedSoAComponents/main.cpp
+++ b/Tests/Particles/NamedSoAComponents/main.cpp
@@ -95,7 +95,7 @@ void addParticles ()
         for (int d = 0; d < AMREX_SPACEDIM; d++) {
             ptile1.pos(i, d) = 12.0;
         }
-        ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = 1.2;  // w
+        ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = Real(1.2);  // w
 
         ptile1.push_back_int(0, int(ParticleType::NextID()));
         ptile1.push_back_int(1, amrex::ParallelDescriptor::MyProc());

--- a/Tests/Particles/NeighborList/main.cpp
+++ b/Tests/Particles/NeighborList/main.cpp
@@ -98,7 +98,7 @@ void testNeighborList ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
+        real_box.setLo(n, Real(0.0));
         real_box.setHi(n, Real(params.size[n]));
     }
 

--- a/Tests/Particles/NeighborList/main.cpp
+++ b/Tests/Particles/NeighborList/main.cpp
@@ -44,10 +44,10 @@ struct CheckPair
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     bool operator() (const P1& p1, const P2& p2) const
     {
-        AMREX_D_TERM(amrex::Real d0 = (p1.pos(0) - p2.pos(0));,
-                     amrex::Real d1 = (p1.pos(1) - p2.pos(1));,
-                     amrex::Real d2 = (p1.pos(2) - p2.pos(2));)
-        amrex::Real dsquared = AMREX_D_TERM(d0*d0, + d1*d1, + d2*d2);
+        AMREX_D_TERM(amrex::ParticleReal d0 = (p1.pos(0) - p2.pos(0));,
+                     amrex::ParticleReal d1 = (p1.pos(1) - p2.pos(1));,
+                     amrex::ParticleReal d2 = (p1.pos(2) - p2.pos(2));)
+        amrex::ParticleReal dsquared = AMREX_D_TERM(d0*d0, + d1*d1, + d2*d2);
         return (dsquared <= 25.0*Params::cutoff*Params::cutoff);
     }
 };

--- a/Tests/Particles/NeighborList/main.cpp
+++ b/Tests/Particles/NeighborList/main.cpp
@@ -35,7 +35,7 @@ void get_test_params(TestParams& params, const std::string& prefix)
 
 namespace Params
 {
-    static constexpr amrex::Real cutoff = 0.2;
+    static constexpr amrex::Real cutoff = Real(0.2);
 }
 
 struct CheckPair
@@ -99,7 +99,7 @@ void testNeighborList ()
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
         real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/NeighborParticles/CheckPair.H
+++ b/Tests/Particles/NeighborParticles/CheckPair.H
@@ -10,11 +10,11 @@ struct CheckPair
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     bool operator()(const P& p1, const P& p2) const
     {
-        AMREX_D_TERM(amrex::Real d0 = (p1.pos(0) - p2.pos(0));,
-                     amrex::Real d1 = (p1.pos(1) - p2.pos(1));,
-                     amrex::Real d2 = (p1.pos(2) - p2.pos(2));)
-        amrex::Real dsquared = AMREX_D_TERM(d0*d0, + d1*d1, + d2*d2);
-        return (dsquared <= 25.0*Params::cutoff*Params::cutoff);
+        AMREX_D_TERM(amrex::ParticleReal d0 = (p1.pos(0) - p2.pos(0));,
+                     amrex::ParticleReal d1 = (p1.pos(1) - p2.pos(1));,
+                     amrex::ParticleReal d2 = (p1.pos(2) - p2.pos(2));)
+        amrex::ParticleReal dsquared = AMREX_D_TERM(d0*d0, + d1*d1, + d2*d2);
+        return (dsquared <= amrex::ParticleReal(25.0)*Params::cutoff*Params::cutoff);
     }
 };
 

--- a/Tests/Particles/NeighborParticles/Constants.H
+++ b/Tests/Particles/NeighborParticles/Constants.H
@@ -8,8 +8,8 @@ namespace Params
     // This is designed to represent MFiX-like conditions where the grid spacing is
     //     roughly 2.5 times the particle diameter.  In main.cpp we set grid spacing to 1
     //     so here we set cutoff to diameter = 1/2.5 --> cutoff = 0.2
-    static constexpr amrex::ParticleReal cutoff = amrex::Real(0.2)  ;
-    static constexpr amrex::ParticleReal min_r  = amrex::Real(1.e-4);
+    static constexpr amrex::ParticleReal cutoff = amrex::ParticleReal(0.2)  ;
+    static constexpr amrex::ParticleReal min_r  = amrex::ParticleReal(1.e-4);
 }
 
 #endif

--- a/Tests/Particles/NeighborParticles/Constants.H
+++ b/Tests/Particles/NeighborParticles/Constants.H
@@ -8,8 +8,8 @@ namespace Params
     // This is designed to represent MFiX-like conditions where the grid spacing is
     //     roughly 2.5 times the particle diameter.  In main.cpp we set grid spacing to 1
     //     so here we set cutoff to diameter = 1/2.5 --> cutoff = 0.2
-    static constexpr amrex::ParticleReal cutoff = 0.2  ;
-    static constexpr amrex::ParticleReal min_r  = 1.e-4;
+    static constexpr amrex::ParticleReal cutoff = amrex::Real(0.2)  ;
+    static constexpr amrex::ParticleReal min_r  = amrex::Real(1.e-4);
 }
 
 #endif

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -121,9 +121,9 @@ namespace
                      int iy_part = (i_part % (ny * nz)) % ny;,
                      int iz_part = (i_part % (ny * nz)) / ny;)
 
-        AMREX_D_TERM(r[0] = (0.5+ix_part)/nx;,
-                     r[1] = (0.5+iy_part)/ny;,
-                     r[2] = (0.5+iz_part)/nz;)
+        AMREX_D_TERM(r[0] = (Real(0.5)+Real(ix_part))/Real(nx);,
+                     r[1] = (Real(0.5)+Real(iy_part))/Real(ny);,
+                     r[2] = (Real(0.5)+Real(iz_part))/Real(nz);)
     }
 
     void get_gaussian_random_momentum(Real* u, Real u_mean, Real u_std) {
@@ -195,9 +195,9 @@ InitParticles(const IntVect& a_num_particles_per_cell,
                 get_gaussian_random_momentum(v, a_thermal_momentum_mean,
                                              a_thermal_momentum_std);
 
-                AMREX_D_TERM(auto x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);,
-                             auto y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);,
-                             auto z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);)
+                AMREX_D_TERM(auto x = static_cast<ParticleReal> (plo[0] + (Real(iv[0]) + r[0])*dx[0]);,
+                             auto y = static_cast<ParticleReal> (plo[1] + (Real(iv[1]) + r[1])*dx[1]);,
+                             auto z = static_cast<ParticleReal> (plo[2] + (Real(iv[2]) + r[2])*dx[2]);)
 
                 ParticleType p;
                 p.id()  = ParticleType::NextID();
@@ -579,7 +579,7 @@ void MDParticleContainer::checkNeighborList()
 
                 Real r2 = AMREX_D_TERM(dx*dx, + dy*dy, + dz*dz);
 
-                Real cutoff_sq = 25.0*Params::cutoff*Params::cutoff;
+                Real cutoff_sq = Real(25.0)*Params::cutoff*Params::cutoff;
 
                 if (r2 <= cutoff_sq)
                 {

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -573,13 +573,13 @@ void MDParticleContainer::checkNeighborList()
                 if ( i == j ) { continue; }
 
                 ParticleType& p2 = h_pstruct[j];
-                AMREX_D_TERM(Real dx = p1.pos(0) - p2.pos(0);,
-                             Real dy = p1.pos(1) - p2.pos(1);,
-                             Real dz = p1.pos(2) - p2.pos(2);)
+                AMREX_D_TERM(ParticleReal dx = p1.pos(0) - p2.pos(0);,
+                             ParticleReal dy = p1.pos(1) - p2.pos(1);,
+                             ParticleReal dz = p1.pos(2) - p2.pos(2);)
 
-                Real r2 = AMREX_D_TERM(dx*dx, + dy*dy, + dz*dz);
+                ParticleReal r2 = AMREX_D_TERM(dx*dx, + dy*dy, + dz*dz);
 
-                Real cutoff_sq = Real(25.0)*Params::cutoff*Params::cutoff;
+                ParticleReal cutoff_sq = ParticleReal(25.0)*Params::cutoff*Params::cutoff;
 
                 if (r2 <= cutoff_sq)
                 {

--- a/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
+++ b/Tests/Particles/NeighborParticles/MDParticleContainer.cpp
@@ -45,8 +45,8 @@ namespace
         std::array<ParticleReal, AMREX_SPACEDIM> pos{};
         std::array<ParticleReal, PIdx::ncomps> struct_real{};
         int struct_int = 0;
-        ParticleReal array_real = 0.0_rt;
-        ParticleReal runtime_real = 0.0_rt;
+        ParticleReal array_real = 0.0_prt;
+        ParticleReal runtime_real = 0.0_prt;
         int array_int = 0;
         int runtime_int = 0;
     };
@@ -55,8 +55,8 @@ namespace
     {
         std::array<ParticleReal, PIdx::ncomps> struct_real{};
         int struct_int = 0;
-        ParticleReal array_real = 0.0_rt;
-        ParticleReal runtime_real = 0.0_rt;
+        ParticleReal array_real = 0.0_prt;
+        ParticleReal runtime_real = 0.0_prt;
         int array_int = 0;
         int runtime_int = 0;
     };
@@ -67,8 +67,8 @@ namespace
         int cpu = -1;
         std::array<ParticleReal, PIdx::ncomps> struct_real{};
         int struct_int = 0;
-        ParticleReal array_real = 0.0_rt;
-        ParticleReal runtime_real = 0.0_rt;
+        ParticleReal array_real = 0.0_prt;
+        ParticleReal runtime_real = 0.0_prt;
         int array_int = 0;
         int runtime_int = 0;
     };
@@ -623,10 +623,10 @@ void MDParticleContainer::checkInverseSumNeighbors ()
 {
     BL_PROFILE("MDParticleContainer::checkInverseSumNeighbors");
 
-    constexpr ParticleReal struct_real_delta = 1.5_rt;
+    constexpr ParticleReal struct_real_delta = 1.5_prt;
     constexpr int struct_int_delta = 9;
-    constexpr ParticleReal array_real_delta = 2.5_rt;
-    constexpr ParticleReal runtime_real_delta = 3.5_rt;
+    constexpr ParticleReal array_real_delta = 2.5_prt;
+    constexpr ParticleReal runtime_real_delta = 3.5_prt;
     constexpr int array_int_delta = 11;
     constexpr int runtime_int_delta = 13;
 

--- a/Tests/Particles/NeighborParticles/main.cpp
+++ b/Tests/Particles/NeighborParticles/main.cpp
@@ -67,7 +67,7 @@ void testNeighborParticles ()
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
         real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
@@ -184,7 +184,7 @@ void testNeighborList ()
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
         real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/NeighborParticles/main.cpp
+++ b/Tests/Particles/NeighborParticles/main.cpp
@@ -66,7 +66,7 @@ void testNeighborParticles ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
+        real_box.setLo(n, Real(0.0));
         real_box.setHi(n, Real(params.size[n]));
     }
 
@@ -183,7 +183,7 @@ void testNeighborList ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
+        real_box.setLo(n, Real(0.0));
         real_box.setHi(n, Real(params.size[n]));
     }
 

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -140,9 +140,9 @@ namespace
                      int iy_part = (i_part % (ny*nz)) % ny;,
                      int iz_part = (i_part % (ny*nz)) / ny;)
 
-        AMREX_D_TERM(r[0] = (0.5_rt + ix_part)/nx;,
-                     r[1] = (0.5_rt + iy_part)/ny;,
-                     r[2] = (0.5_rt + iz_part)/nz;)
+        AMREX_D_TERM(r[0] = (0.5_rt + Real(ix_part))/Real(nx);,
+                     r[1] = (0.5_rt + Real(iy_part))/Real(ny);,
+                     r[2] = (0.5_rt + Real(iz_part))/Real(nz);)
     }
 
     void get_test_params (TestParams& params)
@@ -222,9 +222,9 @@ public:
                     ParticleIDWrapper(host_idcpu.back()) = id;
                     ParticleCPUWrapper(host_idcpu.back()) = ParallelDescriptor::MyProc();
 
-                    AMREX_D_TERM(host_real[0].push_back(static_cast<ParticleReal>(plo[0] + (iv[0] + r[0])*dx[0]));,
-                                 host_real[1].push_back(static_cast<ParticleReal>(plo[1] + (iv[1] + r[1])*dx[1]));,
-                                 host_real[2].push_back(static_cast<ParticleReal>(plo[2] + (iv[2] + r[2])*dx[2]));)
+                    AMREX_D_TERM(host_real[0].push_back(static_cast<ParticleReal>(plo[0] + (Real(iv[0]) + r[0])*dx[0]));,
+                                 host_real[1].push_back(static_cast<ParticleReal>(plo[1] + (Real(iv[1]) + r[1])*dx[1]));,
+                                 host_real[2].push_back(static_cast<ParticleReal>(plo[2] + (Real(iv[2]) + r[2])*dx[2]));)
                     auto const marker_real = static_cast<ParticleReal>(marker);
                     host_real[MarkerRealComp].push_back(marker_real);
                     host_real[PayloadRealComp].push_back(marker_real + ParticleReal(0.5_rt));
@@ -889,7 +889,7 @@ int main (int argc, char* argv[])
     for (int dir = 0; dir < BL_SPACEDIM; ++dir)
     {
         real_box.setLo(dir, 0.0);
-        real_box.setHi(dir, params.size[dir]);
+        real_box.setHi(dir, Real(params.size[dir]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -25,7 +25,7 @@ namespace
     constexpr int PayloadRealComp = AMREX_SPACEDIM + 1;
     constexpr int GridIntComp = 0;
     constexpr int MarkerIntComp = 1;
-    constexpr ParticleReal Cutoff = 0.2_rt;
+    constexpr ParticleReal Cutoff = 0.2_prt;
 
     struct TestParams
     {
@@ -59,9 +59,9 @@ namespace
         int marker_int = 0;
         int runtime_int = 0;
         std::array<ParticleReal, AMREX_SPACEDIM> pos{};
-        ParticleReal marker_real = 0.0_rt;
-        ParticleReal payload_real = 0.0_rt;
-        ParticleReal runtime_real = 0.0_rt;
+        ParticleReal marker_real = 0.0_prt;
+        ParticleReal payload_real = 0.0_prt;
+        ParticleReal runtime_real = 0.0_prt;
     };
 
     struct PackedSourceParticleData
@@ -73,18 +73,18 @@ namespace
         int runtime_int = 0;
         std::array<int, AMREX_SPACEDIM> cell{};
         std::array<ParticleReal, AMREX_SPACEDIM> pos{};
-        ParticleReal marker_real = 0.0_rt;
-        ParticleReal payload_real = 0.0_rt;
-        ParticleReal runtime_real = 0.0_rt;
+        ParticleReal marker_real = 0.0_prt;
+        ParticleReal payload_real = 0.0_prt;
+        ParticleReal runtime_real = 0.0_prt;
     };
 
     static_assert(std::is_trivially_copyable_v<PackedSourceParticleData>);
 
     struct InverseContributionData
     {
-        ParticleReal marker_real = 0.0_rt;
-        ParticleReal payload_real = 0.0_rt;
-        ParticleReal runtime_real = 0.0_rt;
+        ParticleReal marker_real = 0.0_prt;
+        ParticleReal payload_real = 0.0_prt;
+        ParticleReal runtime_real = 0.0_prt;
         int marker_int = 0;
         int runtime_int = 0;
     };
@@ -93,9 +93,9 @@ namespace
     {
         Long id = 0;
         int cpu = -1;
-        ParticleReal marker_real = 0.0_rt;
-        ParticleReal payload_real = 0.0_rt;
-        ParticleReal runtime_real = 0.0_rt;
+        ParticleReal marker_real = 0.0_prt;
+        ParticleReal payload_real = 0.0_prt;
+        ParticleReal runtime_real = 0.0_prt;
         int marker_int = 0;
         int runtime_int = 0;
     };
@@ -154,7 +154,7 @@ namespace
         pp.get("is_periodic", params.is_periodic);
     }
 
-    bool almost_equal (ParticleReal lhs, ParticleReal rhs, ParticleReal tol = 1.0e-12_rt)
+    bool almost_equal (ParticleReal lhs, ParticleReal rhs, ParticleReal tol = 1.0e-12_prt)
     {
         return std::abs(lhs-rhs) <= tol;
     }
@@ -502,9 +502,9 @@ public:
 
     void checkInverseSumNeighbors ()
     {
-        constexpr ParticleReal marker_real_delta = 1.25_rt;
-        constexpr ParticleReal payload_real_delta = 2.5_rt;
-        constexpr ParticleReal runtime_real_delta = 3.75_rt;
+        constexpr ParticleReal marker_real_delta = 1.25_prt;
+        constexpr ParticleReal payload_real_delta = 2.5_prt;
+        constexpr ParticleReal runtime_real_delta = 3.75_prt;
         constexpr int marker_int_delta = 11;
         constexpr int runtime_int_delta = 13;
 
@@ -888,7 +888,7 @@ int main (int argc, char* argv[])
     RealBox real_box;
     for (int dir = 0; dir < BL_SPACEDIM; ++dir)
     {
-        real_box.setLo(dir, 0.0);
+        real_box.setLo(dir, Real(0.0));
         real_box.setHi(dir, Real(params.size[dir]));
     }
 

--- a/Tests/Particles/NeighborParticlesPureSoA/main.cpp
+++ b/Tests/Particles/NeighborParticlesPureSoA/main.cpp
@@ -41,10 +41,10 @@ namespace
         AMREX_GPU_DEVICE AMREX_FORCE_INLINE
         bool operator() (const P1& p1, const P2& p2) const
         {
-            AMREX_D_TERM(Real d0 = p1.pos(0) - p2.pos(0);,
-                         Real d1 = p1.pos(1) - p2.pos(1);,
-                         Real d2 = p1.pos(2) - p2.pos(2);)
-            Real dsquared = AMREX_D_TERM(d0*d0, + d1*d1, + d2*d2);
+            AMREX_D_TERM(ParticleReal d0 = p1.pos(0) - p2.pos(0);,
+                         ParticleReal d1 = p1.pos(1) - p2.pos(1);,
+                         ParticleReal d2 = p1.pos(2) - p2.pos(2);)
+            ParticleReal dsquared = AMREX_D_TERM(d0*d0, + d1*d1, + d2*d2);
             return dsquared <= 25.0_rt*Cutoff*Cutoff;
         }
     };
@@ -463,9 +463,9 @@ public:
                 for (int j = 0; j < np_total; ++j) {
                     if (i == j) { continue; }
 
-                    Real dsquared = 0.0_rt;
+                    ParticleReal dsquared = 0.0_rt;
                     for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                        Real d = host.real[dir][i] - host.real[dir][j];
+                        ParticleReal d = host.real[dir][i] - host.real[dir][j];
                         dsquared += d*d;
                     }
                     if (dsquared <= cutoff_sq) {
@@ -918,7 +918,7 @@ int main (int argc, char* argv[])
     pc.buildNeighborList(CheckPair());
     pc.checkNeighborList();
 
-    pc.moveParticles(0.1_rt);
+    pc.moveParticles(0.1_prt);
     pc.bumpPayload(2000);
     pc.updateNeighbors();
     pc.checkNeighbors();

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -31,9 +31,9 @@ void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
                      int iy_part = (i_part % (ny * nz)) % ny;,
                      int iz_part = (i_part % (ny * nz)) / ny;)
 
-        AMREX_D_TERM(r[0] = (0.5+ix_part)/nx;,
-                     r[1] = (0.5+iy_part)/ny;,
-                     r[2] = (0.5+iz_part)/nz;)
+        AMREX_D_TERM(r[0] = (Real(0.5)+Real(ix_part))/Real(nx);,
+                     r[1] = (Real(0.5)+Real(iy_part))/Real(ny);,
+                     r[2] = (Real(0.5)+Real(iz_part))/Real(nz);)
 }
 
 class TestParticleContainer
@@ -99,12 +99,12 @@ public:
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
                     p.cpu() = ParallelDescriptor::MyProc();
-                    p.pos(0) = static_cast<ParticleReal> (plo[0] + ((iv[0] - dom_lo[0]) + r[0])*dx[0]);
+                    p.pos(0) = static_cast<ParticleReal> (plo[0] + (Real(iv[0] - dom_lo[0]) + r[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                    p.pos(1) = static_cast<ParticleReal> (plo[1] + ((iv[1] - dom_lo[1]) + r[1])*dx[1]);
+                    p.pos(1) = static_cast<ParticleReal> (plo[1] + (Real(iv[1] - dom_lo[1]) + r[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                    p.pos(2) = static_cast<ParticleReal> (plo[2] + ((iv[2] - dom_lo[2]) + r[2])*dx[2]);
+                    p.pos(2) = static_cast<ParticleReal> (plo[2] + (Real(iv[2] - dom_lo[2]) + r[2])*dx[2]);
 #endif
 
                     for (int i = 0; i < NSR; ++i) { p.rdata(i) = ParticleReal(p.id()); }
@@ -198,12 +198,12 @@ public:
                     [=] AMREX_GPU_DEVICE (size_t i) noexcept
                     {
                         ParticleType& p = pstruct[i];
-                        p.pos(0) += static_cast<ParticleReal> (move_dir[0]*dx[0]);
+                        p.pos(0) += static_cast<ParticleReal> (Real(move_dir[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += static_cast<ParticleReal> (move_dir[1]*dx[1]);
+                        p.pos(1) += static_cast<ParticleReal> (Real(move_dir[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += static_cast<ParticleReal> (move_dir[2]*dx[2]);
+                        p.pos(2) += static_cast<ParticleReal> (Real(move_dir[2])*dx[2]);
 #endif
                     });
                 }
@@ -214,12 +214,12 @@ public:
                     {
                         ParticleType& p = pstruct[i];
 
-                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[0]*dx[0]);
+                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[1]*dx[1]);
+                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[2]*dx[2]);
+                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[2])*dx[2]);
 #endif
                     });
                 }
@@ -278,7 +278,7 @@ public:
                 {
                     for (int j = 0; j < NSR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ptd.m_aos[i].id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == Real(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NSI; ++j)
                     {
@@ -286,7 +286,7 @@ public:
                     }
                     for (int j = 0; j < NAR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ptd.m_aos[i].id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NAI; ++j)
                     {
@@ -294,7 +294,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ptd.m_aos[i].id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {
@@ -385,8 +385,8 @@ void testParallelContext ()
         RealBox real_box;
         for (int n = 0; n < BL_SPACEDIM; n++)
         {
-            Real physlo = (n == 0) ? task_me*hs[n] : 0.0;
-            Real physhi = (n == 0) ? task_me*hs[n] + hs[n] : params.size[n];
+            Real physlo = (n == 0) ? Real(task_me)*Real(hs[n]) : Real(0.0);
+            Real physhi = (n == 0) ? Real(task_me)*Real(hs[n]) + Real(hs[n]) : Real(params.size[n]);
             real_box.setLo(n, physlo);
             real_box.setHi(n, physhi);
         }

--- a/Tests/Particles/ParallelContext/main.cpp
+++ b/Tests/Particles/ParallelContext/main.cpp
@@ -278,7 +278,7 @@ public:
                 {
                     for (int j = 0; j < NSR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == Real(ptd.m_aos[i].id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ParticleReal(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NSI; ++j)
                     {
@@ -286,7 +286,7 @@ public:
                     }
                     for (int j = 0; j < NAR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(ptd.m_aos[i].id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ParticleReal(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NAI; ++j)
                     {
@@ -294,7 +294,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(ptd.m_aos[i].id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ParticleReal(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {

--- a/Tests/Particles/ParticleMesh/main.cpp
+++ b/Tests/Particles/ParticleMesh/main.cpp
@@ -106,7 +106,7 @@ void testParticleMesh (TestParams& parms)
                       return arr(i, j, k, comp);  // no weighting
                   },
                   [=] AMREX_GPU_DEVICE (MyParticleContainer::ParticleType& part,
-                                        int comp, amrex::Real val)
+                                        int comp, auto val)
                   {
                       part.rdata(comp) += ParticleReal(val);
                   });

--- a/Tests/Particles/ParticleReduce/main.cpp
+++ b/Tests/Particles/ParticleReduce/main.cpp
@@ -158,8 +158,8 @@ void testReduce ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setLo(n, Real(0.0));
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/ParticleReduce/main.cpp
+++ b/Tests/Particles/ParticleReduce/main.cpp
@@ -188,19 +188,19 @@ void testReduce ()
     using PType   = typename TestParticleContainer::ParticleType;
     using PTDType = typename TestParticleContainer::ParticleTileType::ConstParticleTileDataType;
 
-    auto sm = amrex::ReduceSum(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> Real { return p.rdata(1); });
+    auto sm = amrex::ReduceSum(pc, [=] AMREX_GPU_HOST_DEVICE (const PType& p) -> ParticleReal { return p.rdata(1); });
     AMREX_ALWAYS_ASSERT(sm == pc.TotalNumberOfParticles());
 
-    auto sm2 = amrex::ReduceSum(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> Real { return -p.rdata(NSR+1); });
+    auto sm2 = amrex::ReduceSum(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> ParticleReal { return -p.rdata(NSR+1); });
     AMREX_ALWAYS_ASSERT(sm2 == -pc.TotalNumberOfParticles());
 
-    auto mn = amrex::ReduceMin(pc, [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> Real { return ptd.m_aos[i].rdata(1);});
+    auto mn = amrex::ReduceMin(pc, [=] AMREX_GPU_HOST_DEVICE (const PTDType& ptd, const int i) -> ParticleReal { return ptd.m_aos[i].rdata(1);});
     AMREX_ALWAYS_ASSERT(mn == 1);
 
-    auto mn2 = amrex::ReduceMin(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> Real { return p.rdata(NSR+1); });
+    auto mn2 = amrex::ReduceMin(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> ParticleReal { return p.rdata(NSR+1); });
     AMREX_ALWAYS_ASSERT(mn2 == 1);
 
-    auto mx = amrex::ReduceMax(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> Real { return p.rdata(1); });
+    auto mx = amrex::ReduceMax(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> ParticleReal { return p.rdata(1); });
     AMREX_ALWAYS_ASSERT(mx == 1);
 
     auto mx2 = amrex::ReduceMax(pc, [=] AMREX_GPU_HOST_DEVICE (const SPType& p) -> int { return p.idata(NSI); });
@@ -228,11 +228,11 @@ void testReduce ()
 
     {
         amrex::ReduceOps<ReduceOpSum, ReduceOpMin, ReduceOpMax> reduce_ops;
-        auto r = amrex::ParticleReduce<ReduceData<amrex::Real, amrex::Real,int>> (
-         pc, [=] AMREX_GPU_DEVICE (const SPType& p) noexcept -> amrex::GpuTuple<amrex::Real,amrex::Real,int>
+        auto r = amrex::ParticleReduce<ReduceData<amrex::ParticleReal, amrex::ParticleReal,int>> (
+         pc, [=] AMREX_GPU_DEVICE (const SPType& p) noexcept -> amrex::GpuTuple<amrex::ParticleReal,amrex::ParticleReal,int>
            {
-               const amrex::Real a = p.rdata(1);
-               const amrex::Real b = p.rdata(2);
+               const amrex::ParticleReal a = p.rdata(1);
+               const amrex::ParticleReal b = p.rdata(2);
                const int c = p.idata(1);
                return {a, b, c};
            }, reduce_ops);

--- a/Tests/Particles/ParticleReduce/main.cpp
+++ b/Tests/Particles/ParticleReduce/main.cpp
@@ -30,9 +30,9 @@ void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
                      int iy_part = (i_part % (ny * nz)) % ny;,
                      int iz_part = (i_part % (ny * nz)) / ny;)
 
-        AMREX_D_TERM(r[0] = (0.5+ix_part)/nx;,
-                     r[1] = (0.5+iy_part)/ny;,
-                     r[2] = (0.5+iz_part)/nz;)
+        AMREX_D_TERM(r[0] = (Real(0.5)+Real(ix_part))/Real(nx);,
+                     r[1] = (Real(0.5)+Real(iy_part))/Real(ny);,
+                     r[2] = (Real(0.5)+Real(iz_part))/Real(nz);)
 }
 
 class TestParticleContainer

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -704,7 +704,7 @@ void testTransformations ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
+        real_box.setLo(n, Real(0.0));
         real_box.setHi(n, Real(params.size[n]));
     }
 

--- a/Tests/Particles/ParticleTransformations/main.cpp
+++ b/Tests/Particles/ParticleTransformations/main.cpp
@@ -28,9 +28,9 @@ void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
                      int iy_part = (i_part % (ny * nz)) % ny;,
                      int iz_part = (i_part % (ny * nz)) / ny;)
 
-        AMREX_D_TERM(r[0] = (0.5+ix_part)/nx;,
-                     r[1] = (0.5+iy_part)/ny;,
-                     r[2] = (0.5+iz_part)/nz;)
+        AMREX_D_TERM(r[0] = (Real(0.5)+Real(ix_part))/Real(nx);,
+                     r[1] = (Real(0.5)+Real(iy_part))/Real(ny);,
+                     r[2] = (Real(0.5)+Real(iz_part))/Real(nz);)
 }
 
 class TestParticleContainer
@@ -72,9 +72,9 @@ public:
                     Real r[3];
                     get_position_unit_cell(r, a_num_particles_per_cell, i_part);
 
-                    AMREX_D_TERM(auto x = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);,
-                                 auto y = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);,
-                                 auto z = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);)
+                    AMREX_D_TERM(auto x = static_cast<ParticleReal> (plo[0] + (Real(iv[0]) + r[0])*dx[0]);,
+                                 auto y = static_cast<ParticleReal> (plo[1] + (Real(iv[1]) + r[1])*dx[1]);,
+                                 auto z = static_cast<ParticleReal> (plo[2] + (Real(iv[2]) + r[2])*dx[2]);)
 
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
@@ -705,7 +705,7 @@ void testTransformations ()
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
         real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -35,9 +35,9 @@ void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
     int iy_part = (i_part % (ny * nz)) % ny;
     int iz_part = (i_part % (ny * nz)) / ny;
 
-    r[0] = (0.5+ix_part)/nx;
-    r[1] = (0.5+iy_part)/ny;
-    r[2] = (0.5+iz_part)/nz;
+    r[0] = (Real(0.5)+Real(ix_part))/Real(nx);
+    r[1] = (Real(0.5)+Real(iy_part))/Real(ny);
+    r[2] = (Real(0.5)+Real(iz_part))/Real(nz);
 }
 
 class TestParticleContainer
@@ -126,12 +126,12 @@ public:
                     ParticleType p;
                     p.id()  = ParticleType::NextID();
                     p.cpu() = ParallelDescriptor::MyProc();
-                    p.pos(0) = static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]);
+                    p.pos(0) = static_cast<ParticleReal> (plo[0] + (Real(iv[0]) + r[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                    p.pos(1) = static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]);
+                    p.pos(1) = static_cast<ParticleReal> (plo[1] + (Real(iv[1]) + r[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                    p.pos(2) = static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]);
+                    p.pos(2) = static_cast<ParticleReal> (plo[2] + (Real(iv[2]) + r[2])*dx[2]);
 #endif
 
                     for (int i = 0; i < NSR; ++i) { p.rdata(i) = ParticleReal(p.id()); }
@@ -227,12 +227,12 @@ public:
                     amrex::ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
                     {
                         ParticleType& p = pstruct[i];
-                        p.pos(0) += static_cast<ParticleReal> (move_dir[0]*dx[0]);
+                        p.pos(0) += static_cast<ParticleReal> (Real(move_dir[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += static_cast<ParticleReal> (move_dir[1]*dx[1]);
+                        p.pos(1) += static_cast<ParticleReal> (Real(move_dir[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += static_cast<ParticleReal> (move_dir[2]*dx[2]);
+                        p.pos(2) += static_cast<ParticleReal> (Real(move_dir[2])*dx[2]);
 #endif
                     });
                 }
@@ -243,12 +243,12 @@ public:
                     {
                         ParticleType& p = pstruct[i];
 
-                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[0]*dx[0]);
+                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[1]*dx[1]);
+                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[2]*dx[2]);
+                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[2])*dx[2]);
 #endif
                     });
                 }
@@ -312,7 +312,7 @@ public:
                 {
                     for (int j = 0; j < NSR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ptd.m_aos[i].id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == Real(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NSI; ++j)
                     {
@@ -321,7 +321,7 @@ public:
                     if constexpr (NAR > 0) {
                         for (int j = 0; j < NAR; ++j)
                         {
-                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ptd.m_aos[i].id());
+                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(ptd.m_aos[i].id()));
                         }
                     }
                     if constexpr (NAI > 0) {
@@ -332,7 +332,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ptd.m_aos[i].id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {
@@ -503,7 +503,7 @@ void testRedistribute ()
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
         real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/Redistribute/main.cpp
+++ b/Tests/Particles/Redistribute/main.cpp
@@ -312,7 +312,7 @@ public:
                 {
                     for (int j = 0; j < NSR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == Real(ptd.m_aos[i].id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ParticleReal(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NSI; ++j)
                     {
@@ -321,7 +321,7 @@ public:
                     if constexpr (NAR > 0) {
                         for (int j = 0; j < NAR; ++j)
                         {
-                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(ptd.m_aos[i].id()));
+                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ParticleReal(ptd.m_aos[i].id()));
                         }
                     }
                     if constexpr (NAI > 0) {
@@ -332,7 +332,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(ptd.m_aos[i].id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ParticleReal(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {
@@ -502,7 +502,7 @@ void testRedistribute ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
+        real_box.setLo(n, Real(0.0));
         real_box.setHi(n, Real(params.size[n]));
     }
 

--- a/Tests/Particles/RedistributeGlobal/main.cpp
+++ b/Tests/Particles/RedistributeGlobal/main.cpp
@@ -31,9 +31,9 @@ void get_position_unit_cell(Real* r, const IntVect& nppc, int i_part)
     int iy_part = (i_part % (ny * nz)) % ny;
     int iz_part = (i_part % (ny * nz)) / ny;
 
-    r[0] = (0.5+ix_part)/nx;
-    r[1] = (0.5+iy_part)/ny;
-    r[2] = (0.5+iz_part)/nz;
+    r[0] = (Real(0.5)+Real(ix_part))/Real(nx);
+    r[1] = (Real(0.5)+Real(iy_part))/Real(ny);
+    r[2] = (Real(0.5)+Real(iz_part))/Real(nz);
 }
 
 class TestParticleContainer
@@ -99,12 +99,12 @@ public:
                     ParticleType p;
                     p.id() = ParticleType::NextID();
                     p.cpu() = ParallelDescriptor::MyProc();
-                    p.pos(0) = static_cast<ParticleReal>(plo[0] + (iv[0] + r[0])*dx[0]);
+                    p.pos(0) = static_cast<ParticleReal>(plo[0] + (Real(iv[0]) + r[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                    p.pos(1) = static_cast<ParticleReal>(plo[1] + (iv[1] + r[1])*dx[1]);
+                    p.pos(1) = static_cast<ParticleReal>(plo[1] + (Real(iv[1]) + r[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                    p.pos(2) = static_cast<ParticleReal>(plo[2] + (iv[2] + r[2])*dx[2]);
+                    p.pos(2) = static_cast<ParticleReal>(plo[2] + (Real(iv[2]) + r[2])*dx[2]);
 #endif
 
                     for (int i = 0; i < NSR; ++i) { p.rdata(i) = ParticleReal(p.id()); }
@@ -234,7 +234,7 @@ public:
                 {
                     for (int j = 0; j < NSR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ptd.m_aos[i].id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == Real(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NSI; ++j)
                     {
@@ -243,7 +243,7 @@ public:
                     if constexpr (NAR > 0) {
                         for (int j = 0; j < NAR; ++j)
                         {
-                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ptd.m_aos[i].id());
+                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(ptd.m_aos[i].id()));
                         }
                     }
                     if constexpr (NAI > 0) {
@@ -254,7 +254,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ptd.m_aos[i].id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {
@@ -326,7 +326,7 @@ void testRedistributeGlobal ()
     for (int n = 0; n < BL_SPACEDIM; ++n)
     {
         real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/RedistributeGlobal/main.cpp
+++ b/Tests/Particles/RedistributeGlobal/main.cpp
@@ -234,7 +234,7 @@ public:
                 {
                     for (int j = 0; j < NSR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == Real(ptd.m_aos[i].id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ParticleReal(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NSI; ++j)
                     {
@@ -243,7 +243,7 @@ public:
                     if constexpr (NAR > 0) {
                         for (int j = 0; j < NAR; ++j)
                         {
-                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(ptd.m_aos[i].id()));
+                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ParticleReal(ptd.m_aos[i].id()));
                         }
                     }
                     if constexpr (NAI > 0) {
@@ -254,7 +254,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(ptd.m_aos[i].id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ParticleReal(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {
@@ -325,7 +325,7 @@ void testRedistributeGlobal ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; ++n)
     {
-        real_box.setLo(n, 0.0);
+        real_box.setLo(n, Real(0.0));
         real_box.setHi(n, Real(params.size[n]));
     }
 

--- a/Tests/Particles/RedistributeGlobalDM/main.cpp
+++ b/Tests/Particles/RedistributeGlobalDM/main.cpp
@@ -36,9 +36,9 @@ void get_position_unit_cell (Real* r, const IntVect& nppc, int i_part)
     int iy_part = (i_part % (ny * nz)) % ny;
     int iz_part = (i_part % (ny * nz)) / ny;
 
-    r[0] = (0.5+ix_part)/nx;
-    r[1] = (0.5+iy_part)/ny;
-    r[2] = (0.5+iz_part)/nz;
+    r[0] = (Real(0.5)+Real(ix_part))/Real(nx);
+    r[1] = (Real(0.5)+Real(iy_part))/Real(ny);
+    r[2] = (Real(0.5)+Real(iz_part))/Real(nz);
 }
 
 class TestParticleContainer
@@ -104,12 +104,12 @@ public:
                     ParticleType p;
                     p.id() = ParticleType::NextID();
                     p.cpu() = ParallelDescriptor::MyProc();
-                    p.pos(0) = static_cast<ParticleReal>(plo[0] + (iv[0] + r[0])*dx[0]);
+                    p.pos(0) = static_cast<ParticleReal>(plo[0] + (Real(iv[0]) + r[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                    p.pos(1) = static_cast<ParticleReal>(plo[1] + (iv[1] + r[1])*dx[1]);
+                    p.pos(1) = static_cast<ParticleReal>(plo[1] + (Real(iv[1]) + r[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                    p.pos(2) = static_cast<ParticleReal>(plo[2] + (iv[2] + r[2])*dx[2]);
+                    p.pos(2) = static_cast<ParticleReal>(plo[2] + (Real(iv[2]) + r[2])*dx[2]);
 #endif
 
                     for (int i = 0; i < NSR; ++i) { p.rdata(i) = ParticleReal(p.id()); }
@@ -204,7 +204,7 @@ public:
                 {
                     for (int j = 0; j < NSR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ptd.m_aos[i].id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == Real(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NSI; ++j)
                     {
@@ -213,7 +213,7 @@ public:
                     if constexpr (NAR > 0) {
                         for (int j = 0; j < NAR; ++j)
                         {
-                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ptd.m_aos[i].id());
+                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(ptd.m_aos[i].id()));
                         }
                     }
                     if constexpr (NAI > 0) {
@@ -224,7 +224,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ptd.m_aos[i].id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {
@@ -313,7 +313,7 @@ void testRedistributeGlobalDM ()
     for (int n = 0; n < BL_SPACEDIM; ++n)
     {
         real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));
@@ -372,12 +372,12 @@ void testRedistributeGlobalDM ()
             new_dm.define(pmap);
             pc.SetParticleDistributionMap(lev, new_dm);
         }
-        total_dm_time += amrex::second() - dm_start;
+        total_dm_time += Real(amrex::second() - dm_start);
 
         ParallelDescriptor::Barrier();
         const auto redistribute_start = amrex::second();
         pc.RedistributeGlobal();
-        total_redistribute_time += amrex::second() - redistribute_start;
+        total_redistribute_time += Real(amrex::second() - redistribute_start);
 
         if (params.sort) { pc.SortParticlesByCell(); }
         if (params.check_answer_each_step) { pc.checkAnswer(); }

--- a/Tests/Particles/RedistributeGlobalDM/main.cpp
+++ b/Tests/Particles/RedistributeGlobalDM/main.cpp
@@ -204,7 +204,7 @@ public:
                 {
                     for (int j = 0; j < NSR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == Real(ptd.m_aos[i].id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_aos[i].rdata(j) == ParticleReal(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < NSI; ++j)
                     {
@@ -213,7 +213,7 @@ public:
                     if constexpr (NAR > 0) {
                         for (int j = 0; j < NAR; ++j)
                         {
-                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(ptd.m_aos[i].id()));
+                            AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ParticleReal(ptd.m_aos[i].id()));
                         }
                     }
                     if constexpr (NAI > 0) {
@@ -224,7 +224,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(ptd.m_aos[i].id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ParticleReal(ptd.m_aos[i].id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {
@@ -312,7 +312,7 @@ void testRedistributeGlobalDM ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; ++n)
     {
-        real_box.setLo(n, 0.0);
+        real_box.setLo(n, Real(0.0));
         real_box.setHi(n, Real(params.size[n]));
     }
 

--- a/Tests/Particles/RedistributeRTSOA/main.cpp
+++ b/Tests/Particles/RedistributeRTSOA/main.cpp
@@ -28,9 +28,9 @@ void get_position_unit_cell (Real* r, const IntVect& nppc, int i_part)
     int iy_part = (i_part % (ny * nz)) % ny;
     int iz_part = (i_part % (ny * nz)) / ny;
 
-    r[0] = (0.5+ix_part)/nx;
-    r[1] = (0.5+iy_part)/ny;
-    r[2] = (0.5+iz_part)/nz;
+    r[0] = (Real(0.5)+Real(ix_part))/Real(nx);
+    r[1] = (Real(0.5)+Real(iy_part))/Real(ny);
+    r[2] = (Real(0.5)+Real(iz_part))/Real(nz);
 }
 
 class TestParticleContainer
@@ -109,12 +109,12 @@ public:
                     host_runtime_int[0].push_back(static_cast<int>(id));
                     host_runtime_int[1].push_back(ParallelDescriptor::MyProc());
 
-                    host_runtime_real[0].push_back(static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]));
+                    host_runtime_real[0].push_back(static_cast<ParticleReal> (plo[0] + (Real(iv[0]) + r[0])*dx[0]));
 #if AMREX_SPACEDIM > 1
-                    host_runtime_real[1].push_back(static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]));
+                    host_runtime_real[1].push_back(static_cast<ParticleReal> (plo[1] + (Real(iv[1]) + r[1])*dx[1]));
 #endif
 #if AMREX_SPACEDIM > 2
-                    host_runtime_real[2].push_back(static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]));
+                    host_runtime_real[2].push_back(static_cast<ParticleReal> (plo[2] + (Real(iv[2]) + r[2])*dx[2]));
 #endif
 
                     for (int i = AMREX_SPACEDIM; i < NumRuntimeRealComps(); ++i) {
@@ -183,12 +183,12 @@ public:
                     amrex::ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
                     {
                         ParticleType p(ptd, i);
-                        p.pos(0) += static_cast<ParticleReal> (move_dir[0]*dx[0]);
+                        p.pos(0) += static_cast<ParticleReal> (Real(move_dir[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += static_cast<ParticleReal> (move_dir[1]*dx[1]);
+                        p.pos(1) += static_cast<ParticleReal> (Real(move_dir[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += static_cast<ParticleReal> (move_dir[2]*dx[2]);
+                        p.pos(2) += static_cast<ParticleReal> (Real(move_dir[2])*dx[2]);
 #endif
                     });
                 }
@@ -198,12 +198,12 @@ public:
                     [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
                     {
                         ParticleType p(ptd, i);
-                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[0]*dx[0]);
+                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[1]*dx[1]);
+                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[2]*dx[2]);
+                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[2])*dx[2]);
 #endif
                     });
                 }
@@ -258,7 +258,7 @@ public:
                     ConstParticleType p(ptd, i);
                     for (int j = AMREX_SPACEDIM; j < ptd.m_n_real; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.rdata(j)[i] == p.id());
+                        AMREX_ALWAYS_ASSERT(ptd.rdata(j)[i] == Real(p.id()));
                     }
                     for (int j = 2; j < ptd.m_n_int; ++j)
                     {
@@ -342,7 +342,7 @@ void testRedistribute ()
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
         real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/RedistributeRTSOA/main.cpp
+++ b/Tests/Particles/RedistributeRTSOA/main.cpp
@@ -258,7 +258,7 @@ public:
                     ConstParticleType p(ptd, i);
                     for (int j = AMREX_SPACEDIM; j < ptd.m_n_real; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.rdata(j)[i] == Real(p.id()));
+                        AMREX_ALWAYS_ASSERT(ptd.rdata(j)[i] == ParticleReal(p.id()));
                     }
                     for (int j = 2; j < ptd.m_n_int; ++j)
                     {
@@ -341,7 +341,7 @@ void testRedistribute ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
+        real_box.setLo(n, Real(0.0));
         real_box.setHi(n, Real(params.size[n]));
     }
 

--- a/Tests/Particles/RedistributeSOA/main.cpp
+++ b/Tests/Particles/RedistributeSOA/main.cpp
@@ -286,7 +286,7 @@ public:
                     ConstParticleType p(ptd, i);
                     for (int j = AMREX_SPACEDIM; j < NR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(p.id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == ParticleReal(p.id()));
                     }
                     for (int j = 2; j < NI; ++j)
                     {
@@ -294,7 +294,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(p.id()));
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == ParticleReal(p.id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {
@@ -373,7 +373,7 @@ void testRedistribute ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
+        real_box.setLo(n, Real(0.0));
         real_box.setHi(n, Real(params.size[n]));
     }
 

--- a/Tests/Particles/RedistributeSOA/main.cpp
+++ b/Tests/Particles/RedistributeSOA/main.cpp
@@ -31,9 +31,9 @@ void get_position_unit_cell (Real* r, const IntVect& nppc, int i_part)
     int iy_part = (i_part % (ny * nz)) % ny;
     int iz_part = (i_part % (ny * nz)) / ny;
 
-    r[0] = (0.5+ix_part)/nx;
-    r[1] = (0.5+iy_part)/ny;
-    r[2] = (0.5+iz_part)/nz;
+    r[0] = (Real(0.5)+Real(ix_part))/Real(nx);
+    r[1] = (Real(0.5)+Real(iy_part))/Real(ny);
+    r[2] = (Real(0.5)+Real(iz_part))/Real(nz);
 }
 
 class TestParticleContainer
@@ -113,12 +113,12 @@ public:
 
                     host_int[0].push_back(static_cast<int>(id));
                     host_int[1].push_back(ParallelDescriptor::MyProc());
-                    host_real[0].push_back(static_cast<ParticleReal> (plo[0] + (iv[0] + r[0])*dx[0]));
+                    host_real[0].push_back(static_cast<ParticleReal> (plo[0] + (Real(iv[0]) + r[0])*dx[0]));
 #if AMREX_SPACEDIM > 1
-                    host_real[1].push_back(static_cast<ParticleReal> (plo[1] + (iv[1] + r[1])*dx[1]));
+                    host_real[1].push_back(static_cast<ParticleReal> (plo[1] + (Real(iv[1]) + r[1])*dx[1]));
 #endif
 #if AMREX_SPACEDIM > 2
-                    host_real[2].push_back(static_cast<ParticleReal> (plo[2] + (iv[2] + r[2])*dx[2]));
+                    host_real[2].push_back(static_cast<ParticleReal> (plo[2] + (Real(iv[2]) + r[2])*dx[2]));
 #endif
 
                     for (int i = AMREX_SPACEDIM; i < NR; ++i) {
@@ -208,12 +208,12 @@ public:
                     amrex::ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
                     {
                         ParticleType p(ptd, i);
-                        p.pos(0) += static_cast<ParticleReal> (move_dir[0]*dx[0]);
+                        p.pos(0) += static_cast<ParticleReal> (Real(move_dir[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += static_cast<ParticleReal> (move_dir[1]*dx[1]);
+                        p.pos(1) += static_cast<ParticleReal> (Real(move_dir[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += static_cast<ParticleReal> (move_dir[2]*dx[2]);
+                        p.pos(2) += static_cast<ParticleReal> (Real(move_dir[2])*dx[2]);
 #endif
                     });
                 }
@@ -223,12 +223,12 @@ public:
                     [=] AMREX_GPU_DEVICE (int i, RandomEngine const& engine) noexcept
                     {
                         ParticleType p(ptd, i);
-                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[0]*dx[0]);
+                        p.pos(0) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[0])*dx[0]);
 #if AMREX_SPACEDIM > 1
-                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[1]*dx[1]);
+                        p.pos(1) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[1])*dx[1]);
 #endif
 #if AMREX_SPACEDIM > 2
-                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*move_dir[2]*dx[2]);
+                        p.pos(2) += static_cast<ParticleReal> ((2*amrex::Random(engine)-1)*Real(move_dir[2])*dx[2]);
 #endif
                     });
                 }
@@ -286,7 +286,7 @@ public:
                     ConstParticleType p(ptd, i);
                     for (int j = AMREX_SPACEDIM; j < NR; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == p.id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_rdata[j][i] == Real(p.id()));
                     }
                     for (int j = 2; j < NI; ++j)
                     {
@@ -294,7 +294,7 @@ public:
                     }
                     for (int j = 0; j < num_rr; ++j)
                     {
-                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == p.id());
+                        AMREX_ALWAYS_ASSERT(ptd.m_runtime_rdata[j][i] == Real(p.id()));
                     }
                     for (int j = 0; j < num_ii; ++j)
                     {
@@ -374,7 +374,7 @@ void testRedistribute ()
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
         real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/SENSEI_Insitu_SOA/main.cpp
+++ b/Tests/Particles/SENSEI_Insitu_SOA/main.cpp
@@ -208,8 +208,8 @@ void testRedistribute ()
     RealBox real_box;
     for (int n = 0; n < BL_SPACEDIM; n++)
     {
-        real_box.setLo(n, 0.0);
-        real_box.setHi(n, params.size[n]);
+        real_box.setLo(n, Real(0.0));
+        real_box.setHi(n, Real(params.size[n]));
     }
 
     IntVect domain_lo(AMREX_D_DECL(0, 0, 0));

--- a/Tests/Particles/SOAParticle/main.cpp
+++ b/Tests/Particles/SOAParticle/main.cpp
@@ -54,7 +54,7 @@ void addParticles ()
         for (int d = 0; d < AMREX_SPACEDIM; d++) {
             ptile1.pos(i, d) = 12.0;
         }
-        ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = Real(1.2);  // w
+        ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = ParticleReal(1.2);  // w
 
         ptile1.push_back_int(0, ParticleType::NextID());
         ptile1.push_back_int(1, amrex::ParallelDescriptor::MyProc());

--- a/Tests/Particles/SOAParticle/main.cpp
+++ b/Tests/Particles/SOAParticle/main.cpp
@@ -54,7 +54,7 @@ void addParticles ()
         for (int d = 0; d < AMREX_SPACEDIM; d++) {
             ptile1.pos(i, d) = 12.0;
         }
-        ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = 1.2;  // w
+        ptile1.getParticleTileData().rdata(AMREX_SPACEDIM)[i] = Real(1.2);  // w
 
         ptile1.push_back_int(0, ParticleType::NextID());
         ptile1.push_back_int(1, amrex::ParallelDescriptor::MyProc());
@@ -143,8 +143,8 @@ void addParticles ()
         [=] AMREX_GPU_DEVICE(const ConstPTDType& ptd, const int i) noexcept
         {
             amrex::ParticleReal const x = ptd.rdata(0)[i];
-            amrex::ParticleReal const y = AMREX_SPACEDIM >= 2 ? ptd.rdata(1)[i] : 0.0;
-            amrex::ParticleReal const z = AMREX_SPACEDIM >= 3 ? ptd.rdata(2)[i] : 0.0;
+            amrex::ParticleReal const y = AMREX_SPACEDIM >= 2 ? ptd.rdata(1)[i] : amrex::ParticleReal(0.0);
+            amrex::ParticleReal const z = AMREX_SPACEDIM >= 3 ? ptd.rdata(2)[i] : amrex::ParticleReal(0.0);
 
             amrex::ParticleReal const w = ptd.rdata(AMREX_SPACEDIM)[i];
 


### PR DESCRIPTION
Build in single precision with EB, linear solvers, AmrLevel, particles and FFT, then run ctest and clang-tidy.  Single precision was only exercised by the GitLab H100 GPU runs, so solver breakage kept surfacing late: #4785, #5319 and #5672.  The job found a float-conversion bug in the 2D nodal EB kernel and a NodeTensorLap tolerance that cannot be met in float.  263 -Wfloat-conversion lines remain under Tests/, so that warning is not an error in this job yet; cleanup follows.
