### PR TITLE
GNU Make: fix COMP=llvm-flang for modern LLVM Flang

### DIFF
--- a/Tools/GNUMake/comps/llvm-flang.mak
+++ b/Tools/GNUMake/comps/llvm-flang.mak
@@ -83,9 +83,8 @@ F90FLAGS += $(GENERIC_COMP_FLAGS)
 
 ########################################################################
 
-# libflangrti.so is needed when using OpenMP. It is also needed in
-# Castro_util.o to provide the symbol "__mth_i_idnint" in non-OpenMP builds
-override XTRALIBS += -lflangrti -lflang -lpgmath
+# Needed when clang++ does the linking.
+override XTRALIBS += -lflang_rt.runtime
 
 ifeq ($(FSANITIZER),TRUE)
   override XTRALIBS += -lubsan

--- a/Tools/libamrex/mkconfig.py
+++ b/Tools/libamrex/mkconfig.py
@@ -46,7 +46,7 @@ def doit(defines, undefines, comp, allow_diff_comp):
         elif comp == "nvhpc":
             comp_macro = "__NVCOMPILER"
             comp_id    = "NVHPC"
-        elif comp == "llvm":
+        elif comp == "llvm" or comp == "llvm-flang":
             comp_macro = "__llvm__"
             comp_id    = "Clang/LLVM"
         elif comp == "nec":
@@ -94,8 +94,8 @@ if __name__ == "__main__":
                         default="")
     parser.add_argument("--comp",
                         help="compiler",
-                        choices=["gnu","intel","intel-llvm","intel-classic","cray","pgi","nvhpc","llvm","nag","nec","ibm",
-                                 "armclang","hip","sycl"])
+                        choices=["gnu","intel","intel-llvm","intel-classic","cray","pgi","nvhpc","llvm","llvm-flang",
+                                 "nag","nec","ibm","armclang","hip","sycl"])
     parser.add_argument("--allow-different-compiler",
                         help="allow an application to use a different compiler than the one used to build libamrex",
                         choices=["TRUE","FALSE"])


### PR DESCRIPTION
Link -lflang_rt.runtime instead of the classic-flang libraries -lflangrti -lflang -lpgmath, which LLVM Flang does not provide. Also teach mkconfig.py the llvm-flang comp name; it compiles C++ with clang++, so it maps to `__llvm__` like llvm does.

Tested with flang 21.1.8 on Tests/FortranInterface/Advection_F, linking with both flang and clang++.

