### PR TITLE
Fix `Random()` build on 32-bit x86 (x87 excess precision)

### DIFF
--- a/Src/Base/AMReX_Random.H
+++ b/Src/Base/AMReX_Random.H
@@ -45,8 +45,10 @@ namespace amrex
         // against std::nextafter itself on the host.
         constexpr Real almost_one
             = Real(1) - Real(0.5)*std::numeric_limits<Real>::epsilon();
+        constexpr Real midpoint
+            = Real(1) - Real(0.25)*std::numeric_limits<Real>::epsilon();
         static_assert(almost_one < Real(1));
-        static_assert(Real(1) - Real(0.25)*std::numeric_limits<Real>::epsilon() == Real(1));
+        static_assert(midpoint == Real(1));
         // No generator produces NaN, but note this maps it to almost_one
         // rather than propagating it, since the comparison is false for NaN.
         return (v < almost_one) ? v : almost_one;


### PR DESCRIPTION
## Summary

The second assertion in `random_util::clamp_below_one` compared a floating-point *expression* against one:

    static_assert(Real(1) - Real(0.25)*std::numeric_limits<Real>::epsilon() == Real(1));

On a target with `FLT_EVAL_METHOD == 2` -- 32-bit x86 using x87, where subexpressions are evaluated as `long double` -- `1 - eps/4` is representable and therefore does not round to one, so the assertion fires and no translation unit that includes `AMReX_Random.H` compiles.  Reported from a manylinux_2_28_i686 wheel build with GCC 14.2.1:

    AMReX_Random.H:49:81: error: static assertion failed
    note: the comparison reduces to '(9.99999999999999944489e-1l == 1.0e+0l)'

The claim being asserted is about `Real` arithmetic, so materialize the midpoint as a `constexpr Real` first: initializing an object of type `Real` discards the excess precision, while a bare expression keeps it.  The constant `almost_one` was already correct for the same reason -- it is stored in a `Real` -- as is the runtime clamp, which only compares.  Only the assertion was affected; no generated code changes.

Tested with a real i686 build (`-m32`) of AMReX plus `Tests/Base/Random`, in double and single precision, both passing; the unpatched header reproduces the CI error verbatim in the same build.  x86-64 unchanged.

## Additional background

Follow-up to #5643

Seen in https://github.com/BLAST-ImpactX/impactx-wheels/pull/28

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
