### PR TITLE
Fix: Polymorphic PC Write Plotfile w/ Runtime Arguments on GPU

### DIFF
--- a/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
+++ b/Src/Extern/HDF5/AMReX_WriteBinaryParticleDataHDF5.H
@@ -271,6 +271,9 @@ void WriteHDF5ParticleDataSync (PC const& pc,
         for (const auto& kv : pmap)
         {
             auto& flags = particle_io_flags[lev][kv.first];
+            if constexpr (PC::has_polymorphic_allocator) {
+                flags.setArena(pc.arena());
+            }
             particle_detail::fillFlags(flags, kv.second, f);
         }
     }

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -850,12 +850,6 @@ struct ParticleTile
                 GetStructOfArrays().GetIntData(j).setArena(a_arena);
             }
 
-            // The caches of runtime component pointers are dereferenced wherever the
-            // particle data itself is accessed, so they have to live in the same arena.
-            // Otherwise host code operating on a host-accessible tile - e.g. the plotfile
-            // packing of a pinned temporary container - dereferences device memory.
-            // Note: this has to happen before the vectors are resized below, so that an
-            //       allocation and its matching deallocation use the same arena.
             m_runtime_r_ptrs.setArena(a_arena);
             m_runtime_i_ptrs.setArena(a_arena);
             m_runtime_r_cptrs.setArena(a_arena);

--- a/Src/Particle/AMReX_ParticleTile.H
+++ b/Src/Particle/AMReX_ParticleTile.H
@@ -816,10 +816,6 @@ struct ParticleTile
     )
     {
         GetStructOfArrays().define(a_num_runtime_real, a_num_runtime_int, soa_rdata_names, soa_idata_names);
-        m_runtime_r_ptrs.resize(a_num_runtime_real);
-        m_runtime_i_ptrs.resize(a_num_runtime_int);
-        m_runtime_r_cptrs.resize(a_num_runtime_real);
-        m_runtime_i_cptrs.resize(a_num_runtime_int);
 
         if constexpr (has_polymorphic_allocator) {
             if (m_defined) {
@@ -853,7 +849,23 @@ struct ParticleTile
             for (int j = 0; j < NumIntComps(); ++j) {
                 GetStructOfArrays().GetIntData(j).setArena(a_arena);
             }
+
+            // The caches of runtime component pointers are dereferenced wherever the
+            // particle data itself is accessed, so they have to live in the same arena.
+            // Otherwise host code operating on a host-accessible tile - e.g. the plotfile
+            // packing of a pinned temporary container - dereferences device memory.
+            // Note: this has to happen before the vectors are resized below, so that an
+            //       allocation and its matching deallocation use the same arena.
+            m_runtime_r_ptrs.setArena(a_arena);
+            m_runtime_i_ptrs.setArena(a_arena);
+            m_runtime_r_cptrs.setArena(a_arena);
+            m_runtime_i_cptrs.setArena(a_arena);
         }
+
+        m_runtime_r_ptrs.resize(a_num_runtime_real);
+        m_runtime_i_ptrs.resize(a_num_runtime_int);
+        m_runtime_r_cptrs.resize(a_num_runtime_real);
+        m_runtime_i_cptrs.resize(a_num_runtime_int);
 
         m_defined = true;
         invalidateRuntimePtrCaches();


### PR DESCRIPTION
## Summary

Currently, writing plotfiles with runtime particle arguments using the polymorphic arena on GPU segfaults while accessing device pointers on CPU, because the logic assumes managed memory arenas are used.

This fixes it and sets the arena properly like the other SoA components.

## Additional background

Fix #5706

Seen also in WarpX https://github.com/BLAST-WarpX/warpx-tutorials/pull/2
Segfaulted the very-first WarpX example in our docs :sweat_smile: 
https://warpx.readthedocs.io/en/latest/usage/examples/lwfa/README.html#examples-lwfa

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
