### PR TITLE
Allow VisMF to read denormalized numbers

### DIFF
--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -7,8 +7,10 @@
 #include <AMReX_VisMF.H>
 
 #include <cerrno>
+#include <cmath>
 #include <cstdio>
 #include <iterator>
+#include <ios>
 #include <limits>
 #include <vector>
 #include <utility>
@@ -297,11 +299,15 @@ operator>> (std::istream&         is,
 
         for(Long j = 0; j < M; ++j) {
 #ifdef BL_USE_FLOAT
-            is >> dtemp >> ch;
+            is >> dtemp;
             ar[i][j] = static_cast<Real>(dtemp);
 #else
-            is >> ar[i][j] >> ch;
+            is >> ar[i][j];
 #endif
+            if (is.fail() and ar[i][j] != 0.0 and std::fpclassify(ar[i][j]) == FP_SUBNORMAL) {
+                is.clear(is.rdstate() & ~std::ios_base::failbit);
+            }
+            is >> ch;
             if( ch != ',' ) {
               amrex::Error("Expected a ',' got something else");
             }

--- a/Src/Base/AMReX_VisMF.cpp
+++ b/Src/Base/AMReX_VisMF.cpp
@@ -304,7 +304,7 @@ operator>> (std::istream&         is,
 #else
             is >> ar[i][j];
 #endif
-            if (is.fail() and ar[i][j] != 0.0 and std::fpclassify(ar[i][j]) == FP_SUBNORMAL) {
+            if (is.fail() && ar[i][j] != 0.0 && std::fpclassify(ar[i][j]) == FP_SUBNORMAL) {
                 is.clear(is.rdstate() & ~std::ios_base::failbit);
             }
             is >> ch;


### PR DESCRIPTION
## Summary

There is a bug (I call it a bug) in libc++ when reading in floating point numbers. If the value is a denormalized number that is otherwise valid and representable, the `failbit` is set on the `std::istream` object, even though the number is read in correctly. This PR submits a fix/hack that looks for this case and when it happens, it resets the `failbit` so that the reading of the data can continue. In my case, this problem was happening when reading in the min/max values in a Cell_H file when running amrvis.

## Additional background

In the routine `__num_get_float `, libc++ code uses `strtod` to convert the text string read in to a double precision number. If the number is denormalized the value is interpreted correctly but `strtod` sets the errno to `ERANGE`. Then `__num_get_float` only checks if `errno == ERANGE` and sets the `failbit` when true. It does not distinguish between truly bad numbers and denormalized numbers. The ideal solution is to have the libc++ code fixed.

## Checklist

The proposed changes:
- [x] fix a bug or incorrect behavior in AMReX
- [ ] add new capabilities to AMReX
- [ ] changes answers in the test suite to more than roundoff level
- [ ] are likely to significantly affect the results of downstream AMReX users
- [ ] include documentation in the code and/or rst files, if appropriate
