### PR TITLE
CMake: support LLVMFlang in the compiler flag targets

### DIFF
--- a/Tools/CMake/AMReXFlagsTargets.cmake
+++ b/Tools/CMake/AMReXFlagsTargets.cmake
@@ -23,12 +23,12 @@ include_guard(GLOBAL)
 # for every combination of
 #
 #     <lang> = cxx,fortran,cuda
-#     <id>   = gnu,intel,pgi,cray,clang,appleclang,crayclang,ibmclang,intelllvm,msvc,nvidia,nvhpc,xlclang
+#     <id>   = gnu,intel,pgi,cray,clang,appleclang,crayclang,ibmclang,intelllvm,msvc,nvidia,nvhpc,xlclang,llvmflang
 #
 foreach (_language CXX Fortran CUDA )
    string(TOLOWER "${_language}" _lang)
 
-   foreach (_comp GNU Intel PGI Cray Clang AppleClang CrayClang IBMClang IntelLLVM MSVC NVIDIA NVHPC XLClang )
+   foreach (_comp GNU Intel PGI Cray Clang AppleClang CrayClang IBMClang IntelLLVM MSVC NVIDIA NVHPC XLClang LLVMFlang )
       string(TOLOWER "${_comp}" _id)
       # Define variables
       set(_${_lang}_${_id}      "$<COMPILE_LANG_AND_ID:${_language},${_comp}>")
@@ -104,6 +104,9 @@ target_compile_options( Flags_Fortran
    $<${_fortran_pgi_rel}:-gopt -fast>
    $<${_fortran_cray_dbg}:-O0 -e i>
    $<${_fortran_cray_rel}:>
+   # Flang has no bounds/uninitialized checking options.
+   $<${_fortran_llvmflang_dbg}:-fimplicit-none>
+   $<${_fortran_llvmflang_rel}:-fimplicit-none>
    )
 
 
@@ -125,7 +128,7 @@ target_compile_options( Flags_FASTMATH
       $<${_cxx_pgi}:-ffast-math>
       $<${_fortran_cray}:-ffast-math>
       $<${_cxx_cray}:-ffast-math>
-      $<${_fortran_clang}:-ffast-math>
+      $<${_fortran_llvmflang}:-ffast-math>
       $<${_cxx_clang}:-ffast-math>
       $<${_cxx_appleclang}:-ffast-math>
       $<${_cxx_crayclang}:-ffast-math>
@@ -153,7 +156,8 @@ target_compile_options ( Flags_FPE
    $<${_cxx_pgi}:>
    $<${_fortran_cray}:-K trap=fp>
    $<${_cxx_cray}:-K trap=fp>
-   $<${_fortran_clang}:>
+   # Flang has no FPE trapping option.
+   $<${_fortran_llvmflang}:>
    $<${_cxx_clang}:-ftrapv>
    $<${_cxx_appleclang}:-ftrapv>	
    )

--- a/Tools/CMake/AMReXTypecheck.cmake
+++ b/Tools/CMake/AMReXTypecheck.cmake
@@ -48,8 +48,7 @@ function( add_typecheck_target _target)
    # Check if we have all we need to define the typecheck target
    # 
    if (  NOT (CMAKE_Fortran_COMPILER_ID MATCHES GNU) OR
-         NOT (CMAKE_C_COMPILER_ID MATCHES GNU)       OR
-         NOT (CMAKE_Fortran_COMPILER_ID MATCHES GNU) )
+         NOT (CMAKE_C_COMPILER_ID MATCHES GNU) )
       message(WARNING "Typecheck disabled because compiler ID is not GNU")
       return ()
    endif ()


### PR DESCRIPTION
Flang got no flags from Flags_Fortran, Flags_FASTMATH or Flags_FPE because LLVMFlang was missing from the compiler id list, so Debug builds were silently left without -fimplicit-none. The two existing Fortran/Clang entries could never match and are now spelled correctly. Of the GNU Fortran debug options, Flang 21 accepts only -fimplicit-none; bounds checking and FPE trapping do not exist.

Also drop a duplicated clause in the typecheck compiler check.
