### PR TITLE
EB: fix extdir slope kernels near domlo+1 / domhi-1

### DIFF
--- a/Src/EB/AMReX_EB_Slopes_2D_K.H
+++ b/Src/EB/AMReX_EB_Slopes_2D_K.H
@@ -373,8 +373,10 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     auto yslope = amrex::Real(0.0);
 
     // First get EB-aware slope that doesn't know about extdir
-    bool needs_bdry_stencil = (edlo_x && i <= domlo_x) || (edhi_x && i >= domhi_x) ||
-                              (edlo_y && j <= domlo_y) || (edhi_y && j >= domhi_y);
+    // Note that we include the cells one in from the boundary because the 4th-order
+    //    one-sided stencils reach domlo+1 / domhi-1
+    bool needs_bdry_stencil = (edlo_x && i <= domlo_x+1) || (edhi_x && i >= domhi_x-1) ||
+                              (edlo_y && j <= domlo_y+1) || (edhi_y && j >= domhi_y-1);
 
     //
     // This call does not have any knowledge of extdir / hoextrap boundary conditions
@@ -505,8 +507,11 @@ amrex_calc_slopes_extdir_eb_grown (int i, int j, int k, int n, int nx, int ny,
     auto yslope = amrex::Real(0.0);
 
     // First get EB-aware slope that doesn't know about extdir
-    bool needs_bdry_stencil = (edlo_x && i <= domlo_x) || (edhi_x && i >= domhi_x) ||
-                              (edlo_y && j <= domlo_y) || (edhi_y && j >= domhi_y);
+    // Note that we include the cells one in from the boundary because both the 4th-order
+    //    one-sided stencils and the grown (nx or ny == 2) least squares stencil reach
+    //    domlo+1 / domhi-1
+    bool needs_bdry_stencil = (edlo_x && i <= domlo_x+1) || (edhi_x && i >= domhi_x-1) ||
+                              (edlo_y && j <= domlo_y+1) || (edhi_y && j >= domhi_y-1);
 
     //
     // This call does not have any knowledge of extdir / hoextrap boundary conditions
@@ -529,13 +534,22 @@ amrex_calc_slopes_extdir_eb_grown (int i, int j, int k, int n, int nx, int ny,
         for(int jj(-ny); jj<=ny; jj++) {
         for(int ii(-nx); ii<=nx; ii++)
         {
-            if ( !flag(i+ii,j+jj,k).isCovered() && !(ii==0 && jj==0 && kk==0) )
-            {
-                bool ilo_test = ( edlo_x && (i == domlo_x) && ii == -1);
-                bool ihi_test = ( edhi_x && (i == domhi_x) && ii ==  1);
+            // Cells more than one cell outside an extdir/hoextrap boundary hold no usable data,
+            //    so we exclude them from the fit just as we exclude covered cells
+            bool outside = (edlo_x && i+ii < domlo_x-1) || (edhi_x && i+ii > domhi_x+1) ||
+                           (edlo_y && j+jj < domlo_y-1) || (edhi_y && j+jj > domhi_y+1);
 
-                bool jlo_test = ( edlo_y && (j == domlo_y) && jj == -1);
-                bool jhi_test = ( edhi_y && (j == domhi_y) && jj ==  1);
+            if ( !outside && !flag(i+ii,j+jj,k).isCovered() && !(ii==0 && jj==0 && kk==0) )
+            {
+                // The value in the first ghost cell outside an extdir/hoextrap boundary lives on
+                //    the domain face, not at the cell centroid.  With the grown (n == 2) stencil
+                //    that ghost cell can be reached from a cell one in from the boundary, so we
+                //    key these tests on the neighbor index rather than on the offset alone.
+                bool ilo_test = ( edlo_x && (i+ii == domlo_x-1) );
+                bool ihi_test = ( edhi_x && (i+ii == domhi_x+1) );
+
+                bool jlo_test = ( edlo_y && (j+jj == domlo_y-1) );
+                bool jhi_test = ( edhi_y && (j+jj == domhi_y+1) );
 
                 bool klo_test = false;
                 bool khi_test = false;
@@ -548,16 +562,16 @@ amrex_calc_slopes_extdir_eb_grown (int i, int j, int k, int n, int nx, int ny,
                 {
                     if (!jlo_test && !jhi_test && !klo_test && !khi_test)
                     {
-                        A[lc][1] = amrex::Real(jj) + fcx(i   ,j+jj,k+kk,0);
+                        A[lc][1] = amrex::Real(jj) + fcx(domlo_x,j+jj,k+kk,0);
                     }
-                    A[lc][0] = amrex::Real(-0.5)                      ;
+                    A[lc][0] = amrex::Real(domlo_x-i) - amrex::Real(0.5);
                 } else if (ihi_test) {
 
                     if (!jlo_test && !jhi_test && !klo_test && !khi_test)
                     {
-                        A[lc][1] = amrex::Real(jj) + fcx(i+ii,j+jj,k+kk,0);
+                        A[lc][1] = amrex::Real(jj) + fcx(domhi_x+1,j+jj,k+kk,0);
                     }
-                    A[lc][0] = amrex::Real(0.5)                       ;
+                    A[lc][0] = amrex::Real(domhi_x-i) + amrex::Real(0.5);
                 }
 
                 // Do corrections for entire y-face
@@ -565,17 +579,17 @@ amrex_calc_slopes_extdir_eb_grown (int i, int j, int k, int n, int nx, int ny,
                 {
                     if (!ilo_test && !ihi_test && !klo_test && !khi_test)
                     {
-                        A[lc][0] = amrex::Real(ii) + fcy(i+ii,j   ,k+kk,0);
+                        A[lc][0] = amrex::Real(ii) + fcy(i+ii,domlo_y,k+kk,0);
                     }
-                    A[lc][1] = amrex::Real(-0.5)                      ;
+                    A[lc][1] = amrex::Real(domlo_y-j) - amrex::Real(0.5);
 
                 } else if (jhi_test) {
 
                     if (!ilo_test && !ihi_test && !klo_test && !khi_test)
                     {
-                        A[lc][0] = amrex::Real(ii) + fcy(i+ii,j+jj,k+kk,0);
+                        A[lc][0] = amrex::Real(ii) + fcy(i+ii,domhi_y+1,k+kk,0);
                     }
-                    A[lc][1] = amrex::Real(0.5)                       ;
+                    A[lc][1] = amrex::Real(domhi_y-j) + amrex::Real(0.5);
                 }
 
                 A[lc][0] -= ccent(i,j,k,0);

--- a/Src/EB/AMReX_EB_Slopes_3D_K.H
+++ b/Src/EB/AMReX_EB_Slopes_3D_K.H
@@ -439,9 +439,11 @@ amrex_calc_slopes_extdir_eb (int i, int j, int k, int n,
     auto zslope = amrex::Real(0.0);
 
     // First get EB-aware slope that doesn't know about extdir
-    bool needs_bdry_stencil = (edlo_x && i <= domlo_x) || (edhi_x && i >= domhi_x) ||
-                              (edlo_y && j <= domlo_y) || (edhi_y && j >= domhi_y) ||
-                              (edlo_z && k <= domlo_z) || (edhi_z && k >= domhi_z) ;
+    // Note that we include the cells one in from the boundary because the 4th-order
+    //    one-sided stencils reach domlo+1 / domhi-1
+    bool needs_bdry_stencil = (edlo_x && i <= domlo_x+1) || (edhi_x && i >= domhi_x-1) ||
+                              (edlo_y && j <= domlo_y+1) || (edhi_y && j >= domhi_y-1) ||
+                              (edlo_z && k <= domlo_z+1) || (edhi_z && k >= domhi_z-1) ;
 
     //
     // This call does not have any knowledge of extdir / hoextrap boundary conditions
@@ -606,9 +608,12 @@ amrex_calc_slopes_extdir_eb_grown (int i, int j, int k, int n,
     auto zslope = amrex::Real(0.0);
 
     // First get EB-aware slope that doesn't know about extdir
-    bool needs_bdry_stencil = (edlo_x && i <= domlo_x) || (edhi_x && i >= domhi_x) ||
-                              (edlo_y && j <= domlo_y) || (edhi_y && j >= domhi_y) ||
-                              (edlo_z && k <= domlo_z) || (edhi_z && k >= domhi_z) ;
+    // Note that we include the cells one in from the boundary because both the 4th-order
+    //    one-sided stencils and the grown (nx, ny or nz == 2) least squares stencil reach
+    //    domlo+1 / domhi-1
+    bool needs_bdry_stencil = (edlo_x && i <= domlo_x+1) || (edhi_x && i >= domhi_x-1) ||
+                              (edlo_y && j <= domlo_y+1) || (edhi_y && j >= domhi_y-1) ||
+                              (edlo_z && k <= domlo_z+1) || (edhi_z && k >= domhi_z-1) ;
 
     //
     // This call does not have any knowledge of extdir / hoextrap boundary conditions
@@ -630,16 +635,26 @@ amrex_calc_slopes_extdir_eb_grown (int i, int j, int k, int n,
         for(int jj(-ny); jj<=ny; jj++) {
         for(int ii(-nx); ii<=nx; ii++)
         {
-            if (!flag(i+ii,j+jj,k+kk).isCovered() && !(ii==0 && jj==0 && kk==0))
+            // Cells more than one cell outside an extdir/hoextrap boundary hold no usable data,
+            //    so we exclude them from the fit just as we exclude covered cells
+            bool outside = (edlo_x && i+ii < domlo_x-1) || (edhi_x && i+ii > domhi_x+1) ||
+                           (edlo_y && j+jj < domlo_y-1) || (edhi_y && j+jj > domhi_y+1) ||
+                           (edlo_z && k+kk < domlo_z-1) || (edhi_z && k+kk > domhi_z+1);
+
+            if (!outside && !flag(i+ii,j+jj,k+kk).isCovered() && !(ii==0 && jj==0 && kk==0))
             {
-                bool ilo_test = ( edlo_x && (i == domlo_x) && ii == -1);
-                bool ihi_test = ( edhi_x && (i == domhi_x) && ii ==  1);
+                // The value in the first ghost cell outside an extdir/hoextrap boundary lives on
+                //    the domain face, not at the cell centroid.  With the grown (n == 2) stencil
+                //    that ghost cell can be reached from a cell one in from the boundary, so we
+                //    key these tests on the neighbor index rather than on the offset alone.
+                bool ilo_test = ( edlo_x && (i+ii == domlo_x-1) );
+                bool ihi_test = ( edhi_x && (i+ii == domhi_x+1) );
 
-                bool jlo_test = ( edlo_y && (j == domlo_y) && jj == -1);
-                bool jhi_test = ( edhi_y && (j == domhi_y) && jj ==  1);
+                bool jlo_test = ( edlo_y && (j+jj == domlo_y-1) );
+                bool jhi_test = ( edhi_y && (j+jj == domhi_y+1) );
 
-                bool klo_test = ( edlo_z && (k == domlo_z) && kk == -1);
-                bool khi_test = ( edhi_z && (k == domhi_z) && kk ==  1);
+                bool klo_test = ( edlo_z && (k+kk == domlo_z-1) );
+                bool khi_test = ( edhi_z && (k+kk == domhi_z+1) );
 
                 // These are the default values if no physical boundary
                 A[lc][0] = amrex::Real(ii) + ccent(i+ii,j+jj,k+kk,0);
@@ -650,18 +665,18 @@ amrex_calc_slopes_extdir_eb_grown (int i, int j, int k, int n,
                 {
                     if (!jlo_test && !jhi_test && !klo_test && !khi_test)
                     {
-                        A[lc][1] = amrex::Real(jj) + fcx(i   ,j+jj,k+kk,0);
-                            A[lc][2] = amrex::Real(kk) + fcx(i   ,j+jj,k+kk,1);
+                        A[lc][1] = amrex::Real(jj) + fcx(domlo_x,j+jj,k+kk,0);
+                        A[lc][2] = amrex::Real(kk) + fcx(domlo_x,j+jj,k+kk,1);
                     }
-                    A[lc][0] = -amrex::Real(0.5);
+                    A[lc][0] = amrex::Real(domlo_x-i) - amrex::Real(0.5);
                 } else if (ihi_test) {
 
                     if (!jlo_test && !jhi_test && !klo_test && !khi_test)
                     {
-                        A[lc][1] = amrex::Real(jj) + fcx(i+ii,j+jj,k+kk,0);
-                        A[lc][2] = amrex::Real(kk) + fcx(i+ii,j+jj,k+kk,1);
+                        A[lc][1] = amrex::Real(jj) + fcx(domhi_x+1,j+jj,k+kk,0);
+                        A[lc][2] = amrex::Real(kk) + fcx(domhi_x+1,j+jj,k+kk,1);
                     }
-                    A[lc][0] = amrex::Real(0.5);
+                    A[lc][0] = amrex::Real(domhi_x-i) + amrex::Real(0.5);
                 }
 
                 // Do corrections for entire y-face
@@ -669,19 +684,19 @@ amrex_calc_slopes_extdir_eb_grown (int i, int j, int k, int n,
                 {
                     if (!ilo_test && !ihi_test && !klo_test && !khi_test)
                     {
-                        A[lc][0] = amrex::Real(ii) + fcy(i+ii,j   ,k+kk,0);
-                        A[lc][2] = amrex::Real(kk) + fcy(i+ii,j   ,k+kk,1);
+                        A[lc][0] = amrex::Real(ii) + fcy(i+ii,domlo_y,k+kk,0);
+                        A[lc][2] = amrex::Real(kk) + fcy(i+ii,domlo_y,k+kk,1);
                     }
-                    A[lc][1] = -amrex::Real(0.5);
+                    A[lc][1] = amrex::Real(domlo_y-j) - amrex::Real(0.5);
 
                 } else if (jhi_test) {
 
                     if (!ilo_test && !ihi_test && !klo_test && !khi_test)
                     {
-                        A[lc][0] = amrex::Real(ii) + fcy(i+ii,j+jj,k+kk,0);
-                        A[lc][2] = amrex::Real(kk) + fcy(i+ii,j+jj,k+kk,1);
+                        A[lc][0] = amrex::Real(ii) + fcy(i+ii,domhi_y+1,k+kk,0);
+                        A[lc][2] = amrex::Real(kk) + fcy(i+ii,domhi_y+1,k+kk,1);
                     }
-                    A[lc][1] = amrex::Real(0.5);
+                    A[lc][1] = amrex::Real(domhi_y-j) + amrex::Real(0.5);
                 }
 
                 // Do corrections for entire z-face
@@ -689,18 +704,18 @@ amrex_calc_slopes_extdir_eb_grown (int i, int j, int k, int n,
                 {
                     if (!ilo_test && !ihi_test && !jlo_test && !jhi_test)
                     {
-                        A[lc][0] = amrex::Real(ii) + fcz(i+ii,j+jj,k   ,0);
-                        A[lc][1] = amrex::Real(jj) + fcz(i+ii,j+jj,k   ,1);
+                        A[lc][0] = amrex::Real(ii) + fcz(i+ii,j+jj,domlo_z,0);
+                        A[lc][1] = amrex::Real(jj) + fcz(i+ii,j+jj,domlo_z,1);
                     }
-                    A[lc][2] = -amrex::Real(0.5);
+                    A[lc][2] = amrex::Real(domlo_z-k) - amrex::Real(0.5);
 
                 } else if (khi_test) {
                     if (!ilo_test && !ihi_test && !jlo_test && !jhi_test)
                     {
-                        A[lc][0] = amrex::Real(ii) + fcz(i+ii,j+jj,k+kk,0);
-                        A[lc][1] = amrex::Real(jj) + fcz(i+ii,j+jj,k+kk,1);
+                        A[lc][0] = amrex::Real(ii) + fcz(i+ii,j+jj,domhi_z+1,0);
+                        A[lc][1] = amrex::Real(jj) + fcz(i+ii,j+jj,domhi_z+1,1);
                     }
-                    A[lc][2] = amrex::Real(0.5);
+                    A[lc][2] = amrex::Real(domhi_z-k) + amrex::Real(0.5);
                 }
 
                 A[lc][0] -= ccent(i,j,k,0);

--- a/Tests/EB/Slopes/CMakeLists.txt
+++ b/Tests/EB/Slopes/CMakeLists.txt
@@ -1,0 +1,14 @@
+foreach(D IN LISTS AMReX_SPACEDIM)
+    if (D EQUAL 1)
+       continue()
+    endif ()
+
+    set(_sources  main.cpp)
+
+    set(_input_files)
+
+    setup_test(${D} _sources _input_files)
+
+    unset(_sources)
+    unset(_input_files)
+endforeach()

--- a/Tests/EB/Slopes/GNUmakefile
+++ b/Tests/EB/Slopes/GNUmakefile
@@ -1,0 +1,28 @@
+DEBUG = FALSE
+TEST = TRUE
+USE_ASSERTION = TRUE
+
+USE_EB = TRUE
+
+USE_MPI  = FALSE
+USE_OMP  = FALSE
+
+COMP = gnu
+
+DIM = 3
+
+BL_NO_FORT = TRUE
+
+AMREX_HOME = ../../..
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.defs
+
+include ./Make.package
+
+Pdirs := Base Boundary AmrCore EB
+
+Ppack	+= $(foreach dir, $(Pdirs), $(AMREX_HOME)/Src/$(dir)/Make.package)
+
+include $(Ppack)
+
+include $(AMREX_HOME)/Tools/GNUMake/Make.rules

--- a/Tests/EB/Slopes/Make.package
+++ b/Tests/EB/Slopes/Make.package
@@ -1,0 +1,2 @@
+
+CEXE_sources += main.cpp

--- a/Tests/EB/Slopes/main.cpp
+++ b/Tests/EB/Slopes/main.cpp
@@ -1,0 +1,225 @@
+//
+// Unit test for the extdir/hoextrap-aware EB slope kernels
+//     amrex_calc_slopes_extdir_eb        and
+//     amrex_calc_slopes_extdir_eb_grown
+//
+// The data is an exactly linear profile q = sum_d coef[d] * x_d, where x_d is
+// measured in units of dx and the cell centroids coincide with the cell centers
+// (ccent = 0).  In the direction "dir" the domain has an ext_dir boundary on both
+// sides, so the value in the first ghost cell lives *on* the domain face rather
+// than at the cell center; cells further outside the domain are filled with
+// garbage to make sure they never enter the stencil.
+//
+// Every kernel must return the exact slopes coef[] for such a profile, including
+// at the cells one in from the boundary (domlo+1 / domhi-1), which the 4th-order
+// one-sided stencil and the grown (n == 2) least squares stencil both reach.
+//
+#include <AMReX.H>
+#include <AMReX_BaseFab.H>
+#include <AMReX_EBCellFlag.H>
+#include <AMReX_EB_Slopes_K.H>
+#include <AMReX_FArrayBox.H>
+#include <AMReX_GpuContainers.H>
+#include <AMReX_Print.H>
+#include <AMReX_Vector.H>
+
+#include <cmath>
+
+using namespace amrex;
+
+namespace {
+
+constexpr int ncell = 16;
+
+// Coefficients of the exactly linear test profile
+constexpr Real coef_x = Real(1.5);
+constexpr Real coef_y = Real(-0.75);
+constexpr Real coef_z = Real(0.25);
+
+// A value that must never make it into any stencil
+constexpr Real garbage = Real(12345.);
+
+#ifdef BL_USE_FLOAT
+constexpr Real tol = Real(1.e-4);
+#else
+constexpr Real tol = Real(1.e-11);
+#endif
+
+int
+test_dir (int dir)
+{
+    const Box domain(IntVect(0), IntVect(AMREX_D_DECL(ncell-1,ncell-1,ncell-1)));
+    const Box gbx = amrex::grow(domain, 3);
+
+    const IntVect dlo = domain.smallEnd();
+    const IntVect dhi = domain.bigEnd();
+
+    const int domlo = dlo[dir];
+    const int domhi = dhi[dir];
+
+    FArrayBox state_fab(gbx, 1, The_Arena());
+    FArrayBox ccent_fab(gbx, AMREX_SPACEDIM, The_Arena());
+    FArrayBox vfrac_reg_fab(gbx, 1, The_Arena());
+    FArrayBox vfrac_cut_fab(gbx, 1, The_Arena());
+    BaseFab<EBCellFlag> flag_fab(gbx, 1, The_Arena());
+
+    // Face centroids are all at the center of the face
+    AMREX_D_TERM(FArrayBox fcx_fab(amrex::surroundingNodes(gbx,0), AMREX_SPACEDIM-1, The_Arena());,
+                 FArrayBox fcy_fab(amrex::surroundingNodes(gbx,1), AMREX_SPACEDIM-1, The_Arena());,
+                 FArrayBox fcz_fab(amrex::surroundingNodes(gbx,2), AMREX_SPACEDIM-1, The_Arena()););
+
+    ccent_fab.setVal<RunOn::Device>(Real(0.));
+    AMREX_D_TERM(fcx_fab.setVal<RunOn::Device>(Real(0.));,
+                 fcy_fab.setVal<RunOn::Device>(Real(0.));,
+                 fcz_fab.setVal<RunOn::Device>(Real(0.)););
+
+    // vfrac == 1 everywhere selects the "regular slope" path inside the kernels;
+    // vfrac < 1 everywhere forces the EB least squares fit to be used instead.
+    vfrac_reg_fab.setVal<RunOn::Device>(Real(1.));
+    vfrac_cut_fab.setVal<RunOn::Device>(Real(0.5));
+
+    auto const& state = state_fab.array();
+    auto const& flag  = flag_fab.array();
+
+    ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    {
+        EBCellFlag f;
+        f.setRegular();
+        f.setConnected();
+        flag(i,j,k) = f;
+
+        int idx[3] = {0,0,0};
+        AMREX_D_TERM(idx[0] = i;, idx[1] = j;, idx[2] = k;);
+
+        if (idx[dir] < domlo-1 || idx[dir] > domhi+1) {
+            state(i,j,k,0) = garbage;
+        } else {
+            Real x[3] = {Real(idx[0]), Real(idx[1]), Real(idx[2])};
+            // The first ghost cell outside an ext_dir boundary holds the face value
+            if (idx[dir] == domlo-1) { x[dir] = Real(domlo) - Real(0.5); }
+            if (idx[dir] == domhi+1) { x[dir] = Real(domhi) + Real(0.5); }
+            state(i,j,k,0) = coef_x*x[0] + coef_y*x[1] + coef_z*x[2];
+        }
+    });
+
+    // The cells we evaluate the slopes at: both boundary cells, both cells one in
+    // from the boundary, and an interior cell as a control.
+    const Vector<int> h_pos = {domlo, domlo+1, ncell/2, domhi-1, domhi};
+    const int npos = static_cast<int>(h_pos.size());
+
+    Gpu::DeviceVector<int> d_pos(npos);
+    Gpu::copyAsync(Gpu::hostToDevice, h_pos.begin(), h_pos.end(), d_pos.begin());
+
+    // Two kernels tested at each position: 0 = 3^DIM stencil, 1 = grown stencil
+    const int ntest = 2*npos;
+    Gpu::DeviceVector<Real> d_slopes(std::size_t(ntest)*AMREX_SPACEDIM);
+
+    int const* pos_p = d_pos.data();
+    Real* slopes_p = d_slopes.data();
+
+    auto const& s   = state_fab.const_array();
+    auto const& cc  = ccent_fab.const_array();
+    auto const& vr  = vfrac_reg_fab.const_array();
+    auto const& vc  = vfrac_cut_fab.const_array();
+    auto const& fl  = flag_fab.const_array();
+    AMREX_D_TERM(auto const& fx = fcx_fab.const_array();,
+                 auto const& fy = fcy_fab.const_array();,
+                 auto const& fz = fcz_fab.const_array(););
+
+    Gpu::streamSynchronize();
+
+    ParallelFor(ntest, [=] AMREX_GPU_DEVICE (int t) noexcept
+    {
+        const int ip   = t / 2;
+        const int kern = t % 2;
+
+        IntVect iv(AMREX_D_DECL(ncell/2,ncell/2,ncell/2));
+        iv[dir] = pos_p[ip];
+
+        AMREX_D_TERM(const int i = iv[0];,
+                     const int j = iv[1];,
+                     const int k = iv[2];);
+#if (AMREX_SPACEDIM == 2)
+        const int k = 0;
+#endif
+
+        bool edlo[3] = {false,false,false};
+        bool edhi[3] = {false,false,false};
+        edlo[dir] = true;
+        edhi[dir] = true;
+
+        // Grow the least squares stencil in the direction being tested
+        int nn[3] = {1,1,1};
+        nn[dir] = 2;
+
+        GpuArray<Real,AMREX_SPACEDIM> sl;
+        if (kern == 0) {
+            sl = amrex_calc_slopes_extdir_eb(i,j,k,0,s,cc,vr,
+                                             AMREX_D_DECL(fx,fy,fz),fl,
+                                             AMREX_D_DECL(edlo[0],edlo[1],edlo[2]),
+                                             AMREX_D_DECL(edhi[0],edhi[1],edhi[2]),
+                                             AMREX_D_DECL(dlo[0],dlo[1],dlo[2]),
+                                             AMREX_D_DECL(dhi[0],dhi[1],dhi[2]),
+                                             4);
+        } else {
+            sl = amrex_calc_slopes_extdir_eb_grown(i,j,k,0,
+                                                   AMREX_D_DECL(nn[0],nn[1],nn[2]),
+                                                   s,cc,vc,
+                                                   AMREX_D_DECL(fx,fy,fz),fl,
+                                                   AMREX_D_DECL(edlo[0],edlo[1],edlo[2]),
+                                                   AMREX_D_DECL(edhi[0],edhi[1],edhi[2]),
+                                                   AMREX_D_DECL(dlo[0],dlo[1],dlo[2]),
+                                                   AMREX_D_DECL(dhi[0],dhi[1],dhi[2]),
+                                                   4);
+        }
+
+        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+            slopes_p[t*AMREX_SPACEDIM+d] = sl[d];
+        }
+    });
+
+    Vector<Real> h_slopes(std::size_t(ntest)*AMREX_SPACEDIM);
+    Gpu::copyAsync(Gpu::deviceToHost, d_slopes.begin(), d_slopes.end(), h_slopes.begin());
+    Gpu::streamSynchronize();
+
+    const Real expected[3] = {coef_x, coef_y, coef_z};
+
+    int nfail = 0;
+    for (int t = 0; t < ntest; ++t) {
+        const int ip   = t / 2;
+        const int kern = t % 2;
+        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+            const Real got = h_slopes[std::size_t(t)*AMREX_SPACEDIM+d];
+            if (std::abs(got-expected[d]) > tol*(Real(1.)+std::abs(expected[d]))) {
+                ++nfail;
+                amrex::Print() << "FAIL: dir = " << dir
+                               << ", index = " << h_pos[ip]
+                               << ", kernel = "
+                               << (kern == 0 ? "amrex_calc_slopes_extdir_eb"
+                                             : "amrex_calc_slopes_extdir_eb_grown")
+                               << ", slope[" << d << "] = " << got
+                               << ", expected " << expected[d] << '\n';
+            }
+        }
+    }
+
+    return nfail;
+}
+
+}
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+    {
+        int nfail = 0;
+        for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+            nfail += test_dir(dir);
+        }
+        if (nfail == 0) {
+            amrex::Print() << "EB extdir slopes: PASS\n";
+        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nfail == 0, "EB extdir slopes test failed");
+    }
+    amrex::Finalize();
+}


### PR DESCRIPTION
## Summary

Fixes #5810.

Both `amrex_calc_slopes_extdir_eb` and `amrex_calc_slopes_extdir_eb_grown` (2D and 3D) were written assuming an `ext_dir`/`hoextrap` boundary only affects the cell touching the domain face. Two later additions widened the stencil reach without updating that assumption.

### 1. `needs_bdry_stencil` was one cell too narrow

The gate only fired for `i <= domlo` / `i >= domhi`, so the cell at `domlo+1` (and `domhi-1`) fell through to `amrex_calc_slopes_eb` → `amrex_calc_xslope`, which knows nothing about the BC. That bypassed the `edlo && i == domlo+1` one-sided branch of `amrex_calc_xslope_extdir` (`Src/Base/AMReX_Slopes_K.H:116`).

The gate is now widened by one cell in every direction in all four extdir variants. The `ilo_test`-style relocations still fire only at the boundary cell itself, so the least squares matrix at `domlo+1` is unchanged and `max_order == 2` results are bit-for-bit identical; only the order-4 regular-cell case changes.

### 2. Grown (`n == 2`) stencil mishandled the offset-±2 neighbors

The face relocations were hard-coded for `ii == -1/+1` at `i == domlo_x`/`domhi_x`, but with `nx == 2` (the enlarged stencil `StateRedist` selects at `AMReX_EB_StateRedistribute.cpp:232`) the stencil also reaches offsets ±2:

- at `i == domlo_x+1`, the face-located ghost value at `domlo_x-1` was placed at `-2 + ccent` instead of at the face (`-1.5`);
- at `i == domlo_x`, the cell `domlo_x-2` — entirely outside the domain — was fitted as fluid data.

The relocation tests now key on the neighbor index (`i+ii == domlo_x-1`), the face position is expressed relative to cell `i` (`domlo_x - i - 0.5`), the transverse face centroid is read at the domain-face index, and neighbors more than one cell outside an extdir boundary get a zeroed `A` row — the same treatment as covered cells.

On the maintainer decisions flagged in the issue: I went with excluding the `domlo-2` cells (rather than extrapolating a second face-based row), and left `hoextrap` ghosts treated as face values, matching what the existing code already does.

## Testing

New `Tests/EB/Slopes` — a direct-call unit test with no in-tree caller needed. It builds an exactly linear profile `q = sum_d coef[d]*x_d` with `ccent = 0`, puts the Dirichlet value on the domain face in the first ghost cell, and fills cells further outside with garbage so they must never enter a stencil. Both kernels are evaluated at `domlo`, `domlo+1`, an interior control cell, `domhi-1` and `domhi`, in every coordinate direction, and must return the exact coefficients.

```
cmake -S . -B build -DAMReX_ENABLE_TESTS=ON -DAMReX_EB=ON -DAMReX_SPACEDIM="2;3" -DAMReX_FORTRAN=OFF
cmake --build build -j8
ctest --test-dir build -R EB --output-on-failure
```

All 9 EB tests pass, including the two new ones (`EB_Slopes_2d`, `EB_Slopes_3d`).

The test fails on the unfixed code in both 2D and 3D. Representative output from `development` (3D, `coef = (1.5, -0.75, 0.25)`):

```
FAIL: dir = 0, index = 0,  kernel = amrex_calc_slopes_extdir_eb_grown, slope[0] = -2669.20,  expected 1.5     <- domlo-2 garbage in the fit
FAIL: dir = 0, index = 1,  kernel = amrex_calc_slopes_extdir_eb,       slope[0] = 1.5625,    expected 1.5     <- order-4 gate
FAIL: dir = 0, index = 1,  kernel = amrex_calc_slopes_extdir_eb_grown, slope[0] = 1.35,      expected 1.5     <- ghost at -2 instead of -1.5
FAIL: dir = 0, index = 14, kernel = amrex_calc_slopes_extdir_eb,       slope[0] = 1.5625,    expected 1.5
FAIL: dir = 2, index = 15, kernel = amrex_calc_slopes_extdir_eb_grown, slope[2] = 2667.22,   expected 0.25
```

(30 failures in 3D, 16 in 2D; all clear with the fix.)

Also verified with the GNU make workflow in `Tests/EB/Slopes`: `make -j8 DIM=2` and `make -j8 DIM=3`, both print `EB extdir slopes: PASS`.

No user-facing docs change: nothing under `Docs/sphinx_documentation/` references these kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
