### PR TITLE
AmrCore: option to refine the entire domain in one direction

### DIFF
--- a/Docs/sphinx_documentation/source/GridCreation.rst
+++ b/Docs/sphinx_documentation/source/GridCreation.rst
@@ -81,6 +81,16 @@ grids do not contain too large a fraction of un-tagged cells.   We note that the
 process attempts to satisfy the :cpp:`amr.grid_eff` constraint but will not do so if it means
 violating the :cpp:`blocking_factor` criterion.
 
+Some applications want the fine levels to cover the entire domain in one coordinate
+direction, no matter where the cells are tagged.  Setting :cpp:`amr.refine_whole_domain_dir`
+to that direction (0 for *x*, 1 for *y*, 2 for *z*; the default of -1 disables this)
+makes the tagging of a cell behave as if the whole line of cells through it in that
+direction were tagged.  The clustering is then performed in one fewer dimension, so
+:cpp:`amr.grid_eff` refers to the fraction of tagged cells in the plane perpendicular
+to that direction.  The resulting grids may still be chopped in that direction by
+:cpp:`max_grid_size` and :cpp:`refine_grid_layout`, but together they always cover the
+entire domain.
+
 Users often like to ensure that coarse/fine boundaries are not too close to tagged cells; the
 way to do this is to set :cpp:`amr.n_error_buf` to a large integer value (the default is 1).
 This parameter is used to increase the number of tagged cells before the grids are defined;

--- a/Docs/sphinx_documentation/source/RuntimeParameters.rst
+++ b/Docs/sphinx_documentation/source/RuntimeParameters.rst
@@ -257,6 +257,17 @@ can be set via :cpp:`ParmParse`.
    This parameter, if found, will override the
    :py:data:`amrex.refine_grid_layout` parameter in the z-direction.
 
+.. py:data:: amr.refine_whole_domain_dir
+   :type: int
+   :value: -1
+
+   If this is 0, 1 or 2, the fine levels will cover the entire domain in that
+   coordinate direction, no matter where the cells are tagged. Tagging a cell
+   then behaves as if the whole line of cells through it in that direction were
+   tagged, and :py:data:`amr.grid_eff` refers to the fraction of tagged cells in
+   the plane perpendicular to that direction. A negative value, the default,
+   disables this.
+
 .. py:data:: amr.check_input
    :type: bool
    :value: true

--- a/Src/AmrCore/AMReX_AmrMesh.H
+++ b/Src/AmrCore/AMReX_AmrMesh.H
@@ -57,6 +57,14 @@ struct AmrInfo {
      */
     IntVect refine_grid_layout_dims = IntVect(1);
 
+    /**
+     * Direction in which the fine levels cover the entire domain, no matter
+     * where the cells are tagged.  Tagging a cell then behaves as if the
+     * whole line of cells through it in that direction were tagged.  A
+     * negative value means there is no such direction.
+     */
+    int refine_whole_domain_dir = -1;
+
     bool check_input = true;
     bool use_new_chop = false;
     bool iterate_on_new_grids = true;

--- a/Src/AmrCore/AMReX_AmrMesh.cpp
+++ b/Src/AmrCore/AMReX_AmrMesh.cpp
@@ -376,6 +376,8 @@ AmrMesh::InitAmrMesh (int max_level_in, const Vector<int>& n_cell_in,
         refine_grid_layout = refine_grid_layout_dims != 0;
     }
 
+    pp.queryAdd("refine_whole_domain_dir", refine_whole_domain_dir);
+
     pp.queryAdd("check_input", check_input);
     pp.queryAdd("max_grid_iterations", max_grid_iterations);
 
@@ -820,7 +822,8 @@ AmrMesh::MakeNewGrids (int lbase, Real time, int& new_finest, Vector<BoxArray>& 
                     //
                     // Construct initial cluster.
                     //
-                    ClusterList clist(tagvec.data(), static_cast<Long>(tagvec.size()));
+                    ClusterList clist(tagvec.data(), static_cast<Long>(tagvec.size()),
+                                      pc_domain[levc], refine_whole_domain_dir);
                     if (use_new_chop) {
                         clist.new_chop(grid_eff);
                     } else {
@@ -1288,6 +1291,32 @@ AmrMesh::checkInput ()
         }
     }
 
+    //
+    // Check the direction in which the fine levels cover the entire domain.
+    //
+    if (refine_whole_domain_dir >= 0)
+    {
+        const int idim = refine_whole_domain_dir;
+        if (idim >= AMREX_SPACEDIM) {
+            amrex::Error("Amr::checkInput: refine_whole_domain_dir is out of range");
+        }
+#ifdef AMREX_USE_BITTREE
+        if (use_bittree) {
+            amrex::Error("Amr::checkInput: refine_whole_domain_dir does not work with bittree");
+        }
+#endif
+        for (int i = 0; i < max_level; ++i) {
+            // The tags are coarsened by this factor before they are clustered.
+            int bf = std::max(1,blocking_factor[i+1][idim]/ref_ratio[i][idim]);
+            if (Geom(i).Domain().length(idim) % bf != 0) {
+                amrex::Print() << "On level " << i << " the domain size in direction " << idim
+                               << " is " << Geom(i).Domain().length(idim)
+                               << ", which is not divisible by " << bf << '\n';
+                amrex::Error("Domain size not divisible by blocking_factor/ref_ratio in refine_whole_domain_dir");
+            }
+        }
+    }
+
     if( ! (Geom(0).ProbDomain().volume() > 0.0) ) {
         amrex::Error("Amr::checkInput: bad physical problem size");
     }
@@ -1324,6 +1353,7 @@ std::ostream& operator<< (std::ostream& os, AmrMesh const& amr_mesh)
     os << "  use_fixed_upto_level = " << amr_mesh.use_fixed_upto_level << "\n";
     os << "  use_fixed_coarse_grids = " << amr_mesh.use_fixed_coarse_grids << "\n";
     os << "  refine_grid_layout_dims = " << amr_mesh.refine_grid_layout_dims << "\n";
+    os << "  refine_whole_domain_dir = " << amr_mesh.refine_whole_domain_dir << "\n";
     os << "  check_input = " << amr_mesh.check_input  << "\n";
     os << "  use_new_chop = " << amr_mesh.use_new_chop << "\n";
     os << "  iterate_on_new_grids = " << amr_mesh.iterate_on_new_grids << "\n";

--- a/Src/AmrCore/AMReX_Cluster.H
+++ b/Src/AmrCore/AMReX_Cluster.H
@@ -160,6 +160,26 @@ public:
     ClusterList (IntVect* pts, Long len);
 
     /**
+    * \brief Construct a list containing a single Cluster, clustering in a
+    * reduced number of dimensions.
+    *
+    * The tagged points are projected onto the low end of \p domain in
+    * direction \p whole_domain_dir, so that the clustering is performed in
+    * one fewer dimension.  The boxes returned by boxList and boxArray span
+    * the entire domain in that direction.  In other words, tagging a single
+    * cell behaves as if the whole line of cells through it in that direction
+    * were tagged.  Pass -1 for \p whole_domain_dir to disable this.
+    *
+    * Note that the array \p pts is modified.
+    *
+    * \param pts              Pointer to tagged IntVects (owned by caller).
+    * \param len              Number of tagged entries in \p pts.
+    * \param domain           Problem domain in the index space of \p pts.
+    * \param whole_domain_dir Direction spanning the entire domain, or -1.
+    */
+    ClusterList (IntVect* pts, Long len, const Box& domain, int whole_domain_dir);
+
+    /**
     * \brief The destructor.
     */
     ~ClusterList ();
@@ -177,7 +197,7 @@ public:
     /**
     * \brief Add cluster to end of list.
     *
-    * \param c Cluster pointer transferred into the list (caller retains ownership).
+    * \param c Cluster pointer whose ownership is transferred into the list.
     */
     void append (Cluster* c) { lst.push_back(c); }
 
@@ -231,8 +251,13 @@ public:
 
 private:
 
+    //! Extend a cluster box to the entire domain in m_whole_domain_dir.
+    [[nodiscard]] Box expandBox (const Box& b) const;
+
     //! The data.
     std::list<Cluster*> lst;
+    Box m_domain;
+    int m_whole_domain_dir = -1;
 };
 
 }

--- a/Src/AmrCore/AMReX_Cluster.cpp
+++ b/Src/AmrCore/AMReX_Cluster.cpp
@@ -434,7 +434,24 @@ Cluster::new_chop ()
 }
 
 ClusterList::ClusterList (IntVect* pts, Long len)
+    : ClusterList(pts, len, Box(), -1)
 {
+}
+
+ClusterList::ClusterList (IntVect* pts, Long len, const Box& domain, int whole_domain_dir)
+    : m_domain(domain),
+      m_whole_domain_dir(whole_domain_dir)
+{
+    if (whole_domain_dir >= 0) {
+        const int lo = domain.smallEnd(whole_domain_dir);
+        for (Long i = 0; i < len; ++i) {
+            pts[i][whole_domain_dir] = lo;
+        }
+        // Duplicates would make Cluster::eff() exceed the true efficiency.
+        std::sort(pts, pts+len);
+        len = std::unique(pts, pts+len) - pts;
+    }
+
     lst.push_back(new Cluster(pts,len));
 }
 
@@ -445,6 +462,16 @@ ClusterList::~ClusterList ()
     }
 }
 
+Box
+ClusterList::expandBox (const Box& b) const
+{
+    if (m_whole_domain_dir < 0) { return b; }
+    Box r(b);
+    r.setSmall(m_whole_domain_dir, m_domain.smallEnd(m_whole_domain_dir));
+    r.setBig  (m_whole_domain_dir, m_domain.bigEnd  (m_whole_domain_dir));
+    return r;
+}
+
 BoxArray
 ClusterList::boxArray () const
 {
@@ -452,7 +479,7 @@ ClusterList::boxArray () const
 
     int i = 0;
     for (auto const& cli : lst) {
-        ba.set(i++, cli->box());
+        ba.set(i++, expandBox(cli->box()));
     }
 
     return ba;
@@ -467,7 +494,7 @@ ClusterList::boxArray (BoxArray& ba) const
 
     int i = 0;
     for (auto const& cli : lst) {
-        ba.set(i++, cli->box());
+        ba.set(i++, expandBox(cli->box()));
     }
 }
 
@@ -477,7 +504,7 @@ ClusterList::boxList() const
     BoxList blst;
     blst.reserve(lst.size());
     for (auto const& cli : lst) {
-        blst.push_back(cli->box());
+        blst.push_back(expandBox(cli->box()));
     }
     return blst;
 }
@@ -488,7 +515,7 @@ ClusterList::boxList (BoxList& blst) const
     blst.clear();
     blst.reserve(lst.size());
     for (auto const& cli : lst) {
-        blst.push_back(cli->box());
+        blst.push_back(expandBox(cli->box()));
     }
 }
 
@@ -532,6 +559,28 @@ void
 ClusterList::intersect (BoxArray& domba)
 {
     BL_PROFILE("ClusterList::intersect()");
+
+    if (m_whole_domain_dir >= 0) {
+        // Keep only those lines of cells that lie entirely inside domba,
+        // then flatten them onto the same plane as the clusters.
+        const int dir = m_whole_domain_dir;
+        const int dlo = m_domain.smallEnd(dir);
+        const int dhi = m_domain.bigEnd(dir);
+        BoxList bl;
+        bl.complementIn(m_domain, domba);
+        for (auto& b : bl) {
+            b.setSmall(dir,dlo);
+            b.setBig  (dir,dhi);
+        }
+        BoxArray ba_out(std::move(bl));
+        BoxList bl2;
+        bl2.complementIn(m_domain, ba_out);
+        for (auto& b : bl2) {
+            b.setSmall(dir,dlo);
+            b.setBig  (dir,dlo);
+        }
+        domba = BoxArray(std::move(bl2));
+    }
 
     domba.removeOverlap();
 


### PR DESCRIPTION
Add amr.refine_whole_domain_dir. When set, ClusterList projects the tagged cells onto a single plane and clusters in one fewer dimension, and its boxes span the entire domain in that direction. This replaces the usual workaround of a huge blocking factor plus amr.check_input=0.

