### PR TITLE
Derive Fortran type sizes instead of hardwiring them

### DIFF
--- a/Src/Base/AMReX_fort_mod.F90
+++ b/Src/Base/AMReX_fort_mod.F90
@@ -11,13 +11,11 @@ module amrex_fort_module
 
 #ifdef AMREX_USE_FLOAT
   integer, parameter :: amrex_real = c_float
-  ! We could/should use Fortran 2008 c_sizeof here.
-  integer (kind=c_size_t), parameter :: amrex_real_size = 4_c_size_t
 #else
   integer, parameter :: amrex_real = c_double
-  ! We could/should use Fortran 2008 c_sizeof here.
-  integer (kind=c_size_t), parameter :: amrex_real_size = 8_c_size_t
 #endif
+  integer (kind=c_size_t), parameter :: amrex_real_size = &
+       int(storage_size(1._amrex_real)/8, c_size_t)
 
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
   integer, parameter :: amrex_particle_real = c_float

--- a/Src/Base/AMReX_mempool_mod.F90
+++ b/Src/Base/AMReX_mempool_mod.F90
@@ -6,8 +6,8 @@ module amrex_mempool_module
 
   implicit none
 
-  integer (kind=c_size_t), parameter, private :: szi = 4_c_size_t
-  integer (kind=c_size_t), parameter, private :: szl = 4_c_size_t
+  integer (kind=c_size_t), parameter, private :: szi = int(storage_size(0)/8, c_size_t)
+  integer (kind=c_size_t), parameter, private :: szl = int(storage_size(.false.)/8, c_size_t)
 
   interface amrex_allocate
      module procedure bl_allocate_r1


### PR DESCRIPTION
szi, szl and amrex_real_size were written out as literal byte counts. Use storage_size so the values follow the actual type, and so amrex_real_size can no longer drift out of step with amrex_real.
