### PR TITLE
MLMG: restore nodalSync at the end of the nodal smoothers

### DIFF
--- a/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLEBNodeFDLaplacian.cpp
@@ -634,8 +634,7 @@ MLEBNodeFDLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
         }
     }
 
-    // No nodalSync here.  Every consumer of sol goes through
-    // MLNodeLinOp::applyBC first, and that does FillBoundaryAndSync.
+    nodalSync(amrlev, mglev, sol);
 }
 
 void

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeABecLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeABecLaplacian.cpp
@@ -169,10 +169,7 @@ MLNodeABecLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiF
                                         aarr, barr, dmskarr, dxinvarr);
         }
     }
-    // No nodalSync here.  Every consumer of sol goes through
-    // MLNodeLinOp::applyBC first, and that does FillBoundaryAndSync.  (The
-    // sync in the GPU branch above is not redundant: it reconciles sol
-    // between the m_smooth_num_sweeps sweeps, which no applyBC separates.)
+    nodalSync(amrlev, mglev, sol);
 #endif
 }
 

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeLaplacian_misc.cpp
@@ -576,8 +576,7 @@ MLNodeLaplacian::Fsmooth (int amrlev, int mglev, MultiFab& sol, const MultiFab& 
         if (!Gpu::inNoSyncRegion()) {
             Gpu::streamSynchronize();
         }
-        // No nodalSync here.  Every consumer of sol goes through
-        // MLNodeLinOp::applyBC first, and that does FillBoundaryAndSync.
+        nodalSync(amrlev, mglev, sol);
     }
     else
     {

--- a/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
+++ b/Src/LinearSolvers/MLMG/AMReX_MLNodeTensorLaplacian.cpp
@@ -239,8 +239,7 @@ MLNodeTensorLaplacian::smooth (int amrlev, int mglev, MultiFab& sol, const Multi
             Fsmooth(amrlev, mglev, sol, rhs);
             skip_fillboundary = false;
         }
-        // No nodalSync here.  The applyBC above, and the one in every other
-        // consumer of sol, does FillBoundaryAndSync.
+        nodalSync(amrlev, mglev, sol);
     }
 }
 


### PR DESCRIPTION
#5657 dropped these, on the grounds that every consumer of sol goes through MLNodeLinOp::applyBC and its FillBoundaryAndSync.  Prolongation does not: interpolation() reads the smoothed coarse correction directly.  The smoothers are Gauss-Seidel over validbox, so each box leaves a different value on a shared node, and prolongation consumed unsynchronized data.  MLMG_NodalPoisson drifted 1.6e-6 and lost its box-decomposition independence.  The applyBC change from #5657 is kept; it is the actual fix for the EB nodal solve.
